### PR TITLE
ci: bump every actions/* major to its Node 24 release

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/build-appliance-builder.yml
+++ b/.github/workflows/build-appliance-builder.yml
@@ -24,7 +24,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/build-dhcp-images.yml
+++ b/.github/workflows/build-dhcp-images.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         flavor: [kea]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-dns-images.yml
+++ b/.github/workflows/build-dns-images.yml
@@ -28,7 +28,7 @@ jobs:
         # ghcr.io/spatiumddi/dns-<flavor>).
         flavor: [bind9, powerdns, technitium, dnsdist]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-looking-glass-images.yml
+++ b/.github/workflows/build-looking-glass-images.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         flavor: [gobgp]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build-supervisor-image.yml
+++ b/.github/workflows/build-supervisor-image.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -110,9 +110,9 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -169,9 +169,9 @@ jobs:
     name: Docs — Diagram Geometry
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -197,9 +197,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -222,9 +222,9 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 
@@ -259,9 +259,9 @@ jobs:
       run:
         working-directory: agent/${{ matrix.agent }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
@@ -299,9 +299,9 @@ jobs:
     name: Appliance — Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source ref
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/prune-release-assets.yml
+++ b/.github/workflows/prune-release-assets.yml
@@ -40,7 +40,7 @@ jobs:
     name: Prune old appliance release assets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Prune
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       version: ${{ steps.ver.outputs.version }}
       sha_short: ${{ steps.ver.outputs.sha_short }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - id: ver
         run: |
           echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
@@ -42,7 +42,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -77,7 +77,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -109,7 +109,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -139,7 +139,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -169,7 +169,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -199,7 +199,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -229,7 +229,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -264,7 +264,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -299,7 +299,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
@@ -343,7 +343,7 @@ jobs:
     outputs:
       chart_version: ${{ steps.pkg.outputs.chart_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: azure/setup-helm@v4
         with:
           version: v3.20.2
@@ -417,7 +417,7 @@ jobs:
       packages: read
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
@@ -604,7 +604,7 @@ jobs:
           ls -lh "$VERSIONED_XZ" "$STABLE_XZ" "$VERSIONED_SHA" "$STABLE_SHA"
           echo "slot_name=spatiumddi-appliance-slot-${VERSION}-amd64.raw.xz" >> "$GITHUB_OUTPUT"
       - name: Upload appliance artifacts (ISO + slot image)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: appliance-artifacts
           path: |
@@ -639,7 +639,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -738,7 +738,7 @@ jobs:
           fi
 
       - name: Download appliance artifacts (ISO + slot image)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: appliance-artifacts
           path: dist/

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -39,7 +39,7 @@ jobs:
     name: Trivy — all shipped images
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build and scan every image
         id: scan
@@ -156,7 +156,7 @@ jobs:
 
       - name: Open, update or close the tracking issue
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           HAS_FINDINGS: ${{ steps.scan.outputs.has_findings }}
         with:


### PR DESCRIPTION
Every job was emitting *"Node.js 20 is deprecated … being forced to run
on Node.js 24"*. Non-blocking while the runner shims it — but the shim
goes away, and then every workflow breaks at once.

All **39 usages across 11 workflows**:

| action | | uses |
|---|---|---|
| `checkout` | v4 → **v7** | 29 |
| `setup-python` | v5 → **v7** | 5 |
| `setup-node` | v4 → **v7** | 2 |
| `github-script` | v7 → **v9** | 1 |
| `upload-artifact` | v4 → **v7** | 1 |
| `download-artifact` | v4 → **v8** | 1 |

## Latest, not the minimum Node-24 major

Landing on the minimum means repeating this exercise in a few months.
And for `setup-node` the minimum is actually the *more* surprising
version: v5 auto-caches whenever `package.json` carries a
`packageManager` field, and v6 narrows that back to npm only.

## The issue's version table has an error

It lists `download-artifact` **v6** as the Node-24 minimum. v6 is still
`node20` — so is v5 — and the real minimum is **v7**.

Every tag here was verified by reading `using:` out of that tag's own
`action.yml` rather than trusting the table. Following the table as
written would have bumped `release.yml` to a version that is *still on
Node 20* — silently unfixed, in the one workflow nothing exercises until
a real release is cut.

## Breaking changes, checked against this repo

All inapplicable:

- **checkout v7** blocks fork checkout for `pull_request_target` /
  `workflow_run` — we use neither trigger.
- **setup-python v7** removed the `pip-install` input — unused here.
- **setup-node v5** auto-caches on a `packageManager` field — we have
  none, and set no `cache:`.
- **download-artifact v5** changed output paths for downloads **by ID** —
  we download by name.
- **github-script v9** is ESM: `require('@actions/github')` is gone, and
  a script declaring `getOctokit` now `SyntaxError`s. Our one script does
  neither — a single `require('fs')` (a Node built-in, which is not what
  v9 broke). Its body still parses when wrapped the way the action
  evaluates it.
- **Minimum runner 2.327.1** — GitHub-hosted, satisfied.

## Verification

- Every pinned tag confirmed `runs.using: node24`.
- `actionlint` clean apart from pre-existing shellcheck warnings in
  `run:` blocks this PR doesn't touch.
- Diff is *exactly* the 39 `uses:` lines — nothing else changed.
- The CI-path actions (checkout / setup-python / setup-node) are
  exercised by this PR itself, so those are self-verifying.

## Residual risk

`release.yml` is tag-push only with no `workflow_dispatch`, so **nothing
validates the artifact pair until a release is cut**. Usage there is the
simplest supported shape (one named artifact up, same name down), but
`download-artifact@v8` turns a digest mismatch into a hard failure rather
than a warning — worth watching the next release.

`trivy-scheduled.yml` *does* have `workflow_dispatch`, so
`github-script@v9` can be verified on demand without waiting for Monday.

## Follow-up: seven third-party actions are also on Node 20

Out of scope here — `actions/*` is only the part GitHub *names* in the
warning — but these break at the identical moment:

```
azure/setup-helm@v4              node20  → v5.0.1  node24
docker/build-push-action@v5,@v6  node20  → v7.3.0  node24
docker/login-action@v3           node20  → v4.6.0  node24
docker/metadata-action@v5        node20  → v6.2.0  node24
docker/setup-buildx-action@v3    node20  → v4.2.0  node24
docker/setup-qemu-action@v3      node20  → v4.2.0  node24
softprops/action-gh-release@v2   node20  → v3.0.2  node24
```

Left out deliberately: `softprops/action-gh-release` is what actually
publishes releases and `docker/build-push-action` spans every image-build
workflow, so that is a materially riskier second set. Note also that
`build-push-action` is pinned at **both v5 and v6** today — pre-existing
drift worth collapsing when they are bumped.

#764 stays open until those land, since its stated goal — no workflow
breaking on the runtime removal — is not met while seven actions remain
on Node 20.

Refs #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
