### PR TITLE
docs: rewrite Getting Started with progressive disclosure for all skill levels

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -11,6 +11,67 @@ SpatiumDDI has a few internal dependencies between modules (records need zones, 
 
 ---
 
+## Pick your path
+
+Three kinds of readers land on this page. Start where you actually are:
+
+- **"I'm evaluating whether this fits my org."** Read [Project status](#project-status) for what to expect from a beta and the lowest-risk way to trial it, then [Concepts in two minutes](#concepts-in-two-minutes) for what a [DDI](#ddi) platform does, then skim [Common setup shapes](#common-setup-shapes) to see which deployment matches your environment. You can stop there — everything in between is the how.
+- **"I know DDI. Get me running."** Go straight to the [TL;DR](#tldr--the-order) and work down the numbered steps. Plain-language framing sits in one lead sentence per step and in collapsible blocks — skip past both and the mechanics read as before.
+- **"I run networks, but DDI vocabulary is new to me."** Read [Concepts in two minutes](#concepts-in-two-minutes) first, then work through [Before you start](#before-you-start) and follow the numbered steps in order. Each step opens with what it does and why, a [worked example](#the-worked-example--ridgeline-college) runs through the whole sequence, and unfamiliar terms link to the [glossary](#glossary).
+
+---
+
+## Project status
+
+SpatiumDDI is **beta software** under active development. Core IPAM / DNS / DHCP / appliance surfaces have stabilised since the `2026.04.16-1` alpha cut, but expect occasional schema changes between releases and roadmap features still in flight. It is a good fit today for labs, homelabs, and pilots in front of non-critical client populations; production deploys in front of business-critical DHCP should pin to a tested release and snapshot Postgres before upgrading.
+
+**The lowest-risk way to try it: IPAM-only evaluation.** You do not have to hand SpatiumDDI control of anything on day one. Run it as the source of truth for your address plan — spaces, blocks, subnets, allocations — while your existing DNS and DHCP servers keep serving live traffic untouched. If you run Windows DHCP, register it read-only (Path A) so live [leases](#dhcp-lease) mirror into IPAM and you get real visibility with zero write path to production. That is the third of the [Common setup shapes](#common-setup-shapes) below. When you're ready, enable write paths one subnet or one zone at a time.
+
+---
+
+## Concepts in two minutes
+
+If you already know what a zone, a scope and a PTR record are, skip this.
+
+<details markdown="1">
+<summary>What DNS, DHCP and IPAM each do — and why one source of truth matters</summary>
+
+Three systems keep a network's addressing coherent. An office-campus analogy holds for all three:
+
+- **IPAM** (IP Address Management) is the **floor plan and seating chart**: the authoritative record of what address space exists, how it is divided up, and which addresses are assigned to what. Without it, that record is usually a spreadsheet.
+- **DHCP** (Dynamic Host Configuration Protocol) is the **front desk**: when a device joins the network, DHCP hands it an unoccupied address from a defined range, plus the settings it needs (router, DNS servers, domain), for a limited time.
+- **DNS** (Domain Name System) is the **directory**: it turns names people use (`print-01.corp.example.edu`) into addresses machines use (`10.20.21.10`), and — via [reverse zones](#forward-and-reverse-zones) — addresses back into names.
+
+The analogy stops there; desks don't expire, but DHCP [leases](#dhcp-lease) do.
+
+**Why one source of truth matters.** When the seating chart, the front desk and the directory are maintained separately — a spreadsheet, a DHCP console, a DNS console — they drift. The spreadsheet says an address is free, DHCP has leased it, DNS still points a name at it. [DDI](#ddi) means running all three off one record, so allocating an address in IPAM *is* what creates its DNS records, and DHCP ranges are defined against the same subnets IPAM tracks.
+
+**The IPAM hierarchy.** SpatiumDDI organises address space top-down, and the setup steps below follow the same order:
+
+- **Space** → the whole estate (campus): your entire addressing universe, e.g. everything corporate.
+- **Block** → a building: a large aggregate like `10.20.0.0/16`, carved out of the space.
+- **Subnet** → a floor: an operating network like `10.20.21.0/24`, usually mapped to one [VLAN](#vlan).
+- **Address** → a desk: one IP, assigned to one device.
+
+**Control plane vs data plane.** SpatiumDDI itself never answers a DNS query or a DHCP request. It is the [control plane](#control-plane-and-data-plane): the API, database and UI that decide what the configuration should be. The actual answering is done by the data plane — BIND9/Kea containers it deploys, or Windows servers it drives remotely. Managed containers cache their last-known-good configuration locally, so the data plane keeps serving even if the control plane is down.
+
+</details>
+
+---
+
+## Before you start
+
+Have these in hand before step 1:
+
+- **A Docker host.** Docker Engine 25+ and Docker Compose v2.20+, 2 GB RAM minimum (4 GB recommended), ports 8077 (frontend) and optionally 8000 (API) free — see the [Docker prerequisites](deployment/DOCKER.md#prerequisites). Kubernetes and the OS appliance ISO are alternatives; see the [deployment topologies](deployment/TOPOLOGIES.md).
+- **Admin access** to that host, and credentials to log in to SpatiumDDI (`admin` / `admin` on first boot; you will be forced to change it).
+- **Your list of subnets and [VLANs](#vlan)**, even a rough one, in [CIDR](#cidr) notation (`10.20.21.0/24`). You will enter these in steps 6–8, and a written plan beats improvising in the create form.
+- **Whether you have existing Windows DNS or DHCP.** This decides your backend choice in steps 3 and 5. If yes, you will need [WinRM](#winrm) enabled and a service account on the Windows side — read [WINDOWS.md](deployment/WINDOWS.md) first, since those prerequisites need Windows-admin time. If no, the built-in [agent](#agent-and-agentless) containers cover everything.
+- **Whether you need SSO on day one.** If people other than you will log in from the start, decide the provider (LDAP / OIDC / SAML) now — OIDC and SAML need the External URL set correctly in step 1 before their redirect flows work. Local accounts work fine without any of this.
+- **For live DHCP service from the built-in Kea:** clients reach a DHCP server by broadcast, so the server must share a layer-2 segment with them or be reachable via an IP helper / DHCP relay on your router. Not needed for the read-only Windows mirroring shape.
+
+---
+
 ## TL;DR — the order
 
 ```
@@ -30,13 +91,21 @@ The cleanest mental model is: **servers → zones/scopes → subnets → address
 
 ---
 
+## The worked example — Ridgeline College
+
+Steps 3–10 each carry a short worked example so you can watch one setup come together end to end. The scenario: **Ridgeline College**, a fictional small college with one campus. Its internal domain is `corp.example.edu`; its campus network is `10.20.0.0/16` (a private [RFC 1918](#rfc-1918) range) carved into one /24 per VLAN using the convention `10.20.<VLAN>.0/24`. Ridgeline runs the built-in BIND9 + Kea containers. The first subnet brought under management is staff VLAN 21 — `10.20.21.0/24`.
+
+---
+
 ## 1. Platform settings (first login)
+
+*What this does: sets the platform-wide defaults that every later form pre-fills — deciding them once here saves re-typing them on every zone and scope you create.*
 
 After logging in as `admin` / `admin` and changing your password:
 
 1. Go to **Settings**.
 2. Set **Branding & URL** — especially **External URL** if you're going to use OIDC or SAML (those redirect flows need it).
-3. Tune **DNS Defaults** (default zone TTL, DNSSEC mode) and **DHCP Defaults** (default DNS servers, search domain, lease time) — these are the pre-filled values when you later create zones and scopes, so setting them up front saves repetition.
+3. Tune **DNS Defaults** (default zone [TTL](#ttl), [DNSSEC](#dnssec) mode) and **DHCP Defaults** (default DNS servers, search domain, lease time) — these are the pre-filled values when you later create zones and scopes, so setting them up front saves repetition.
 4. Leave the two sync jobs **off** for now:
    - *IPAM → DNS Reconciliation* — turn this on once you have zones + subnets.
    - *Zone ↔ Server Reconciliation* — turn this on once at least one Windows DNS server with credentials is registered.
@@ -44,9 +113,13 @@ After logging in as `admin` / `admin` and changing your password:
 
 Each section has a **Reset to defaults** button at the top. It populates the section with the built-in defaults but still requires **Save** — you can back out by navigating away.
 
+> **How you know it worked:** reload the Settings page — your values persist. Later, in steps 4 and 9, the new-zone and new-scope forms come pre-filled with the defaults you set here.
+
 ---
 
 ## 2. (Optional) Auth providers
+
+*What this does: connects sign-in to your existing identity system so people use their normal accounts; skip it and local accounts keep working.*
 
 If you want SSO before anyone logs in, do it now. Otherwise, skip and come back later.
 
@@ -57,14 +130,23 @@ If you want SSO before anyone logs in, do it now. Otherwise, skip and come back 
 
 See [AUTH.md](features/AUTH.md) for the full provider matrix.
 
+> **How you know it worked:** the provider's **Test connection** succeeds, and a test user can sign in and lands with the groups you mapped. Note that a user whose groups match no mapping is rejected at login by design — if a test login fails, check the group mappings before anything else.
+
 ---
 
 ## 3. DNS — server groups + servers
 
+*What this does: registers the DNS servers SpatiumDDI manages and how it talks to them — every [zone](#zone) you create in step 4 must live on one of these groups.*
+
 Zones live under server groups, so this has to come before zones.
 
-1. **DNS → Server Groups → New Group**. Give it a name (`default`, `internal`, `corp`, whatever) and pick the recursion / DNSSEC defaults.
-2. **Add a server** to the group. You have three options:
+1. **DNS → Server Groups → New Group**. Give it a name (`default`, `internal`, `corp`, whatever) and pick the [recursion](#recursion) / DNSSEC defaults.
+2. **Add a server** to the group.
+
+   **Choosing a backend — two questions.** If you'd rather read the full matrix, it follows below unchanged.
+
+   1. **Does your org already run DNS on Windows Server / Active Directory?** If yes, keep it — register the DC as a `windows_dns` server rather than migrating anything. Provide WinRM credentials if your Windows admins allow it (**Path B** — full experience: zone create/delete, server-side reads without [AXFR](#axfr)); without credentials you still get record-level writes via [RFC 2136](#rfc-2136) dynamic updates (**Path A**). If no, use a built-in container — question 2.
+   2. **Using the built-in stack: do you need online DNSSEC signing with one-button sign-zone, ALIAS records (CNAME-at-apex), or LUA computed records?** If yes, run **PowerDNS**. Otherwise run **BIND9**, the default choice — it brings the BIND ecosystem (RPZ, full views support).
 
    | Backend | Setup | When to choose |
    |---|---|---|
@@ -77,27 +159,58 @@ Zones live under server groups, so this has to come before zones.
 
 3. Click **Sync with Servers** on the group header. For Windows servers this AXFRs/WinRM-pulls every zone on the wire, auto-imports zones that aren't in SpatiumDDI yet, and pushes any DB-only zones back to the server.
 
+<details markdown="1">
+<summary>Background: how the built-in containers register themselves</summary>
+
+The BIND9 / PowerDNS / Kea containers are [agents](#agent-and-agentless): each starts with a pre-shared key from its environment (`DNS_AGENT_KEY` / `DHCP_AGENT_KEY`), exchanges it with the control plane for a rotating token, and appears as a registered server without manual entry. From then on the agent polls for configuration changes and keeps a local copy of its last-known-good config, so DNS and DHCP keep answering even if the control plane is down. Details in [DNS_AGENT.md](deployment/DNS_AGENT.md).
+
+</details>
+
+> **Worked example — Ridgeline College.** Ridgeline creates one server group named `default`, leaves the group defaults as-is, and runs `docker compose --profile dns-bind9 up -d` on the SpatiumDDI host. The BIND9 container auto-registers and appears in the group.
+
+> **How you know it worked:** the server appears in the group's server list, enabled, and **Sync with Servers** completes with a healthy per-server status. A group with zero enabled servers can't push anything — that state is the top cause of "my record never appeared" later.
+
 ---
 
 ## 4. DNS — zones
 
+*What this does: creates the containers your records will live in — [forward zones](#forward-and-reverse-zones) for name → IP lookups, reverse zones for IP → name.*
+
 Zones come in two flavours, and the order matters a little:
 
-1. **Forward zones first.** Create `corp.example.com`, `lab.example.com`, etc. These are what your A/AAAA records live in.
-2. **Reverse zones second.** These back PTR records. You can either:
-   - Create them manually now (`0.20.10.in-addr.arpa` for `10.20.0.0/16` — standard RFC 2317 layout), or
+1. **Forward zones first.** Create `corp.example.com`, `lab.example.com`, etc. These are what your [A/AAAA](#a-and-aaaa-records) records live in.
+2. **Reverse zones second.** These back [PTR](#ptr-record) records. You can either:
+   - Create them manually now (`20.10.in-addr.arpa` for `10.20.0.0/16`, or `21.20.10.in-addr.arpa` for `10.20.21.0/24` — the zone name is the network octets reversed under [`in-addr.arpa`](#in-addrarpa-and-ip6arpa)), or
    - Let SpatiumDDI auto-create them when you create the subnet in step 8 — the matching `in-addr.arpa` (or `ip6.arpa`) zone is created automatically once the subnet has an effective DNS group/zone, unless you opt out with `skip_reverse_zone`.
 
 Zones that SpatiumDDI didn't create itself can be imported by clicking **Sync with Servers** on the group — anything present on the wire but not in the DB is auto-imported as `is_auto_generated=False` (so it won't be touched by stale-record cleanup).
+
+<details markdown="1">
+<summary>Background: how reverse zone names map to subnets</summary>
+
+Reverse DNS stores IP-to-name mappings in ordinary zones under the special domains `in-addr.arpa` (IPv4) and `ip6.arpa` (IPv6), with the address octets written in reverse: the PTR record for `10.20.21.10` lives at `10.21.20.10.in-addr.arpa`, inside a zone such as `21.20.10.in-addr.arpa` (covering `10.20.21.0/24`). Reverse zones split cleanly only on octet boundaries — /8, /16, /24 — so for a subnet that isn't octet-aligned (a /23, say) SpatiumDDI creates the zone at the nearest enclosing octet boundary, the standard BIND convention for an aggregated reverse zone covering several smaller subnets.
+
+</details>
+
+> **Worked example — Ridgeline College.** Ridgeline creates one forward zone, `corp.example.edu`, in the `default` group — and stops there. Rather than hand-creating reverse zones, they let SpatiumDDI auto-create `21.20.10.in-addr.arpa` when the `10.20.21.0/24` subnet is created in step 8.
+
+> **How you know it worked:** the zone appears in the group's zone list with SOA/NS records, and after **Sync with Servers** the per-server state on the zone shows it present on the wire.
 
 ---
 
 ## 5. DHCP — server groups + servers
 
+*What this does: registers the servers that will answer lease requests — the [scopes](#dhcp-scope) you define in step 9 attach to these.*
+
 Same pattern as DNS. Do this before you start pinning subnets to DHCP servers.
 
 1. **DHCP → Server Groups → New Group**.
-2. **Add a server**:
+2. **Add a server**.
+
+   **Choosing a backend — two questions.** The matrix follows below unchanged.
+
+   1. **Do you have an existing Windows DHCP server that must keep serving leases?** If yes, register it read-only (**Path A**): SpatiumDDI polls its leases into IPAM for visibility, and you keep managing scopes in the Windows DHCP console. Nothing about the running service changes.
+   2. **Otherwise — greenfield, or ready to serve DHCP from SpatiumDDI?** Run the built-in **Kea** container and let SpatiumDDI own scopes, pools and [reservations](#dhcp-reservation) end to end.
 
    | Backend | Setup | When to choose |
    |---|---|---|
@@ -108,9 +221,15 @@ Same pattern as DNS. Do this before you start pinning subnets to DHCP servers.
 
 3. Toggle **DHCP Lease Sync** on in Settings once you have at least one agentless server — the Celery beat task pulls leases on a short polling interval (15 s by default, tunable in Settings, 10 s minimum).
 
+> **Worked example — Ridgeline College.** Ridgeline creates a DHCP group named `default` and runs `docker compose --profile dhcp up -d`. The Kea container auto-registers into it. No Windows DHCP exists, so lease sync stays off.
+
+> **How you know it worked:** the server appears in the DHCP group's server list, enabled and healthy. For a Windows Path A server, leases start appearing in IPAM (as `dhcp` rows) within a polling interval of enabling **DHCP Lease Sync**.
+
 ---
 
 ## 6–8. IPAM — space → block → subnet
+
+*What this does: builds the address ledger, top-down — the record of what address space you have and how it's carved up, which everything else (scopes, records, allocations) hangs off.*
 
 IPAM is the root of the hierarchy everything else hangs off. The top-down order is:
 
@@ -123,6 +242,8 @@ An **IP Space** is the top-level container — think "address universe". Most or
 
 Create a space with **IPAM → New Space**. You can pin a default DNS group + DHCP group here; anything below will inherit unless overridden.
 
+> **Worked example — Ridgeline College.** One space: `Campus`. Ridgeline pins nothing here, choosing to pin groups on the block below instead.
+
 ### 7. IP Blocks (optional)
 
 A **Block** is an aggregate — a `10.0.0.0/8` under Corporate, broken into `10.1.0.0/16` for HQ and `10.2.0.0/16` for datacentre, etc. Blocks exist to:
@@ -130,6 +251,8 @@ A **Block** is an aggregate — a `10.0.0.0/8` under Corporate, broken into `10.
 - Give the tree shape when you have dozens of subnets.
 
 You can skip blocks entirely if your network is small — subnets can live directly under a space.
+
+> **Worked example — Ridgeline College.** One block: `10.20.0.0/16` under `Campus`. This is where Ridgeline pins the `default` DNS group and `default` DHCP group, so every per-VLAN subnet created under it inherits both and needs no per-subnet pinning.
 
 ### 8. Subnets
 
@@ -148,22 +271,34 @@ On the subnet create form:
 
 **Important:** subnets and blocks respect inheritance independently for DNS and DHCP. If you want a subnet to inherit DNS from its parent but use a different DHCP group, that works — toggle `dns_inherit_settings` on, `dhcp_inherit_settings` off, and pin the DHCP group.
 
+> **Worked example — Ridgeline College.** First subnet: `10.20.21.0/24`, VLAN ID 21, primary DNS zone `corp.example.edu`. Both server-group fields stay blank — the subnet inherits the `default` DNS and DHCP groups from the `10.20.0.0/16` block. On save, SpatiumDDI auto-creates the reverse zone `21.20.10.in-addr.arpa` in the `default` group.
+
+> **How you know it worked:** the IPAM tree shows `Campus → 10.20.0.0/16 → 10.20.21.0/24`, the subnet detail shows the effective (inherited) DNS and DHCP groups, and the new reverse zone is listed under the DNS group alongside your forward zone.
+
 ---
 
 ## 9. DHCP scopes
 
+*What this does: turns a documented subnet into a range the DHCP server actually serves — until now the subnet only exists on paper.*
+
 With a subnet and a DHCP server group in place, open the subnet → **DHCP** tab → **New Scope**. The form pre-fills defaults from Settings (DNS servers, domain, search list, NTP, lease time), so most scopes are a one-click save.
 
-Pools go under scopes:
+[Pools](#dhcp-pool) go under scopes:
 - **Dynamic** — handed out to clients.
 - **Reserved** — held for static assignments only.
 - **Excluded** — this range exists in the subnet but DHCP will never offer it (e.g. infrastructure).
 
 For Windows DHCP servers in Path A (read-only) you can't create scopes from SpatiumDDI — you create them in the Windows DHCP MMC, and SpatiumDDI auto-imports them on the next lease sync.
 
+> **Worked example — Ridgeline College.** On `10.20.21.0/24`, Ridgeline creates one scope, accepts the pre-filled defaults, and defines two pools: a **dynamic** pool `10.20.21.100–10.20.21.199` for staff laptops, and an **excluded** pool `10.20.21.1–10.20.21.9` for network infrastructure. Everything else is left for static allocation in step 10.
+
+> **How you know it worked:** the scope and its pools are listed on the subnet's DHCP tab, and the subnet's IP grid marks the pool boundaries — allocating inside a dynamic pool is refused, which is the guardrail working as intended.
+
 ---
 
 ## 10. Addresses
+
+*What this does: allocating an address is what makes DNS records appear — this is the step the previous nine were setting up.*
 
 Now the fun part. In the subnet view:
 
@@ -176,6 +311,13 @@ When you save an IP with a hostname + DNS zone:
 2. SpatiumDDI creates a PTR record in the reverse zone (if one is linked).
 3. For BIND9, the update goes over RFC 2136; for Windows, record writes go over RFC 2136 in both Path A and Path B (WinRM in Path B is used only for zone create/delete and server-side reads, not for hot record writes).
 
+<details markdown="1">
+<summary>Background: why updates ride RFC 2136 instead of rewriting zone files</summary>
+
+RFC 2136 dynamic update changes individual records on a live server — no zone-file editing, no service restart, no full-zone push. That is what makes a record write cheap enough to happen automatically on every allocation, and it is the same mechanism in both Windows paths, which is why the "allow nonsecure dynamic updates" zone setting matters in the troubleshooting list below.
+
+</details>
+
 If anything ever drifts between IPAM and your DNS servers, the **Sync DNS** option (under the `[Sync ▾]` menu on the subnet/block/space header) opens a drift report, and two scheduled reconciliation jobs you can enable in Settings:
 
 | Job | What it reconciles |
@@ -184,6 +326,10 @@ If anything ever drifts between IPAM and your DNS servers, the **Sync DNS** opti
 | **Zone ↔ Server Reconciliation** | SpatiumDDI's DNS DB vs the authoritative server's wire — imports out-of-band edits, pushes DB-only records back. |
 
 Both are off by default and additive-only.
+
+> **Worked example — Ridgeline College.** Ridgeline allocates `10.20.21.10` with hostname `print-01`, zone `corp.example.edu`. On save, an A record `print-01.corp.example.edu → 10.20.21.10` lands in the forward zone and a PTR record appears in `21.20.10.in-addr.arpa`. A staff laptop joining VLAN 21 picks up a lease from the `10.20.21.100–199` pool.
+
+> **How you know it worked:** both records are visible in the zone record lists, and a query against the DNS server answers — for Ridgeline, `dig @<bind9-host> print-01.corp.example.edu` returns `10.20.21.10` and `dig @<bind9-host> -x 10.20.21.10` returns the name. The subnet's **Sync DNS** drift report shows the subnet in sync. If the record didn't appear, work through [Troubleshooting the first IP](#troubleshooting-the-first-ip).
 
 ---
 
@@ -209,20 +355,118 @@ Both are off by default and additive-only.
 3. Enable **DHCP Lease Sync** in Settings so leases mirror into IPAM as `status=dhcp`.
 4. Manage scopes in Windows DHCP MMC; SpatiumDDI auto-imports them on each lease poll.
 
+This third shape is also the [lowest-risk evaluation pattern](#project-status): SpatiumDDI becomes the source of truth for the address plan while the servers your users depend on keep running exactly as before.
+
 ---
 
 ## Troubleshooting the first IP
 
-If allocating your first IP doesn't produce a DNS record, check in this order:
+**Symptom: you allocated an IP with a hostname, but no DNS record appeared.**
 
-1. **Subnet has a primary DNS zone?** — open the subnet, check the DNS zone field is set.
-2. **Zone is on a server group?** — every zone has to belong to a group.
-3. **Group has at least one enabled server?** — a group with zero `is_enabled=True` servers won't push anything.
-4. **Server is healthy?** — hit **Sync with Servers** and watch the per-server status column.
-5. **For Windows Path A**, is the zone set to "Nonsecure and secure" updates? — secure-only rejects our unsigned RFC 2136 updates.
-6. **For Windows Path B, are credentials stored?** — the server detail page shows whether WinRM credentials are configured. Credentials unlock zone create/delete and server-side reads; record writes ride RFC 2136 in both paths, so check that the zone allows nonsecure updates regardless.
+Work through these in order — each is a likely cause, how to check it, and the fix:
+
+1. **The subnet has no primary DNS zone.** Without one, SpatiumDDI has nowhere to put the A record. *Check:* open the subnet and look at the DNS zone field. *Fix:* set a primary zone on the subnet (or on a parent block/space and let it inherit).
+2. **The zone isn't on a server group.** Every zone has to belong to a group; a zone that exists only in the DB reaches no server. *Check:* open the zone and confirm its group. *Fix:* assign it to the group whose servers should serve it.
+3. **The group has no enabled server.** A group with zero `is_enabled=True` servers won't push anything — the write succeeds in the DB and goes nowhere. *Check:* the group's server list. *Fix:* enable a server, or add one (step 3).
+4. **The server is unhealthy or unreachable.** *Check:* hit **Sync with Servers** and watch the per-server status column. *Fix:* whatever the status reports — network path, service down, credentials.
+5. **(Windows Path A) The zone only accepts secure dynamic updates.** Secure-only zones reject SpatiumDDI's unsigned RFC 2136 updates, so record writes silently fail. *Check:* the zone's dynamic-updates setting in Windows DNS Manager. *Fix:* set it to "Nonsecure and secure".
+6. **(Windows Path B) Credentials aren't stored — and the same update setting applies.** *Check:* the server detail page shows whether WinRM credentials are configured. Credentials unlock zone create/delete and server-side reads; record writes ride RFC 2136 in both paths, so check that the zone allows nonsecure updates regardless. *Fix:* store the credentials, and apply the fix from item 5.
 
 If a record is expected but missing, the subnet's **Sync DNS** drift report will tell you exactly what's missing and let you apply it with one click.
+
+---
+
+## Glossary
+
+Definitions in setup-order context — each is linked from its first use above.
+
+#### DDI
+
+Industry shorthand for **D**NS + **D**HCP + **I**PAM run as one integrated system, so that names, leases and the address ledger can't drift apart. SpatiumDDI is a DDI platform.
+
+#### Control plane and data plane
+
+The **control plane** decides what the configuration should be — in SpatiumDDI, the API, database and UI. The **data plane** does the actual serving: BIND9/Kea containers or Windows servers answering queries and handing out leases. SpatiumDDI's managed containers cache their last-known-good config, so the data plane keeps serving if the control plane goes down.
+
+#### Zone
+
+The unit of DNS ownership: a portion of the namespace (such as `corp.example.edu`) served authoritatively as one set of records, by one set of servers.
+
+#### Forward and reverse zones
+
+A **forward zone** maps names to addresses (`print-01.corp.example.edu → 10.20.21.10`). A **reverse zone** maps addresses back to names, lives under [`in-addr.arpa` / `ip6.arpa`](#in-addrarpa-and-ip6arpa), and holds [PTR](#ptr-record) records.
+
+#### A and AAAA records
+
+The name-to-address record types: **A** for an IPv4 address, **AAAA** for IPv6.
+
+#### PTR record
+
+The address-to-name record type, stored in a reverse zone. Mail servers, logging and monitoring commonly resolve PTRs, which is why keeping them in sync with A records matters.
+
+#### TTL
+
+Time To Live — how many seconds resolvers may cache a record before asking again. Low TTLs propagate changes fast at the cost of more queries; high TTLs the reverse.
+
+#### DNSSEC
+
+Cryptographic signatures on DNS data so resolvers can verify records weren't forged or tampered with in transit. Adds key material and signing to zone management.
+
+#### Recursion
+
+A **recursive** DNS server chases down answers on behalf of clients, querying other servers as needed. An **authoritative-only** server answers solely for its own zones. Mixing the roles on one server is possible but widens what that server will answer for.
+
+#### AXFR
+
+Full zone transfer — a standard mechanism for pulling a zone's complete contents from a server over TCP. SpatiumDDI uses it to import and compare zones on backends that support it.
+
+#### RFC 2136
+
+The dynamic DNS update protocol: changes individual records on a live server without editing zone files or restarting anything. SpatiumDDI's record writes ride RFC 2136 on BIND9 and on both Windows paths.
+
+#### TSIG
+
+Transaction SIGnature — a shared-secret signature that authenticates DNS messages, commonly required for zone transfers and dynamic updates between parties that must trust each other.
+
+#### in-addr.arpa and ip6.arpa
+
+The special DNS domains where reverse zones live. The zone name is the network portion of the address reversed: `21.20.10.in-addr.arpa` is the reverse zone for `10.20.21.0/24`. IPv6 uses `ip6.arpa` with the address's hex digits reversed one nibble at a time.
+
+#### DHCP scope
+
+A DHCP server's configuration for one subnet: which ranges to serve and with what options (router, DNS servers, domain, lease time).
+
+#### DHCP pool
+
+A contiguous range of addresses inside a scope, with a role: **dynamic** (offered to clients), **reserved** (held for static use), or **excluded** (never offered).
+
+#### DHCP lease
+
+A temporary assignment of an address to a client, with an expiry time. The client must renew before expiry or the address returns to the pool.
+
+#### DHCP reservation
+
+A standing rule that a specific client (usually identified by MAC address) always receives the same IP from DHCP.
+
+#### CIDR
+
+The `network/prefix-length` notation for IP ranges: `10.20.21.0/24` means the first 24 bits are fixed, leaving 256 addresses. A larger number after the slash means a smaller network.
+
+#### RFC 1918
+
+The reserved private IPv4 ranges — `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` — usable inside any organisation but never routed on the public internet.
+
+#### VLAN
+
+Virtual LAN — a layer-2 network segment isolated by switch configuration. In most designs each VLAN carries exactly one IPv4 subnet, which is why SpatiumDDI lets you link a VLAN ID to a subnet.
+
+#### WinRM
+
+Windows Remote Management — the remote-management channel (remote PowerShell) SpatiumDDI uses to drive existing Windows DNS/DHCP servers without installing anything on them.
+
+#### Agent and agentless
+
+An **agent** backend is a container SpatiumDDI deploys and configures itself (built-in BIND9, PowerDNS, Kea). An **agentless** backend is an existing server SpatiumDDI drives remotely over that server's own protocols ([WinRM](#winrm), [RFC 2136](#rfc-2136), cloud provider APIs) with nothing installed on it.
 
 ---
 

--- a/docs/SHIPPED.md
+++ b/docs/SHIPPED.md
@@ -1597,10 +1597,9 @@ Mirrors CLAUDE.md's three mixed sections:
   `mode=consumer` ships the producer's IP. The agent renders
   the catalog zone file per RFC 9432 §4.1 — SOA + NS at apex,
   `version IN TXT "2"`, and one `<sha1-of-wire-name>.zones IN
-  PTR <member>` per primary zone — and on consumers injects a
-  single `catalog-zones { zone "<catalog>." default-masters {
-  <producer-ip>; } in-memory yes; };` directive into the
-  options block. The catalog block is part of the structural
+  PTR <member>` per primary zone — and on consumers injects a single
+  `catalog-zones { zone "<catalog>." default-masters { <producer-ip>; } in-memory yes; };`
+  directive into the options block. The catalog block is part of the structural
   ETag so membership changes trigger a daemon reload, and SHA-1
   hashing uses the proper wire format (length-prefixed labels +
   null terminator) so consumer BINDs find the same labels.

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -808,9 +808,10 @@ one whole disk. Prefer a stable `/dev/disk/by-id/…` or `by-path/…` id
 (a bare `sda` can renumber). A supplied-but-unresolvable disk drops to
 the interactive picker rather than guessing.
 
-**Lint a preseed offline (#581).** `spatium-install --check-preseed
-<preseed.yaml>` dry-runs the answer file **without installing
-anything** — it is unprivileged, read-only, and host-portable (runs
+**Lint a preseed offline (#581).**
+`spatium-install --check-preseed <preseed.yaml>` dry-runs the answer
+file **without installing anything** — it is unprivileged, read-only,
+and host-portable (runs
 identically on a dev laptop and the appliance). It parses the file via
 the same `spatium-preseed-parse` helper a real headless install uses,
 then re-runs the wizard's own validators (hostname RFC 1123; k3s CIDR


### PR DESCRIPTION
Closes #765

Rewrites `docs/GETTING_STARTED.md` (published as `GETTING_STARTED.html`) with progressive disclosure so it serves three audiences at once — evaluating manager, expert wanting the fast path, and generalist sysadmin new to DDI — without slowing the expert down. Nothing technical was removed; layers were added around it.

## What changed

- **Pick your path** — three entry points at the top (evaluating / fast path / new to DDI), each linking to the right starting section.
- **Project status** — honest beta note matching the README's wording, leading with the lowest-risk trial: the IPAM-only pattern (SpatiumDDI as source of truth while existing DNS/DHCP keep serving live traffic), cross-linked to the read-only-mirroring setup shape.
- **Concepts in two minutes** — collapsible primer on DNS / DHCP / IPAM, why one source of truth matters, and the space → block → subnet → address hierarchy, on a single office-campus analogy with an explicit stop line.
- **Before you start** checklist — host specs verbatim from DOCKER.md prerequisites, subnet/VLAN list, existing-Windows question, SSO-on-day-one decision, DHCP relay note.
- **Per-step leads** — one italic plain-language "what this does and why" sentence on every numbered step.
- **Decision helpers** — two-question backend chooser before both the DNS and DHCP tables; both matrices preserved byte-for-byte below.
- **"How you know it worked"** success checks after steps 1–5, 8, 9, 10.
- **Worked example** threaded through steps 3–10: fictional Ridgeline College, `corp.example.edu`, `10.20.0.0/16`, VLAN 21 → `10.20.21.0/24`, `print-01` at `.10`.
- **Troubleshooting** restructured as symptom → likely cause → check → fix; all six original checks and the drift-report closer retained.
- **Glossary** — all required terms (DDI, control/data plane, zone, forward/reverse, A/AAAA, PTR, TTL, DNSSEC, recursion, AXFR, RFC 2136, TSIG, in-addr.arpa/ip6.arpa, scope/pool/lease/reservation, CIDR, RFC 1918, VLAN, WinRM, agent vs agentless) as anchored headings, linked from first substantive use.
- Three `<details>` background blocks: agent auto-registration, reverse-zone naming, why record writes ride RFC 2136.

## Corrections to existing text (verified against code)

- The reverse-zone example claimed `0.20.10.in-addr.arpa` covers `10.20.0.0/16` "standard RFC 2317 layout" — wrong on both counts (that zone covers only `10.20.0.x`; RFC 2317 is sub-/24 delegation). Corrected to `20.10.in-addr.arpa`, matching `compute_reverse_zone_name()` in `backend/app/services/dns/reverse_zone.py`.
- Dropped "You have three options:" before the DNS backend table — it has four rows.

## Preservation guarantees

- Every pre-existing heading is byte-identical, so all auto-generated anchor IDs survive for external deep links.
- TL;DR block, both backend tables, the reconciliation-jobs table, all existing links and the setup sequence unchanged.
- All 29 internal glossary/section anchors validated against the GitHub-style ID algorithm the site's kramdown-GFM config uses, and the rendered output checked on the local Jekyll container (same plugin set as Pages): `<details>` blocks render, `markdown="1"` consumed, IDs match.

## Known deviations (from the task brief)

- Brief said "alpha status"; the README badge and warning say **beta** — followed the repo's own wording.
- TSIG never occurs in the page body, so it has a glossary entry but no first-use link; the TL;DR is a code block, so no links inside it.
- The one remaining "just" on the page is inside the preserved Path A table row the brief required left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
