### PR TITLE
feat(migration): guided Windows → SpatiumDDI cutover (#756)

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -140,6 +140,10 @@ backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:83
 backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:84
 backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:85
 backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:86
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:222
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:225
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:230
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:237
 backend/alembic/versions/a4f81c26b9e3_self_service_requests.py:drop_column:88
 backend/alembic/versions/a4f81c26b9e3_self_service_requests.py:drop_column:89
 backend/alembic/versions/a4f9c2e8b316_appliance_supervisor_identity.py:drop_column:153

--- a/backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py
+++ b/backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py
@@ -1,0 +1,233 @@
+"""Windows → SpatiumDDI cutover plans (#756)
+
+Adds the ``migration.cutover`` feature module and its four tables — the
+state behind the guided migration off a Windows DNS / DHCP estate that
+the one-shot importers (#128 / #129) stop short of.
+
+* ``cutover_plan`` — one named migration: a Windows source server (DNS
+  and/or DHCP, both nullable so a plan may cover either half) and the
+  SpatiumDDI target group it is moving to.
+* ``cutover_item`` — one zone or one scope inside a plan. Carries
+  everything a rollback needs to be exact: the last parity report, the
+  last shadow-query comparison, the pristine pre-flight TTL snapshot,
+  the lease-handover result, and the current blocker set.
+* ``cutover_checklist_item`` — the Phase 4 decommission list, seeded per
+  plan from a static catalog so ticks and notes survive a page reload.
+* ``cutover_event`` — append-only timeline. No ``modified_at``: an event
+  has exactly one time, the moment it happened.
+
+``cutover_item.zone_id`` / ``scope_id`` are ``ON DELETE SET NULL`` while
+``plan_id`` is ``CASCADE``. The asymmetry is deliberate: deleting a plan
+is throwing away bookkeeping and should take its children with it, but
+deleting the SpatiumDDI-side zone or scope mid-migration must leave the
+item — and the history of what was already done to it — standing.
+``source_ref`` (the Windows-side name) is the identity that survives.
+
+Default-ENABLED per non-negotiable #14: the surface is read-mostly, and
+every mutating step behind it is separately superadmin-gated. An
+operator cannot turn off what they never knew shipped.
+
+Revision ID: a4f1c93d7e28
+Revises: b2d47f1c8a30
+Create Date: 2026-07-31
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a4f1c93d7e28"
+down_revision: str | None = "b2d47f1c8a30"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # ── cutover_plan ───────────────────────────────────────────────────
+    op.create_table(
+        "cutover_plan",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="draft"),
+        sa.Column("source_dns_server_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("source_dhcp_server_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("target_dns_group_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("target_dhcp_group_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rolled_back_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["source_dns_server_id"], ["dns_server.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["source_dhcp_server_id"], ["dhcp_server.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(
+            ["target_dns_group_id"], ["dns_server_group.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_dhcp_group_id"], ["dhcp_server_group.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(["created_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # ``name`` is declared ``unique=True, index=True`` on the model, which
+    # SQLAlchemy emits as a single UNIQUE INDEX (not a separate constraint).
+    op.create_index("ix_cutover_plan_name", "cutover_plan", ["name"], unique=True)
+    op.create_index(
+        "ix_cutover_plan_source_dns_server_id", "cutover_plan", ["source_dns_server_id"]
+    )
+    op.create_index(
+        "ix_cutover_plan_source_dhcp_server_id", "cutover_plan", ["source_dhcp_server_id"]
+    )
+    op.create_index("ix_cutover_plan_target_dns_group_id", "cutover_plan", ["target_dns_group_id"])
+    op.create_index(
+        "ix_cutover_plan_target_dhcp_group_id", "cutover_plan", ["target_dhcp_group_id"]
+    )
+
+    # ── cutover_item ───────────────────────────────────────────────────
+    op.create_table(
+        "cutover_item",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("plan_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("kind", sa.String(length=12), nullable=False),
+        sa.Column("source_ref", sa.String(length=255), nullable=False),
+        sa.Column("zone_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("scope_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("stage", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column(
+            "blockers",
+            postgresql.JSONB(),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("last_parity", postgresql.JSONB(), nullable=True),
+        sa.Column("last_parity_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_shadow", postgresql.JSONB(), nullable=True),
+        sa.Column("last_shadow_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("ttl_snapshot", postgresql.JSONB(), nullable=True),
+        sa.Column("ttl_lowered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("lease_handover", postgresql.JSONB(), nullable=True),
+        sa.Column("cut_over_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("rolled_back_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(["plan_id"], ["cutover_plan.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["zone_id"], ["dns_zone.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["scope_id"], ["dhcp_scope.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("plan_id", "kind", "source_ref", name="uq_cutover_item_plan_kind_ref"),
+    )
+    op.create_index("ix_cutover_item_plan", "cutover_item", ["plan_id"])
+    op.create_index("ix_cutover_item_zone_id", "cutover_item", ["zone_id"])
+    op.create_index("ix_cutover_item_scope_id", "cutover_item", ["scope_id"])
+
+    # ── cutover_checklist_item ─────────────────────────────────────────
+    op.create_table(
+        "cutover_checklist_item",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("plan_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("key", sa.String(length=64), nullable=False),
+        sa.Column("category", sa.String(length=32), nullable=False),
+        sa.Column("label", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("applies_to", sa.String(length=12), nullable=False, server_default="general"),
+        sa.Column("is_done", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("done_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("done_by_user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=False),
+        sa.Column("sort_order", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.ForeignKeyConstraint(["plan_id"], ["cutover_plan.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["done_by_user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("plan_id", "key", name="uq_cutover_checklist_plan_key"),
+    )
+    op.create_index("ix_cutover_checklist_plan", "cutover_checklist_item", ["plan_id"])
+
+    # ── cutover_event ──────────────────────────────────────────────────
+    op.create_table(
+        "cutover_event",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("plan_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("item_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column(
+            "at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("kind", sa.String(length=24), nullable=False),
+        sa.Column("summary", sa.String(length=512), nullable=False),
+        sa.Column("detail", postgresql.JSONB(), nullable=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("user_display_name", sa.String(length=255), nullable=False),
+        sa.ForeignKeyConstraint(["plan_id"], ["cutover_plan.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["item_id"], ["cutover_item.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["user.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_cutover_event_plan_at", "cutover_event", ["plan_id", "at"])
+    op.create_index("ix_cutover_event_item_id", "cutover_event", ["item_id"])
+
+    # ── feature_module seed (non-negotiable #14) ───────────────────────
+    op.execute(sa.text("""
+            INSERT INTO feature_module (id, enabled)
+            VALUES ('migration.cutover', TRUE)
+            ON CONFLICT (id) DO NOTHING
+            """))
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DELETE FROM feature_module WHERE id = 'migration.cutover'"))
+
+    op.drop_index("ix_cutover_event_item_id", table_name="cutover_event")
+    op.drop_index("ix_cutover_event_plan_at", table_name="cutover_event")
+    op.drop_table("cutover_event")
+
+    op.drop_index("ix_cutover_checklist_plan", table_name="cutover_checklist_item")
+    op.drop_table("cutover_checklist_item")
+
+    op.drop_index("ix_cutover_item_scope_id", table_name="cutover_item")
+    op.drop_index("ix_cutover_item_zone_id", table_name="cutover_item")
+    op.drop_index("ix_cutover_item_plan", table_name="cutover_item")
+    op.drop_table("cutover_item")
+
+    op.drop_index("ix_cutover_plan_target_dhcp_group_id", table_name="cutover_plan")
+    op.drop_index("ix_cutover_plan_target_dns_group_id", table_name="cutover_plan")
+    op.drop_index("ix_cutover_plan_source_dhcp_server_id", table_name="cutover_plan")
+    op.drop_index("ix_cutover_plan_source_dns_server_id", table_name="cutover_plan")
+    op.drop_index("ix_cutover_plan_name", table_name="cutover_plan")
+    op.drop_table("cutover_plan")

--- a/backend/app/api/v1/cutover/__init__.py
+++ b/backend/app/api/v1/cutover/__init__.py
@@ -1,0 +1,18 @@
+"""Windows → SpatiumDDI cutover endpoints (issue #756).
+
+Exposes ``/migration/cutover/plans/…`` — the guided migration surface that
+picks up where the one-shot DNS (#128) / DHCP (#129) importers stop. The
+importers get an operator's Windows estate *into* SpatiumDDI; this router
+drives the rest: per-item parity against the live Windows server, a shadow
+query comparison during the parallel run, the TTL pre-flight and DHCP lease
+handover, the switch itself, the rollback, and the decommission checklist.
+
+See :mod:`app.services.cutover` for the workflow logic — every handler here
+is transport, authorization, audit, and the timeline row.
+"""
+
+from __future__ import annotations
+
+from .router import router
+
+__all__ = ["router"]

--- a/backend/app/api/v1/cutover/router.py
+++ b/backend/app/api/v1/cutover/router.py
@@ -1,0 +1,1300 @@
+"""Windows → SpatiumDDI cutover REST surface (issue #756).
+
+Every handler here is transport, authorization, audit, and the timeline row —
+the workflow itself lives in :mod:`app.services.cutover`. Three conventions run
+through the whole file:
+
+**Superadmin on every route.** The same posture as the three importers this
+extends (``docs/features/MIGRATION.md``, RBAC row). A cutover is strictly more
+dangerous than an import: it deactivates a live DHCP scope, rewrites TTLs on a
+production zone, and mints reservations. Delegating that with a grantable
+permission is a decision worth making deliberately later, not a side effect of
+shipping the surface.
+
+**Every mutation writes an ``AuditLog`` row before the response** (non-negotiable
+#4), plus a :class:`~app.models.cutover.CutoverEvent` so the plan keeps an
+ordered, human-readable timeline of what was done to it and by whom. The audit
+row is the compliance record; the event is the operator's narrative. They are
+deliberately both written rather than one derived from the other — ``audit_log``
+is append-only and global, the timeline is per-plan and rendered in the UI.
+
+**Session discipline on the fan-out endpoints.** ``POST …/parity`` walks every
+item in a plan, and each parity computation makes a network call. The obvious
+``asyncio.gather`` over the whole thing is wrong: one ``AsyncSession`` cannot
+serve concurrent operations, and every parity function reads from the DB before
+it touches the wire (see the module note in ``services/cutover/parity.py``). So
+the fan-out here is **sequential**. A slow Windows box makes the request slow;
+it does not corrupt the session.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+import structlog
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import DB, SuperAdmin
+from app.core.dns_names import sanitize_hostname
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.cutover import (
+    PLAN_STATUSES,
+    CutoverEvent,
+    CutoverItem,
+    CutoverPlan,
+)
+from app.models.dhcp import DHCPScope, DHCPServer
+from app.models.dns import DNSServer, DNSZone
+from app.services.cutover import checklist as checklist_svc
+from app.services.cutover import leases as leases_svc
+from app.services.cutover import parity as parity_svc
+from app.services.cutover import plans as plans_svc
+from app.services.cutover import preflight as preflight_svc
+from app.services.cutover import readiness as readiness_svc
+from app.services.cutover import runbook as runbook_svc
+from app.services.cutover import shadow as shadow_svc
+from app.services.cutover import switch as switch_svc
+from app.services.cutover.canonical import LeaseHandoverEntry, LeaseHandoverPlan, ParityReport
+from app.services.dhcp_import.options import normalise_mac
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+_RESOURCE_TYPE = "cutover_plan"
+
+
+# ── Schemas ────────────────────────────────────────────────────────────
+
+
+class PlanCreate(BaseModel):
+    name: str = Field(min_length=1, max_length=255)
+    description: str = ""
+    source_dns_server_id: uuid.UUID | None = None
+    source_dhcp_server_id: uuid.UUID | None = None
+    target_dns_group_id: uuid.UUID | None = None
+    target_dhcp_group_id: uuid.UUID | None = None
+    notes: str = ""
+
+
+class PlanUpdate(BaseModel):
+    """Every field optional; ``exclude_unset`` decides what actually changes."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    description: str | None = None
+    status: str | None = None
+    source_dns_server_id: uuid.UUID | None = None
+    source_dhcp_server_id: uuid.UUID | None = None
+    target_dns_group_id: uuid.UUID | None = None
+    target_dhcp_group_id: uuid.UUID | None = None
+    notes: str | None = None
+
+
+class ItemIn(BaseModel):
+    kind: Literal["dns_zone", "dhcp_scope"]
+    source_ref: str = Field(min_length=1, max_length=255)
+    zone_id: uuid.UUID | None = None
+    scope_id: uuid.UUID | None = None
+    notes: str = ""
+
+
+class ItemsIn(BaseModel):
+    items: list[ItemIn] = Field(min_length=1)
+
+
+class ItemOut(BaseModel):
+    id: uuid.UUID
+    plan_id: uuid.UUID
+    kind: str
+    source_ref: str
+    zone_id: uuid.UUID | None
+    scope_id: uuid.UUID | None
+    stage: str
+    blockers: list[dict[str, Any]]
+    last_parity: dict[str, Any] | None
+    last_parity_at: datetime | None
+    last_shadow: dict[str, Any] | None
+    last_shadow_at: datetime | None
+    ttl_snapshot: dict[str, Any] | None
+    ttl_lowered_at: datetime | None
+    lease_handover: dict[str, Any] | None
+    cut_over_at: datetime | None
+    rolled_back_at: datetime | None
+    notes: str
+
+
+class PlanOut(BaseModel):
+    id: uuid.UUID
+    name: str
+    description: str
+    status: str
+    source_dns_server_id: uuid.UUID | None
+    source_dhcp_server_id: uuid.UUID | None
+    target_dns_group_id: uuid.UUID | None
+    target_dhcp_group_id: uuid.UUID | None
+    notes: str
+    created_at: datetime
+    modified_at: datetime
+    completed_at: datetime | None
+    rolled_back_at: datetime | None
+    item_count: int
+    stage_counts: dict[str, int]
+    blocked_count: int
+
+
+class PlanDetailOut(PlanOut):
+    items: list[ItemOut]
+
+
+class ChecklistItemOut(BaseModel):
+    key: str
+    category: str
+    label: str
+    description: str
+    applies_to: str
+    is_done: bool
+    done_at: datetime | None
+    notes: str
+    sort_order: int
+    auto_state: str
+    auto_detail: str
+
+
+class ChecklistPatch(BaseModel):
+    is_done: bool | None = None
+    notes: str | None = None
+
+
+class EventOut(BaseModel):
+    id: uuid.UUID
+    item_id: uuid.UUID | None
+    at: datetime
+    kind: str
+    summary: str
+    detail: dict[str, Any] | None
+    user_display_name: str
+
+
+class TTLPreflightIn(BaseModel):
+    target_ttl: int = Field(
+        default=300,
+        description="Seconds. Bounded by the service (30..86400); see preflight.validate_target_ttl.",
+    )
+
+
+class ShadowIn(BaseModel):
+    sample_size: int = Field(default=25, ge=1, le=shadow_svc.MAX_SAMPLE_SIZE)
+
+
+class LeaseHandoverCommitIn(BaseModel):
+    """The previewed plan, handed straight back.
+
+    Same statelessness contract as the importers: the server keeps nothing
+    between preview and commit, and the commit re-validates every entry against
+    live DB state rather than trusting what it is given.
+    """
+
+    # Bounded like every other list input on this router. Each ``create`` entry
+    # costs a savepoint, a flush and an IPAM upsert inside one transaction, so
+    # an unbounded body would hold that transaction open against every other
+    # writer. 8192 is far above any real scope (a /19 of live leases) and far
+    # below a body that could wedge the database.
+    entries: list[dict[str, Any]] = Field(default_factory=list, max_length=8192)
+
+
+class CutoverIn(BaseModel):
+    force: bool = Field(
+        default=False,
+        description=(
+            "Acknowledge the warn-severity blockers. Never bypasses a "
+            "block-severity one — notably not the AD 'Secure only' refusal."
+        ),
+    )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+
+def _stage_counts(items: list[CutoverItem]) -> dict[str, int]:
+    out: dict[str, int] = {}
+    for it in items:
+        out[it.stage] = out.get(it.stage, 0) + 1
+    return out
+
+
+def _blocked_count(items: list[CutoverItem]) -> int:
+    return sum(
+        1 for it in items if any((b or {}).get("severity") == "block" for b in (it.blockers or []))
+    )
+
+
+def _item_out(item: CutoverItem) -> ItemOut:
+    return ItemOut(
+        id=item.id,
+        plan_id=item.plan_id,
+        kind=item.kind,
+        source_ref=item.source_ref,
+        zone_id=item.zone_id,
+        scope_id=item.scope_id,
+        stage=item.stage,
+        blockers=list(item.blockers or []),
+        last_parity=item.last_parity,
+        last_parity_at=item.last_parity_at,
+        last_shadow=item.last_shadow,
+        last_shadow_at=item.last_shadow_at,
+        ttl_snapshot=item.ttl_snapshot,
+        ttl_lowered_at=item.ttl_lowered_at,
+        lease_handover=item.lease_handover,
+        cut_over_at=item.cut_over_at,
+        rolled_back_at=item.rolled_back_at,
+        notes=item.notes,
+    )
+
+
+def _plan_out(plan: CutoverPlan, items: list[CutoverItem]) -> PlanOut:
+    return PlanOut(
+        id=plan.id,
+        name=plan.name,
+        description=plan.description,
+        status=plan.status,
+        source_dns_server_id=plan.source_dns_server_id,
+        source_dhcp_server_id=plan.source_dhcp_server_id,
+        target_dns_group_id=plan.target_dns_group_id,
+        target_dhcp_group_id=plan.target_dhcp_group_id,
+        notes=plan.notes,
+        created_at=plan.created_at,
+        modified_at=plan.modified_at,
+        completed_at=plan.completed_at,
+        rolled_back_at=plan.rolled_back_at,
+        item_count=len(items),
+        stage_counts=_stage_counts(items),
+        blocked_count=_blocked_count(items),
+    )
+
+
+async def _require_plan(db: DB, plan_id: uuid.UUID) -> CutoverPlan:
+    plan = (
+        await db.execute(
+            select(CutoverPlan)
+            .where(CutoverPlan.id == plan_id)
+            .options(selectinload(CutoverPlan.items))
+        )
+    ).scalar_one_or_none()
+    if plan is None:
+        raise HTTPException(status_code=404, detail="Cutover plan not found")
+    return plan
+
+
+async def _require_item(db: DB, plan: CutoverPlan, item_id: uuid.UUID) -> CutoverItem:
+    """Fetch an item, enforcing that it belongs to ``plan``.
+
+    Scoping on both ids rather than looking the item up alone: the URL makes
+    the plan explicit at every level, and an item id from another plan must
+    404, not silently operate on someone else's migration.
+    """
+    item = (
+        await db.execute(
+            select(CutoverItem).where(CutoverItem.id == item_id, CutoverItem.plan_id == plan.id)
+        )
+    ).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(status_code=404, detail="Cutover item not found on this plan")
+    return item
+
+
+def _require_kind(item: CutoverItem, kind: str, what: str) -> None:
+    if item.kind != kind:
+        raise HTTPException(
+            status_code=422,
+            detail=f"{what} applies to {kind} items; {item.source_ref!r} is a {item.kind}.",
+        )
+
+
+async def _require_zone(db: DB, item: CutoverItem) -> DNSZone:
+    if item.zone_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Item {item.source_ref!r} is not linked to a SpatiumDDI zone. Run Discover "
+                "and re-add it, or set zone_id."
+            ),
+        )
+    zone = await db.get(DNSZone, item.zone_id)
+    if zone is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"The zone item {item.source_ref!r} points at no longer exists.",
+        )
+    return zone
+
+
+async def _require_scope(db: DB, item: CutoverItem) -> DHCPScope:
+    if item.scope_id is None:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Item {item.source_ref!r} is not linked to a SpatiumDDI scope. Run Discover "
+                "and re-add it, or set scope_id."
+            ),
+        )
+    scope = await db.get(DHCPScope, item.scope_id)
+    if scope is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"The scope item {item.source_ref!r} points at no longer exists.",
+        )
+    return scope
+
+
+async def _require_source_dns(db: DB, plan: CutoverPlan) -> DNSServer:
+    if plan.source_dns_server_id is None:
+        raise HTTPException(status_code=422, detail="This plan has no source Windows DNS server.")
+    server = await db.get(DNSServer, plan.source_dns_server_id)
+    if server is None:
+        raise HTTPException(
+            status_code=422, detail="The plan's source DNS server no longer exists."
+        )
+    return server
+
+
+async def _require_source_dhcp(db: DB, plan: CutoverPlan) -> DHCPServer:
+    if plan.source_dhcp_server_id is None:
+        raise HTTPException(status_code=422, detail="This plan has no source Windows DHCP server.")
+    server = await db.get(DHCPServer, plan.source_dhcp_server_id)
+    if server is None:
+        raise HTTPException(
+            status_code=422, detail="The plan's source DHCP server no longer exists."
+        )
+    return server
+
+
+def _audit(
+    db: DB,
+    user: User,
+    *,
+    action: str,
+    plan: CutoverPlan,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    """One ``audit_log`` row per mutation, keyed to the plan (non-negotiable #4)."""
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action=action,
+            resource_type=_RESOURCE_TYPE,
+            resource_id=str(plan.id),
+            resource_display=plan.name,
+            result="success",
+            new_value=detail or {},
+        )
+    )
+
+
+def _event(
+    db: DB,
+    user: User,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem | None,
+    kind: str,
+    summary: str,
+    detail: dict[str, Any] | None = None,
+) -> None:
+    db.add(
+        CutoverEvent(
+            plan_id=plan.id,
+            item_id=item.id if item is not None else None,
+            kind=kind,
+            summary=summary[:512],
+            detail=detail,
+            user_id=user.id,
+            user_display_name=user.display_name,
+        )
+    )
+
+
+async def _run_parity(db: DB, plan: CutoverPlan, item: CutoverItem) -> ParityReport:
+    """Compute + persist one item's parity report, refreshing its blockers.
+
+    Does not commit. Raises ``HTTPException`` only for a wiring problem the
+    operator has to fix (an unlinked item, a missing source server); a failed
+    *pull* comes back inside the report, which is what lets the whole-plan run
+    report per-item failures instead of dying on the first unreachable host.
+    """
+    if item.kind == "dns_zone":
+        zone = await _require_zone(db, item)
+        dns_source = await _require_source_dns(db, plan)
+        report = await parity_svc.compute_dns_parity(
+            db, source_server=dns_source, zone=zone, source_zone_name=item.source_ref
+        )
+    else:
+        scope = await _require_scope(db, item)
+        dhcp_source = await _require_source_dhcp(db, plan)
+        report = await parity_svc.compute_dhcp_parity(
+            db, source_server=dhcp_source, scope=scope, source_scope_id=item.source_ref
+        )
+
+    item.last_parity = report.as_dict()
+    item.last_parity_at = datetime.now(UTC)
+    if item.stage == "pending":
+        item.stage = "parity_checked"
+    await readiness_svc.refresh_blockers(db, plan=plan, item=item)
+    return report
+
+
+# ── Plans ──────────────────────────────────────────────────────────────
+
+
+@router.get("/plans", response_model=list[PlanOut])
+async def list_plans(db: DB, _user: SuperAdmin) -> list[PlanOut]:
+    """Every plan, newest first, with a per-plan item-stage rollup."""
+    plans = list(
+        (
+            await db.execute(
+                select(CutoverPlan)
+                .options(selectinload(CutoverPlan.items))
+                .order_by(CutoverPlan.created_at.desc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [_plan_out(p, list(p.items)) for p in plans]
+
+
+@router.post("/plans", response_model=PlanDetailOut, status_code=status.HTTP_201_CREATED)
+async def create_plan(body: PlanCreate, db: DB, user: SuperAdmin) -> PlanDetailOut:
+    plan = CutoverPlan(
+        name=body.name.strip(),
+        description=body.description,
+        status="draft",
+        source_dns_server_id=body.source_dns_server_id,
+        source_dhcp_server_id=body.source_dhcp_server_id,
+        target_dns_group_id=body.target_dns_group_id,
+        target_dhcp_group_id=body.target_dhcp_group_id,
+        notes=body.notes,
+        created_by_user_id=user.id,
+    )
+    db.add(plan)
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409, detail=f"A cutover plan named {body.name!r} already exists."
+        ) from exc
+
+    _audit(db, user, action="create_cutover_plan", plan=plan, detail={"name": plan.name})
+    _event(db, user, plan=plan, item=None, kind="plan", summary=f"Created plan {plan.name!r}")
+    await db.commit()
+    await db.refresh(plan)
+    return PlanDetailOut(**_plan_out(plan, []).model_dump(), items=[])
+
+
+@router.get("/plans/{plan_id}", response_model=PlanDetailOut)
+async def get_plan(plan_id: uuid.UUID, db: DB, _user: SuperAdmin) -> PlanDetailOut:
+    plan = await _require_plan(db, plan_id)
+    items = list(plan.items)
+    return PlanDetailOut(**_plan_out(plan, items).model_dump(), items=[_item_out(i) for i in items])
+
+
+@router.patch("/plans/{plan_id}", response_model=PlanDetailOut)
+async def update_plan(
+    plan_id: uuid.UUID, body: PlanUpdate, db: DB, user: SuperAdmin
+) -> PlanDetailOut:
+    plan = await _require_plan(db, plan_id)
+    changes = body.model_dump(exclude_unset=True)
+    if "status" in changes and changes["status"] not in PLAN_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"status must be one of {sorted(PLAN_STATUSES)}.",
+        )
+
+    # ``create_plan`` strips; PATCH must too, or " Retire DC01" and
+    # "Retire DC01" become two rows the unique index treats as distinct and
+    # the name-addressable MCP tools cannot find.
+    if isinstance(changes.get("name"), str):
+        changes["name"] = changes["name"].strip()
+        if not changes["name"]:
+            raise HTTPException(status_code=422, detail="name cannot be blank.")
+    for field_name, value in changes.items():
+        setattr(plan, field_name, value)
+    if changes.get("status") == "completed" and plan.completed_at is None:
+        plan.completed_at = datetime.now(UTC)
+    if changes.get("status") == "rolled_back" and plan.rolled_back_at is None:
+        plan.rolled_back_at = datetime.now(UTC)
+
+    try:
+        await db.flush()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(
+            status_code=409, detail="Another cutover plan already uses that name."
+        ) from exc
+
+    _audit(db, user, action="update_cutover_plan", plan=plan, detail=changes)
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=None,
+        kind="plan",
+        summary=f"Updated plan ({', '.join(sorted(changes)) or 'no fields'})",
+        detail=changes,
+    )
+    await db.commit()
+
+    plan = await _require_plan(db, plan_id)
+    items = list(plan.items)
+    return PlanDetailOut(**_plan_out(plan, items).model_dump(), items=[_item_out(i) for i in items])
+
+
+@router.delete("/plans/{plan_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_plan(plan_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
+    """Hard delete. Cascades to items, checklist, and timeline.
+
+    Nothing the plan points at is touched — the zones, scopes, reservations and
+    TTLs it references are owned by their own tables. Deleting an in-flight plan
+    does throw away its pre-flight TTL snapshot, which is the only record of the
+    pre-migration values, so the UI confirms first.
+    """
+    plan = await _require_plan(db, plan_id)
+    name = plan.name
+    _audit(
+        db,
+        user,
+        action="delete_cutover_plan",
+        plan=plan,
+        detail={"name": name, "items": len(plan.items)},
+    )
+    await db.delete(plan)
+    await db.commit()
+    logger.info("cutover.plan.deleted", plan=str(plan_id), name=name, user=user.username)
+
+
+# ── Discovery + items ──────────────────────────────────────────────────
+
+
+@router.post("/plans/{plan_id}/discover")
+async def discover(plan_id: uuid.UUID, db: DB, _user: SuperAdmin) -> dict[str, Any]:
+    """Live-pull the Windows source estate and return addable candidates.
+
+    Read-only, so no audit row: it writes nothing and reads the same data the
+    parity check does. The DNS and DHCP halves are independent — a WinRM failure
+    on one comes back as an ``error`` string on that side only.
+    """
+    plan = await _require_plan(db, plan_id)
+    return await plans_svc.discover_candidates(db, plan=plan)
+
+
+@router.post("/plans/{plan_id}/items", response_model=list[ItemOut], status_code=201)
+async def add_items(plan_id: uuid.UUID, body: ItemsIn, db: DB, user: SuperAdmin) -> list[ItemOut]:
+    plan = await _require_plan(db, plan_id)
+    existing = {(i.kind, i.source_ref) for i in plan.items}
+
+    created: list[CutoverItem] = []
+    # ``ItemIn.kind`` is a Literal, so pydantic has already rejected anything
+    # outside ITEM_KINDS with a 422 before this body runs.
+    for spec in body.items:
+        ref = spec.source_ref.strip()
+        if (spec.kind, ref) in existing:
+            # Idempotent add: re-selecting a candidate that is already on the
+            # plan is a no-op rather than a 409, because the discover UI
+            # legitimately re-offers rows the operator already picked.
+            continue
+        item = CutoverItem(
+            plan_id=plan.id,
+            kind=spec.kind,
+            source_ref=ref,
+            zone_id=spec.zone_id,
+            scope_id=spec.scope_id,
+            stage="pending",
+            blockers=[],
+            notes=spec.notes,
+        )
+        db.add(item)
+        created.append(item)
+        existing.add((spec.kind, ref))
+
+    if not created:
+        return []
+
+    await db.flush()
+    _audit(
+        db,
+        user,
+        action="add_cutover_items",
+        plan=plan,
+        detail={"added": [{"kind": i.kind, "source_ref": i.source_ref} for i in created]},
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=None,
+        kind="plan",
+        summary=f"Added {len(created)} item(s) to the plan",
+        detail={"source_refs": [i.source_ref for i in created]},
+    )
+    await db.commit()
+    for item in created:
+        await db.refresh(item)
+    return [_item_out(i) for i in created]
+
+
+@router.delete("/plans/{plan_id}/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_item(plan_id: uuid.UUID, item_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    if item.stage == "cut_over":
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"{item.source_ref!r} has been cut over. Roll it back before removing it, or "
+                "the plan loses the only record of how to reverse the switch."
+            ),
+        )
+    ref, kind = item.source_ref, item.kind
+    _audit(
+        db,
+        user,
+        action="remove_cutover_item",
+        plan=plan,
+        detail={"kind": kind, "source_ref": ref},
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=None,
+        kind="plan",
+        summary=f"Removed {kind} item {ref!r} from the plan",
+    )
+    await db.delete(item)
+    await db.commit()
+
+
+# ── Phase 1 — parity ───────────────────────────────────────────────────
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/parity")
+async def run_item_parity(
+    plan_id: uuid.UUID, item_id: uuid.UUID, db: DB, user: SuperAdmin
+) -> dict[str, Any]:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    report = await _run_parity(db, plan, item)
+
+    _audit(
+        db,
+        user,
+        action="run_cutover_parity",
+        plan=plan,
+        detail={"source_ref": item.source_ref, "status": report.status},
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=item,
+        kind="parity",
+        summary=(
+            f"Parity check on {item.source_ref}: {report.status}, "
+            f"{report.difference_count} difference(s)"
+        ),
+        detail=report.as_dict(),
+    )
+    await db.commit()
+    return {"report": report.as_dict(), "blockers": list(item.blockers or [])}
+
+
+@router.post("/plans/{plan_id}/parity")
+async def run_plan_parity(plan_id: uuid.UUID, db: DB, user: SuperAdmin) -> dict[str, Any]:
+    """Run parity for every item on the plan.
+
+    Sequential on purpose — see the module docstring. Per-item wiring problems
+    (an unlinked item, a deleted zone) are caught and reported in-band so one
+    bad item does not deny the operator the whole report; pull failures are
+    already in-band by construction.
+    """
+    plan = await _require_plan(db, plan_id)
+    results: list[dict[str, Any]] = []
+
+    for item in list(plan.items):
+        try:
+            report = await _run_parity(db, plan, item)
+        except HTTPException as exc:
+            results.append(
+                {
+                    "item_id": str(item.id),
+                    "source_ref": item.source_ref,
+                    "kind": item.kind,
+                    "status": "error",
+                    "error": str(exc.detail),
+                }
+            )
+            continue
+        results.append(
+            {
+                "item_id": str(item.id),
+                "source_ref": item.source_ref,
+                "kind": item.kind,
+                **report.as_dict(),
+            }
+        )
+
+    in_parity = sum(1 for r in results if r.get("is_parity"))
+    _audit(
+        db,
+        user,
+        action="run_cutover_parity_all",
+        plan=plan,
+        detail={"items": len(results), "in_parity": in_parity},
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=None,
+        kind="parity",
+        summary=f"Parity check across {len(results)} item(s): {in_parity} in parity",
+        detail={"results": results},
+    )
+    await db.commit()
+    return {"items": results, "in_parity": in_parity, "total": len(results)}
+
+
+# ── Phase 2 — parallel run ─────────────────────────────────────────────
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/shadow")
+async def run_shadow(
+    plan_id: uuid.UUID, item_id: uuid.UUID, body: ShadowIn, db: DB, user: SuperAdmin
+) -> dict[str, Any]:
+    """Replay recently-observed queries at both sides and compare the answers."""
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    _require_kind(item, "dns_zone", "The shadow query comparison")
+
+    zone = await _require_zone(db, item)
+    source = await _require_source_dns(db, plan)
+    report = await shadow_svc.run_shadow_comparison(
+        db, source_server=source, zone=zone, sample_size=body.sample_size
+    )
+
+    item.last_shadow = report.as_dict()
+    item.last_shadow_at = datetime.now(UTC)
+    _audit(
+        db,
+        user,
+        action="run_cutover_shadow",
+        plan=plan,
+        detail={
+            "source_ref": item.source_ref,
+            "sampled": report.sampled,
+            "mismatched": report.mismatched,
+        },
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=item,
+        kind="shadow",
+        summary=(
+            f"Shadow comparison on {item.source_ref}: {report.matched}/{report.sampled} matched "
+            f"({report.sample_source})"
+        ),
+        detail=report.as_dict(),
+    )
+    await db.commit()
+    return report.as_dict()
+
+
+# ── Phase 3a — TTL pre-flight ──────────────────────────────────────────
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/ttl-preflight/preview")
+async def preview_ttl(
+    plan_id: uuid.UUID, item_id: uuid.UUID, body: TTLPreflightIn, db: DB, _user: SuperAdmin
+) -> dict[str, Any]:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    _require_kind(item, "dns_zone", "The TTL pre-flight")
+    zone = await _require_zone(db, item)
+    try:
+        result = await preflight_svc.preview_ttl_preflight(
+            db, zone=zone, target_ttl=body.target_ttl
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return result.as_dict()
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/ttl-preflight/commit")
+async def commit_ttl(
+    plan_id: uuid.UUID, item_id: uuid.UUID, body: TTLPreflightIn, db: DB, user: SuperAdmin
+) -> dict[str, Any]:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    _require_kind(item, "dns_zone", "The TTL pre-flight")
+    zone = await _require_zone(db, item)
+    try:
+        result = await preflight_svc.apply_ttl_preflight(
+            db, zone=zone, item=item, target_ttl=body.target_ttl, current_user=user
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    _audit(
+        db,
+        user,
+        action="apply_cutover_ttl_preflight",
+        plan=plan,
+        detail={
+            "source_ref": item.source_ref,
+            "zone": zone.name,
+            "target_ttl": result.target_ttl,
+            "records_changed": len(result.records),
+        },
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=item,
+        kind="preflight",
+        summary=(
+            f"Lowered TTLs on {zone.name} to {result.target_ttl}s "
+            f"({len(result.records)} record(s))"
+        ),
+        detail=result.as_dict(),
+    )
+    await db.commit()
+    return result.as_dict()
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/ttl-preflight/restore")
+async def restore_ttl(
+    plan_id: uuid.UUID, item_id: uuid.UUID, db: DB, user: SuperAdmin
+) -> dict[str, Any]:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    _require_kind(item, "dns_zone", "The TTL pre-flight")
+    zone = await _require_zone(db, item)
+
+    restored = await preflight_svc.restore_ttl_preflight(
+        db, zone=zone, item=item, current_user=user
+    )
+    _audit(
+        db,
+        user,
+        action="restore_cutover_ttl_preflight",
+        plan=plan,
+        detail={"source_ref": item.source_ref, "zone": zone.name, "records_restored": restored},
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=item,
+        kind="preflight",
+        summary=f"Restored the pre-flight TTL snapshot on {zone.name} ({restored} record(s))",
+    )
+    await db.commit()
+    return {"records_restored": restored, "zone": zone.name}
+
+
+# ── Phase 3b — DHCP lease handover ─────────────────────────────────────
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/lease-handover/preview")
+async def preview_leases(
+    plan_id: uuid.UUID, item_id: uuid.UUID, db: DB, _user: SuperAdmin
+) -> dict[str, Any]:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    _require_kind(item, "dhcp_scope", "The lease handover")
+    scope = await _require_scope(db, item)
+    source = await _require_source_dhcp(db, plan)
+    try:
+        result = await leases_svc.preview_lease_handover(
+            db, source_server=source, scope=scope, source_scope_id=item.source_ref
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return result.as_dict()
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/lease-handover/commit")
+async def commit_leases(
+    plan_id: uuid.UUID,
+    item_id: uuid.UUID,
+    body: LeaseHandoverCommitIn,
+    db: DB,
+    user: SuperAdmin,
+) -> dict[str, Any]:
+    """Write the previewed ``create`` entries as reservations.
+
+    The plan comes back from the client (the server keeps no state between the
+    two calls, same as the importers), but every entry is re-classified against
+    live DB state inside the service — an operator who added a reservation
+    between preview and commit gets that entry skipped, not an IntegrityError.
+    """
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    _require_kind(item, "dhcp_scope", "The lease handover")
+    scope = await _require_scope(db, item)
+    source = await _require_source_dhcp(db, plan)
+
+    # The body is client-supplied, so it gets the same normalisation the preview
+    # applied — it is not a trusted echo. An un-normalised MAC would miss the
+    # dedup maps in ``_classify`` (which key on the canonical form) and only
+    # fail at the MACADDR unique index, and an unsanitised hostname would reach
+    # the Kea reservation and the DDNS name path verbatim.
+    entries: list[LeaseHandoverEntry] = []
+    for raw in body.entries:
+        ip = str(raw.get("ip_address") or "").strip()
+        mac = normalise_mac(raw.get("mac_address"))
+        if not ip or mac is None:
+            continue
+        entries.append(
+            LeaseHandoverEntry(
+                ip_address=ip,
+                mac_address=mac,
+                hostname=sanitize_hostname(raw.get("hostname")),
+                action=raw.get("action") or "create",
+                reason=str(raw.get("reason") or ""),
+            )
+        )
+    if not entries:
+        raise HTTPException(
+            status_code=422,
+            detail="No usable lease entries in the request body. Re-run the preview.",
+        )
+
+    handover = LeaseHandoverPlan(scope_cidr="", source_scope_id=item.source_ref, entries=entries)
+    try:
+        result = await leases_svc.commit_lease_handover(
+            db,
+            source_server=source,
+            scope=scope,
+            item=item,
+            plan=handover,
+            current_user=user,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    _audit(
+        db,
+        user,
+        action="commit_cutover_lease_handover",
+        plan=plan,
+        detail={
+            "source_ref": item.source_ref,
+            "created": result.created,
+            "skipped": result.skipped,
+            "failed": result.failed,
+        },
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=item,
+        kind="lease_handover",
+        summary=(
+            f"Lease handover on {item.source_ref}: {result.created} reservation(s) created, "
+            f"{result.skipped} skipped, {result.failed} failed"
+        ),
+        detail=result.as_dict(),
+    )
+    await db.commit()
+    return result.as_dict()
+
+
+# ── Phase 3c — the switch ──────────────────────────────────────────────
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/cutover")
+async def cut_item_over(
+    plan_id: uuid.UUID, item_id: uuid.UUID, body: CutoverIn, db: DB, user: SuperAdmin
+) -> dict[str, Any]:
+    """Cut one item over. 409 with the blocker list when it is refused.
+
+    409 rather than 422 because the request is well-formed — the *state* is what
+    refuses it, and the UI renders ``detail.blockers`` verbatim so the operator
+    reads the fix rather than a status code.
+    """
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    try:
+        result = await switch_svc.execute_cutover(
+            db, plan=plan, item=item, current_user=user, force=body.force
+        )
+    except switch_svc.CutoverBlocked as exc:
+        # Persist the refusal rather than rolling it away. ``execute_cutover``
+        # re-derives the blockers against live Windows state and writes them onto
+        # the item; that is precisely the verdict the plan list, the MCP tools and
+        # the runbook read. Discarding it would leave every one of those surfaces
+        # reporting the stale set at the exact moment it matters most — a zone
+        # that was just flipped to AD 'Secure only'. Nothing was mutated on either
+        # server: the switch raised before it acted.
+        item.blockers = [b.as_dict() for b in exc.blockers]
+        _event(
+            db,
+            user,
+            plan=plan,
+            item=item,
+            kind="cutover",
+            summary=f"Cutover of {item.source_ref} refused: {len(exc.blockers)} blocker(s)",
+            detail=exc.as_dict(),
+        )
+        _audit(
+            db,
+            user,
+            action="cutover_item_refused",
+            plan=plan,
+            detail={"source_ref": item.source_ref, "blockers": [b.as_dict() for b in exc.blockers]},
+        )
+        await db.commit()
+        raise HTTPException(status_code=409, detail=exc.as_dict()) from exc
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if plan.status in ("draft", "verifying", "parallel"):
+        plan.status = "cutting_over"
+    _audit(
+        db,
+        user,
+        action="cutover_item",
+        plan=plan,
+        detail={"source_ref": item.source_ref, "kind": item.kind, "force": body.force},
+    )
+    await db.commit()
+    return result
+
+
+@router.post("/plans/{plan_id}/items/{item_id}/rollback")
+async def roll_item_back(
+    plan_id: uuid.UUID, item_id: uuid.UUID, db: DB, user: SuperAdmin
+) -> dict[str, Any]:
+    plan = await _require_plan(db, plan_id)
+    item = await _require_item(db, plan, item_id)
+    try:
+        result = await switch_svc.execute_rollback(db, plan=plan, item=item, current_user=user)
+    except ValueError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    _audit(
+        db,
+        user,
+        action="rollback_cutover_item",
+        plan=plan,
+        detail={"source_ref": item.source_ref, "kind": item.kind},
+    )
+    await db.commit()
+    return result
+
+
+# ── Phase 4 — decommission checklist ───────────────────────────────────
+
+
+@router.get("/plans/{plan_id}/checklist", response_model=list[ChecklistItemOut])
+async def get_checklist(plan_id: uuid.UUID, db: DB, _user: SuperAdmin) -> list[ChecklistItemOut]:
+    """The plan's checklist: the static catalog merged with the plan's state.
+
+    Read-only. Rows are created lazily by the PATCH below when the operator
+    first ticks or annotates a line, so a plan created before a catalog entry
+    existed still shows it with no write. A GET that seeded rows would owe an
+    ``audit_log`` entry per non-negotiable #4 and would slip a database write
+    past the maintenance-mode middleware, which gates on the HTTP method.
+    """
+    plan = await _require_plan(db, plan_id)
+    rows = await checklist_svc.read_checklist(db, plan=plan)
+    auto = await checklist_svc.evaluate_auto_checks(db, plan=plan)
+    return [
+        ChecklistItemOut(
+            key=r.key,
+            category=r.category,
+            label=r.label,
+            description=r.description,
+            applies_to=r.applies_to,
+            is_done=r.is_done,
+            done_at=r.done_at,
+            notes=r.notes,
+            sort_order=r.sort_order,
+            auto_state=(auto.get(r.key) or {}).get("state", "manual"),
+            auto_detail=(auto.get(r.key) or {}).get("detail", ""),
+        )
+        for r in rows
+    ]
+
+
+@router.patch("/plans/{plan_id}/checklist/{key}", response_model=ChecklistItemOut)
+async def patch_checklist_item(
+    plan_id: uuid.UUID, key: str, body: ChecklistPatch, db: DB, user: SuperAdmin
+) -> ChecklistItemOut:
+    plan = await _require_plan(db, plan_id)
+    # Creates the row from the catalog on first touch; returns None only for a
+    # key that is neither in the catalog nor already stored, so a typo 404s
+    # rather than minting a phantom checklist line.
+    row = await checklist_svc.upsert_checklist_row(db, plan=plan, key=key)
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"No checklist item {key!r} on this plan.")
+
+    changes = body.model_dump(exclude_unset=True)
+    if "is_done" in changes:
+        row.is_done = bool(changes["is_done"])
+        # ``done_at`` / ``done_by`` follow the tick in both directions, so an
+        # un-tick does not leave a stale "completed by" on an open item.
+        row.done_at = datetime.now(UTC) if row.is_done else None
+        row.done_by_user_id = user.id if row.is_done else None
+    if "notes" in changes:
+        row.notes = changes["notes"] or ""
+
+    _audit(
+        db,
+        user,
+        action="update_cutover_checklist_item",
+        plan=plan,
+        detail={"key": key, **changes},
+    )
+    _event(
+        db,
+        user,
+        plan=plan,
+        item=None,
+        kind="checklist",
+        summary=(
+            f"Marked decommission step {key!r} " f"{'done' if row.is_done else 'not done'}"
+            if "is_done" in changes
+            else f"Annotated decommission step {key!r}"
+        ),
+        detail=changes,
+    )
+    await db.commit()
+    await db.refresh(row)
+
+    auto = await checklist_svc.evaluate_auto_checks(db, plan=plan)
+    return ChecklistItemOut(
+        key=row.key,
+        category=row.category,
+        label=row.label,
+        description=row.description,
+        applies_to=row.applies_to,
+        is_done=row.is_done,
+        done_at=row.done_at,
+        notes=row.notes,
+        sort_order=row.sort_order,
+        auto_state=(auto.get(row.key) or {}).get("state", "manual"),
+        auto_detail=(auto.get(row.key) or {}).get("detail", ""),
+    )
+
+
+# ── Timeline + runbook ─────────────────────────────────────────────────
+
+
+@router.get("/plans/{plan_id}/events", response_model=list[EventOut])
+async def list_events(
+    plan_id: uuid.UUID,
+    db: DB,
+    _user: SuperAdmin,
+    limit: int = Query(default=100, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+) -> list[EventOut]:
+    plan = await _require_plan(db, plan_id)
+    rows = list(
+        (
+            await db.execute(
+                select(CutoverEvent)
+                .where(CutoverEvent.plan_id == plan.id)
+                .order_by(CutoverEvent.at.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return [
+        EventOut(
+            id=e.id,
+            item_id=e.item_id,
+            at=e.at,
+            kind=e.kind,
+            summary=e.summary,
+            detail=e.detail,
+            user_display_name=e.user_display_name,
+        )
+        for e in rows
+    ]
+
+
+@router.get("/plans/{plan_id}/events/count")
+async def count_events(plan_id: uuid.UUID, db: DB, _user: SuperAdmin) -> dict[str, int]:
+    plan = await _require_plan(db, plan_id)
+    total = (
+        await db.execute(
+            select(func.count()).select_from(CutoverEvent).where(CutoverEvent.plan_id == plan.id)
+        )
+    ).scalar_one()
+    return {"total": int(total)}
+
+
+@router.get("/plans/{plan_id}/runbook")
+async def get_runbook(plan_id: uuid.UUID, db: DB, _user: SuperAdmin) -> dict[str, str]:
+    """The generated operator runbook, as markdown.
+
+    Read-only, built from persisted state — it does not re-pull the source, so
+    an operator can produce it for a change ticket without touching the Windows
+    box. Parity facts come from each item's last recorded report.
+    """
+    plan = await _require_plan(db, plan_id)
+    items = list(plan.items)
+
+    dns_host: str | None = None
+    if plan.source_dns_server_id is not None:
+        server = await db.get(DNSServer, plan.source_dns_server_id)
+        dns_host = server.host if server else None
+    dhcp_host: str | None = None
+    if plan.source_dhcp_server_id is not None:
+        dhcp_server = await db.get(DHCPServer, plan.source_dhcp_server_id)
+        dhcp_host = dhcp_server.host if dhcp_server else None
+
+    # Give the runbook the real per-item recovery numbers. Without them it
+    # falls back to an assumed 3600s TTL / 24-hour lease and says so in the
+    # operator's change ticket — which both overstates the rollback window and
+    # leaks a developer-facing hint into a document someone signs off.
+    propagation: dict[str, int] = {}
+    for it in items:
+        if it.kind == "dns_zone" and it.zone_id is not None:
+            zone = await db.get(DNSZone, it.zone_id)
+            if zone is not None:
+                propagation[str(it.id)] = int(zone.ttl)
+        elif it.kind == "dhcp_scope" and it.scope_id is not None:
+            scope = await db.get(DHCPScope, it.scope_id)
+            if scope is not None:
+                propagation[str(it.id)] = int(scope.lease_time)
+
+    markdown = runbook_svc.render_runbook(
+        plan,
+        items,
+        None,
+        source_dns_host=dns_host,
+        source_dhcp_host=dhcp_host,
+        propagation_seconds=propagation,
+    )
+    return {"markdown": markdown}

--- a/backend/app/api/v1/cutover/router.py
+++ b/backend/app/api/v1/cutover/router.py
@@ -1038,9 +1038,27 @@ async def cut_item_over(
     """
     plan = await _require_plan(db, plan_id)
     item = await _require_item(db, plan, item_id)
+
+    # The switch pairs an irreversible WinRM call with a database write, so
+    # WHERE the commit lands relative to that call decides what a crash leaves
+    # behind. That sequencing knowledge belongs with the ordering rules in
+    # ``switch.py``, so the transaction boundary is handed in rather than
+    # applied here — see that module's docstring.
+    async def _finalize() -> None:
+        if plan.status in ("draft", "verifying", "parallel"):
+            plan.status = "cutting_over"
+        _audit(
+            db,
+            user,
+            action="cutover_item",
+            plan=plan,
+            detail={"source_ref": item.source_ref, "kind": item.kind, "force": body.force},
+        )
+        await db.commit()
+
     try:
         result = await switch_svc.execute_cutover(
-            db, plan=plan, item=item, current_user=user, force=body.force
+            db, plan=plan, item=item, current_user=user, force=body.force, finalize=_finalize
         )
     except switch_svc.CutoverBlocked as exc:
         # Persist the refusal rather than rolling it away. ``execute_cutover``
@@ -1073,16 +1091,6 @@ async def cut_item_over(
         await db.rollback()
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    if plan.status in ("draft", "verifying", "parallel"):
-        plan.status = "cutting_over"
-    _audit(
-        db,
-        user,
-        action="cutover_item",
-        plan=plan,
-        detail={"source_ref": item.source_ref, "kind": item.kind, "force": body.force},
-    )
-    await db.commit()
     return result
 
 
@@ -1092,20 +1100,28 @@ async def roll_item_back(
 ) -> dict[str, Any]:
     plan = await _require_plan(db, plan_id)
     item = await _require_item(db, plan, item_id)
+
+    # Same reasoning as the cutover above: the rollback commits the managed-side
+    # deactivation BEFORE re-activating Windows, so a failed commit can never
+    # leave both servers answering. ``switch.py`` owns that ordering.
+    async def _finalize() -> None:
+        _audit(
+            db,
+            user,
+            action="rollback_cutover_item",
+            plan=plan,
+            detail={"source_ref": item.source_ref, "kind": item.kind},
+        )
+        await db.commit()
+
     try:
-        result = await switch_svc.execute_rollback(db, plan=plan, item=item, current_user=user)
+        result = await switch_svc.execute_rollback(
+            db, plan=plan, item=item, current_user=user, finalize=_finalize
+        )
     except ValueError as exc:
         await db.rollback()
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    _audit(
-        db,
-        user,
-        action="rollback_cutover_item",
-        plan=plan,
-        detail={"source_ref": item.source_ref, "kind": item.kind},
-    )
-    await db.commit()
     return result
 
 

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -29,6 +29,7 @@ from app.api.v1.circuits import router as circuits_router
 from app.api.v1.cloud import router as cloud_router
 from app.api.v1.conformity import router as conformity_router
 from app.api.v1.custom_fields.router import router as custom_fields_router
+from app.api.v1.cutover import router as cutover_router
 from app.api.v1.dashboards import router as dashboards_router
 from app.api.v1.dhcp import router as dhcp_router
 from app.api.v1.dhcp.ra_routers import router as ra_routers_router
@@ -354,6 +355,16 @@ api_v1_router.include_router(
     prefix="/netbird",
     tags=["netbird"],
     dependencies=[Depends(require_module("integrations.netbird"))],
+)
+api_v1_router.include_router(
+    cutover_router,
+    prefix="/migration/cutover",
+    tags=["cutover"],
+    # 404 when the module is off. wake_publishing because the cutover DOES
+    # touch agent config: the TTL pre-flight rewrites records (shifting the DNS
+    # bundle ETag) and the switch flips DHCPScope.is_active — parked agents
+    # should re-poll on commit rather than wait out the safety tick.
+    dependencies=[Depends(require_module("migration.cutover")), Depends(wake_publishing)],
 )
 api_v1_router.include_router(
     netbox_import_router,

--- a/backend/app/drivers/dhcp/windows.py
+++ b/backend/app/drivers/dhcp/windows.py
@@ -383,6 +383,28 @@ Remove-DhcpServerv4Scope -ScopeId {_ps_literal(scope_id)} -Force
         creds = _load_credentials(server)
         await asyncio.to_thread(_run_ps, server, creds, script)
 
+    async def set_scope_state(self, server: Any, scope_id: str, *, active: bool) -> None:
+        """Activate or deactivate an existing scope, changing nothing else.
+
+        ``Set-DhcpServerv4Scope -ScopeId <id> -State Active|InActive``.
+
+        Deliberately narrow rather than routed through ``apply_scope``: that
+        method would need the full mask / range / option set re-supplied just to
+        flip this one flag, and re-applying a scope we have only ever *read* is
+        how an operator's hand-tuned Windows config gets overwritten. The #756
+        cutover uses this to take the Windows scope out of service immediately
+        before the managed scope starts answering, so the two never serve the
+        same subnet at once — and to put it back on a rollback.
+        """
+        state = "Active" if active else "InActive"
+        script = f"""
+$ErrorActionPreference = 'Stop'
+Set-DhcpServerv4Scope -ScopeId {_ps_literal(scope_id)} -State {_ps_literal(state)}
+"OK"
+"""
+        creds = _load_credentials(server)
+        await asyncio.to_thread(_run_ps, server, creds, script)
+
     async def apply_reservation(
         self,
         server: Any,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -30,6 +30,12 @@ from app.models.change_request import ApprovalPolicy, ChangeRequest
 from app.models.circuit import Circuit
 from app.models.cloud import CloudEndpoint
 from app.models.conformity import ConformityPolicy, ConformityResult
+from app.models.cutover import (
+    CutoverChecklistItem,
+    CutoverEvent,
+    CutoverItem,
+    CutoverPlan,
+)
 from app.models.dhcp import (
     DHCPClientClass,
     DHCPConfigOp,
@@ -298,4 +304,8 @@ __all__ = [
     "WolCalendar",
     "WolCalendarEvent",
     "DNSRPZHit",
+    "CutoverPlan",
+    "CutoverItem",
+    "CutoverChecklistItem",
+    "CutoverEvent",
 ]

--- a/backend/app/models/cutover.py
+++ b/backend/app/models/cutover.py
@@ -1,0 +1,305 @@
+"""Windows → SpatiumDDI cutover plans (issue #756).
+
+The one-shot importers (#128 / #129) get an operator's Windows DNS / DHCP
+estate *into* SpatiumDDI. Nothing took them the rest of the way: proving the
+imported rows still match what Windows is serving, running both sides in
+parallel, performing the switch per zone / per scope, and knowing what is safe
+to turn off on the Windows side afterwards. These four tables are the state
+behind that workflow.
+
+A :class:`CutoverPlan` is operator scratch space — a named migration with a
+source Windows server (DNS and/or DHCP), a target SpatiumDDI server group, and
+a set of :class:`CutoverItem` rows, one per zone or scope being migrated. The
+item carries everything that has to survive a page reload *and* a rollback:
+the last parity report, the last shadow-query comparison, the pre-flight TTL
+snapshot (so a rollback restores the exact values that were there before), the
+lease-handover result, and the current blocker set.
+
+:class:`CutoverChecklistItem` is the Phase 4 decommission list, seeded per plan
+from a static catalog so an operator's ticks and notes persist. Every state
+transition also appends a :class:`CutoverEvent`, giving the plan an ordered
+timeline that outlives the items themselves.
+
+No ``SoftDeleteMixin`` anywhere here on purpose: a plan is a working document,
+not an authoritative record of network state. Deleting one throws away
+bookkeeping, never configuration — the zones, scopes, and reservations it
+points at are owned by their own tables and are untouched by the cascade.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy import text as sa_text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# ── Enumerated string values ───────────────────────────────────────────
+# Kept as plain strings (matching every other model in the codebase) rather
+# than native PG enums, so adding a stage never needs a migration.
+
+#: ``CutoverPlan.status``.
+PLAN_STATUSES: frozenset[str] = frozenset(
+    {
+        "draft",  # being assembled; nothing verified yet
+        "verifying",  # Phase 1 — parity checks running / reviewed
+        "parallel",  # Phase 2 — both sides up, managed side unreachable by clients
+        "cutting_over",  # Phase 3 — at least one item switched
+        "completed",  # every item cut over
+        "rolled_back",  # the switch was reversed
+        "abandoned",  # operator gave up; kept for the audit trail
+    }
+)
+
+#: ``CutoverItem.kind``.
+ITEM_KINDS: frozenset[str] = frozenset({"dns_zone", "dhcp_scope"})
+
+#: ``CutoverItem.stage``.
+ITEM_STAGES: frozenset[str] = frozenset(
+    {
+        "pending",  # added to the plan, nothing run
+        "parity_checked",  # a parity report exists for it
+        "preflight_done",  # TTLs lowered (DNS) / leases handed over (DHCP)
+        "cut_over",  # the switch happened
+        "rolled_back",  # the switch was reversed
+    }
+)
+
+#: ``CutoverEvent.kind`` — the timeline's event vocabulary.
+EVENT_KINDS: frozenset[str] = frozenset(
+    {
+        "plan",
+        "parity",
+        "shadow",
+        "preflight",
+        "lease_handover",
+        "cutover",
+        "rollback",
+        "checklist",
+        "note",
+    }
+)
+
+
+class CutoverPlan(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One named Windows → SpatiumDDI migration."""
+
+    __tablename__ = "cutover_plan"
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="draft", server_default="draft"
+    )
+
+    # Where we're migrating FROM. Both nullable because a plan may cover DNS
+    # only, DHCP only, or both. SET NULL rather than CASCADE: deleting the
+    # Windows server row (a plausible *last* decommission step) must not
+    # silently destroy the record of the migration that retired it.
+    source_dns_server_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_server.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    source_dhcp_server_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dhcp_server.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    # Where we're migrating TO. Groups, not servers — a group is the unit of
+    # configuration on both the DNS and DHCP sides.
+    target_dns_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_server_group.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    target_dhcp_group_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dhcp_server_group.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    notes: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rolled_back_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    items: Mapped[list[CutoverItem]] = relationship(
+        "CutoverItem",
+        back_populates="plan",
+        cascade="all, delete-orphan",
+        order_by="CutoverItem.source_ref",
+    )
+    checklist: Mapped[list[CutoverChecklistItem]] = relationship(
+        "CutoverChecklistItem",
+        back_populates="plan",
+        cascade="all, delete-orphan",
+        order_by="CutoverChecklistItem.sort_order",
+    )
+
+
+class CutoverItem(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One zone or one scope being migrated, and everything known about it.
+
+    ``source_ref`` is how the object is named on the *Windows* side — a zone
+    name without its trailing dot, or a DHCP scope id (its network address).
+    It is the stable identity: ``zone_id`` / ``scope_id`` are nullable and
+    ``SET NULL``, so deleting the SpatiumDDI-side row during a messy migration
+    leaves the item (and its history) intact rather than vanishing mid-cutover.
+    """
+
+    __tablename__ = "cutover_item"
+    __table_args__ = (
+        UniqueConstraint("plan_id", "kind", "source_ref", name="uq_cutover_item_plan_kind_ref"),
+        Index("ix_cutover_item_plan", "plan_id"),
+    )
+
+    plan_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("cutover_plan.id", ondelete="CASCADE"), nullable=False
+    )
+    kind: Mapped[str] = mapped_column(String(12), nullable=False)
+    source_ref: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    zone_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dns_zone.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    scope_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dhcp_scope.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    stage: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="pending", server_default="pending"
+    )
+
+    # Latest readiness verdict — a list of ``{code, severity, message}`` dicts.
+    # Recomputed on every parity run and immediately before a cutover; the
+    # cutover endpoint refuses while any entry has ``severity == "block"``.
+    blockers: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default=sa_text("'[]'::jsonb")
+    )
+
+    last_parity: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    last_parity_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_shadow: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    last_shadow_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Pre-flight TTL snapshot (DNS items). Written once, on the first apply,
+    # and never overwritten by a second apply — it holds the *pristine*
+    # pre-migration values, which is the whole point of keeping it.
+    ttl_snapshot: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    ttl_lowered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Lease-handover result (DHCP items): counts + timestamp.
+    lease_handover: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    cut_over_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    rolled_back_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    notes: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    plan: Mapped[CutoverPlan] = relationship("CutoverPlan", back_populates="items")
+
+
+class CutoverChecklistItem(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One line of the Phase 4 decommission checklist, per plan.
+
+    Rows are seeded from the static catalog in
+    :mod:`app.services.cutover.checklist` the first time a plan's checklist is
+    read. The catalog can grow between releases; seeding is an idempotent
+    upsert on ``(plan_id, key)``, so a plan created before a new item existed
+    picks it up on the next read without losing any existing ticks.
+    """
+
+    __tablename__ = "cutover_checklist_item"
+    __table_args__ = (
+        UniqueConstraint("plan_id", "key", name="uq_cutover_checklist_plan_key"),
+        Index("ix_cutover_checklist_plan", "plan_id"),
+    )
+
+    plan_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("cutover_plan.id", ondelete="CASCADE"), nullable=False
+    )
+    key: Mapped[str] = mapped_column(String(64), nullable=False)
+    category: Mapped[str] = mapped_column(String(32), nullable=False, default="general")
+    label: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    # Which half of the migration the item belongs to: dns_zone | dhcp_scope |
+    # general. Drives whether the UI shows it at all — a DNS-only plan has no
+    # business being nagged about deauthorizing a DHCP server in AD.
+    applies_to: Mapped[str] = mapped_column(
+        String(12), nullable=False, default="general", server_default="general"
+    )
+
+    is_done: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    done_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    done_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    notes: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    sort_order: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=sa_text("0")
+    )
+
+    plan: Mapped[CutoverPlan] = relationship("CutoverPlan", back_populates="checklist")
+
+
+class CutoverEvent(UUIDPrimaryKeyMixin, Base):
+    """Append-only timeline entry for a plan.
+
+    Deliberately not a ``TimestampMixin`` model: an event has one time, the
+    moment it happened, and a ``modified_at`` on an append-only row would be a
+    lie. ``item_id`` is ``SET NULL`` so removing an item from a plan doesn't
+    erase the record of what was already done to it.
+    """
+
+    __tablename__ = "cutover_event"
+    __table_args__ = (Index("ix_cutover_event_plan_at", "plan_id", "at"),)
+
+    plan_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("cutover_plan.id", ondelete="CASCADE"), nullable=False
+    )
+    item_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("cutover_item.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    kind: Mapped[str] = mapped_column(String(24), nullable=False)
+    summary: Mapped[str] = mapped_column(String(512), nullable=False)
+    detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("user.id", ondelete="SET NULL"), nullable=True
+    )
+    user_display_name: Mapped[str] = mapped_column(String(255), nullable=False, default="")

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -24,6 +24,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     changes,
     conformity,
     copilot,
+    cutover,
     dhcp,
     diagnostics,
     dicom,

--- a/backend/app/services/ai/tools/cutover.py
+++ b/backend/app/services/ai/tools/cutover.py
@@ -1,0 +1,779 @@
+"""Operator Copilot tools for Windows → SpatiumDDI cutover plans (issue #756).
+
+The importers (#128 / #129) get a Windows estate into native rows; the cutover
+workflow is the rest of the journey (parity → parallel run → switch →
+decommission). These four tools let the copilot answer the questions an
+operator actually asks mid-migration — "what's left in the plan?", "why won't
+corp.example cut over?", "is anything blocked?" — without them having to read
+the Fleet-style UI.
+
+Every tool carries ``module="migration.cutover"`` so turning the (default-on)
+feature module off strips them from the AI surface as well as the REST surface
+(non-negotiable #14).
+
+**Superadmin on all four.** The REST surface is superadmin-only on every
+endpoint — a cutover is strictly more dangerous than an import — and an MCP
+tool has no router dependency to inherit that from, so each executor re-checks
+in-tool. That is the same shape ``pairing`` / ``appliance`` use for their
+superadmin-only REST surfaces, and the reason ``changes`` re-implements its
+router's read rule in-tool.
+
+**Why one of them is default-off.** ``find_cutover_plans`` /
+``find_cutover_plan_status`` / ``count_cutover_blockers`` read persisted rows
+and nothing else, so they ship enabled — an operator should discover them
+without opting in. ``find_cutover_parity_check`` runs a **live pull from the
+Windows source over WinRM using stored credentials**, exactly like
+``find_dns_import_preview``, so it ships disabled per non-negotiable #13's
+"off-prem calls default to disabled" rule and the operator opts in via
+Settings → AI → Tool Catalog.
+
+All four are reads. The parity tool deliberately does *not* persist its report
+onto the item — that is a mutation, and it belongs to
+``POST /api/v1/migration/cutover/plans/{pid}/items/{iid}/parity``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import is_effective_superadmin
+from app.models.auth import User
+from app.models.cutover import (
+    ITEM_STAGES,
+    PLAN_STATUSES,
+    CutoverChecklistItem,
+    CutoverItem,
+    CutoverPlan,
+)
+from app.models.dhcp import DHCPScope, DHCPServer
+from app.models.dns import DNSServer, DNSZone
+from app.services.ai.tools.base import register_tool
+from app.services.cutover.canonical import ParityReport
+from app.services.cutover.parity import compute_dhcp_parity, compute_dns_parity
+
+MODULE = "migration.cutover"
+
+# Payload caps. A plan can legitimately carry hundreds of zones and a parity
+# report thousands of differences; neither belongs in an LLM context window in
+# full. Every truncation is flagged in the payload so the model can say so
+# rather than silently under-reporting.
+_MAX_ITEMS = 100
+_MAX_DIFFERENCES = 25
+_MAX_WARNINGS = 10
+_MAX_BLOCKERS = 20
+_MAX_BLOCKED_ITEMS = 100
+#: Ceiling on the item rows ``count_cutover_blockers`` scans when it runs
+#: across every plan.
+_MAX_SCAN = 1000
+
+
+def _superadmin_gate(user: User) -> dict[str, Any] | None:
+    if not is_effective_superadmin(user):
+        return {"error": "Cutover tools are restricted to superadmin users."}
+    return None
+
+
+class _PlanLookupError(ValueError):
+    """A plan could not be resolved from the supplied args.
+
+    Carries an operator-readable message that each tool returns as
+    ``{"error": …}`` rather than raising out to the MCP layer — "no plan called
+    that" is an answer, not a failure.
+    """
+
+
+async def _resolve_plan(db: AsyncSession, *, plan_id: str | None, name: str | None) -> CutoverPlan:
+    """Find a plan by id or by exact (case-insensitive) name."""
+    if plan_id:
+        try:
+            pid = uuid.UUID(plan_id)
+        except ValueError as exc:
+            raise _PlanLookupError(f"plan_id must be a UUID, got {plan_id!r}.") from exc
+        plan = await db.get(CutoverPlan, pid)
+        if plan is None:
+            raise _PlanLookupError(f"No cutover plan with id {plan_id}.")
+        return plan
+    if name:
+        wanted = name.strip().lower()
+        plan = (
+            await db.execute(select(CutoverPlan).where(func.lower(CutoverPlan.name) == wanted))
+        ).scalar_one_or_none()
+        if plan is None:
+            raise _PlanLookupError(
+                f"No cutover plan named {name!r}. Use find_cutover_plans to list them."
+            )
+        return plan
+    raise _PlanLookupError("Pass either plan_id or name to identify the cutover plan.")
+
+
+def _blockers_of(item: CutoverItem) -> list[dict[str, Any]]:
+    """``item.blockers`` as a list of well-formed dicts.
+
+    The column is JSONB written by ``readiness.refresh_blockers``, so the shape
+    is ours — but it is still free-form JSON at the DB level, and a malformed
+    entry must not take out a whole rollup, so anything that is not a dict is
+    dropped.
+    """
+    raw = item.blockers if isinstance(item.blockers, list) else []
+    return [
+        {
+            "code": str(b.get("code") or ""),
+            "severity": str(b.get("severity") or ""),
+            "message": str(b.get("message") or ""),
+        }
+        for b in raw
+        if isinstance(b, dict)
+    ]
+
+
+def _blocker_counts(blockers: list[dict[str, Any]]) -> tuple[int, int]:
+    """``(blocking, warning)`` counts for one item's blocker list."""
+    blocking = sum(1 for b in blockers if b["severity"] == "block")
+    return blocking, len(blockers) - blocking
+
+
+def _parity_summary(item: CutoverItem) -> dict[str, Any] | None:
+    """The persisted parity report with its ``differences`` list stripped.
+
+    The stored blob is a full ``ParityReport.as_dict()``; the per-difference
+    detail is what ``find_cutover_parity_check`` is for. Here only the verdict
+    and the counts travel, which keeps a 40-zone plan inside a context window.
+    """
+    stored = item.last_parity
+    if not isinstance(stored, dict):
+        return None
+    return {
+        "status": stored.get("status"),
+        "error": stored.get("error"),
+        "is_parity": stored.get("is_parity"),
+        "in_sync": stored.get("in_sync"),
+        "not_compared": stored.get("not_compared"),
+        "difference_count": stored.get("difference_count"),
+        "counts_by_class": stored.get("counts_by_class"),
+        "at": item.last_parity_at.isoformat() if item.last_parity_at else None,
+    }
+
+
+def _shadow_summary(item: CutoverItem) -> dict[str, Any] | None:
+    """Counts from the persisted shadow-comparison report, without the samples."""
+    stored = item.last_shadow
+    if not isinstance(stored, dict):
+        return None
+    return {
+        "sample_source": stored.get("sample_source"),
+        "sampled": stored.get("sampled"),
+        "matched": stored.get("matched"),
+        "mismatched": stored.get("mismatched"),
+        "errors": stored.get("errors"),
+        "at": item.last_shadow_at.isoformat() if item.last_shadow_at else None,
+    }
+
+
+def _ttl_summary(item: CutoverItem) -> dict[str, Any] | None:
+    """Pre-flight TTL snapshot metadata — never the snapshot itself.
+
+    The snapshot holds one entry per record in the zone, so returning it would
+    blow the payload for exactly the large zones an operator is most likely to
+    be asking about.
+    """
+    snapshot = item.ttl_snapshot
+    if not isinstance(snapshot, dict):
+        return None
+    records = snapshot.get("records")
+    return {
+        "target_ttl": snapshot.get("target_ttl"),
+        "taken_at": snapshot.get("taken_at"),
+        "records_snapshotted": len(records) if isinstance(records, list) else None,
+        "lowered_at": item.ttl_lowered_at.isoformat() if item.ttl_lowered_at else None,
+    }
+
+
+def _item_row(item: CutoverItem) -> dict[str, Any]:
+    blockers = _blockers_of(item)
+    blocking, warning = _blocker_counts(blockers)
+    return {
+        "item_id": str(item.id),
+        "kind": item.kind,
+        "source_ref": item.source_ref,
+        "stage": item.stage,
+        "zone_id": str(item.zone_id) if item.zone_id else None,
+        "scope_id": str(item.scope_id) if item.scope_id else None,
+        "blocking_count": blocking,
+        "warning_count": warning,
+        "blockers": blockers[:_MAX_BLOCKERS],
+        "blockers_truncated": len(blockers) > _MAX_BLOCKERS,
+        "parity": _parity_summary(item),
+        "shadow": _shadow_summary(item),
+        "ttl_preflight": _ttl_summary(item),
+        "lease_handover": item.lease_handover if isinstance(item.lease_handover, dict) else None,
+        "cut_over_at": item.cut_over_at.isoformat() if item.cut_over_at else None,
+        "rolled_back_at": item.rolled_back_at.isoformat() if item.rolled_back_at else None,
+        "notes": item.notes,
+    }
+
+
+def _plan_row(plan: CutoverPlan) -> dict[str, Any]:
+    return {
+        "id": str(plan.id),
+        "name": plan.name,
+        "description": plan.description,
+        "status": plan.status,
+        "source_dns_server_id": (
+            str(plan.source_dns_server_id) if plan.source_dns_server_id else None
+        ),
+        "source_dhcp_server_id": (
+            str(plan.source_dhcp_server_id) if plan.source_dhcp_server_id else None
+        ),
+        "target_dns_group_id": (
+            str(plan.target_dns_group_id) if plan.target_dns_group_id else None
+        ),
+        "target_dhcp_group_id": (
+            str(plan.target_dhcp_group_id) if plan.target_dhcp_group_id else None
+        ),
+        "notes": plan.notes,
+        "created_at": plan.created_at.isoformat(),
+        "completed_at": plan.completed_at.isoformat() if plan.completed_at else None,
+        "rolled_back_at": plan.rolled_back_at.isoformat() if plan.rolled_back_at else None,
+    }
+
+
+def _empty_stage_rollup() -> dict[str, int]:
+    return {stage: 0 for stage in sorted(ITEM_STAGES)}
+
+
+# ── find_cutover_plans ───────────────────────────────────────────────
+
+
+class FindCutoverPlansArgs(BaseModel):
+    search: str | None = Field(
+        default=None,
+        description="Case-insensitive substring match on the plan name or description.",
+    )
+    status: str | None = Field(
+        default=None,
+        description=(
+            "Filter to one lifecycle status: draft / verifying / parallel / "
+            "cutting_over / completed / rolled_back / abandoned. Omit for all."
+        ),
+    )
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+@register_tool(
+    name="find_cutover_plans",
+    description=(
+        "List Windows → SpatiumDDI cutover plans (superadmin only). Each row "
+        "carries the plan's lifecycle status, its source Windows DNS / DHCP "
+        "server ids, its target SpatiumDDI group ids, and a rollup of its "
+        "items by stage (pending / parity_checked / preflight_done / "
+        "cut_over / rolled_back) plus how many items currently have a "
+        "blocking readiness problem. Use to answer 'what migrations are in "
+        "flight?', 'is the corp.example cutover finished?', or to find a "
+        "plan id for the other cutover tools. Read-only, DB-only."
+    ),
+    args_model=FindCutoverPlansArgs,
+    category="ops",
+    default_enabled=True,
+    module=MODULE,
+)
+async def find_cutover_plans(
+    db: AsyncSession, user: User, args: FindCutoverPlansArgs
+) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
+    if args.status is not None and args.status not in PLAN_STATUSES:
+        return {
+            "error": (
+                f"Unknown status {args.status!r}. Valid values: "
+                f"{', '.join(sorted(PLAN_STATUSES))}."
+            )
+        }
+
+    stmt = select(CutoverPlan).order_by(CutoverPlan.created_at.desc()).limit(args.limit)
+    if args.status is not None:
+        stmt = stmt.where(CutoverPlan.status == args.status)
+    if args.search:
+        needle = f"%{args.search.strip()}%"
+        stmt = stmt.where(
+            or_(CutoverPlan.name.ilike(needle), CutoverPlan.description.ilike(needle))
+        )
+    plans = list((await db.execute(stmt)).scalars().all())
+
+    rollups: dict[uuid.UUID, dict[str, Any]] = {
+        p.id: {"total": 0, "blocked": 0, "by_stage": _empty_stage_rollup()} for p in plans
+    }
+    if plans:
+        item_rows = (
+            await db.execute(
+                select(CutoverItem.plan_id, CutoverItem.stage, CutoverItem.blockers).where(
+                    CutoverItem.plan_id.in_([p.id for p in plans])
+                )
+            )
+        ).all()
+        for plan_id, stage, blockers in item_rows:
+            rollup = rollups[plan_id]
+            rollup["total"] += 1
+            rollup["by_stage"][stage] = rollup["by_stage"].get(stage, 0) + 1
+            if isinstance(blockers, list) and any(
+                isinstance(b, dict) and b.get("severity") == "block" for b in blockers
+            ):
+                rollup["blocked"] += 1
+
+    return {
+        "plans": [{**_plan_row(p), "items": rollups[p.id]} for p in plans],
+        "count": len(plans),
+    }
+
+
+# ── find_cutover_plan_status ─────────────────────────────────────────
+
+
+class FindCutoverPlanStatusArgs(BaseModel):
+    plan_id: str | None = Field(default=None, description="The plan's UUID.")
+    name: str | None = Field(
+        default=None,
+        description="The plan's exact name (case-insensitive). Use instead of plan_id.",
+    )
+    kind: str | None = Field(
+        default=None,
+        description="Filter items to 'dns_zone' or 'dhcp_scope'. Omit for both.",
+    )
+    stage: str | None = Field(
+        default=None,
+        description=(
+            "Filter items to one stage: pending / parity_checked / "
+            "preflight_done / cut_over / rolled_back. Omit for all."
+        ),
+    )
+    item_limit: int = Field(default=_MAX_ITEMS, ge=1, le=_MAX_ITEMS)
+
+
+@register_tool(
+    name="find_cutover_plan_status",
+    description=(
+        "Full status of one cutover plan (superadmin only) — the per-item "
+        "detail behind find_cutover_plans. Identify the plan by plan_id or "
+        "name. Returns each zone / scope item with its stage, its current "
+        "readiness blockers (code + severity + the operator-facing fix), a "
+        "summary of the last parity check and last shadow-query comparison, "
+        "TTL pre-flight snapshot metadata, lease-handover counts, and "
+        "cut-over / rollback timestamps, plus the decommission-checklist "
+        "progress. Use to answer 'why can't this zone cut over?' or 'what "
+        "stage is each scope at?'. Per-difference parity detail is NOT "
+        "included here — that is find_cutover_parity_check. Read-only, "
+        "DB-only (no Windows pull)."
+    ),
+    args_model=FindCutoverPlanStatusArgs,
+    category="ops",
+    default_enabled=True,
+    module=MODULE,
+)
+async def find_cutover_plan_status(
+    db: AsyncSession, user: User, args: FindCutoverPlanStatusArgs
+) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
+    try:
+        plan = await _resolve_plan(db, plan_id=args.plan_id, name=args.name)
+    except _PlanLookupError as exc:
+        return {"error": str(exc)}
+    if args.stage is not None and args.stage not in ITEM_STAGES:
+        return {
+            "error": (
+                f"Unknown stage {args.stage!r}. Valid values: {', '.join(sorted(ITEM_STAGES))}."
+            )
+        }
+
+    stmt = (
+        select(CutoverItem)
+        .where(CutoverItem.plan_id == plan.id)
+        .order_by(CutoverItem.kind, CutoverItem.source_ref)
+    )
+    if args.kind is not None:
+        stmt = stmt.where(CutoverItem.kind == args.kind)
+    if args.stage is not None:
+        stmt = stmt.where(CutoverItem.stage == args.stage)
+    items = list((await db.execute(stmt)).scalars().all())
+
+    by_stage = _empty_stage_rollup()
+    blocked = 0
+    warned = 0
+    for item in items:
+        by_stage[item.stage] = by_stage.get(item.stage, 0) + 1
+        blocking, warning = _blocker_counts(_blockers_of(item))
+        if blocking:
+            blocked += 1
+        if warning:
+            warned += 1
+
+    checklist_rows = (
+        await db.execute(
+            select(CutoverChecklistItem.is_done, func.count())
+            .where(CutoverChecklistItem.plan_id == plan.id)
+            .group_by(CutoverChecklistItem.is_done)
+        )
+    ).all()
+    checklist_done = 0
+    checklist_total = 0
+    for is_done, count in checklist_rows:
+        checklist_total += count
+        if is_done:
+            checklist_done += count
+
+    return {
+        "plan": _plan_row(plan),
+        "summary": {
+            "items_total": len(items),
+            "items_blocked": blocked,
+            "items_with_warnings": warned,
+            "by_stage": by_stage,
+        },
+        "checklist": {
+            "done": checklist_done,
+            "total": checklist_total,
+            # 0 items means the checklist has never been read (it seeds
+            # lazily on the first GET of the plan's checklist), not that
+            # there is nothing to do.
+            "seeded": checklist_total > 0,
+        },
+        "items": [_item_row(i) for i in items[: args.item_limit]],
+        "items_truncated": len(items) > args.item_limit,
+    }
+
+
+# ── count_cutover_blockers ───────────────────────────────────────────
+
+
+class CountCutoverBlockersArgs(BaseModel):
+    plan_id: str | None = Field(
+        default=None,
+        description="Restrict to one plan by UUID. Omit (and omit name) to count across all plans.",
+    )
+    name: str | None = Field(
+        default=None,
+        description="Restrict to one plan by exact name (case-insensitive).",
+    )
+    severity: str | None = Field(
+        default=None,
+        description=(
+            "Filter the code rollup to 'block' (refuses the cutover outright) "
+            "or 'warn' (acknowledgeable). Omit for both."
+        ),
+    )
+
+
+@register_tool(
+    name="count_cutover_blockers",
+    description=(
+        "Roll up cutover readiness blockers (superadmin only) — across every "
+        "plan, or one plan identified by plan_id / name. Returns how many "
+        "items are blocked outright versus merely warned, a per-code "
+        "breakdown (ad_secure_dynamic_update, no_target_zone, "
+        "managed_scope_active, parity_not_verified, …), and the blocked "
+        "items themselves. The blocker set is whatever the last readiness "
+        "evaluation persisted, so re-run a parity check if it looks stale. "
+        "Use to answer 'is anything blocking the migration?' or 'how many "
+        "zones are stuck on secure dynamic updates?'. Read-only, DB-only."
+    ),
+    args_model=CountCutoverBlockersArgs,
+    category="ops",
+    default_enabled=True,
+    module=MODULE,
+)
+async def count_cutover_blockers(
+    db: AsyncSession, user: User, args: CountCutoverBlockersArgs
+) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
+    if args.severity is not None and args.severity not in {"block", "warn"}:
+        return {"error": f"severity must be 'block' or 'warn', got {args.severity!r}."}
+
+    plan: CutoverPlan | None = None
+    if args.plan_id or args.name:
+        try:
+            plan = await _resolve_plan(db, plan_id=args.plan_id, name=args.name)
+        except _PlanLookupError as exc:
+            return {"error": str(exc)}
+
+    stmt = select(CutoverItem).order_by(CutoverItem.plan_id, CutoverItem.source_ref)
+    if plan is not None:
+        stmt = stmt.where(CutoverItem.plan_id == plan.id)
+    # +1 so the payload can honestly say the scan hit its ceiling.
+    items = list((await db.execute(stmt.limit(_MAX_SCAN + 1))).scalars().all())
+    truncated = len(items) > _MAX_SCAN
+    items = items[:_MAX_SCAN]
+
+    plan_names: dict[uuid.UUID, str] = {}
+    if plan is not None:
+        plan_names[plan.id] = plan.name
+    elif items:
+        plan_names = {
+            pid: pname
+            for pid, pname in (
+                await db.execute(
+                    select(CutoverPlan.id, CutoverPlan.name).where(
+                        CutoverPlan.id.in_({i.plan_id for i in items})
+                    )
+                )
+            ).all()
+        }
+
+    by_code: dict[str, dict[str, Any]] = {}
+    blocked_items: list[dict[str, Any]] = []
+    items_blocked = 0
+    items_warned = 0
+
+    for item in items:
+        blockers = _blockers_of(item)
+        blocking, warning = _blocker_counts(blockers)
+        if blocking:
+            items_blocked += 1
+        if warning:
+            items_warned += 1
+        for blocker in blockers:
+            if args.severity is not None and blocker["severity"] != args.severity:
+                continue
+            entry = by_code.setdefault(
+                blocker["code"],
+                {"code": blocker["code"], "severity": blocker["severity"], "items": 0},
+            )
+            entry["items"] += 1
+        if blocking and len(blocked_items) < _MAX_BLOCKED_ITEMS:
+            blocked_items.append(
+                {
+                    "plan_id": str(item.plan_id),
+                    "plan_name": plan_names.get(item.plan_id, ""),
+                    **_item_row(item),
+                }
+            )
+
+    return {
+        "scope": {
+            "plan_id": str(plan.id) if plan is not None else None,
+            "plan_name": plan.name if plan is not None else None,
+        },
+        "items_scanned": len(items),
+        "items_blocked": items_blocked,
+        "items_with_warnings": items_warned,
+        "by_code": sorted(by_code.values(), key=lambda e: (-e["items"], e["code"])),
+        "blocked_items": blocked_items,
+        "blocked_items_truncated": items_blocked > len(blocked_items),
+        "scan_truncated": truncated,
+    }
+
+
+# ── find_cutover_parity_check ────────────────────────────────────────
+
+
+class FindCutoverParityCheckArgs(BaseModel):
+    plan_id: str | None = Field(default=None, description="The plan's UUID.")
+    name: str | None = Field(
+        default=None,
+        description="The plan's exact name (case-insensitive). Use instead of plan_id.",
+    )
+    item_id: str | None = Field(
+        default=None,
+        description="Check exactly one item by its UUID (from find_cutover_plan_status).",
+    )
+    source_ref: str | None = Field(
+        default=None,
+        description=(
+            "Check the item whose Windows-side reference matches — a zone name "
+            "without its trailing dot, or a DHCP scope id (its network address)."
+        ),
+    )
+    max_items: int = Field(
+        default=5,
+        ge=1,
+        le=25,
+        description=(
+            "Ceiling on how many items to check when neither item_id nor "
+            "source_ref is given. Each item is one live pull from the Windows "
+            "server, so keep this small."
+        ),
+    )
+
+
+def _trim_report(report: ParityReport) -> dict[str, Any]:
+    """``ParityReport.as_dict()`` with its unbounded lists capped."""
+    data = report.as_dict()
+    differences = data["differences"]
+    warnings = data["warnings"]
+    data["differences"] = differences[:_MAX_DIFFERENCES]
+    data["differences_truncated"] = len(differences) > _MAX_DIFFERENCES
+    data["warnings"] = warnings[:_MAX_WARNINGS]
+    return data
+
+
+async def _parity_for_item(
+    db: AsyncSession,
+    *,
+    item: CutoverItem,
+    dns_source: DNSServer | None,
+    dhcp_source: DHCPServer | None,
+) -> dict[str, Any]:
+    """Run one item's parity check, or explain why it could not run.
+
+    Both ``compute_*_parity`` helpers already turn a driver / WinRM failure
+    into ``status="error"`` on the report, so nothing here needs a catch-all —
+    what this function handles is the item being unrunnable in the first place
+    (no source server configured on the plan, or the SpatiumDDI-side row gone).
+    """
+    head: dict[str, Any] = {
+        "item_id": str(item.id),
+        "kind": item.kind,
+        "source_ref": item.source_ref,
+        "stage": item.stage,
+    }
+
+    if item.kind == "dns_zone":
+        if dns_source is None:
+            return {
+                **head,
+                "status": "error",
+                "error": (
+                    "The plan has no source Windows DNS server set (or it has been "
+                    "deleted), so there is nothing to compare against."
+                ),
+            }
+        zone: DNSZone | None = None
+        if item.zone_id is not None:
+            zone = (
+                await db.execute(select(DNSZone).where(DNSZone.id == item.zone_id))
+            ).scalar_one_or_none()
+        if zone is None:
+            return {
+                **head,
+                "status": "error",
+                "error": (
+                    "This item is not linked to a live SpatiumDDI zone (never matched, "
+                    "or the zone was deleted). Re-run Discover on the plan."
+                ),
+            }
+        report = await compute_dns_parity(
+            db, source_server=dns_source, zone=zone, source_zone_name=item.source_ref
+        )
+        return {**head, "zone_id": str(zone.id), "zone_name": zone.name, **_trim_report(report)}
+
+    if item.kind == "dhcp_scope":
+        if dhcp_source is None:
+            return {
+                **head,
+                "status": "error",
+                "error": (
+                    "The plan has no source Windows DHCP server set (or it has been "
+                    "deleted), so there is nothing to compare against."
+                ),
+            }
+        scope: DHCPScope | None = None
+        if item.scope_id is not None:
+            scope = (
+                await db.execute(select(DHCPScope).where(DHCPScope.id == item.scope_id))
+            ).scalar_one_or_none()
+        if scope is None:
+            return {
+                **head,
+                "status": "error",
+                "error": (
+                    "This item is not linked to a live SpatiumDDI scope (never matched, "
+                    "or the scope was deleted). Re-run Discover on the plan."
+                ),
+            }
+        report = await compute_dhcp_parity(
+            db, source_server=dhcp_source, scope=scope, source_scope_id=item.source_ref
+        )
+        return {**head, "scope_id": str(scope.id), "scope_name": scope.name, **_trim_report(report)}
+
+    return {**head, "status": "error", "error": f"Unsupported cutover item kind {item.kind!r}."}
+
+
+@register_tool(
+    name="find_cutover_parity_check",
+    description=(
+        "Run a LIVE parity check for cutover plan items (superadmin only; "
+        "makes an off-prem WinRM pull from the source Windows server). "
+        "Identify the plan by plan_id or name, then optionally one item by "
+        "item_id or source_ref — otherwise up to max_items are checked. For "
+        "a DNS zone it diffs the records Windows is serving right now "
+        "against the SpatiumDDI zone; for a DHCP scope it diffs lease time, "
+        "activation, pools, reservations, and options. Each difference is "
+        "classified: value_mismatch / drifted_since_import / never_imported "
+        "/ intentionally_diverged. Use before a cutover to answer 'is this "
+        "zone actually in sync?'. Nothing is persisted — the plan item's "
+        "stored report is only updated by the REST parity endpoint."
+    ),
+    args_model=FindCutoverParityCheckArgs,
+    category="ops",
+    default_enabled=False,
+    module=MODULE,
+)
+async def find_cutover_parity_check(
+    db: AsyncSession, user: User, args: FindCutoverParityCheckArgs
+) -> dict[str, Any]:
+    if (err := _superadmin_gate(user)) is not None:
+        return err
+    try:
+        plan = await _resolve_plan(db, plan_id=args.plan_id, name=args.name)
+    except _PlanLookupError as exc:
+        return {"error": str(exc)}
+
+    stmt = (
+        select(CutoverItem)
+        .where(CutoverItem.plan_id == plan.id)
+        .order_by(CutoverItem.kind, CutoverItem.source_ref)
+    )
+    if args.item_id:
+        try:
+            iid = uuid.UUID(args.item_id)
+        except ValueError:
+            return {"error": f"item_id must be a UUID, got {args.item_id!r}."}
+        stmt = stmt.where(CutoverItem.id == iid)
+    elif args.source_ref:
+        stmt = stmt.where(func.lower(CutoverItem.source_ref) == args.source_ref.strip().lower())
+    else:
+        # Each item is a separate WinRM round trip, so a whole-plan run is
+        # capped rather than fanned out over everything.
+        stmt = stmt.limit(args.max_items)
+    items = list((await db.execute(stmt)).scalars().all())
+    if not items:
+        return {
+            "error": (
+                f"No matching items in plan {plan.name!r}. Use find_cutover_plan_status "
+                "to list them."
+            )
+        }
+
+    dns_source: DNSServer | None = None
+    if plan.source_dns_server_id is not None and any(i.kind == "dns_zone" for i in items):
+        dns_source = (
+            await db.execute(select(DNSServer).where(DNSServer.id == plan.source_dns_server_id))
+        ).scalar_one_or_none()
+    dhcp_source: DHCPServer | None = None
+    if plan.source_dhcp_server_id is not None and any(i.kind == "dhcp_scope" for i in items):
+        dhcp_source = (
+            await db.execute(select(DHCPServer).where(DHCPServer.id == plan.source_dhcp_server_id))
+        ).scalar_one_or_none()
+
+    # Sequential on purpose, and there is no concurrent path anywhere: one
+    # AsyncSession cannot serve concurrent operations, so the REST fan-out in
+    # ``api/v1/cutover/router.py`` is a plain loop for the same reason (see the
+    # session note at the top of ``services/cutover/parity.py``). This is also a
+    # pull against one operator's production Windows box, which is not somewhere
+    # an LLM-triggered fan-out belongs.
+    reports = [
+        await _parity_for_item(db, item=item, dns_source=dns_source, dhcp_source=dhcp_source)
+        for item in items
+    ]
+
+    return {
+        "plan_id": str(plan.id),
+        "plan_name": plan.name,
+        "checked": len(reports),
+        "in_parity": sum(1 for r in reports if r.get("is_parity") is True),
+        "reports": reports,
+    }

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -268,6 +268,28 @@ SECTIONS: tuple[Section, ...] = (
         ),
     ),
     Section(
+        key="migration",
+        label="Migration (Windows cutover plans)",
+        description=(
+            "Windows → SpatiumDDI cutover plans, their per-zone / "
+            "per-scope items (parity + shadow reports, pre-flight TTL "
+            "snapshots, lease-handover results), the decommission "
+            "checklist, and the plan timeline. Its own section rather "
+            "than a DNS or DHCP one because a single plan spans both. "
+            "The zones, scopes and reservations a plan points at are "
+            "owned by the DNS / DHCP sections — this is the "
+            "bookkeeping around them, and the pre-flight TTL snapshot "
+            "is the only copy of the pre-migration TTLs, so a restore "
+            "without it loses the ability to roll a cutover back."
+        ),
+        tables=(
+            "cutover_plan",
+            "cutover_item",
+            "cutover_checklist_item",
+            "cutover_event",
+        ),
+    ),
+    Section(
         key="integrations",
         label="Integrations + network discovery",
         description=(

--- a/backend/app/services/cutover/__init__.py
+++ b/backend/app/services/cutover/__init__.py
@@ -1,0 +1,25 @@
+"""Windows → SpatiumDDI cutover workflow (issue #756).
+
+The importers (#128 / #129) load a Windows DNS / DHCP estate into native rows
+and stop there. This package is the rest of the journey:
+
+* :mod:`.parity` — Phase 1. Diff what SpatiumDDI holds against what the Windows
+  server is *currently* serving, and classify every difference.
+* :mod:`.readiness` — the blocker set. Most importantly, it refuses to migrate
+  an AD-integrated zone with "Secure only" dynamic updates, because GSS-TSIG is
+  unimplemented (#444) and a DC that can't register its SRV records breaks AD.
+* :mod:`.shadow` — Phase 2. Replay recently-observed production queries against
+  both the Windows source and the managed targets and compare the answers.
+* :mod:`.preflight` — Phase 3a. Lower TTLs ahead of the switch so a rollback
+  propagates in minutes, snapshotting the originals so it can be undone exactly.
+* :mod:`.leases` — Phase 3b. Hand the live Windows lease set over as
+  reservations, so clients don't meet a Kea with an empty lease database.
+* :mod:`.switch` — Phase 3c. The switch itself, and the rollback.
+* :mod:`.checklist` — Phase 4. The decommission list.
+* :mod:`.runbook` — the generated operator runbook.
+* :mod:`.plans` — candidate discovery from the live Windows source.
+
+Everything is per-zone / per-scope. There is no big-bang path on purpose.
+"""
+
+from __future__ import annotations

--- a/backend/app/services/cutover/canonical.py
+++ b/backend/app/services/cutover/canonical.py
@@ -1,0 +1,370 @@
+"""Canonical dataclasses shared across the cutover workflow (issue #756).
+
+One module so parity, readiness, shadow, pre-flight, lease-handover, and the
+router all agree on the same shapes — the same reason the importers keep a
+``canonical.py``. Everything here is a plain dataclass with an ``as_dict()``
+so it can be persisted straight into the JSONB columns on ``cutover_item``
+and handed back over the API without a second translation layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+# ── Parity ─────────────────────────────────────────────────────────────
+
+#: How a single difference between SpatiumDDI and the live Windows server is
+#: explained to the operator. The distinction that matters for a migration is
+#: *why* the two sides differ, not merely that they do:
+#:
+#: ``drifted_since_import``
+#:     Windows has it, SpatiumDDI doesn't, and the SpatiumDDI object carries
+#:     import provenance — so it was imported once and Windows has moved on.
+#:     These are the ones a re-import (or a manual add) has to catch up.
+#: ``never_imported``
+#:     Windows has it, SpatiumDDI doesn't, and there is no import provenance —
+#:     the object was created here by hand, or imported from somewhere else.
+#:     Nothing "drifted"; it was simply never brought across.
+#: ``intentionally_diverged``
+#:     SpatiumDDI has it, Windows doesn't. Almost always an operator addition
+#:     made after the import. Surfaced, never auto-reconciled.
+#: ``value_mismatch``
+#:     Both sides have the name+type, with different data. Reported as one
+#:     difference rather than the missing+extra pair #61's drift report would
+#:     produce, because during a migration "the value changed" is a different
+#:     decision from "a record appeared".
+DiffClass = Literal[
+    "in_sync",
+    "drifted_since_import",
+    "never_imported",
+    "intentionally_diverged",
+    "value_mismatch",
+]
+
+#: Every non-``in_sync`` classification, in the order the UI should rank them.
+DIFF_CLASSES: tuple[DiffClass, ...] = (
+    "value_mismatch",
+    "drifted_since_import",
+    "never_imported",
+    "intentionally_diverged",
+)
+
+
+@dataclass
+class ParityDifference:
+    """One explained difference between the two sides."""
+
+    classification: DiffClass
+    #: Relative record label for DNS ("@" = apex); for DHCP, the facet that
+    #: differs ("lease_time", "pool", a reservation MAC, an option name).
+    name: str
+    #: Human-readable one-liner. Rendered verbatim in the UI.
+    detail: str
+    source_value: str | None = None
+    target_value: str | None = None
+    #: DNS record type, when the difference is about a record.
+    record_type: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "classification": self.classification,
+            "name": self.name,
+            "detail": self.detail,
+            "source_value": self.source_value,
+            "target_value": self.target_value,
+            "record_type": self.record_type,
+        }
+
+
+@dataclass
+class ParityReport:
+    """Result of comparing one SpatiumDDI object to its live Windows original.
+
+    ``status``:
+        ``ok``         — the pull succeeded and the diff below is meaningful.
+        ``unmatched``  — the object exists on one side only, so there is
+                         nothing to diff. ``error`` says which side is missing.
+        ``error``      — the pull failed (WinRM / auth / PowerShell). Never
+                         raises: a failed parity check must not take down a
+                         whole-plan run.
+        ``unverified`` — the pull *returned*, but its result cannot be trusted
+                         as an answer. The case that forces this to exist:
+                         ``WindowsDNSDriver._parse_records`` logs a warning and
+                         returns ``[]`` when the PowerShell output does not
+                         parse, which is byte-identical to a genuinely empty
+                         zone. Calling that "every record diverged" would be
+                         actively misleading, and calling it "in parity" would
+                         be dangerous, so it gets its own status.
+
+    ``not_compared`` counts records the source's read path physically cannot
+    report (see ``parity._comparable_record``). They are excluded from both
+    ``in_sync`` and ``differences`` because a difference there says something
+    about the reader, not about the two servers.
+    """
+
+    kind: str  # "dns_zone" | "dhcp_scope"
+    source_ref: str
+    status: str = "ok"
+    error: str | None = None
+    in_sync: int = 0
+    not_compared: int = 0
+    differences: list[ParityDifference] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def difference_count(self) -> int:
+        return len(self.differences)
+
+    @property
+    def is_parity(self) -> bool:
+        """True only when the pull worked *and* found nothing to reconcile.
+
+        A failed or unmatched pull is emphatically not parity — treating
+        "we couldn't check" as "it's fine" is how a migration breaks
+        resolution at 2am.
+        """
+        return self.status == "ok" and not self.differences
+
+    def counts_by_class(self) -> dict[str, int]:
+        out: dict[str, int] = {c: 0 for c in DIFF_CLASSES}
+        for d in self.differences:
+            if d.classification in out:
+                out[d.classification] += 1
+        return out
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "source_ref": self.source_ref,
+            "status": self.status,
+            "error": self.error,
+            "in_sync": self.in_sync,
+            "not_compared": self.not_compared,
+            "difference_count": self.difference_count,
+            "is_parity": self.is_parity,
+            "counts_by_class": self.counts_by_class(),
+            "differences": [d.as_dict() for d in self.differences],
+            "warnings": list(self.warnings),
+        }
+
+
+# ── Readiness / blockers ───────────────────────────────────────────────
+
+#: ``"block"`` refuses the cutover outright and cannot be forced.
+#: ``"warn"`` is surfaced, and can be acknowledged with ``force=true``.
+BlockerSeverity = Literal["block", "warn"]
+
+# Stable machine-readable blocker codes. The UI keys help text off these, so
+# renaming one is a breaking change — add a new code instead.
+BLOCKER_AD_SECURE_DDNS = "ad_secure_dynamic_update"
+BLOCKER_NO_TARGET_ZONE = "no_target_zone"
+BLOCKER_NO_TARGET_SCOPE = "no_target_scope"
+BLOCKER_NO_SOURCE_SERVER = "no_source_server"
+BLOCKER_SOURCE_ZONE_MISSING = "source_zone_missing"
+BLOCKER_SOURCE_SCOPE_MISSING = "source_scope_missing"
+BLOCKER_TARGET_GROUP_NO_SERVERS = "target_group_has_no_servers"
+BLOCKER_MANAGED_SCOPE_ACTIVE = "managed_scope_active"
+BLOCKER_PARITY_NOT_VERIFIED = "parity_not_verified"
+BLOCKER_PARITY_DIFFERENCES = "parity_differences"
+BLOCKER_MISSING_REVERSE_ZONE = "missing_reverse_zone"
+BLOCKER_AD_NONSECURE_DDNS = "ad_nonsecure_dynamic_update"
+BLOCKER_ZONE_IS_AD_INTEGRATED = "zone_is_ad_integrated"
+BLOCKER_TARGET_ZONE_VIEW_SCOPED = "target_zone_view_scoped"
+BLOCKER_SOURCE_SCOPE_INACTIVE = "source_scope_inactive"
+BLOCKER_LEASE_HANDOVER_PENDING = "lease_handover_pending"
+
+
+@dataclass
+class Blocker:
+    """One reason an item is not ready to be cut over.
+
+    ``message`` is operator-facing and should always state the fix, not just
+    the symptom — it is the only thing shown next to a refused cutover.
+    """
+
+    code: str
+    severity: BlockerSeverity
+    message: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "severity": self.severity, "message": self.message}
+
+
+def blocking(blockers: list[Blocker]) -> list[Blocker]:
+    """Only the entries that refuse a cutover outright."""
+    return [b for b in blockers if b.severity == "block"]
+
+
+# ── Shadow-query comparison ────────────────────────────────────────────
+
+
+@dataclass
+class ShadowSample:
+    """One name+type asked of both sides."""
+
+    name: str
+    qtype: str
+    #: Rendered rdata, sorted + normalised, per side.
+    source_answers: list[str] = field(default_factory=list)
+    target_answers: dict[str, list[str]] = field(default_factory=dict)
+    #: "match" | "mismatch" | "source_error" | "target_error"
+    verdict: str = "match"
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "qtype": self.qtype,
+            "source_answers": list(self.source_answers),
+            "target_answers": {k: list(v) for k, v in self.target_answers.items()},
+            "verdict": self.verdict,
+            "error": self.error,
+        }
+
+
+@dataclass
+class ShadowReport:
+    zone_name: str
+    source: str  # display label for the Windows server
+    targets: list[str] = field(default_factory=list)
+    #: Where the sampled names came from — "query_log" (real traffic) or
+    #: "zone_records" (fallback). Worth surfacing: parity demonstrated against
+    #: production traffic is a stronger claim than parity against our own rows.
+    sample_source: str = "zone_records"
+    sampled: int = 0
+    matched: int = 0
+    mismatched: int = 0
+    errors: int = 0
+    samples: list[ShadowSample] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "zone_name": self.zone_name,
+            "source": self.source,
+            "targets": list(self.targets),
+            "sample_source": self.sample_source,
+            "sampled": self.sampled,
+            "matched": self.matched,
+            "mismatched": self.mismatched,
+            "errors": self.errors,
+            "samples": [s.as_dict() for s in self.samples],
+            "warnings": list(self.warnings),
+        }
+
+
+# ── TTL pre-flight ─────────────────────────────────────────────────────
+
+
+@dataclass
+class TTLRecordChange:
+    record_id: str
+    name: str
+    record_type: str
+    current_ttl: int | None
+    new_ttl: int
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "record_id": self.record_id,
+            "name": self.name,
+            "record_type": self.record_type,
+            "current_ttl": self.current_ttl,
+            "new_ttl": self.new_ttl,
+        }
+
+
+@dataclass
+class TTLPreflightPlan:
+    target_ttl: int
+    zone_current: dict[str, int] = field(default_factory=dict)
+    zone_after: dict[str, int] = field(default_factory=dict)
+    records: list[TTLRecordChange] = field(default_factory=list)
+    #: Records already at or below ``target_ttl`` — left alone.
+    unchanged: int = 0
+    warnings: list[str] = field(default_factory=list)
+    #: What the operator must do on the Windows side, which we deliberately
+    #: do not do for them. See :mod:`app.services.cutover.preflight`.
+    source_side_instructions: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "target_ttl": self.target_ttl,
+            "zone_current": dict(self.zone_current),
+            "zone_after": dict(self.zone_after),
+            "records": [r.as_dict() for r in self.records],
+            "changed": len(self.records),
+            "unchanged": self.unchanged,
+            "warnings": list(self.warnings),
+            "source_side_instructions": self.source_side_instructions,
+        }
+
+
+# ── DHCP lease handover ────────────────────────────────────────────────
+
+#: ``create``   — will become a reservation on the managed scope.
+#: ``skip``     — deliberately not carried over; ``reason`` says why.
+#: ``conflict`` — carrying it over would contradict an existing reservation.
+LeaseAction = Literal["create", "skip", "conflict"]
+
+
+@dataclass
+class LeaseHandoverEntry:
+    ip_address: str
+    mac_address: str
+    hostname: str = ""
+    action: LeaseAction = "create"
+    reason: str = ""
+    #: Set on commit: "created" | "skipped" | "failed".
+    result: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "ip_address": self.ip_address,
+            "mac_address": self.mac_address,
+            "hostname": self.hostname,
+            "action": self.action,
+            "reason": self.reason,
+            "result": self.result,
+            "error": self.error,
+        }
+
+
+@dataclass
+class LeaseHandoverPlan:
+    scope_cidr: str
+    source_scope_id: str
+    entries: list[LeaseHandoverEntry] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    #: Populated on commit.
+    created: int = 0
+    skipped: int = 0
+    failed: int = 0
+
+    @property
+    def create_count(self) -> int:
+        return sum(1 for e in self.entries if e.action == "create")
+
+    @property
+    def skip_count(self) -> int:
+        return sum(1 for e in self.entries if e.action == "skip")
+
+    @property
+    def conflict_count(self) -> int:
+        return sum(1 for e in self.entries if e.action == "conflict")
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "scope_cidr": self.scope_cidr,
+            "source_scope_id": self.source_scope_id,
+            "entries": [e.as_dict() for e in self.entries],
+            "create_count": self.create_count,
+            "skip_count": self.skip_count,
+            "conflict_count": self.conflict_count,
+            "created": self.created,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "warnings": list(self.warnings),
+        }

--- a/backend/app/services/cutover/checklist.py
+++ b/backend/app/services/cutover/checklist.py
@@ -1,0 +1,649 @@
+"""Phase 4 decommission checklist for the Windows cutover (issue #756).
+
+The switch is the visible part of a migration; the decommission is the part
+that bites weeks later. A Windows DNS server left running with scavenging on
+quietly deletes the fallback copy of the zone. A DHCP server left *authorized
+in Active Directory* starts answering again the first time it is patched and
+rebooted, racing the managed scope for the same subnet. A conditional
+forwarder on one resolver in one branch office keeps a whole site resolving
+from a box everybody believes is retired.
+
+None of that is discoverable from the cutover state, so it is a checklist: a
+static catalog of the things that have to be true before the Windows side is
+switched off, with per-plan state so an operator's ticks and notes persist.
+
+Two rules shape the module:
+
+* **The catalog is versioned code, the ticks are data.** :func:`read_checklist`
+  merges the two at read time and writes nothing; a row appears only when the
+  operator first ticks or annotates a line
+  (:func:`upsert_checklist_row`). So a plan created three releases ago picks up
+  items added since — with their current wording — without losing a tick, and
+  without a page load turning into a database write.
+* **Auto-checks never tick a box.** :func:`evaluate_auto_checks` returns
+  advisory state next to each item. Some of the catalog is genuinely
+  answerable from the database, and surfacing that saves real work, but the
+  operator is the one who decides an item is done. A checklist that ticks
+  itself is a checklist nobody reads.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.cutover import CutoverChecklistItem, CutoverItem, CutoverPlan
+from app.models.dns import DNSRecord, DNSServerOptions, DNSZone
+
+__all__ = [
+    "CHECK_STATES",
+    "DECOMMISSION_CHECKLIST",
+    "ChecklistSpec",
+    "evaluate_auto_checks",
+    "ChecklistView",
+    "read_checklist",
+    "upsert_checklist_row",
+]
+
+
+@dataclass(frozen=True)
+class ChecklistSpec:
+    """One catalog entry. ``key`` is the stable identity — never rename one."""
+
+    key: str
+    category: str  # dns | dhcp | ad | general
+    label: str
+    description: str
+    applies_to: str  # dns_zone | dhcp_scope | general
+    sort_order: int
+
+
+#: Advisory states :func:`evaluate_auto_checks` reports.
+#:
+#: ``ok``             — evaluated, and nothing needs attention.
+#: ``attention``      — evaluated, and something does. The detail says what.
+#: ``not_applicable`` — the plan has nothing of the kind this item checks.
+#: ``manual``         — not machine-answerable; the operator has to look.
+STATE_OK = "ok"
+STATE_ATTENTION = "attention"
+STATE_NOT_APPLICABLE = "not_applicable"
+STATE_MANUAL = "manual"
+
+CHECK_STATES: frozenset[str] = frozenset(
+    {STATE_OK, STATE_ATTENTION, STATE_NOT_APPLICABLE, STATE_MANUAL}
+)
+
+
+DECOMMISSION_CHECKLIST: tuple[ChecklistSpec, ...] = (
+    # ── Active Directory ──────────────────────────────────────────────
+    ChecklistSpec(
+        key="dc_srv_registration",
+        category="ad",
+        label="Domain controllers re-registered their SRV records",
+        description=(
+            "Confirm every domain controller's _ldap._tcp / _kerberos._tcp / _gc._tcp SRV "
+            "records resolve from the SpatiumDDI servers. This is the loudest failure mode of "
+            "a DNS migration: clients locate a DC purely by SRV lookup, so if those records "
+            "are missing or stale, domain logon, Group Policy and Kerberos all fail at once — "
+            "and the error users see says nothing about DNS."
+        ),
+        applies_to="dns_zone",
+        sort_order=10,
+    ),
+    ChecklistSpec(
+        key="netlogon_dns_registration",
+        category="ad",
+        label="Netlogon re-registration forced on each DC",
+        description=(
+            "Run 'nltest /dsregdns' (or restart the Netlogon service) on every domain "
+            "controller after the delegation moves, and confirm the records land. DCs "
+            "otherwise only re-register on their own schedule — roughly hourly — so anything "
+            "the migration did not carry across can be absent for an hour with no warning."
+        ),
+        applies_to="dns_zone",
+        sort_order=20,
+    ),
+    ChecklistSpec(
+        key="ad_dns_scavenging",
+        category="ad",
+        label="Scavenging disabled on the retired Windows zones",
+        description=(
+            "Turn DNS scavenging off on the Windows copies of the migrated zones. While the "
+            "delegation points at SpatiumDDI the Windows zone is your rollback target, and "
+            "scavenging keeps quietly deleting its aged dynamic records — so a rollback three "
+            "days later restores a zone that has lost every dynamically-registered host."
+        ),
+        applies_to="dns_zone",
+        sort_order=30,
+    ),
+    ChecklistSpec(
+        key="ad_dynamic_update_permissions",
+        category="ad",
+        label="Dynamic-update sources repointed and permitted",
+        description=(
+            "Work out what still sends RFC 2136 / AD dynamic updates to the Windows zone and "
+            "repoint it, then grant it on the SpatiumDDI zone (per-zone update ACL, by TSIG "
+            "key or source address). Note the hard limit: SpatiumDDI does not implement "
+            "GSS-TSIG, so a zone set to 'Secure only' on Windows cannot have its secure "
+            "updates accepted here — that is why the cutover refuses such zones outright."
+        ),
+        applies_to="dns_zone",
+        sort_order=40,
+    ),
+    ChecklistSpec(
+        key="dhcp_ad_authorization",
+        category="ad",
+        label="Windows DHCP server deauthorized in Active Directory",
+        description=(
+            "Run 'Remove-DhcpServerInDC' for the retired server. Deactivating its scopes is "
+            "not enough: an authorized Windows DHCP server that is merely idle will start "
+            "answering again the first time the service restarts — a patch Tuesday reboot is "
+            "all it takes — and then two servers are leasing the same subnet. "
+            "Deauthorization is what makes that structurally impossible."
+        ),
+        applies_to="dhcp_scope",
+        sort_order=50,
+    ),
+    # ── DNS ───────────────────────────────────────────────────────────
+    ChecklistSpec(
+        key="conditional_forwarders",
+        category="dns",
+        label="Conditional forwarders and stub zones repointed",
+        description=(
+            "Find every resolver holding a conditional forwarder or stub zone aimed at the "
+            "Windows server and repoint it. These are configured per resolver and are "
+            "invisible from the zone itself, so one missed appliance in one branch office "
+            "keeps that whole site resolving from the old server — and the symptom is the "
+            "worst kind: 'it works for me'."
+        ),
+        applies_to="dns_zone",
+        sort_order=60,
+    ),
+    ChecklistSpec(
+        key="reverse_zone_ownership",
+        category="dns",
+        label="Reverse zones migrated alongside their forward zones",
+        description=(
+            "Check that the in-addr.arpa / ip6.arpa zones covering the migrated address space "
+            "moved too. A forward zone that migrates without its reverse looks completely "
+            "healthy until something does a PTR lookup — mail servers, log pipelines, SSH "
+            "reverse checks and some access-control lists all do, and they fail long after "
+            "the change window has closed."
+        ),
+        applies_to="dns_zone",
+        sort_order=70,
+    ),
+    ChecklistSpec(
+        key="zone_transfer_acls",
+        category="dns",
+        label="Zone-transfer ACLs reviewed on the migrated zones",
+        description=(
+            "Review allow-transfer on each migrated zone and revoke anything that was opened "
+            "for the migration itself. An imported zone can end up inheriting a permissive "
+            "group default, and a zone open to AXFR from anywhere hands an attacker a "
+            "complete map of the estate in one query."
+        ),
+        applies_to="dns_zone",
+        sort_order=80,
+    ),
+    ChecklistSpec(
+        key="wins_and_globalnames",
+        category="dns",
+        label="WINS / GlobalNames dependencies accounted for",
+        description=(
+            "Check the retired zones for WINS forward-lookup, WINS-R and GlobalNames-zone "
+            "configuration. These are Windows-specific single-label resolution paths with no "
+            "equivalent in BIND9, so anything still relying on them keeps working right up "
+            "until the Windows server stops — and then breaks in a way that does not look "
+            "like DNS at all."
+        ),
+        applies_to="general",
+        sort_order=90,
+    ),
+    # ── DHCP ──────────────────────────────────────────────────────────
+    ChecklistSpec(
+        key="dhcp_failover_peer",
+        category="dhcp",
+        label="Windows DHCP failover relationship removed",
+        description=(
+            "Delete the failover relationship covering the migrated scopes before retiring "
+            "the server. Deactivating one half of a Windows failover pair does not stop the "
+            "partner: it keeps serving the subnet and keeps trying to sync scope state, so "
+            "the subnet still has a second DHCP server handing out addresses."
+        ),
+        applies_to="dhcp_scope",
+        sort_order=100,
+    ),
+    ChecklistSpec(
+        key="resolver_dhcp_option",
+        category="dhcp",
+        label="DHCP option 6 (dns-servers) updated everywhere",
+        description=(
+            "Update every place that still hands clients the Windows resolver's address — "
+            "including scopes that are not part of this plan, and any statically-configured "
+            "hosts. This is the change with the longest tail: a client keeps the resolver "
+            "list it was given until its lease expires, so the last stragglers can be a full "
+            "lease time behind the switch."
+        ),
+        applies_to="general",
+        sort_order=110,
+    ),
+    # ── General decommission ──────────────────────────────────────────
+    ChecklistSpec(
+        key="monitoring_alerting",
+        category="general",
+        label="Monitoring and alerting moved to the SpatiumDDI servers",
+        description=(
+            "Repoint DNS/DHCP checks, dashboards and on-call alerts at the managed servers. "
+            "Until you do, the monitors keep going green against a box nobody uses while the "
+            "service that actually matters is unmonitored — the outage is invisible precisely "
+            "because the dashboard looks fine."
+        ),
+        applies_to="general",
+        sort_order=120,
+    ),
+    ChecklistSpec(
+        key="backup_retention",
+        category="general",
+        label="Final Windows DNS / DHCP export taken and retained",
+        description=(
+            "Export the Windows zones and the DHCP scope configuration one last time and "
+            "store it with your change record. Once the role is removed, that export is the "
+            "only remaining description of what Windows was serving; keep it at least as long "
+            "as your rollback horizon."
+        ),
+        applies_to="general",
+        sort_order=130,
+    ),
+    ChecklistSpec(
+        key="windows_dns_service_stop",
+        category="general",
+        label="Windows DNS Server service stopped (not uninstalled)",
+        description=(
+            "Once every zone in the plan is cut over and the old TTLs have expired, stop the "
+            "DNS Server service — and stop there. Stopping is the real test that nothing "
+            "still depends on it, and it is reversible in seconds; removing the role is not. "
+            "Leave the removal to a separate change once the zones have been quiet for a "
+            "full business cycle."
+        ),
+        applies_to="dns_zone",
+        sort_order=140,
+    ),
+    ChecklistSpec(
+        key="windows_dhcp_service_stop",
+        category="general",
+        label="Windows DHCP Server service stopped after the longest lease",
+        description=(
+            "Wait out the longest lease time on the migrated scopes before stopping the "
+            "service. A client that has not renewed still holds an address Windows issued; "
+            "stopping sooner leaves it with an address, no way to renew it, and no record of "
+            "it on the managed server."
+        ),
+        applies_to="dhcp_scope",
+        sort_order=150,
+    ),
+)
+
+
+@dataclass
+class ChecklistView:
+    """One checklist line as the API renders it.
+
+    The catalog supplies the presentation (label / description / category /
+    ``applies_to`` / ordering); the optional stored row supplies the operator's
+    state (``is_done`` / ``done_at`` / ``notes``). Merging them at read time is
+    what lets a plan created before a catalog entry existed pick it up with no
+    migration and no write.
+    """
+
+    key: str
+    category: str
+    label: str
+    description: str
+    applies_to: str
+    sort_order: int
+    is_done: bool = False
+    done_at: datetime | None = None
+    notes: str = ""
+
+
+def _view(spec: ChecklistSpec, row: CutoverChecklistItem | None) -> ChecklistView:
+    return ChecklistView(
+        key=spec.key,
+        category=spec.category,
+        label=spec.label,
+        description=spec.description,
+        applies_to=spec.applies_to,
+        sort_order=spec.sort_order,
+        is_done=bool(row.is_done) if row is not None else False,
+        done_at=row.done_at if row is not None else None,
+        notes=(row.notes or "") if row is not None else "",
+    )
+
+
+async def read_checklist(db: AsyncSession, *, plan: CutoverPlan) -> list[ChecklistView]:
+    """The plan's checklist, merged from the catalog and any stored state.
+
+    **Read-only.** Rows are created lazily by :func:`upsert_checklist_row` when
+    the operator first ticks or annotates a line — a plan with an untouched
+    checklist has no rows at all. That is deliberate: a GET that writes would
+    need an ``audit_log`` entry per non-negotiable #4, and would slip a database
+    write past the maintenance-mode middleware (#57), which gates on the HTTP
+    method. Neither is a thing a page load should be doing.
+
+    Keys stored on the plan but no longer in the catalog are appended at the
+    end rather than dropped: they carry an operator's tick and notes, and
+    silently discarding those to tidy up a list is how someone loses an audit
+    finding.
+    """
+    rows = (
+        (
+            await db.execute(
+                select(CutoverChecklistItem).where(CutoverChecklistItem.plan_id == plan.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    by_key: dict[str, CutoverChecklistItem] = {row.key: row for row in rows}
+    catalog_keys = {spec.key for spec in DECOMMISSION_CHECKLIST}
+
+    out = [_view(spec, by_key.get(spec.key)) for spec in DECOMMISSION_CHECKLIST]
+    out.extend(
+        ChecklistView(
+            key=row.key,
+            category=row.category,
+            label=row.label,
+            description=row.description,
+            applies_to=row.applies_to,
+            sort_order=row.sort_order,
+            is_done=row.is_done,
+            done_at=row.done_at,
+            notes=row.notes or "",
+        )
+        for key, row in sorted(by_key.items())
+        if key not in catalog_keys
+    )
+    return sorted(out, key=lambda v: (v.sort_order, v.key))
+
+
+async def upsert_checklist_row(
+    db: AsyncSession, *, plan: CutoverPlan, key: str
+) -> CutoverChecklistItem | None:
+    """Return the stored row for ``key``, creating it from the catalog if needed.
+
+    ``None`` when ``key`` is neither in the catalog nor already stored — the
+    router turns that into a 404 rather than minting a row for a typo.
+
+    Presentation fields are refreshed from the catalog on every call so improved
+    wording lands without touching ``is_done`` / ``done_at`` / ``notes``.
+    Flushes but does not commit; the caller owns the transaction.
+    """
+    row = (
+        await db.execute(
+            select(CutoverChecklistItem).where(
+                CutoverChecklistItem.plan_id == plan.id, CutoverChecklistItem.key == key
+            )
+        )
+    ).scalar_one_or_none()
+
+    spec = next((s for s in DECOMMISSION_CHECKLIST if s.key == key), None)
+    if spec is None:
+        return row  # stored-but-retired key, or nothing at all
+
+    if row is None:
+        row = CutoverChecklistItem(
+            plan_id=plan.id,
+            key=spec.key,
+            category=spec.category,
+            label=spec.label,
+            description=spec.description,
+            applies_to=spec.applies_to,
+            sort_order=spec.sort_order,
+            is_done=False,
+            notes="",
+        )
+        db.add(row)
+    else:
+        row.category = spec.category
+        row.label = spec.label
+        row.description = spec.description
+        row.applies_to = spec.applies_to
+        row.sort_order = spec.sort_order
+
+    await db.flush()
+    return row
+
+
+# ── advisory auto-checks ──────────────────────────────────────────────
+
+
+async def _plan_zones(db: AsyncSession, plan: CutoverPlan) -> list[DNSZone]:
+    """The live DNS zones this plan's ``dns_zone`` items point at."""
+    zone_ids = [
+        zid
+        for (zid,) in (
+            await db.execute(
+                select(CutoverItem.zone_id).where(
+                    CutoverItem.plan_id == plan.id,
+                    CutoverItem.kind == "dns_zone",
+                    CutoverItem.zone_id.is_not(None),
+                )
+            )
+        ).all()
+        if zid is not None
+    ]
+    if not zone_ids:
+        return []
+    return list((await db.execute(select(DNSZone).where(DNSZone.id.in_(zone_ids)))).scalars().all())
+
+
+# SRV owner prefixes a domain controller registers. Matched as a substring of
+# the record's relative name, because a DC registers them both at the zone apex
+# (``_ldap._tcp``) and under ``_msdcs`` / per-site labels.
+_AD_SRV_MARKERS: tuple[str, ...] = ("_ldap._tcp", "_kerberos._tcp", "_gc._tcp", "_kpasswd._tcp")
+
+
+async def _check_dc_srv(db: AsyncSession, zones: list[DNSZone]) -> dict[str, str]:
+    """Do any of the plan's zones still carry AD service records?"""
+    if not zones:
+        return {"state": STATE_NOT_APPLICABLE, "detail": "This plan contains no DNS zones."}
+
+    by_id = {z.id: z for z in zones}
+    rows = (
+        await db.execute(
+            select(DNSRecord.zone_id, DNSRecord.name).where(
+                DNSRecord.zone_id.in_(list(by_id)),
+                DNSRecord.record_type == "SRV",
+            )
+        )
+    ).all()
+
+    hits: dict[str, int] = {}
+    for zone_id, name in rows:
+        label = (name or "").lower()
+        if any(marker in label for marker in _AD_SRV_MARKERS):
+            zone = by_id.get(zone_id)
+            if zone is not None:
+                hits[zone.name] = hits.get(zone.name, 0) + 1
+
+    if not hits:
+        return {
+            "state": STATE_OK,
+            "detail": (
+                "No _ldap._tcp / _kerberos._tcp / _gc._tcp SRV records were found in this "
+                "plan's zones, so no domain controller appears to locate itself through them. "
+                "Confirm that matches your estate before ticking."
+            ),
+        }
+    listed = ", ".join(f"{name} ({count})" for name, count in sorted(hits.items()))
+    return {
+        "state": STATE_ATTENTION,
+        "detail": (
+            f"AD service records live in: {listed}. Verify every domain controller has "
+            "re-registered them against the SpatiumDDI servers before retiring Windows DNS."
+        ),
+    }
+
+
+def _reverse_zone_names_for(values: list[str]) -> set[str]:
+    """Map A-record values to the ``/24`` in-addr.arpa zone names covering them.
+
+    IPv6 is intentionally not derived: an AAAA record's reverse zone boundary
+    is a site convention (there is no ``/24`` equivalent), so guessing it would
+    report companions that were never supposed to exist.
+    """
+    out: set[str] = set()
+    for raw in values:
+        try:
+            addr = ipaddress.ip_address(str(raw).strip())
+        except ValueError:
+            continue
+        if not isinstance(addr, ipaddress.IPv4Address):
+            continue
+        # "3.2.1.10.in-addr.arpa" → drop the host octet → the /24's zone name.
+        pointer = addr.reverse_pointer.split(".", 1)[1]
+        out.add(f"{pointer}.".lower())
+    return out
+
+
+async def _check_reverse_zones(db: AsyncSession, zones: list[DNSZone]) -> dict[str, str]:
+    """Is every reverse companion of the plan's forward zones also migrating?"""
+    forward = [z for z in zones if z.kind != "reverse"]
+    if not forward:
+        return {
+            "state": STATE_NOT_APPLICABLE,
+            "detail": "This plan contains no forward DNS zones.",
+        }
+
+    in_plan = {z.name.lower() for z in zones}
+    values = [
+        str(v)
+        for (v,) in (
+            await db.execute(
+                select(DNSRecord.value)
+                .where(
+                    DNSRecord.zone_id.in_([z.id for z in forward]),
+                    DNSRecord.record_type == "A",
+                )
+                .limit(2000)
+            )
+        ).all()
+    ]
+    wanted = _reverse_zone_names_for(values) - in_plan
+    if not wanted:
+        return {
+            "state": STATE_OK,
+            "detail": (
+                "Every /24 reverse zone implied by the plan's A records is already part of "
+                "the plan."
+            ),
+        }
+
+    # Scoped to the groups this plan's own zones live in. An unscoped lookup
+    # would count a same-named reverse zone in an unrelated group (a lab, or
+    # the other half of a split-horizon deployment) as "managed", and tell the
+    # operator to add an existing zone to the plan when what they actually need
+    # is to create one — leaving the PTR gap this check exists to catch open.
+    group_ids = {z.group_id for z in zones}
+    known = {
+        name.lower()
+        for (name,) in (
+            await db.execute(
+                select(DNSZone.name).where(
+                    DNSZone.name.in_(sorted(wanted)),
+                    DNSZone.group_id.in_(group_ids),
+                )
+            )
+        ).all()
+    }
+    missing_from_plan = sorted(wanted & known)
+    unmanaged = sorted(wanted - known)
+
+    parts: list[str] = []
+    if missing_from_plan:
+        parts.append(
+            "managed in SpatiumDDI but not in this plan: " + ", ".join(missing_from_plan[:10])
+        )
+    if unmanaged:
+        parts.append("not present in SpatiumDDI at all: " + ", ".join(unmanaged[:10]))
+    return {
+        "state": STATE_ATTENTION,
+        "detail": (
+            "Reverse zones covering addresses in this plan's forward zones — "
+            + "; ".join(parts)
+            + ". PTR lookups for those addresses will not follow the cutover."
+        ),
+    }
+
+
+async def _check_transfer_acls(db: AsyncSession, zones: list[DNSZone]) -> dict[str, str]:
+    """Does any migrated zone end up transferable by anyone?
+
+    The effective ACL is the zone's own ``allow_transfer`` when set, otherwise
+    the server group's default — the same precedence the renderer uses — so a
+    zone that inherits a permissive group default is caught too.
+    """
+    if not zones:
+        return {"state": STATE_NOT_APPLICABLE, "detail": "This plan contains no DNS zones."}
+
+    group_ids = {z.group_id for z in zones}
+    group_default: dict[uuid.UUID, list] = {
+        opts.group_id: list(opts.allow_transfer or [])
+        for opts in (
+            (
+                await db.execute(
+                    select(DNSServerOptions).where(DNSServerOptions.group_id.in_(group_ids))
+                )
+            )
+            .scalars()
+            .all()
+        )
+    }
+
+    open_zones: list[str] = []
+    for zone in zones:
+        effective = zone.allow_transfer
+        if effective is None:
+            effective = group_default.get(zone.group_id, ["none"])
+        if any(str(entry).strip().lower() == "any" for entry in effective):
+            open_zones.append(zone.name)
+
+    if not open_zones:
+        return {
+            "state": STATE_OK,
+            "detail": "No migrated zone allows AXFR from 'any'.",
+        }
+    return {
+        "state": STATE_ATTENTION,
+        "detail": (
+            "allow-transfer resolves to 'any' for: "
+            + ", ".join(sorted(open_zones)[:10])
+            + ". Restrict these to the secondaries that actually need AXFR."
+        ),
+    }
+
+
+async def evaluate_auto_checks(db: AsyncSession, *, plan: CutoverPlan) -> dict[str, dict[str, str]]:
+    """Advisory state for each checklist item. **Never sets ``is_done``.**
+
+    Returns ``{key: {"state", "detail"}}`` for every catalog key, so the UI can
+    render one uniform column. Most entries come back ``manual`` — they are
+    about the state of a Windows box, a resolver in a branch office, or a
+    monitoring system, none of which SpatiumDDI can see. The three that *are*
+    answerable from our own data are evaluated properly, because they are also
+    the three an operator is most likely to get wrong.
+    """
+    out: dict[str, dict[str, str]] = {
+        spec.key: {"state": STATE_MANUAL, "detail": ""} for spec in DECOMMISSION_CHECKLIST
+    }
+    zones = await _plan_zones(db, plan)
+    out["dc_srv_registration"] = await _check_dc_srv(db, zones)
+    out["reverse_zone_ownership"] = await _check_reverse_zones(db, zones)
+    out["zone_transfer_acls"] = await _check_transfer_acls(db, zones)
+    return out

--- a/backend/app/services/cutover/leases.py
+++ b/backend/app/services/cutover/leases.py
@@ -1,0 +1,391 @@
+"""DHCP lease handover — Phase 3b of the Windows cutover (issue #756).
+
+The DHCP importer (#129) deliberately carries scopes, pools, options and
+*reservations* across and stops there: leases are ephemeral state, and an
+importer that invents reservations out of them would be lying about operator
+intent. A **cutover** is the one moment where that trade flips. At the instant
+the managed scope starts answering, Kea's lease database is empty — so the
+first client to renew is handed a fresh address out of the pool while it is
+still using, and still answering on, the one Windows gave it. On a busy
+subnet that is a wave of duplicate-address complaints during the exact window
+an operator is least able to absorb them.
+
+This module closes that gap: it reads the live Windows lease set and turns
+each one into a :class:`DHCPStaticAssignment` on the managed scope, so a
+renewing client gets **the address it already holds**. The reservations are
+stamped ``import_source="windows_cutover"`` so they are trivially identifiable
+afterwards — an operator who wants the addresses back in the dynamic pool can
+find and drop exactly this set once leases have naturally churned.
+
+Three things are load-bearing here:
+
+* **Scope selection is by subnet CIDR.** The driver's neutral lease dict
+  (``WindowsDHCPReadOnlyDriver.get_leases``) carries no scope id, so
+  containment in the managed scope's subnet is what decides whether a lease
+  belongs to this item. Every lease the server reported still gets an explicit
+  disposition in the plan rather than silently vanishing — an operator
+  reviewing a handover should be able to account for the whole lease table.
+* **Nothing is created that would contradict an existing reservation.** The
+  ``uq_dhcp_static_scope_mac`` / ``uq_dhcp_static_scope_ip`` partial unique
+  indexes are on *live* rows, so a duplicate is an ``IntegrityError`` at flush
+  and not a silent no-op. Duplicates are classified up front, and the commit
+  re-checks against live DB state rather than trusting a stale preview.
+* **Each create gets its own savepoint.** One reservation that cannot be
+  written (a racing operator edit, an IPAM mirror collision) must never roll
+  back the ones that already succeeded — same ledger idiom the importers use.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_wake import collect_wake, dhcp_group_channel
+from app.core.dns_names import sanitize_hostname
+from app.drivers.dhcp.windows import WindowsDHCPReadOnlyDriver
+from app.models.auth import User
+from app.models.cutover import CutoverItem
+from app.models.dhcp import DHCPScope, DHCPServer, DHCPStaticAssignment
+from app.models.ipam import Subnet
+from app.services.cutover.canonical import LeaseHandoverEntry, LeaseHandoverPlan
+from app.services.dhcp.static_ipam import upsert_ipam_for_static
+from app.services.dhcp_import.options import normalise_mac
+
+logger = structlog.get_logger(__name__)
+
+#: Provenance stamped on every reservation this module creates. 15 characters,
+#: so it fits ``DHCPStaticAssignment.import_source`` (``String(20)``), and it is
+#: distinct from the importer's ``windows_dhcp`` on purpose: these rows were
+#: synthesised from *leases* at cutover, not read from the server's config.
+CUTOVER_IMPORT_SOURCE = "windows_cutover"
+
+_IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+__all__ = [
+    "CUTOVER_IMPORT_SOURCE",
+    "commit_lease_handover",
+    "preview_lease_handover",
+]
+
+
+async def _scope_network(db: AsyncSession, scope: DHCPScope) -> tuple[Subnet, _IPNetwork]:
+    """Resolve the managed scope's IPAM subnet and its parsed CIDR."""
+    subnet = await db.get(Subnet, scope.subnet_id)
+    if subnet is None:
+        raise ValueError(
+            f"DHCP scope {scope.id} points at IPAM subnet {scope.subnet_id}, which no longer "
+            "exists — re-link the scope before handing leases over."
+        )
+    try:
+        network = ipaddress.ip_network(str(subnet.network), strict=False)
+    except ValueError as exc:
+        raise ValueError(f"IPAM subnet {subnet.network!r} is not a parseable CIDR: {exc}") from exc
+    return subnet, network
+
+
+async def _live_reservation_maps(
+    db: AsyncSession, scope_id: Any
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Return ``(mac → ip, ip → mac)`` for the scope's **live** reservations.
+
+    Soft-deleted rows are excluded by the global filter, which is exactly right:
+    the unique indexes these maps guard against are themselves partial on
+    ``deleted_at IS NULL``, so a trashed reservation holds no slot.
+    """
+    rows = (
+        await db.execute(
+            select(DHCPStaticAssignment.mac_address, DHCPStaticAssignment.ip_address).where(
+                DHCPStaticAssignment.scope_id == scope_id
+            )
+        )
+    ).all()
+    mac_to_ip: dict[str, str] = {}
+    ip_to_mac: dict[str, str] = {}
+    for mac, ip in rows:
+        mac_s = str(mac).lower()
+        ip_s = str(ip)
+        mac_to_ip[mac_s] = ip_s
+        ip_to_mac[ip_s] = mac_s
+    return mac_to_ip, ip_to_mac
+
+
+def _in_network(ip: str, network: _IPNetwork) -> bool:
+    try:
+        return ipaddress.ip_address(ip) in network
+    except ValueError:
+        return False
+
+
+def _classify(
+    *,
+    ip: str,
+    mac: str,
+    network: _IPNetwork,
+    mac_to_ip: dict[str, str],
+    ip_to_mac: dict[str, str],
+) -> tuple[str, str]:
+    """Decide one lease's disposition. Returns ``(action, reason)``.
+
+    ``mac_to_ip`` / ``ip_to_mac`` describe the reservations that already exist
+    (or are already planned) on the managed scope, so the caller can feed
+    planned rows back in and catch duplicates *within* one handover as well as
+    against the database.
+    """
+    if not _in_network(ip, network):
+        return "skip", f"{ip} is outside the managed scope's subnet {network} — another scope"
+
+    reserved_ip = mac_to_ip.get(mac)
+    reserved_mac = ip_to_mac.get(ip)
+
+    if reserved_ip == ip:
+        # Same MAC, same IP: the reservation the handover would create is
+        # already there (a re-run, or the importer brought it across).
+        return "skip", "already reserved on the managed scope with this address"
+    if reserved_ip is not None:
+        return (
+            "conflict",
+            f"MAC is already reserved to {reserved_ip} on this scope; the Windows lease says {ip}",
+        )
+    if reserved_mac is not None:
+        return (
+            "conflict",
+            f"{ip} is already reserved to MAC {reserved_mac} on this scope",
+        )
+    return "create", ""
+
+
+async def preview_lease_handover(
+    db: AsyncSession,
+    *,
+    source_server: DHCPServer,
+    scope: DHCPScope,
+    source_scope_id: str,
+) -> LeaseHandoverPlan:
+    """Build the handover plan without writing anything.
+
+    Pulls the live lease table off the Windows server (``get_leases`` already
+    filters to the states Windows considers live) and classifies every lease
+    against the managed scope: ``create`` for one that will become a
+    reservation, ``skip`` for one that belongs to a different scope / is
+    already reserved / has no usable MAC, ``conflict`` for one whose MAC or
+    address is already spoken for by a *different* reservation.
+
+    ``source_scope_id`` is only used for reporting and a sanity warning — the
+    driver's neutral lease dict has no scope id, so subnet containment is what
+    actually selects this scope's leases.
+    """
+    _subnet, network = await _scope_network(db, scope)
+    plan = LeaseHandoverPlan(scope_cidr=str(network), source_scope_id=source_scope_id)
+
+    declared = (source_scope_id or "").strip()
+    if declared and declared != str(network.network_address):
+        plan.warnings.append(
+            f"The Windows scope id on this item is {declared}, but the managed scope's subnet is "
+            f"{network}. Leases are selected by subnet containment, so double-check the item is "
+            "pointing at the right scope."
+        )
+
+    driver = WindowsDHCPReadOnlyDriver()
+    leases = await driver.get_leases(source_server)
+    if not leases:
+        plan.warnings.append(
+            f"{source_server.name} reported no active leases. If the scope is busy, check the "
+            "service account can read leases before treating this as a clean handover."
+        )
+
+    mac_to_ip, ip_to_mac = await _live_reservation_maps(db, scope.id)
+    # Planned rows fold into the same maps so two leases in one pull can't both
+    # claim a MAC or an address and then collide at flush time.
+    planned_mac_to_ip: dict[str, str] = dict(mac_to_ip)
+    planned_ip_to_mac: dict[str, str] = dict(ip_to_mac)
+
+    foreign = 0
+    unusable_mac = 0
+    for lease in leases:
+        ip = str(lease.get("ip_address") or "").strip()
+        mac = normalise_mac(lease.get("mac_address") or lease.get("client_id"))
+        hostname = sanitize_hostname(lease.get("hostname"))
+        if not ip:
+            continue
+        if mac is None:
+            unusable_mac += 1
+            plan.entries.append(
+                LeaseHandoverEntry(
+                    ip_address=ip,
+                    mac_address=str(lease.get("mac_address") or lease.get("client_id") or ""),
+                    hostname=hostname,
+                    action="skip",
+                    reason="no usable MAC address on the lease — nothing to key a reservation on",
+                )
+            )
+            continue
+
+        action, reason = _classify(
+            ip=ip,
+            mac=mac,
+            network=network,
+            mac_to_ip=planned_mac_to_ip,
+            ip_to_mac=planned_ip_to_mac,
+        )
+        if action == "skip" and not _in_network(ip, network):
+            foreign += 1
+        if action == "create":
+            planned_mac_to_ip[mac] = ip
+            planned_ip_to_mac[ip] = mac
+        plan.entries.append(
+            LeaseHandoverEntry(
+                ip_address=ip,
+                mac_address=mac,
+                hostname=hostname,
+                action=action,  # type: ignore[arg-type]  # narrowed by _classify
+                reason=reason,
+            )
+        )
+
+    if foreign:
+        plan.warnings.append(
+            f"{foreign} lease(s) belong to other scopes on {source_server.name} and are listed "
+            "as skipped. Hand those over from their own cutover items."
+        )
+    if unusable_mac:
+        plan.warnings.append(
+            f"{unusable_mac} lease(s) carry a client id that is not a MAC address and cannot "
+            "become a reservation."
+        )
+    if plan.conflict_count:
+        plan.warnings.append(
+            f"{plan.conflict_count} lease(s) contradict a reservation that already exists on the "
+            "managed scope. Resolve those by hand — the handover will not overwrite them."
+        )
+    return plan
+
+
+async def commit_lease_handover(
+    db: AsyncSession,
+    *,
+    source_server: DHCPServer,
+    scope: DHCPScope,
+    item: CutoverItem,
+    plan: LeaseHandoverPlan,
+    current_user: User,
+) -> LeaseHandoverPlan:
+    """Write the ``create`` entries of ``plan`` as reservations on ``scope``.
+
+    Each row is written inside its own ``db.begin_nested()`` savepoint together
+    with its IPAM mirror, so one failure fails exactly one entry and the rest of
+    the batch still lands. The per-entry outcome is recorded back onto the
+    ``LeaseHandoverEntry`` (``result`` / ``error``) and the rollup onto
+    ``item.lease_handover``.
+
+    The plan is re-validated against **live** DB state as it goes rather than
+    trusted: an operator may have added a reservation between the preview and
+    the commit, and the unique indexes would turn that into an
+    ``IntegrityError`` at flush.
+
+    Does not commit — the calling router owns the transaction (and the audit
+    row, and the timeline event).
+    """
+    _subnet, network = await _scope_network(db, scope)
+    mac_to_ip, ip_to_mac = await _live_reservation_maps(db, scope.id)
+
+    now = datetime.now(UTC)
+    description = f"Carried over from {source_server.name} at cutover"
+    created = skipped = failed = 0
+
+    for entry in plan.entries:
+        if entry.action != "create":
+            entry.result = "skipped"
+            skipped += 1
+            continue
+
+        action, reason = _classify(
+            ip=entry.ip_address,
+            mac=entry.mac_address,
+            network=network,
+            mac_to_ip=mac_to_ip,
+            ip_to_mac=ip_to_mac,
+        )
+        if action != "create":
+            # State moved under the preview — record why and move on.
+            entry.action = action  # type: ignore[assignment]  # narrowed by _classify
+            entry.reason = reason
+            entry.result = "skipped"
+            skipped += 1
+            continue
+
+        st = DHCPStaticAssignment(
+            scope_id=scope.id,
+            ip_address=entry.ip_address,
+            mac_address=entry.mac_address,
+            hostname=entry.hostname or "",
+            description=description,
+            # ``client_id`` deliberately left NULL. The Kea driver renders it as
+            # the DHCP option-61 client-identifier a client must present for the
+            # reservation to match; Windows' ClientId is just the hardware
+            # address in dash form, so copying it across would narrow the match
+            # to clients sending an option 61 they mostly do not send — the
+            # precise failure this handover exists to prevent. hw-address alone
+            # is the reliable key.
+            import_source=CUTOVER_IMPORT_SOURCE,
+            imported_at=now,
+            created_by_user_id=current_user.id,
+        )
+        try:
+            async with db.begin_nested():
+                db.add(st)
+                await db.flush()
+                await upsert_ipam_for_static(db, scope, st, action="create")
+        except Exception as exc:  # noqa: BLE001 — one bad row must not sink the batch
+            entry.result = "failed"
+            entry.error = str(exc)
+            failed += 1
+            logger.warning(
+                "cutover_lease_handover_row_failed",
+                scope_id=str(scope.id),
+                ip=entry.ip_address,
+                mac=entry.mac_address,
+                error=str(exc),
+            )
+            continue
+
+        entry.result = "created"
+        created += 1
+        mac_to_ip[entry.mac_address] = entry.ip_address
+        ip_to_mac[entry.ip_address] = entry.mac_address
+
+    plan.created = created
+    plan.skipped = skipped
+    plan.failed = failed
+    item.lease_handover = {
+        "created": created,
+        "skipped": skipped,
+        "failed": failed,
+        "at": now.isoformat(),
+    }
+    # A clean run is the DHCP half of "pre-flight done" — the managed scope now
+    # knows every address currently in use. A run with failures leaves the stage
+    # alone so the operator is not told the pre-flight finished.
+    if failed == 0 and item.stage in {"pending", "parity_checked"}:
+        item.stage = "preflight_done"
+
+    if created:
+        # New reservations change the rendered scope, so the group's parked
+        # agents should re-read rather than wait out the safety tick. Advisory
+        # only — the config-bundle ETag stays the source of truth.
+        collect_wake(dhcp_group_channel(scope.group_id))
+
+    logger.info(
+        "cutover_lease_handover_committed",
+        plan_id=str(item.plan_id),
+        item_id=str(item.id),
+        scope_id=str(scope.id),
+        created=created,
+        skipped=skipped,
+        failed=failed,
+    )
+    return plan

--- a/backend/app/services/cutover/parity.py
+++ b/backend/app/services/cutover/parity.py
@@ -1,0 +1,787 @@
+"""Phase 1 parity — what SpatiumDDI holds vs what Windows is serving *now* (#756).
+
+The importers (#128 / #129) prove nothing about the present: they loaded a
+snapshot, and the Windows server has kept running since. Before anyone reroutes
+traffic, the operator has to be able to say "these two answer the same". That is
+what this module computes, per zone and per scope.
+
+It is deliberately close to, but not the same as, the #61 drift report:
+
+* #61 keys on ``(name, type, value)`` and so reports a *changed* record as a
+  missing+extra pair. During a migration that reads as two problems when it is
+  one decision, so parity buckets on ``(name, type)`` first and pairs the
+  leftovers into a single :data:`~app.services.cutover.canonical.ParityDifference`
+  with ``classification="value_mismatch"``.
+* #61 answers "is my managed estate converged". Parity answers "may I stop
+  serving this from Windows", so a record only Windows has is classified by
+  *why* it is only there — ``drifted_since_import`` when the SpatiumDDI object
+  carries import provenance, ``never_imported`` when it does not.
+
+Identity and value normalisation are reused verbatim from
+:func:`app.services.dns.pull_from_server._key`, so relative-vs-FQDN storage and
+TTL-only differences do not register as parity failures — the same rule the
+additive sync and the drift report already apply. TTLs are the pre-flight step's
+business (:mod:`app.services.cutover.preflight`), not parity's.
+
+Nothing here raises for a per-object failure: an unreachable server or a
+PowerShell error comes back as ``status="error"`` on the report, because a
+whole-plan parity run fans out over every item and one dead host must not take
+the rest of the report with it.
+
+**Session note for callers that fan out.** Both entry points read from ``db``
+*before* they touch the network, and never afterwards. Running several of them
+concurrently against the same :class:`~sqlalchemy.ext.asyncio.AsyncSession` is
+still unsafe (one session, one operation at a time) — a whole-plan run should
+collect the DB-side inputs it needs first, or await these sequentially.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from collections import Counter
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dhcp import get_driver as get_dhcp_driver
+from app.drivers.dns import get_driver as get_dns_driver
+from app.drivers.dns._axfr import _DNSSEC_ARTEFACTS
+from app.drivers.dns.base import RecordData
+from app.drivers.dns.windows import _PULL_RECORD_TYPES
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPServer, DHCPStaticAssignment
+from app.models.dns import DNSRecord, DNSServer, DNSZone
+from app.models.ipam import Subnet
+from app.services.cutover.canonical import ParityDifference, ParityReport
+from app.services.dhcp_import.options import normalise_mac
+from app.services.dns.pull_from_server import _key
+
+logger = structlog.get_logger(__name__)
+
+
+# Carried verbatim from #61 (``app.services.dns.drift``): the same caveats apply
+# to a parity pull, for the same reason — an AXFR is addressed by zone name, not
+# by view, so under split horizon the wire may be answering from a different view
+# than the row we are diffing.
+_SPLIT_HORIZON_ZONE_WARNING = (
+    "This zone belongs to a DNS view. A zone transfer is answered by "
+    "whichever view matches the control plane's source address, so "
+    "differences below may reflect a different view rather than real drift."
+)
+_SPLIT_HORIZON_RECORD_WARNING = (
+    "Some records in this zone are scoped to a specific DNS view and are "
+    "only served to clients matching it. They may appear as missing here "
+    "even when the server is correct."
+)
+
+
+def _comparable_record(source_server: DNSServer, name: str, rtype: str) -> bool:
+    """Can the source's read path see this record type at all?
+
+    ``WindowsDNSDriver.pull_zone_records`` picks its path from
+    ``bool(server.credentials_encrypted)`` alone — ``capabilities()`` is a
+    static dict and says nothing about it — and the two paths are blind to
+    different things:
+
+    * **Path B** (WinRM ``Get-DnsServerResourceRecord``) maps only
+      ``_PULL_RECORD_TYPES``. Anything else reaches the parser as a raw
+      ``.ToString()`` it refuses to guess at, so a CAA / TLSA / SSHFP / NAPTR /
+      LOC row in the database would read as "Windows does not have it" purely
+      because the PowerShell walker cannot emit it.
+    * **Path A** (AXFR) has no type allowlist but strips DNSSEC artefacts,
+      which the signing daemon mints and rotates and which never exist as
+      SpatiumDDI records anyway.
+
+    Both paths also drop the SOA and the apex NS set, which SpatiumDDI manages
+    as zone-level fields rather than as records.
+
+    Excluding these from the diff — rather than letting them fall out as
+    ``intentionally_diverged`` — is the difference between a parity report an
+    operator can act on and one that sends them to "fix" records that are
+    already correct on both sides. They are counted into ``not_compared`` and
+    surfaced as a warning instead.
+    """
+    if rtype == "SOA":
+        return False
+    if rtype == "NS" and name in ("", "@"):
+        return False
+    if rtype in _DNSSEC_ARTEFACTS:
+        return False
+    if getattr(source_server, "credentials_encrypted", None):
+        return rtype in _PULL_RECORD_TYPES
+    return True
+
+
+# ── shared helpers ─────────────────────────────────────────────────────
+
+
+def _display_name(raw: str | None) -> str:
+    """Record label for the report — apex records read better as ``@``."""
+    name = (raw or "").strip()
+    return name or "@"
+
+
+def normalise_ip(raw: Any) -> str:
+    """Canonicalise an address for comparison, tolerating junk.
+
+    Postgres ``INET`` and PowerShell both hand back dotted-quad strings, but
+    they can disagree on IPv6 zero-compression, so both sides go through
+    :mod:`ipaddress`. A value that will not parse is compared as lowercased
+    text rather than dropped — a malformed address on one side is exactly the
+    kind of difference the operator wants to see.
+    """
+    text = str(raw or "").strip()
+    if not text:
+        return ""
+    try:
+        return str(ipaddress.ip_address(text))
+    except ValueError:
+        return text.lower()
+
+
+def normalise_option_value(value: Any) -> str:
+    """Render a DHCP option value as one stable comparable string.
+
+    Windows emits every option as a PowerShell array; the importer collapses
+    single-element arrays to scalars for the options Kea treats as scalar
+    (:func:`app.services.dhcp_import.options.coerce_option_value`). So the same
+    configuration legitimately arrives as ``["corp.local"]`` on one side and
+    ``"corp.local"`` on the other. Flattening both to a joined string makes that
+    a non-difference while a genuinely different list still compares unequal.
+
+    Case is preserved: ``bootfile-name`` and ``tftp-server-name`` are passed to
+    case-sensitive TFTP servers, so folding case here would hide a real break.
+    """
+    if value is None:
+        return ""
+    items = list(value) if isinstance(value, list | tuple) else [value]
+    return ", ".join(str(v).strip() for v in items)
+
+
+# ── DNS ────────────────────────────────────────────────────────────────
+
+
+def _bucket_records(
+    rows: list[Any], zone_name: str
+) -> dict[tuple[str, str], list[tuple[str, Any]]]:
+    """Group records by ``(name, type)``, carrying each one's canonical value.
+
+    The ``(name, type, value)`` triple from
+    :func:`app.services.dns.pull_from_server._key` is split: the first two
+    elements form the bucket, the third is the normalised value used for
+    multiset matching inside it.
+    """
+    buckets: dict[tuple[str, str], list[tuple[str, Any]]] = {}
+    for row in rows:
+        name, rtype, value = _key(row, zone_name)
+        buckets.setdefault((name, rtype), []).append((value, row))
+    return buckets
+
+
+def _split_bucket(
+    wire_items: list[tuple[str, Any]], db_items: list[tuple[str, Any]]
+) -> tuple[int, list[Any], list[Any]]:
+    """Multiset-match one ``(name, type)`` bucket.
+
+    Returns ``(matched_count, wire_only, db_only)``. Duplicates are handled by
+    count rather than by set membership, so a zone with three A records at the
+    same name where Windows has four reports exactly one leftover, not zero.
+    """
+    remaining: Counter[str] = Counter(value for value, _ in db_items)
+
+    matched = 0
+    wire_only: list[Any] = []
+    for value, row in wire_items:
+        if remaining[value] > 0:
+            remaining[value] -= 1
+            matched += 1
+        else:
+            wire_only.append(row)
+
+    # Whatever is still counted in ``remaining`` had no partner on the wire.
+    # Walk the DB rows in their original order and take that many of each value
+    # so the leftovers are real rows (with ids), not just value strings.
+    db_only: list[Any] = []
+    for value, row in db_items:
+        if remaining[value] > 0:
+            remaining[value] -= 1
+            db_only.append(row)
+
+    return matched, wire_only, db_only
+
+
+def _windows_only_class(zone: DNSZone) -> str:
+    """Why does Windows have a record SpatiumDDI does not?
+
+    Provenance is the only evidence available: if the zone was imported, the
+    object came across once and Windows has moved on since (``drifted``). If it
+    was not, nothing drifted — it was simply never brought over.
+    """
+    return "drifted_since_import" if zone.import_source else "never_imported"
+
+
+async def compute_dns_parity(
+    db: AsyncSession,
+    *,
+    source_server: DNSServer,
+    zone: DNSZone,
+    source_zone_name: str,
+) -> ParityReport:
+    """Diff ``zone``'s records against what ``source_server`` serves live.
+
+    ``source_zone_name`` is the zone's name on the *Windows* side (no trailing
+    dot required); it can differ in trailing-dot form from ``zone.name``, which
+    is what the value normaliser uses as the origin for both sides.
+
+    Never raises for a source-side failure — an unknown driver, a driver that
+    cannot pull records, or a WinRM/PowerShell error all come back as
+    ``status="error"`` with the message.
+    """
+    report = ParityReport(kind="dns_zone", source_ref=source_zone_name)
+
+    db_rows = list(
+        (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id))).scalars().all()
+    )
+
+    if zone.view_id is not None:
+        report.warnings.append(_SPLIT_HORIZON_ZONE_WARNING)
+    elif any(r.view_id is not None for r in db_rows):
+        report.warnings.append(_SPLIT_HORIZON_RECORD_WARNING)
+
+    try:
+        driver = get_dns_driver(source_server.driver)
+    except ValueError as exc:
+        report.status = "error"
+        report.error = str(exc)
+        return report
+
+    if not hasattr(driver, "pull_zone_records"):
+        report.status = "error"
+        report.error = (
+            f"DNS driver {source_server.driver!r} cannot read live records, so parity "
+            "against it cannot be established. Only the Windows DNS driver "
+            "(and any driver implementing pull_zone_records) is supported as a "
+            "cutover source."
+        )
+        return report
+
+    try:
+        on_wire: list[RecordData] = await driver.pull_zone_records(source_server, source_zone_name)
+    except Exception as exc:  # noqa: BLE001 — per-item; a whole-plan run fans these out
+        report.status = "error"
+        report.error = str(exc)
+        logger.warning(
+            "cutover.parity.dns_pull_failed",
+            zone=zone.name,
+            source_zone=source_zone_name,
+            server=str(source_server.id),
+            driver=source_server.driver,
+            error=str(exc),
+        )
+        return report
+
+    wire_buckets = _bucket_records(list(on_wire), zone.name)
+    db_buckets = _bucket_records(db_rows, zone.name)
+    windows_only_class = _windows_only_class(zone)
+
+    # An empty pull is NOT proof of an empty zone. ``_parse_records`` logs
+    # ``windows_dns_record_parse_failed`` and returns ``[]`` on unparseable
+    # output — indistinguishable from a zone with no records (contrast the DHCP
+    # lease parser, which raises, #426). Reporting every DB row as
+    # "SpatiumDDI-only" off the back of a transient PowerShell failure is the
+    # worst possible answer, so the report says it could not be established
+    # instead.
+    if not on_wire and db_rows:
+        report.status = "unverified"
+        report.error = (
+            f"The pull from {source_server.name} returned no records at all while "
+            f"SpatiumDDI holds {len(db_rows)}. That is either a genuinely empty zone "
+            "on Windows or a failed read that came back empty — the two are "
+            "indistinguishable from here. Re-run the parity check, and check the "
+            "server logs for a record-parse warning before trusting a clean result."
+        )
+        return report
+
+    not_compared = 0
+    uncomparable_types: set[str] = set()
+
+    for bucket in sorted(set(wire_buckets) | set(db_buckets)):
+        name, rtype = bucket
+        label = _display_name(name)
+
+        if not _comparable_record(source_server, name, rtype):
+            not_compared += len(wire_buckets.get(bucket, [])) + len(db_buckets.get(bucket, []))
+            uncomparable_types.add(rtype)
+            continue
+        matched, wire_only, db_only = _split_bucket(
+            wire_buckets.get(bucket, []), db_buckets.get(bucket, [])
+        )
+        report.in_sync += matched
+
+        # Pair leftovers positionally: the same name+type on both sides with
+        # different data is one changed record, not one addition plus one
+        # removal. Order within a bucket is arbitrary, so the pairing is too —
+        # it only decides which value lands opposite which, and every leftover
+        # is reported either way.
+        paired = min(len(wire_only), len(db_only))
+        for wire_row, db_row in zip(wire_only[:paired], db_only[:paired], strict=True):
+            report.differences.append(
+                ParityDifference(
+                    classification="value_mismatch",
+                    name=label,
+                    record_type=rtype,
+                    detail=(
+                        f"{label} {rtype} exists on both sides with different data. "
+                        "Decide which value is correct before cutting over."
+                    ),
+                    source_value=wire_row.value,
+                    target_value=db_row.value,
+                )
+            )
+
+        for wire_row in wire_only[paired:]:
+            if windows_only_class == "drifted_since_import":
+                detail = (
+                    f"{label} {rtype} is served by Windows but missing from SpatiumDDI. "
+                    f"This zone was imported from {zone.import_source!r}, so it was added "
+                    "or changed on Windows afterwards — re-import or add it here."
+                )
+            else:
+                detail = (
+                    f"{label} {rtype} is served by Windows but missing from SpatiumDDI. "
+                    "This zone carries no import provenance, so the record was never "
+                    "brought across — add it here before cutting over."
+                )
+            report.differences.append(
+                ParityDifference(
+                    classification=windows_only_class,  # type: ignore[arg-type]
+                    name=label,
+                    record_type=rtype,
+                    detail=detail,
+                    source_value=wire_row.value,
+                    target_value=None,
+                )
+            )
+
+        for db_row in db_only[paired:]:
+            report.differences.append(
+                ParityDifference(
+                    classification="intentionally_diverged",
+                    name=label,
+                    record_type=rtype,
+                    detail=(
+                        f"{label} {rtype} exists in SpatiumDDI but is not served by "
+                        "Windows. Usually an addition made here after the import; "
+                        "it will start being served at cutover."
+                    ),
+                    source_value=None,
+                    target_value=db_row.value,
+                )
+            )
+
+    report.not_compared = not_compared
+    if not_compared:
+        report.warnings.append(
+            f"{not_compared} record(s) of type "
+            f"{', '.join(sorted(uncomparable_types))} were not compared: the source "
+            "server's read path cannot report them, so a difference here would be an "
+            "artefact of the reader rather than real. Verify those types by hand."
+        )
+
+    logger.info(
+        "cutover.parity.dns",
+        zone=zone.name,
+        source_zone=source_zone_name,
+        server=str(source_server.id),
+        on_wire=len(on_wire),
+        in_db=len(db_rows),
+        in_sync=report.in_sync,
+        not_compared=not_compared,
+        differences=report.difference_count,
+    )
+    return report
+
+
+# ── DHCP ───────────────────────────────────────────────────────────────
+
+
+def match_source_scope(
+    scopes: list[dict[str, Any]], *, subnet_cidr: str, source_scope_id: str
+) -> dict[str, Any] | None:
+    """Find the Windows scope backing this managed scope.
+
+    CIDR first — it is the identity the DHCP importer already reconciles on —
+    then the scope id (its network address), which is what the plan item stores
+    as ``source_ref`` and the only handle available if IPAM's prefix length was
+    edited after the import.
+
+    Public because :mod:`app.services.cutover.readiness` matches the same live
+    ``get_scopes()`` payload when it re-evaluates blockers, and the two must not
+    be able to disagree about which Windows scope an item refers to.
+    """
+    # An empty ``subnet_cidr`` matches nothing. Callers legitimately pass ""
+    # when the item has no linked scope or its IPAM subnet is gone
+    # (``readiness._refresh_dhcp_blockers``), and without this guard that empty
+    # string would equal any pulled scope whose own ``subnet_cidr`` is absent —
+    # returning an arbitrary Windows scope as the item's source and suppressing
+    # the ``source_scope_missing`` hard block that should have fired.
+    want_cidr = (subnet_cidr or "").strip().lower()
+    if want_cidr:
+        for entry in scopes:
+            if str(entry.get("subnet_cidr") or "").strip().lower() == want_cidr:
+                return entry
+    want_id = normalise_ip(source_scope_id)
+    if want_id:
+        for entry in scopes:
+            if normalise_ip(entry.get("scope_id")) == want_id:
+                return entry
+    return None
+
+
+def _pool_key(start: Any, end: Any, pool_type: Any) -> tuple[str, str, str]:
+    return (normalise_ip(start), normalise_ip(end), str(pool_type or "dynamic").strip().lower())
+
+
+def _diff_dhcp_pools(
+    report: ParityReport,
+    *,
+    source: dict[str, Any],
+    pools: list[DHCPPool],
+    windows_only_class: str,
+) -> None:
+    """Compare the pool set as ``(start, end, type)`` triples."""
+    if not source.get("pools_ok", True):
+        # #620: the driver could not enumerate exclusions, so its pool list is
+        # short by an unknown amount. Reporting the difference would invent
+        # drift out of a transient PowerShell failure.
+        report.warnings.append(
+            "Exclusion ranges could not be enumerated on the Windows scope, so "
+            "pools were not compared. Re-run the parity check."
+        )
+        return
+
+    wire = {
+        _pool_key(p.get("start_ip"), p.get("end_ip"), p.get("pool_type"))
+        for p in source.get("pools") or []
+    }
+    ours = {_pool_key(p.start_ip, p.end_ip, p.pool_type) for p in pools}
+
+    report.in_sync += len(wire & ours)
+
+    for start, end, ptype in sorted(wire - ours):
+        report.differences.append(
+            ParityDifference(
+                classification=windows_only_class,  # type: ignore[arg-type]
+                name="pool",
+                detail=(
+                    f"Windows serves a {ptype} range {start}–{end} that this scope "
+                    "does not have. Clients in it would stop being served at cutover."
+                ),
+                source_value=f"{start}-{end} ({ptype})",
+                target_value=None,
+            )
+        )
+    for start, end, ptype in sorted(ours - wire):
+        report.differences.append(
+            ParityDifference(
+                classification="intentionally_diverged",
+                name="pool",
+                detail=(
+                    f"This scope has a {ptype} range {start}–{end} that Windows does "
+                    "not. It starts being served at cutover."
+                ),
+                source_value=None,
+                target_value=f"{start}-{end} ({ptype})",
+            )
+        )
+
+
+def _diff_dhcp_reservations(
+    report: ParityReport,
+    *,
+    source: dict[str, Any],
+    statics: list[DHCPStaticAssignment],
+    windows_only_class: str,
+) -> None:
+    """Compare reservations keyed by MAC — the identity Windows itself uses."""
+    if not source.get("statics_ok", True):
+        # Same #620 reasoning as pools: an enumeration failure is not an empty
+        # reservation list, and must not be reported as one.
+        report.warnings.append(
+            "Reservations could not be enumerated on the Windows scope, so they "
+            "were not compared. Re-run the parity check."
+        )
+        return
+
+    wire: dict[str, tuple[str, str]] = {}
+    for entry in source.get("statics") or []:
+        mac = normalise_mac(entry.get("mac_address"))
+        if mac is None:
+            continue
+        wire[mac] = (
+            normalise_ip(entry.get("ip_address")),
+            str(entry.get("hostname") or "").strip(),
+        )
+
+    ours: dict[str, tuple[str, str]] = {}
+    for row in statics:
+        mac = normalise_mac(row.mac_address)
+        if mac is None:
+            continue
+        ours[mac] = (normalise_ip(row.ip_address), (row.hostname or "").strip())
+
+    for mac in sorted(set(wire) & set(ours)):
+        wire_ip, wire_host = wire[mac]
+        our_ip, our_host = ours[mac]
+        if wire_ip == our_ip and wire_host.lower() == our_host.lower():
+            report.in_sync += 1
+            continue
+        report.differences.append(
+            ParityDifference(
+                classification="value_mismatch",
+                name=mac,
+                detail=(
+                    f"Reservation for {mac} differs. A client honouring the wrong one "
+                    "changes address at cutover."
+                ),
+                source_value=f"{wire_ip} {wire_host}".strip(),
+                target_value=f"{our_ip} {our_host}".strip(),
+            )
+        )
+
+    for mac in sorted(set(wire) - set(ours)):
+        wire_ip, wire_host = wire[mac]
+        report.differences.append(
+            ParityDifference(
+                classification=windows_only_class,  # type: ignore[arg-type]
+                name=mac,
+                detail=(
+                    f"Windows reserves {wire_ip} for {mac}; this scope does not. The "
+                    "client would get a pool address at cutover unless the lease "
+                    "handover carries it across."
+                ),
+                source_value=f"{wire_ip} {wire_host}".strip(),
+                target_value=None,
+            )
+        )
+    for mac in sorted(set(ours) - set(wire)):
+        our_ip, our_host = ours[mac]
+        report.differences.append(
+            ParityDifference(
+                classification="intentionally_diverged",
+                name=mac,
+                detail=f"This scope reserves {our_ip} for {mac}; Windows does not.",
+                source_value=None,
+                target_value=f"{our_ip} {our_host}".strip(),
+            )
+        )
+
+
+def _diff_dhcp_options(
+    report: ParityReport,
+    *,
+    source: dict[str, Any],
+    scope: DHCPScope,
+    windows_only_class: str,
+) -> None:
+    """Compare scope options by canonical name."""
+    wire = {str(k): normalise_option_value(v) for k, v in (source.get("options") or {}).items()}
+    ours = {str(k): normalise_option_value(v) for k, v in (scope.options or {}).items()}
+
+    for key in sorted(set(wire) & set(ours)):
+        if wire[key] == ours[key]:
+            report.in_sync += 1
+            continue
+        report.differences.append(
+            ParityDifference(
+                classification="value_mismatch",
+                name=key,
+                detail=f"Scope option {key!r} differs between Windows and SpatiumDDI.",
+                source_value=wire[key],
+                target_value=ours[key],
+            )
+        )
+    for key in sorted(set(wire) - set(ours)):
+        report.differences.append(
+            ParityDifference(
+                classification=windows_only_class,  # type: ignore[arg-type]
+                name=key,
+                detail=(
+                    f"Windows hands out scope option {key!r}; this scope does not. "
+                    "Clients stop receiving it at cutover."
+                ),
+                source_value=wire[key],
+                target_value=None,
+            )
+        )
+    for key in sorted(set(ours) - set(wire)):
+        report.differences.append(
+            ParityDifference(
+                classification="intentionally_diverged",
+                name=key,
+                detail=f"This scope hands out option {key!r}; Windows does not.",
+                source_value=None,
+                target_value=ours[key],
+            )
+        )
+
+
+def _diff_dhcp_activation(
+    report: ParityReport, *, source_active: bool, target_active: bool
+) -> None:
+    """Report the activation posture — as a warning, never as a difference.
+
+    ``is_active`` is migration *state*, not configuration. Through the whole
+    parallel-run phase the two sides are deliberately never both active (an
+    active managed scope is a hard blocker in
+    :mod:`app.services.cutover.readiness`, precisely so the two never answer at
+    once), so a mismatch here is the expected posture rather than drift.
+    Recording it as a ``ParityDifference`` would make ``is_parity`` structurally
+    unreachable and permanently trip the ``parity_differences`` blocker.
+    """
+    if source_active == target_active:
+        report.in_sync += 1
+        return
+    if source_active and not target_active:
+        report.warnings.append(
+            "The Windows scope is active and this scope is not. That is the expected "
+            "parallel-run posture, not a difference."
+        )
+        return
+    report.warnings.append(
+        "This scope is active and the Windows scope is not — the switch appears to "
+        "have already happened. Verify before running it again."
+    )
+
+
+async def compute_dhcp_parity(
+    db: AsyncSession,
+    *,
+    source_server: DHCPServer,
+    scope: DHCPScope,
+    source_scope_id: str,
+) -> ParityReport:
+    """Diff ``scope`` against the live Windows scope it was imported from.
+
+    Compares lease time, activation posture, the pool set, reservations, and
+    scope options. Like the DNS side, a source-side failure comes back as
+    ``status="error"``; a scope the source server does not have comes back as
+    ``status="unmatched"``.
+    """
+    report = ParityReport(kind="dhcp_scope", source_ref=source_scope_id)
+
+    subnet = (
+        await db.execute(select(Subnet).where(Subnet.id == scope.subnet_id))
+    ).scalar_one_or_none()
+    if subnet is None:
+        report.status = "error"
+        report.error = (
+            "The IPAM subnet backing this scope no longer exists, so there is "
+            "nothing to match the Windows scope against."
+        )
+        return report
+
+    pools = list(
+        (await db.execute(select(DHCPPool).where(DHCPPool.scope_id == scope.id))).scalars().all()
+    )
+    statics = list(
+        (
+            await db.execute(
+                select(DHCPStaticAssignment).where(DHCPStaticAssignment.scope_id == scope.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    try:
+        driver = get_dhcp_driver(source_server.driver)
+    except ValueError as exc:
+        report.status = "error"
+        report.error = str(exc)
+        return report
+
+    if not hasattr(driver, "get_scopes"):
+        report.status = "error"
+        report.error = (
+            f"DHCP driver {source_server.driver!r} cannot read live scopes, so parity "
+            "against it cannot be established. Windows DHCP is the supported "
+            "cutover source."
+        )
+        return report
+
+    try:
+        source_scopes: list[dict[str, Any]] = await driver.get_scopes(source_server)
+    except Exception as exc:  # noqa: BLE001 — per-item; a whole-plan run fans these out
+        report.status = "error"
+        report.error = str(exc)
+        logger.warning(
+            "cutover.parity.dhcp_pull_failed",
+            scope=str(scope.id),
+            source_scope=source_scope_id,
+            server=str(source_server.id),
+            driver=source_server.driver,
+            error=str(exc),
+        )
+        return report
+
+    source = match_source_scope(
+        source_scopes, subnet_cidr=str(subnet.network), source_scope_id=source_scope_id
+    )
+    if source is None:
+        report.status = "unmatched"
+        report.error = (
+            f"No scope for {subnet.network} (id {source_scope_id}) exists on the source "
+            "Windows DHCP server. It was removed there, or the plan item's source "
+            "reference is wrong — re-run Discover."
+        )
+        return report
+
+    windows_only_class = "drifted_since_import" if scope.import_source else "never_imported"
+
+    source_lease = int(source.get("lease_time") or 0)
+    if source_lease == int(scope.lease_time):
+        report.in_sync += 1
+    else:
+        report.differences.append(
+            ParityDifference(
+                classification="value_mismatch",
+                name="lease_time",
+                detail=(
+                    "Lease duration differs. Clients re-lease on the new value at "
+                    "cutover, which changes how long a rollback takes to drain."
+                ),
+                source_value=str(source_lease),
+                target_value=str(scope.lease_time),
+            )
+        )
+
+    _diff_dhcp_activation(
+        report, source_active=bool(source.get("is_active")), target_active=bool(scope.is_active)
+    )
+    _diff_dhcp_pools(report, source=source, pools=pools, windows_only_class=windows_only_class)
+    _diff_dhcp_reservations(
+        report, source=source, statics=statics, windows_only_class=windows_only_class
+    )
+    _diff_dhcp_options(report, source=source, scope=scope, windows_only_class=windows_only_class)
+
+    logger.info(
+        "cutover.parity.dhcp",
+        scope=str(scope.id),
+        subnet=str(subnet.network),
+        source_scope=source_scope_id,
+        server=str(source_server.id),
+        in_sync=report.in_sync,
+        differences=report.difference_count,
+    )
+    return report
+
+
+__all__ = [
+    "compute_dhcp_parity",
+    "compute_dns_parity",
+    "match_source_scope",
+    "normalise_ip",
+    "normalise_option_value",
+]

--- a/backend/app/services/cutover/plans.py
+++ b/backend/app/services/cutover/plans.py
@@ -1,0 +1,425 @@
+"""Candidate discovery for a cutover plan (issue #756).
+
+An operator building a plan should not have to *type* zone names and scope
+ids that already exist on both sides of the migration. :func:`discover_candidates`
+live-pulls the Windows source estate, matches each object against the
+SpatiumDDI rows in the plan's target group, pre-computes the readiness
+blockers, and hands back a pickable list.
+
+Matching rules, and why:
+
+* **Zones by name.** Windows reports ``corp.example``; SpatiumDDI stores
+  ``corp.example.`` (FQDN with the trailing dot). Both sides are stripped of
+  the trailing dot and lowercased before comparison. Name is the only stable
+  identity across the two systems — there is no shared id.
+* **Scopes by subnet CIDR.** Windows reports a ``scope_id`` (the network
+  address) plus a ``subnet_cidr``; SpatiumDDI models a scope as a
+  ``(group, subnet)`` pair. The subnet's CIDR is therefore the join key, run
+  through :func:`ipaddress.ip_network` on both sides so ``10.0.20.0/24`` and a
+  sloppier ``10.0.20.5/24`` land on the same canonical network.
+
+The DNS and DHCP halves are independent: a plan may cover either one, and a
+pull failure on one side is reported as an ``error`` string on that side while
+the other still returns its candidates. Discovery is a read-only convenience —
+losing half of it must not cost the operator the other half.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from typing import Any
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dhcp.windows import WindowsDHCPReadOnlyDriver
+from app.drivers.dns import get_driver
+from app.models.cutover import CutoverItem, CutoverPlan
+from app.models.dhcp import DHCPScope, DHCPServer
+from app.models.dns import DNSServer, DNSZone
+from app.models.ipam import Subnet
+from app.services.cutover import readiness
+from app.services.cutover.canonical import Blocker
+
+logger = structlog.get_logger(__name__)
+
+#: Windows DNS drivers we know how to pull a zone topology from. Anything else
+#: on ``DNSServer.driver`` is refused up front with an operator-readable
+#: message rather than an ``AttributeError`` from the driver call.
+_PULLABLE_DNS_DRIVERS: frozenset[str] = frozenset({"windows_dns"})
+
+#: Same for the DHCP side.
+_PULLABLE_DHCP_DRIVERS: frozenset[str] = frozenset({"windows_dhcp"})
+
+
+def _normalise_zone_name(raw: str) -> str:
+    """``"Corp.Example."`` → ``"corp.example"``.
+
+    Windows and SpatiumDDI disagree about the trailing dot and about case;
+    neither disagreement is meaningful, so both are normalised away before the
+    two sides are compared.
+    """
+    return raw.strip().rstrip(".").lower()
+
+
+def _canonical_cidr(raw: str) -> str | None:
+    """Canonical network string, or ``None`` when ``raw`` isn't a network."""
+    try:
+        return str(ipaddress.ip_network(raw, strict=False))
+    except ValueError:
+        # Non-CIDR junk from the wire (empty string, a hostname, a v6 literal
+        # on a v4-only pull). Unmatched is the correct outcome, not a 500.
+        return None
+
+
+def _transient_item(
+    plan: CutoverPlan,
+    *,
+    kind: str,
+    source_ref: str,
+    zone_id: uuid.UUID | None = None,
+    scope_id: uuid.UUID | None = None,
+) -> CutoverItem:
+    """Build an unpersisted :class:`CutoverItem` for blocker evaluation.
+
+    A candidate is by definition not yet in the plan, but the readiness
+    evaluators are written against an item. The object is deliberately never
+    added to the session and never attached to ``plan.items``, so nothing here
+    can be flushed: it exists only to carry the four fields the evaluators
+    read. Column defaults are applied at flush time, so ``stage`` / ``blockers``
+    are set explicitly rather than left as ``None``.
+    """
+    return CutoverItem(
+        plan_id=plan.id,
+        kind=kind,
+        source_ref=source_ref,
+        zone_id=zone_id,
+        scope_id=scope_id,
+        stage="pending",
+        blockers=[],
+        notes="",
+    )
+
+
+async def _safe_blockers(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    zone: DNSZone | None = None,
+    scope: DHCPScope | None = None,
+    source_zone_meta: dict[str, Any] | None = None,
+    source_scope: dict[str, Any] | None = None,
+) -> list[Blocker]:
+    """Evaluate one candidate's blockers, never raising.
+
+    Discovery lists tens to hundreds of candidates in one call; a single
+    evaluator failure (a half-populated zone row, a driver quirk in the pulled
+    metadata) must degrade that one row rather than the whole list. The failure
+    is surfaced in-band as a ``warn`` so the operator sees that the readiness
+    verdict is incomplete instead of reading an empty list as "all clear".
+    """
+    try:
+        if item.kind == "dns_zone":
+            return await readiness.evaluate_dns_item(
+                db, plan=plan, item=item, zone=zone, source_zone_meta=source_zone_meta
+            )
+        return await readiness.evaluate_dhcp_item(
+            db, plan=plan, item=item, scope=scope, source_scope=source_scope
+        )
+    except Exception as exc:  # noqa: BLE001 — one bad candidate must not kill discovery
+        logger.warning(
+            "cutover.discover.blocker_eval_failed",
+            plan_id=str(plan.id),
+            kind=item.kind,
+            source_ref=item.source_ref,
+            error=str(exc),
+        )
+        return [
+            Blocker(
+                code="readiness_eval_failed",
+                severity="warn",
+                message=(
+                    f"Could not evaluate readiness for {item.source_ref!r}: {exc}. "
+                    "Add the item and re-run the parity check to get a real verdict."
+                ),
+            )
+        ]
+
+
+# ── DNS ────────────────────────────────────────────────────────────────
+
+
+async def _target_zones(db: AsyncSession, group_id: uuid.UUID) -> dict[str, DNSZone]:
+    """Live zones in the target group, keyed by normalised name.
+
+    A split-horizon group holds the same name once per view. Only one of them
+    can be the cutover target, so the first is kept and the readiness layer
+    raises ``target_zone_view_scoped`` on it — surfacing the ambiguity to the
+    operator beats silently picking a view.
+    """
+    rows = (await db.execute(select(DNSZone).where(DNSZone.group_id == group_id))).scalars().all()
+    out: dict[str, DNSZone] = {}
+    for zone in rows:
+        out.setdefault(_normalise_zone_name(zone.name), zone)
+    return out
+
+
+async def _discover_dns(
+    db: AsyncSession, *, plan: CutoverPlan, existing: set[tuple[str, str]]
+) -> dict[str, Any]:
+    """Pull the Windows zone topology and match it against the target group."""
+    side: dict[str, Any] = {
+        "available": False,
+        "error": None,
+        "source_server": None,
+        "target_group_id": str(plan.target_dns_group_id) if plan.target_dns_group_id else None,
+        "candidates": [],
+    }
+    if plan.source_dns_server_id is None:
+        side["error"] = "This plan has no source Windows DNS server."
+        return side
+
+    server = await db.get(DNSServer, plan.source_dns_server_id)
+    if server is None:
+        side["error"] = "The plan's source DNS server no longer exists."
+        return side
+
+    side["available"] = True
+    side["source_server"] = server.name
+    if server.driver not in _PULLABLE_DNS_DRIVERS:
+        side["error"] = (
+            f"Zone discovery needs a Windows DNS source server; {server.name!r} uses the "
+            f"{server.driver!r} driver."
+        )
+        return side
+
+    try:
+        zone_meta: list[dict[str, Any]] = await get_driver(server.driver).pull_zones_from_server(
+            server
+        )
+    except Exception as exc:  # noqa: BLE001 — WinRM / auth / PowerShell errors go to the operator
+        logger.warning(
+            "cutover.discover.dns_pull_failed",
+            plan_id=str(plan.id),
+            server=server.name,
+            error=str(exc),
+        )
+        side["error"] = f"Could not list zones on {server.name}: {exc}"
+        return side
+
+    targets = (
+        await _target_zones(db, plan.target_dns_group_id)
+        if plan.target_dns_group_id is not None
+        else {}
+    )
+
+    candidates: list[dict[str, Any]] = []
+    for meta in zone_meta:
+        raw_name = str(meta.get("name") or "").strip()
+        if not raw_name:
+            continue
+        source_ref = raw_name.rstrip(".")
+        zone = targets.get(_normalise_zone_name(raw_name))
+        item = _transient_item(
+            plan,
+            kind="dns_zone",
+            source_ref=source_ref,
+            zone_id=zone.id if zone is not None else None,
+        )
+        blockers = await _safe_blockers(db, plan=plan, item=item, zone=zone, source_zone_meta=meta)
+        candidates.append(
+            {
+                "kind": "dns_zone",
+                "source_ref": source_ref,
+                "display_name": source_ref,
+                "matched_id": str(zone.id) if zone is not None else None,
+                "matched_display": zone.name if zone is not None else None,
+                "already_in_plan": ("dns_zone", source_ref) in existing,
+                "blockers": [b.as_dict() for b in blockers],
+                "source": {
+                    "zone_type": meta.get("zone_type"),
+                    "is_ad_integrated": meta.get("is_ad_integrated"),
+                    "is_reverse_lookup": meta.get("is_reverse_lookup"),
+                    "dynamic_update": meta.get("dynamic_update"),
+                },
+            }
+        )
+
+    candidates.sort(key=lambda c: str(c["source_ref"]))
+    side["candidates"] = candidates
+    return side
+
+
+# ── DHCP ───────────────────────────────────────────────────────────────
+
+
+async def _target_scopes(db: AsyncSession, group_id: uuid.UUID) -> dict[str, DHCPScope]:
+    """Live scopes in the target group, keyed by canonical subnet CIDR.
+
+    ``DHCPScope`` has no ``subnet`` relationship, so the CIDR is fetched in a
+    second, column-only query rather than a join — a join would put ``Subnet``
+    in the same statement as the soft-delete-filtered ``DHCPScope`` primary
+    entity, and the two have independent soft-delete state.
+    """
+    scopes = (
+        (await db.execute(select(DHCPScope).where(DHCPScope.group_id == group_id))).scalars().all()
+    )
+    subnet_ids = {s.subnet_id for s in scopes}
+    if not subnet_ids:
+        return {}
+    networks: dict[uuid.UUID, str] = {
+        row[0]: str(row[1])
+        for row in (
+            await db.execute(select(Subnet.id, Subnet.network).where(Subnet.id.in_(subnet_ids)))
+        ).all()
+    }
+
+    out: dict[str, DHCPScope] = {}
+    for scope in scopes:
+        raw = networks.get(scope.subnet_id)
+        if raw is None:
+            # Subnet is soft-deleted (filtered out of the second query) — the
+            # scope has no addressable CIDR to match a Windows scope against.
+            continue
+        cidr = _canonical_cidr(raw)
+        if cidr is not None:
+            out.setdefault(cidr, scope)
+    return out
+
+
+async def _discover_dhcp(
+    db: AsyncSession, *, plan: CutoverPlan, existing: set[tuple[str, str]]
+) -> dict[str, Any]:
+    """Pull the Windows scope topology and match it against the target group."""
+    side: dict[str, Any] = {
+        "available": False,
+        "error": None,
+        "source_server": None,
+        "target_group_id": str(plan.target_dhcp_group_id) if plan.target_dhcp_group_id else None,
+        "candidates": [],
+    }
+    if plan.source_dhcp_server_id is None:
+        side["error"] = "This plan has no source Windows DHCP server."
+        return side
+
+    server = await db.get(DHCPServer, plan.source_dhcp_server_id)
+    if server is None:
+        side["error"] = "The plan's source DHCP server no longer exists."
+        return side
+
+    side["available"] = True
+    side["source_server"] = server.name
+    if server.driver not in _PULLABLE_DHCP_DRIVERS:
+        side["error"] = (
+            f"Scope discovery needs a Windows DHCP source server; {server.name!r} uses the "
+            f"{server.driver!r} driver."
+        )
+        return side
+
+    try:
+        raw_scopes: list[dict[str, Any]] = await WindowsDHCPReadOnlyDriver().get_scopes(server)
+    except Exception as exc:  # noqa: BLE001 — WinRM / auth / PowerShell errors go to the operator
+        logger.warning(
+            "cutover.discover.dhcp_pull_failed",
+            plan_id=str(plan.id),
+            server=server.name,
+            error=str(exc),
+        )
+        side["error"] = f"Could not list scopes on {server.name}: {exc}"
+        return side
+
+    targets = (
+        await _target_scopes(db, plan.target_dhcp_group_id)
+        if plan.target_dhcp_group_id is not None
+        else {}
+    )
+
+    candidates: list[dict[str, Any]] = []
+    for raw in raw_scopes:
+        source_ref = str(raw.get("scope_id") or "").strip()
+        cidr = _canonical_cidr(str(raw.get("subnet_cidr") or ""))
+        if not source_ref:
+            # ``scope_id`` is the item's identity on the Windows side; without
+            # it there is nothing stable to add to the plan. Fall back to the
+            # network address when the CIDR came through.
+            if cidr is None:
+                continue
+            source_ref = cidr.split("/")[0]
+        scope = targets.get(cidr) if cidr is not None else None
+        item = _transient_item(
+            plan,
+            kind="dhcp_scope",
+            source_ref=source_ref,
+            scope_id=scope.id if scope is not None else None,
+        )
+        blockers = await _safe_blockers(db, plan=plan, item=item, scope=scope, source_scope=raw)
+        name = str(raw.get("name") or "")
+        candidates.append(
+            {
+                "kind": "dhcp_scope",
+                "source_ref": source_ref,
+                "display_name": f"{cidr or source_ref}" + (f" — {name}" if name else ""),
+                "matched_id": str(scope.id) if scope is not None else None,
+                "matched_display": cidr if scope is not None else None,
+                "already_in_plan": ("dhcp_scope", source_ref) in existing,
+                "blockers": [b.as_dict() for b in blockers],
+                "source": {
+                    "subnet_cidr": cidr,
+                    "name": name,
+                    "is_active": raw.get("is_active"),
+                    "lease_time": raw.get("lease_time"),
+                    "pool_count": len(raw.get("pools") or []),
+                    "reservation_count": len(raw.get("statics") or []),
+                },
+            }
+        )
+
+    candidates.sort(key=lambda c: str(c["source_ref"]))
+    side["candidates"] = candidates
+    return side
+
+
+# ── public entry point ─────────────────────────────────────────────────
+
+
+async def discover_candidates(db: AsyncSession, *, plan: CutoverPlan) -> dict[str, Any]:
+    """Live-pull the Windows source estate and return addable plan candidates.
+
+    Returns ``{"dns": {…}, "dhcp": {…}}``. Each side carries:
+
+    ``available``
+        The plan names a source server of the right kind and it still exists.
+        ``False`` means this half of the plan simply isn't configured — a
+        DNS-only plan reports ``available=False`` on the DHCP side, which is
+        not an error state.
+    ``error``
+        Why the side produced no candidates, in operator-readable prose.
+        Populated for a missing source server, a non-Windows driver, or a
+        failed pull. Never raised — the sides are independent, and a WinRM
+        timeout on DHCP must not cost the operator their zone list.
+    ``source_server`` / ``target_group_id``
+        What was pulled from, and what it was matched against.
+    ``candidates``
+        One entry per object on the Windows side, sorted by ``source_ref``,
+        each with its matched SpatiumDDI id (or ``None``), whether it is
+        already an item on this plan, and its pre-computed blockers.
+
+    Read-only: nothing here writes to the database.
+    """
+    existing_rows = (
+        await db.execute(
+            select(CutoverItem.kind, CutoverItem.source_ref).where(CutoverItem.plan_id == plan.id)
+        )
+    ).all()
+    existing: set[tuple[str, str]] = {(str(row[0]), str(row[1])) for row in existing_rows}
+
+    # Sequential, not gathered: both halves talk WinRM to the same estate over
+    # the same operator credentials, and a Windows box handles two concurrent
+    # PowerShell remoting sessions worse than it handles two sequential ones.
+    return {
+        "dns": await _discover_dns(db, plan=plan, existing=existing),
+        "dhcp": await _discover_dhcp(db, plan=plan, existing=existing),
+    }

--- a/backend/app/services/cutover/preflight.py
+++ b/backend/app/services/cutover/preflight.py
@@ -1,0 +1,459 @@
+"""Phase 3a pre-flight — drop DNS TTLs so a rollback is measured in minutes.
+
+The switch itself is a delegation or forwarder change made outside SpatiumDDI.
+Its blast radius is therefore governed entirely by how long resolvers keep
+serving the old answers, and that is the TTL. A zone sitting on the common
+3600 default means a bad cutover is visible for an hour after it is reverted;
+lowered to 300 well ahead of the window, the same mistake clears in five
+minutes. Nothing else in the cutover buys as much safety for as little effort.
+
+What this module does, on the SpatiumDDI side:
+
+* Snapshots the zone SOA (``ttl`` / ``minimum`` / ``refresh`` / ``retry``) and
+  **every** record's ``ttl`` into ``CutoverItem.ttl_snapshot`` — once. A second
+  apply (say, dropping from 300 to 60) must not overwrite that snapshot, or the
+  restore would put the zone back to an intermediate value that was never the
+  operator's configuration.
+* Lowers ``zone.ttl`` / ``zone.minimum`` and every record whose ``ttl`` exceeds
+  the target. Records with ``ttl IS NULL`` inherit ``zone.ttl``, so lowering the
+  zone changes them implicitly; they are set **explicitly** to the target and
+  snapshotted as ``None``, so a restore can put the inheritance back rather than
+  leaving them pinned to whatever the zone default happened to be.
+* Pushes the changes through the ordinary record pipeline: one
+  ``bump_zone_serial`` for the whole batch, then ``enqueue_record_ops_batch``.
+  No private fan-out — the batch path already handles agentless (one driver
+  call) and agent-based (queued rows per server) correctly.
+
+What it deliberately does **not** do is lower the TTLs on the Windows source,
+even though those are the values resolvers are actually caching today and are
+therefore the ones that matter. Record writes to a Windows DNS server ride
+RFC 2136 by default, where "change the TTL" is expressed as a delete of the
+rrset followed by an add — and we are not issuing an unattended delete against
+a zone that is still live and authoritative for production. (The WinRM Path B
+alternative is no better here: it is a clone-and-``Set`` per record against
+that same live zone.) Instead ``TTLPreflightPlan.source_side_instructions``
+carries a copy-pasteable PowerShell block for the operator to run there, and
+the runbook repeats it. A TTL drop applied to only one side is worse than none
+at all — it looks done and buys nothing — so the instructions are part of every
+preview and apply response, not an optional extra.
+
+Neither :func:`apply_ttl_preflight` nor :func:`restore_ttl_preflight` commits;
+the caller owns the transaction.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_wake import collect_wake, dns_group_channel
+from app.drivers.dns import is_agentless
+from app.models.auth import User
+from app.models.cutover import CutoverItem
+from app.models.dns import DNSRecord, DNSZone
+from app.services.cutover.canonical import TTLPreflightPlan, TTLRecordChange
+from app.services.dns.record_ops import (
+    enqueue_record_ops_batch,
+    record_op_payload,
+    resolve_primary_server,
+)
+from app.services.dns.serial import bump_zone_serial
+
+logger = structlog.get_logger(__name__)
+
+#: Floor. Below ~30 s the query load on the authoritative servers stops being
+#: negligible and cache-miss latency starts showing up for clients, for a
+#: rollback window that is already short enough.
+MIN_TARGET_TTL = 30
+
+#: Ceiling — one day. A "pre-flight" that leaves the TTL at a day is not a
+#: pre-flight, and accepting an arbitrarily large value here would let an
+#: operator quietly *raise* every TTL in the zone through a screen labelled
+#: "lower TTLs".
+MAX_TARGET_TTL = 86400
+
+#: Zone SOA fields captured in the snapshot. ``refresh`` / ``retry`` are not
+#: modified, but are recorded so the snapshot is a complete picture of the SOA
+#: timing as it stood before the migration.
+_SOA_FIELDS = ("ttl", "minimum", "refresh", "retry")
+
+
+def validate_target_ttl(target_ttl: int) -> int:
+    """Return ``target_ttl`` or raise ``ValueError`` describing the bounds."""
+    try:
+        value = int(target_ttl)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("target_ttl must be an integer number of seconds.") from exc
+    if value < MIN_TARGET_TTL or value > MAX_TARGET_TTL:
+        raise ValueError(
+            f"target_ttl must be between {MIN_TARGET_TTL} and {MAX_TARGET_TTL} seconds "
+            f"(got {value})."
+        )
+    return value
+
+
+async def _assert_target_is_not_the_source(db: AsyncSession, zone: DNSZone) -> None:
+    """Refuse to run when the zone's group writes through to an agentless server.
+
+    The module's central promise is that it does not touch the Windows source.
+    ``enqueue_record_ops_batch`` does not know that: it resolves the zone
+    group's ``is_primary`` server and, when that server is agentless, dispatches
+    the change straight at the provider — for ``windows_dns`` that is a
+    delete+add per record over RFC 2136, against a zone that is still live and
+    authoritative for production.
+
+    A plan can legitimately point at a group the Windows server is also
+    registered in (``shadow._collect_targets`` documents exactly that case), and
+    nothing else stops the operator choosing one. So check here and refuse with
+    an explanation, rather than quietly doing the thing the docstring says we
+    never do.
+    """
+    primary = await resolve_primary_server(db, zone)
+    if primary is None or not is_agentless(primary.driver):
+        return
+    raise ValueError(
+        f"The primary server of {zone.name}'s group is {primary.name!r}, which uses the "
+        f"agentless {primary.driver!r} driver — record writes to it are applied directly "
+        "to that server. Lowering TTLs here would rewrite records on the very server "
+        "this migration is moving away from, which the pre-flight deliberately never "
+        "does. Point the item at a group whose primary is an agent-managed server "
+        "(BIND9 / PowerDNS / Technitium), and lower the source's TTLs with the "
+        "PowerShell in the pre-flight preview instead."
+    )
+
+
+def _needs_lowering(record: DNSRecord, target_ttl: int) -> bool:
+    """True when this record's TTL has to be written to reach ``target_ttl``.
+
+    ``None`` counts: it means "inherit ``zone.ttl``", and leaving it that way
+    would make the record's effective TTL a side effect of the zone change
+    rather than something the snapshot can restore exactly.
+    """
+    return record.ttl is None or record.ttl > target_ttl
+
+
+async def _load_records(db: AsyncSession, zone: DNSZone) -> list[DNSRecord]:
+    """Every live record in the zone. Soft-deleted rows are filtered by the
+    session-wide ``deleted_at IS NULL`` criterion in ``app.db``."""
+    return list(
+        (
+            await db.execute(
+                select(DNSRecord)
+                .where(DNSRecord.zone_id == zone.id)
+                .order_by(DNSRecord.name, DNSRecord.record_type)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+def windows_ttl_powershell(
+    zone_name: str,
+    target_ttl: int,
+    current_zone_ttl: int,
+    *,
+    computer_name: str | None = None,
+) -> str:
+    """The Windows-side TTL drop, ready to paste into an elevated shell.
+
+    The single source for this script. It is surfaced twice — inline as
+    ``TTLPreflightPlan.source_side_instructions`` on every preview and apply
+    response, and again in the generated runbook — and an operator who is handed
+    two subtly different versions of the same command has been handed a bug. So
+    :mod:`app.services.cutover.runbook` calls this rather than keeping a copy.
+
+    ``computer_name`` adds ``-ComputerName`` so the block can be run from an
+    admin workstation instead of on the server itself; omit it for the
+    run-it-on-the-box form.
+    """
+    label = zone_name.strip().rstrip(".")
+    escaped = label.replace("'", "''")
+    where = "" if computer_name is None else " -ComputerName $Server"
+    server_line = (
+        ""
+        if computer_name is None
+        else f"$Server = '{computer_name.replace(chr(39), chr(39) * 2)}'\n"
+    )
+    ran_on = (
+        f"# Run on the Windows DNS server that is still authoritative for {label},"
+        if computer_name is None
+        else f"# Lower the Windows-side TTLs for {label} on {computer_name}."
+    )
+    return f"""{ran_on}
+# in an elevated PowerShell session, BEFORE the cutover window.
+#
+# These are the TTLs resolvers are caching right now, so lowering them here is
+# what actually shortens a rollback. Lowering only the SpatiumDDI side changes
+# nothing until after the switch has already happened.
+#
+# Allow at least the CURRENT TTL ({current_zone_ttl}s) to pass after running
+# this, so every cached copy of the old value has expired before you cut over.
+
+{server_line}$Zone   = '{escaped}'
+$NewTtl = [TimeSpan]::FromSeconds({target_ttl})
+
+# 1. SOA — the zone default, and the negative-caching TTL. MinimumTimeToLive
+#    governs how long a resolver remembers an NXDOMAIN from the old server,
+#    which is exactly the failure mode a rollback has to clear.
+$soa = Get-DnsServerResourceRecord{where} -ZoneName $Zone -RRType SOA
+$new = $soa.Clone()
+$new.TimeToLive = $NewTtl
+$new.RecordData.MinimumTimeToLive = $NewTtl
+Set-DnsServerResourceRecord{where} -ZoneName $Zone -OldInputObject $soa -NewInputObject $new -Force
+
+# 2. Every other record currently above the target.
+Get-DnsServerResourceRecord{where} -ZoneName $Zone |
+    Where-Object {{ $_.RecordType -ne 'SOA' -and $_.TimeToLive -gt $NewTtl }} |
+    ForEach-Object {{
+        $old = $_
+        $rec = $_.Clone()
+        $rec.TimeToLive = $NewTtl
+        Set-DnsServerResourceRecord{where} -ZoneName $Zone `
+            -OldInputObject $old -NewInputObject $rec -Force
+    }}
+
+# To put it back after the migration is finished (or abandoned), re-run the
+# same block with $NewTtl = [TimeSpan]::FromSeconds({current_zone_ttl}).
+"""
+
+
+def _build_plan(zone: DNSZone, records: list[DNSRecord], target_ttl: int) -> TTLPreflightPlan:
+    """Describe what lowering ``zone`` to ``target_ttl`` would change."""
+    changed = [r for r in records if _needs_lowering(r, target_ttl)]
+    zone_current = {f: int(getattr(zone, f)) for f in _SOA_FIELDS}
+    zone_after = dict(zone_current)
+    zone_after["ttl"] = min(zone_current["ttl"], target_ttl)
+    zone_after["minimum"] = min(zone_current["minimum"], target_ttl)
+
+    plan = TTLPreflightPlan(
+        target_ttl=target_ttl,
+        zone_current=zone_current,
+        zone_after=zone_after,
+        records=[
+            TTLRecordChange(
+                record_id=str(r.id),
+                name=r.name or "@",
+                record_type=r.record_type,
+                current_ttl=r.ttl,
+                new_ttl=target_ttl,
+            )
+            for r in changed
+        ],
+        unchanged=len(records) - len(changed),
+        source_side_instructions=windows_ttl_powershell(zone.name, target_ttl, zone_current["ttl"]),
+    )
+
+    # The single most common way to get no benefit from this step: run it an
+    # hour before the window, when the value being replaced has an hour of
+    # cache lifetime left. Say the number rather than "plan ahead".
+    plan.warnings.append(
+        f"Resolvers may keep serving the previous values for up to "
+        f"{zone_current['ttl']}s. Apply this at least that long before the "
+        f"cutover window, on both sides."
+    )
+    if zone_current["ttl"] <= target_ttl and not changed:
+        plan.warnings.append(
+            "Nothing to lower — the zone and every record are already at or below "
+            f"{target_ttl}s."
+        )
+    if any(r.ttl is None for r in changed):
+        plan.warnings.append(
+            "Records that inherit the zone TTL will be given an explicit TTL so the "
+            "original inheritance can be restored exactly on rollback."
+        )
+    if zone.view_id is not None:
+        plan.warnings.append(
+            "This zone is scoped to a DNS view. Its other views are separate zone rows "
+            "and are not touched here — lower each one you are migrating."
+        )
+    return plan
+
+
+async def preview_ttl_preflight(
+    db: AsyncSession, *, zone: DNSZone, target_ttl: int
+) -> TTLPreflightPlan:
+    """Read-only: what :func:`apply_ttl_preflight` would do. Mutates nothing."""
+    ttl = validate_target_ttl(target_ttl)
+    records = await _load_records(db, zone)
+    return _build_plan(zone, records, ttl)
+
+
+async def apply_ttl_preflight(
+    db: AsyncSession,
+    *,
+    zone: DNSZone,
+    item: CutoverItem,
+    target_ttl: int,
+    current_user: User | None = None,
+) -> TTLPreflightPlan:
+    """Lower the zone + record TTLs, snapshotting the originals first.
+
+    The returned plan describes the state as it was *before* the mutation —
+    ``records[].current_ttl`` is what each record held on the way in — so it
+    doubles as the report of what was changed.
+
+    The snapshot is written only on the first apply. Re-applying with a lower
+    target still lowers TTLs, but leaves the pristine snapshot alone and says so
+    in ``warnings``; ``restore_ttl_preflight`` therefore always returns the zone
+    to its true pre-migration values, however many times this ran.
+
+    Does not commit.
+    """
+    ttl = validate_target_ttl(target_ttl)
+    await _assert_target_is_not_the_source(db, zone)
+    records = await _load_records(db, zone)
+    plan = _build_plan(zone, records, ttl)
+    changed = [r for r in records if _needs_lowering(r, ttl)]
+
+    if item.ttl_snapshot is None:
+        item.ttl_snapshot = {
+            "target_ttl": ttl,
+            "taken_at": datetime.now(UTC).isoformat(),
+            "zone": {f: int(getattr(zone, f)) for f in _SOA_FIELDS},
+            # Every record, not only the ones being changed now: a later apply
+            # at a lower target can touch rows this one left alone, and the
+            # snapshot has to cover those too.
+            "records": [{"id": str(r.id), "ttl": r.ttl} for r in records],
+        }
+    else:
+        taken_at = item.ttl_snapshot.get("taken_at") or "an earlier run"
+        plan.warnings.append(
+            f"A TTL snapshot was already taken ({taken_at}) and has been kept, so a "
+            "restore still returns the original pre-migration values."
+        )
+
+    zone_changed = False
+    if zone.ttl > ttl:
+        zone.ttl = ttl
+        zone_changed = True
+    if zone.minimum > ttl:
+        zone.minimum = ttl
+        zone_changed = True
+
+    for record in changed:
+        record.ttl = ttl
+
+    if changed or zone_changed:
+        # One serial for the whole batch — a serial per record would make every
+        # secondary transfer the zone N times for a single logical change.
+        target_serial = bump_zone_serial(zone)
+        if changed:
+            await enqueue_record_ops_batch(
+                db,
+                zone,
+                [
+                    {"op": "update", "record": record_op_payload(r), "target_serial": target_serial}
+                    for r in changed
+                ],
+            )
+        # The SOA change alone shifts the rendered config bundle, and the
+        # record-op path only wakes the group when there were record ops.
+        collect_wake(dns_group_channel(zone.group_id))
+
+    item.ttl_lowered_at = datetime.now(UTC)
+    if item.stage in ("pending", "parity_checked"):
+        item.stage = "preflight_done"
+    await db.flush()
+
+    logger.info(
+        "cutover.preflight.applied",
+        zone=zone.name,
+        item=str(item.id),
+        target_ttl=ttl,
+        records_changed=len(changed),
+        zone_changed=zone_changed,
+        user=current_user.username if current_user else None,
+    )
+    return plan
+
+
+async def restore_ttl_preflight(
+    db: AsyncSession,
+    *,
+    zone: DNSZone,
+    item: CutoverItem,
+    current_user: User | None = None,
+) -> int:
+    """Put the snapshotted TTLs back and clear the snapshot.
+
+    Returns the number of **record** rows whose TTL was rewritten; the zone SOA
+    restore is not counted. Returns 0 when no snapshot exists (nothing was ever
+    lowered, or a previous restore already ran) — that is not an error, so a
+    rollback can call this unconditionally.
+
+    Does not commit.
+    """
+    snapshot = item.ttl_snapshot
+    if not snapshot:
+        return 0
+    await _assert_target_is_not_the_source(db, zone)
+
+    zone_snapshot: dict = snapshot.get("zone") or {}
+    zone_changed = False
+    for field_name in _SOA_FIELDS:
+        original = zone_snapshot.get(field_name)
+        if original is None:
+            continue
+        if getattr(zone, field_name) != int(original):
+            setattr(zone, field_name, int(original))
+            zone_changed = True
+
+    # ``ttl`` here is deliberately allowed to be None — that is the stored form
+    # of "inherits the zone TTL", and restoring it as anything else would leave
+    # the record pinned forever.
+    original_ttls: dict[str, int | None] = {
+        str(entry.get("id")): entry.get("ttl")
+        for entry in (snapshot.get("records") or [])
+        if entry.get("id")
+    }
+
+    records = await _load_records(db, zone)
+    restored = [
+        r for r in records if str(r.id) in original_ttls and r.ttl != original_ttls[str(r.id)]
+    ]
+    for record in restored:
+        record.ttl = original_ttls[str(record.id)]
+
+    if restored or zone_changed:
+        target_serial = bump_zone_serial(zone)
+        if restored:
+            await enqueue_record_ops_batch(
+                db,
+                zone,
+                [
+                    {"op": "update", "record": record_op_payload(r), "target_serial": target_serial}
+                    for r in restored
+                ],
+            )
+        collect_wake(dns_group_channel(zone.group_id))
+
+    item.ttl_snapshot = None
+    item.ttl_lowered_at = None
+    if item.stage == "preflight_done":
+        item.stage = "parity_checked"
+    await db.flush()
+
+    logger.info(
+        "cutover.preflight.restored",
+        zone=zone.name,
+        item=str(item.id),
+        records_restored=len(restored),
+        zone_changed=zone_changed,
+        user=current_user.username if current_user else None,
+    )
+    return len(restored)
+
+
+__all__ = [
+    "MAX_TARGET_TTL",
+    "MIN_TARGET_TTL",
+    "apply_ttl_preflight",
+    "preview_ttl_preflight",
+    "restore_ttl_preflight",
+    "validate_target_ttl",
+    "windows_ttl_powershell",
+]

--- a/backend/app/services/cutover/preflight.py
+++ b/backend/app/services/cutover/preflight.py
@@ -126,7 +126,7 @@ async def _assert_target_is_not_the_source(db: AsyncSession, zone: DNSZone) -> N
     )
 
 
-def _ttl_ops(records: list[DNSRecord]) -> list[dict[str, Any]]:
+def _ttl_ops(records: list[DNSRecord], zone: DNSZone) -> list[dict[str, Any]]:
     """Build the record-op batch for a TTL rewrite, RRset-aware.
 
     The BIND9 agent turns a ``create`` / ``update`` op into an RFC 2136
@@ -142,6 +142,13 @@ def _ttl_ops(records: list[DNSRecord]) -> list[dict[str, Any]]:
     ``rrset_action="add"`` to append onto it. The result is one RRset with every
     original value at the new TTL. Groups of one are unchanged, so the common
     case emits exactly what it did before.
+
+    A ``None`` TTL is resolved to ``zone.ttl`` **on the wire**. The row keeps its
+    NULL — that is how "inherit the zone default" is stored, and the restore path
+    depends on it — but the agent's record-op branch falls back to a hardcoded
+    3600 rather than the zone's own default, so shipping the null would silently
+    write 3600 onto every inheriting record of a zone whose default is anything
+    else. Resolving here keeps the wire honest without touching the row.
     """
     grouped: dict[tuple[str, str], list[DNSRecord]] = {}
     for rec in records:
@@ -151,6 +158,8 @@ def _ttl_ops(records: list[DNSRecord]) -> list[dict[str, Any]]:
     for group in grouped.values():
         for index, rec in enumerate(group):
             payload = record_op_payload(rec)
+            if payload.get("ttl") is None:
+                payload["ttl"] = zone.ttl
             if index:
                 payload["rrset_action"] = "add"
             ops.append({"op": "update", "record": payload})
@@ -374,7 +383,7 @@ async def apply_ttl_preflight(
         # secondary transfer the zone N times for a single logical change.
         target_serial = bump_zone_serial(zone)
         if changed:
-            ops = _ttl_ops(changed)
+            ops = _ttl_ops(changed, zone)
             for op in ops:
                 op["target_serial"] = target_serial
             await enqueue_record_ops_batch(db, zone, ops)
@@ -449,7 +458,7 @@ async def restore_ttl_preflight(
     if restored or zone_changed:
         target_serial = bump_zone_serial(zone)
         if restored:
-            ops = _ttl_ops(restored)
+            ops = _ttl_ops(restored, zone)
             for op in ops:
                 op["target_serial"] = target_serial
             await enqueue_record_ops_batch(db, zone, ops)

--- a/backend/app/services/cutover/preflight.py
+++ b/backend/app/services/cutover/preflight.py
@@ -44,6 +44,7 @@ the caller owns the transaction.
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any
 
 import structlog
 from sqlalchemy import select
@@ -123,6 +124,37 @@ async def _assert_target_is_not_the_source(db: AsyncSession, zone: DNSZone) -> N
         "(BIND9 / PowerDNS / Technitium), and lower the source's TTLs with the "
         "PowerShell in the pre-flight preview instead."
     )
+
+
+def _ttl_ops(records: list[DNSRecord]) -> list[dict[str, Any]]:
+    """Build the record-op batch for a TTL rewrite, RRset-aware.
+
+    The BIND9 agent turns a ``create`` / ``update`` op into an RFC 2136
+    ``replace`` by default, which swaps the **whole RRset** for the single value
+    in that op. That is right for the one-value-per-name case the record CRUD
+    path was written for, and silently destructive for anything else: a name
+    with three round-robin A records would be rewritten three times and end up
+    serving only the last one. Lowering a TTL must not cost the operator two
+    thirds of their addresses.
+
+    So ops are grouped by ``(name, type)``. The first op in a group keeps the
+    default ``replace`` — which clears the old RRset — and every sibling carries
+    ``rrset_action="add"`` to append onto it. The result is one RRset with every
+    original value at the new TTL. Groups of one are unchanged, so the common
+    case emits exactly what it did before.
+    """
+    grouped: dict[tuple[str, str], list[DNSRecord]] = {}
+    for rec in records:
+        grouped.setdefault(((rec.name or "@").lower(), rec.record_type.upper()), []).append(rec)
+
+    ops: list[dict[str, Any]] = []
+    for group in grouped.values():
+        for index, rec in enumerate(group):
+            payload = record_op_payload(rec)
+            if index:
+                payload["rrset_action"] = "add"
+            ops.append({"op": "update", "record": payload})
+    return ops
 
 
 def _needs_lowering(record: DNSRecord, target_ttl: int) -> bool:
@@ -342,14 +374,10 @@ async def apply_ttl_preflight(
         # secondary transfer the zone N times for a single logical change.
         target_serial = bump_zone_serial(zone)
         if changed:
-            await enqueue_record_ops_batch(
-                db,
-                zone,
-                [
-                    {"op": "update", "record": record_op_payload(r), "target_serial": target_serial}
-                    for r in changed
-                ],
-            )
+            ops = _ttl_ops(changed)
+            for op in ops:
+                op["target_serial"] = target_serial
+            await enqueue_record_ops_batch(db, zone, ops)
         # The SOA change alone shifts the rendered config bundle, and the
         # record-op path only wakes the group when there were record ops.
         collect_wake(dns_group_channel(zone.group_id))
@@ -421,14 +449,10 @@ async def restore_ttl_preflight(
     if restored or zone_changed:
         target_serial = bump_zone_serial(zone)
         if restored:
-            await enqueue_record_ops_batch(
-                db,
-                zone,
-                [
-                    {"op": "update", "record": record_op_payload(r), "target_serial": target_serial}
-                    for r in restored
-                ],
-            )
+            ops = _ttl_ops(restored)
+            for op in ops:
+                op["target_serial"] = target_serial
+            await enqueue_record_ops_batch(db, zone, ops)
         collect_wake(dns_group_channel(zone.group_id))
 
     item.ttl_snapshot = None

--- a/backend/app/services/cutover/readiness.py
+++ b/backend/app/services/cutover/readiness.py
@@ -1,0 +1,670 @@
+"""Is this item safe to cut over yet? (#756)
+
+Every reason an item is *not* ready is a :class:`~app.services.cutover.canonical.Blocker`
+with a stable code and one of two severities. ``warn`` is advisory and can be
+acknowledged with ``force=true``; ``block`` refuses the cutover outright and
+cannot be forced, ever.
+
+**The one that matters is** ``ad_secure_dynamic_update``. A Windows zone set to
+AD "Secure only" dynamic updates accepts registrations exclusively over
+GSS-TSIG. SpatiumDDI does not implement GSS-TSIG yet (#444), so the moment that
+zone is served from here instead, every domain controller and domain-joined
+client silently fails to register — no error the operator will see, just an
+Active Directory that stops resolving itself. That is the difference between a
+DNS migration and a domain outage, so it is a hard block and
+:func:`normalize_dynamic_update` is written to be paranoid about detecting it:
+Windows' ``DynamicUpdate`` arrives from ``ConvertTo-Json`` either as the string
+(``None`` / ``NonsecureAndSecure`` / ``Secure``) or as the raw enum integer
+(``0`` / ``1`` / ``2``), and both forms are handled. An AD-integrated zone whose
+mode cannot be interpreted at all is treated as ``Secure``, because "we could
+not tell" must not read as "it is fine".
+
+:func:`refresh_blockers` deliberately performs a **live** read of the source
+Windows server rather than trusting anything cached on the item. The whole guard
+is worthless if an operator can flip a zone to "Secure only" on Windows after
+the last parity run and still be allowed to cut over. It persists the result
+onto ``item.blockers`` but does not commit — the caller owns the transaction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dhcp import get_driver as get_dhcp_driver
+from app.drivers.dns import get_driver as get_dns_driver
+from app.models.cutover import CutoverItem, CutoverPlan
+from app.models.dhcp import DHCPScope, DHCPServer
+from app.models.dns import DNSServer, DNSZone
+from app.models.ipam import Subnet
+from app.services.cutover.canonical import (
+    BLOCKER_AD_NONSECURE_DDNS,
+    BLOCKER_AD_SECURE_DDNS,
+    BLOCKER_LEASE_HANDOVER_PENDING,
+    BLOCKER_MANAGED_SCOPE_ACTIVE,
+    BLOCKER_MISSING_REVERSE_ZONE,
+    BLOCKER_NO_SOURCE_SERVER,
+    BLOCKER_NO_TARGET_SCOPE,
+    BLOCKER_NO_TARGET_ZONE,
+    BLOCKER_PARITY_DIFFERENCES,
+    BLOCKER_PARITY_NOT_VERIFIED,
+    BLOCKER_SOURCE_SCOPE_INACTIVE,
+    BLOCKER_SOURCE_SCOPE_MISSING,
+    BLOCKER_SOURCE_ZONE_MISSING,
+    BLOCKER_TARGET_GROUP_NO_SERVERS,
+    BLOCKER_TARGET_ZONE_VIEW_SCOPED,
+    BLOCKER_ZONE_IS_AD_INTEGRATED,
+    Blocker,
+)
+from app.services.cutover.parity import match_source_scope
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Windows DynamicUpdate normalisation ────────────────────────────────
+
+#: The ``DnsZoneDynamicUpdate`` enum as PowerShell serialises it when
+#: ``ConvertTo-Json`` decides the property is numeric rather than a string.
+#: Which of the two shapes you get depends on the Windows / PowerShell build,
+#: so both are handled rather than assumed.
+_DYNAMIC_UPDATE_BY_INT: dict[int, str] = {
+    0: "none",
+    1: "nonsecure_and_secure",
+    2: "secure",
+}
+
+#: Keyed on the mode name with every non-alphanumeric character stripped, so
+#: ``"NonsecureAndSecure"``, ``"nonsecure and secure"`` and
+#: ``"Nonsecure_And_Secure"`` all land on the same entry.
+_DYNAMIC_UPDATE_BY_TEXT: dict[str, str] = {
+    "none": "none",
+    "nonsecureandsecure": "nonsecure_and_secure",
+    "secure": "secure",
+}
+
+
+def normalize_dynamic_update(raw: Any) -> str | None:
+    """Canonicalise Windows' ``DynamicUpdate`` value.
+
+    Returns ``"none"``, ``"nonsecure_and_secure"``, ``"secure"``, or ``None``
+    when the value is absent or in a shape we do not recognise. Callers must
+    treat ``None`` as *unknown*, never as *safe* — see
+    :func:`evaluate_dns_item`, which escalates an unknown mode on an
+    AD-integrated zone to a hard block.
+
+    Accepts both wire shapes (see ``_DYNAMIC_UPDATE_BY_INT``) plus a numeric
+    string, and compares text case-insensitively.
+    """
+    # ``bool`` is an ``int`` subclass, and ``True`` would otherwise decode as
+    # ``NonsecureAndSecure``. A boolean here is nonsense, so report unknown.
+    if raw is None or isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return _DYNAMIC_UPDATE_BY_INT.get(raw)
+    if isinstance(raw, float):
+        return _DYNAMIC_UPDATE_BY_INT.get(int(raw)) if raw.is_integer() else None
+
+    text = str(raw).strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return _DYNAMIC_UPDATE_BY_INT.get(int(text))
+    squashed = "".join(ch for ch in text.lower() if ch.isalnum())
+    return _DYNAMIC_UPDATE_BY_TEXT.get(squashed)
+
+
+# ── shared blocker helpers ─────────────────────────────────────────────
+
+
+def _is_cut_over(item: CutoverItem) -> bool:
+    """Has the switch already happened for this item?
+
+    Several checks describe the *pre*-switch posture (the managed scope must be
+    inactive, leases must still be handed over). Once the item is cut over those
+    are satisfied-by-having-happened, and leaving them in place would make a
+    completed item permanently look unready.
+    """
+    return item.cut_over_at is not None or item.stage == "cut_over"
+
+
+#: Why a stored parity report with this status proves nothing, phrased for the
+#: operator. Anything not listed here falls back to a generic line. Mirrors the
+#: ``status`` vocabulary documented on
+#: :class:`~app.services.cutover.canonical.ParityReport`.
+_PARITY_STATUS_REASON: dict[str, str] = {
+    "error": "the source server could not be read",
+    "unmatched": "the object exists on only one of the two servers",
+    "unverified": "the source returned a result that cannot be trusted as an answer",
+}
+
+
+def _parity_blockers(item: CutoverItem) -> list[Blocker]:
+    """Turn the last stored parity report into readiness verdicts.
+
+    Never having run a parity check, and having run one that did not produce a
+    trustworthy answer, are the same thing from here: nobody has demonstrated
+    the two sides agree, so the cutover is refused. Actual differences are only
+    a warning — an operator who has reviewed them and decided they are
+    acceptable can force past.
+    """
+    last = item.last_parity
+    if not isinstance(last, dict):
+        return [
+            Blocker(
+                BLOCKER_PARITY_NOT_VERIFIED,
+                "block",
+                "No parity check has been run for this item. Run one so the "
+                "SpatiumDDI copy can be compared against what Windows is serving "
+                "right now.",
+            )
+        ]
+
+    status = str(last.get("status") or "unknown")
+    if status != "ok":
+        reason = _PARITY_STATUS_REASON.get(status, f"it finished with status {status!r}")
+        detail = str(last.get("error") or "no detail was recorded")
+        return [
+            Blocker(
+                BLOCKER_PARITY_NOT_VERIFIED,
+                "block",
+                f"The last parity check proved nothing because {reason}: {detail}. "
+                "Fix that and re-run it — an item whose parity is unverified cannot "
+                "be cut over.",
+            )
+        ]
+
+    count = int(last.get("difference_count") or 0)
+    if count:
+        return [
+            Blocker(
+                BLOCKER_PARITY_DIFFERENCES,
+                "warn",
+                f"The last parity check found {count} difference(s) between Windows and "
+                "SpatiumDDI. Reconcile them, or acknowledge them and force the cutover "
+                "if they are intentional.",
+            )
+        ]
+    return []
+
+
+# ── DNS ────────────────────────────────────────────────────────────────
+
+
+async def evaluate_dns_item(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    zone: DNSZone | None,
+    source_zone_meta: dict[str, Any] | None,
+) -> list[Blocker]:
+    """Readiness verdicts for one ``dns_zone`` item.
+
+    ``source_zone_meta`` is one entry from
+    :meth:`app.drivers.dns.windows.WindowsDNSDriver.pull_zones_from_server` —
+    ``{"name", "zone_type", "is_ad_integrated", "is_reverse_lookup",
+    "dynamic_update"}``. ``None`` means the zone was not found on the source
+    server *or* the source could not be read; either way the AD dynamic-update
+    mode is unverified, which is a hard block.
+    """
+    blockers: list[Blocker] = []
+
+    if plan.source_dns_server_id is None:
+        blockers.append(
+            Blocker(
+                BLOCKER_NO_SOURCE_SERVER,
+                "block",
+                "The plan has no source Windows DNS server. Set one so parity and the "
+                "AD dynamic-update check can run against the zone this item migrates.",
+            )
+        )
+    elif source_zone_meta is None:
+        blockers.append(
+            Blocker(
+                BLOCKER_SOURCE_ZONE_MISSING,
+                "block",
+                f"Zone {item.source_ref!r} could not be read from the source Windows DNS "
+                "server, so its dynamic-update mode is unverified. Re-run Discover to "
+                "confirm the zone name, or remove this item.",
+            )
+        )
+
+    if source_zone_meta is not None:
+        mode = normalize_dynamic_update(source_zone_meta.get("dynamic_update"))
+        ad_integrated = bool(source_zone_meta.get("is_ad_integrated"))
+
+        if mode == "secure":
+            logger.warning(
+                "cutover.readiness.ad_secure_dynamic_update",
+                plan=str(plan.id),
+                item=str(item.id),
+                zone=item.source_ref,
+            )
+            blockers.append(
+                Blocker(
+                    BLOCKER_AD_SECURE_DDNS,
+                    "block",
+                    f"Zone {item.source_ref!r} uses Active Directory 'Secure only' dynamic "
+                    "updates. SpatiumDDI cannot accept GSS-TSIG updates yet (#444), so "
+                    "after the switch domain controllers and domain-joined clients would "
+                    "silently fail to register their records and AD would stop resolving "
+                    "itself. Either set the zone's dynamic-update mode on Windows to "
+                    "'Nonsecure and secure' before cutting over, or leave this zone on "
+                    "Windows and migrate the rest. This cannot be forced.",
+                )
+            )
+        elif mode is None and ad_integrated:
+            blockers.append(
+                Blocker(
+                    BLOCKER_AD_SECURE_DDNS,
+                    "block",
+                    f"The dynamic-update mode of AD-integrated zone {item.source_ref!r} "
+                    f"could not be interpreted (Windows reported "
+                    f"{source_zone_meta.get('dynamic_update')!r}). It is treated as "
+                    "'Secure only' rather than assumed safe, because migrating a "
+                    "GSS-TSIG zone breaks Active Directory. Check the zone in DNS "
+                    "Manager and re-run Discover.",
+                )
+            )
+        elif mode == "nonsecure_and_secure":
+            blockers.append(
+                Blocker(
+                    BLOCKER_AD_NONSECURE_DDNS,
+                    "warn",
+                    f"Zone {item.source_ref!r} accepts nonsecure dynamic updates. Clients "
+                    "registering into it will keep working after the switch only if the "
+                    "target zone also allows dynamic updates — enable them on the "
+                    "SpatiumDDI zone first.",
+                )
+            )
+
+        if ad_integrated:
+            blockers.append(
+                Blocker(
+                    BLOCKER_ZONE_IS_AD_INTEGRATED,
+                    "warn",
+                    f"Zone {item.source_ref!r} is Active Directory-integrated, so it "
+                    "replicates between domain controllers and other DCs will keep "
+                    "serving it after the switch. Confirm the delegation / forwarder "
+                    "change reaches every resolver, and plan the AD-side removal "
+                    "separately (see the decommission checklist).",
+                )
+            )
+
+    if zone is None:
+        blockers.append(
+            Blocker(
+                BLOCKER_NO_TARGET_ZONE,
+                "block",
+                "This item has no SpatiumDDI zone linked. Import the Windows zone (or "
+                "link the existing one) before cutting over — there is nothing here to "
+                "answer queries.",
+            )
+        )
+        return blockers
+
+    server_count = (
+        await db.execute(
+            select(func.count())
+            .select_from(DNSServer)
+            .where(DNSServer.group_id == zone.group_id, DNSServer.is_enabled.is_(True))
+        )
+    ).scalar_one()
+    if not server_count:
+        blockers.append(
+            Blocker(
+                BLOCKER_TARGET_GROUP_NO_SERVERS,
+                "block",
+                "The target DNS server group has no enabled servers, so nothing would "
+                "answer for this zone after the switch. Add or enable a server in the "
+                "group first.",
+            )
+        )
+
+    if zone.view_id is not None:
+        blockers.append(
+            Blocker(
+                BLOCKER_TARGET_ZONE_VIEW_SCOPED,
+                "warn",
+                "The target zone is scoped to a DNS view, so only clients matching that "
+                "view's match-clients list will receive it. Confirm the view covers "
+                "every client the Windows zone serves today.",
+            )
+        )
+
+    # A forward zone whose group has no reverse zone at all means PTR records
+    # have nowhere to live once this zone is authoritative here — DDNS PTR
+    # updates and reverse lookups that work today would quietly stop. Only
+    # checked for forward zones, and only as a warning: plenty of estates
+    # legitimately run without reverse DNS.
+    if source_zone_meta is not None and not source_zone_meta.get("is_reverse_lookup"):
+        reverse_count = (
+            await db.execute(
+                select(func.count())
+                .select_from(DNSZone)
+                .where(
+                    DNSZone.group_id == zone.group_id,
+                    DNSZone.kind == "reverse",
+                    DNSZone.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one()
+        if not reverse_count:
+            blockers.append(
+                Blocker(
+                    BLOCKER_MISSING_REVERSE_ZONE,
+                    "warn",
+                    "The target DNS server group holds no reverse zone, so PTR records "
+                    "for this zone's hosts have nowhere to go after the switch. Import "
+                    "or create the matching in-addr.arpa / ip6.arpa zone if reverse "
+                    "lookups matter here.",
+                )
+            )
+
+    blockers.extend(_parity_blockers(item))
+    return blockers
+
+
+# ── DHCP ───────────────────────────────────────────────────────────────
+
+
+async def evaluate_dhcp_item(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    scope: DHCPScope | None,
+    source_scope: dict[str, Any] | None,
+) -> list[Blocker]:
+    """Readiness verdicts for one ``dhcp_scope`` item.
+
+    ``source_scope`` is one entry from
+    :meth:`app.drivers.dhcp.windows.WindowsDHCPReadOnlyDriver.get_scopes` —
+    ``{"scope_id", "subnet_cidr", "lease_time", "is_active", "pools",
+    "statics", …}``, or ``None`` when the scope was not found on the source
+    server or the source could not be read.
+    """
+    blockers: list[Blocker] = []
+    cut_over = _is_cut_over(item)
+
+    if plan.source_dhcp_server_id is None:
+        blockers.append(
+            Blocker(
+                BLOCKER_NO_SOURCE_SERVER,
+                "block",
+                "The plan has no source Windows DHCP server. Set one so parity can run "
+                "and so the switch has a server to deactivate the old scope on.",
+            )
+        )
+    elif source_scope is None:
+        blockers.append(
+            Blocker(
+                BLOCKER_SOURCE_SCOPE_MISSING,
+                "block",
+                f"Scope {item.source_ref!r} could not be read from the source Windows "
+                "DHCP server, so the switch has nothing to deactivate and both servers "
+                "could end up answering. Re-run Discover, or remove this item.",
+            )
+        )
+    elif not source_scope.get("is_active"):
+        blockers.append(
+            Blocker(
+                BLOCKER_SOURCE_SCOPE_INACTIVE,
+                "warn",
+                f"The Windows scope {item.source_ref!r} is already inactive, so the "
+                "switch will have nothing to turn off. Confirm clients are not being "
+                "served from somewhere else before activating the managed scope.",
+            )
+        )
+
+    if scope is None:
+        blockers.append(
+            Blocker(
+                BLOCKER_NO_TARGET_SCOPE,
+                "block",
+                "This item has no SpatiumDDI scope linked. Import the Windows scope (or "
+                "link the existing one) before cutting over — there is nothing here to "
+                "hand out addresses.",
+            )
+        )
+        return blockers
+
+    server_count = (
+        await db.execute(
+            select(func.count())
+            .select_from(DHCPServer)
+            .where(DHCPServer.server_group_id == scope.group_id)
+        )
+    ).scalar_one()
+    if not server_count:
+        blockers.append(
+            Blocker(
+                BLOCKER_TARGET_GROUP_NO_SERVERS,
+                "block",
+                "The target DHCP server group has no servers, so nothing would hand out "
+                "addresses after the switch. Add a server to the group first.",
+            )
+        )
+
+    if scope.is_active and not cut_over:
+        blockers.append(
+            Blocker(
+                BLOCKER_MANAGED_SCOPE_ACTIVE,
+                "block",
+                "The managed scope is already active while the Windows scope is still "
+                "serving, so two DHCP servers can answer the same subnet and hand out "
+                "conflicting addresses. Deactivate the SpatiumDDI scope — the parallel "
+                "run must be structurally unreachable to clients — and let the cutover "
+                "activate it.",
+            )
+        )
+
+    if item.lease_handover is None and not cut_over:
+        blockers.append(
+            Blocker(
+                BLOCKER_LEASE_HANDOVER_PENDING,
+                "warn",
+                "Live Windows leases have not been handed over as reservations, so "
+                "clients renewing against the managed server would be offered a "
+                "different address than the one they hold. Run the lease handover "
+                "first, or accept the re-addressing.",
+            )
+        )
+
+    blockers.extend(_parity_blockers(item))
+    return blockers
+
+
+# ── Live refresh ───────────────────────────────────────────────────────
+
+
+async def _pull_source_zone_meta(
+    source_server: DNSServer, source_ref: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Live-read the source zone's metadata.
+
+    Returns ``(meta, error)``. ``(None, None)`` means the server answered and
+    genuinely does not host the zone; ``(None, "…")`` means we could not ask.
+    """
+    try:
+        driver = get_dns_driver(source_server.driver)
+    except ValueError as exc:
+        return None, str(exc)
+
+    if not hasattr(driver, "pull_zones_from_server"):
+        return None, (
+            f"DNS driver {source_server.driver!r} cannot list zones, so the zone's "
+            "dynamic-update mode cannot be verified."
+        )
+
+    try:
+        zones: list[dict[str, Any]] = await driver.pull_zones_from_server(source_server)
+    except Exception as exc:  # noqa: BLE001 — surfaced as a blocker, never raised
+        logger.warning(
+            "cutover.readiness.zone_pull_failed",
+            server=str(source_server.id),
+            driver=source_server.driver,
+            zone=source_ref,
+            error=str(exc),
+        )
+        return None, str(exc)
+
+    want = (source_ref or "").rstrip(".").lower()
+    for entry in zones:
+        if str(entry.get("name") or "").rstrip(".").lower() == want:
+            return entry, None
+    return None, None
+
+
+async def _pull_source_scope(
+    source_server: DHCPServer, source_ref: str, subnet_cidr: str
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Live-read the source scope. Same ``(entry, error)`` contract as above."""
+    try:
+        driver = get_dhcp_driver(source_server.driver)
+    except ValueError as exc:
+        return None, str(exc)
+
+    if not hasattr(driver, "get_scopes"):
+        return None, (
+            f"DHCP driver {source_server.driver!r} cannot list scopes, so the source "
+            "scope's state cannot be verified."
+        )
+
+    try:
+        scopes: list[dict[str, Any]] = await driver.get_scopes(source_server)
+    except Exception as exc:  # noqa: BLE001 — surfaced as a blocker, never raised
+        logger.warning(
+            "cutover.readiness.scope_pull_failed",
+            server=str(source_server.id),
+            driver=source_server.driver,
+            scope=source_ref,
+            error=str(exc),
+        )
+        return None, str(exc)
+
+    return match_source_scope(scopes, subnet_cidr=subnet_cidr, source_scope_id=source_ref), None
+
+
+def _annotate_unreadable_source(blockers: list[Blocker], code: str, error: str) -> None:
+    """Replace a "not found on the source" message with the real transport error.
+
+    ``evaluate_*`` cannot tell the two apart from a ``None`` payload, but they
+    need different fixes: a missing zone means remove the item, an unreachable
+    server means fix WinRM. Only the message changes — the code and the ``block``
+    severity stay, because either way the item is unverified.
+    """
+    for blocker in blockers:
+        if blocker.code == code:
+            blocker.message = (
+                "The source Windows server could not be read, so this item is "
+                f"unverified: {error}. Fix the connection and re-check before cutting "
+                "over."
+            )
+
+
+async def refresh_blockers(
+    db: AsyncSession, *, plan: CutoverPlan, item: CutoverItem
+) -> list[Blocker]:
+    """Re-evaluate ``item`` against live source state and persist the verdict.
+
+    Reads the source Windows server for real on every call — a zone flipped to
+    "Secure only" after the last parity run must still be caught. Writes the
+    result to ``item.blockers`` and **does not commit**: the caller owns the
+    transaction, so a cutover handler can refresh, refuse, and roll back its own
+    unit of work without leaving a half-written item behind.
+    """
+    if item.kind == "dns_zone":
+        blockers = await _refresh_dns_blockers(db, plan=plan, item=item)
+    elif item.kind == "dhcp_scope":
+        blockers = await _refresh_dhcp_blockers(db, plan=plan, item=item)
+    else:
+        raise ValueError(f"Unsupported cutover item kind {item.kind!r}")
+
+    item.blockers = [b.as_dict() for b in blockers]
+    db.add(item)
+
+    logger.info(
+        "cutover.readiness.refreshed",
+        plan=str(plan.id),
+        item=str(item.id),
+        kind=item.kind,
+        source_ref=item.source_ref,
+        blocking=sum(1 for b in blockers if b.severity == "block"),
+        warnings=sum(1 for b in blockers if b.severity == "warn"),
+    )
+    return blockers
+
+
+async def _refresh_dns_blockers(
+    db: AsyncSession, *, plan: CutoverPlan, item: CutoverItem
+) -> list[Blocker]:
+    zone: DNSZone | None = None
+    if item.zone_id is not None:
+        zone = (
+            await db.execute(select(DNSZone).where(DNSZone.id == item.zone_id))
+        ).scalar_one_or_none()
+
+    source_server: DNSServer | None = None
+    if plan.source_dns_server_id is not None:
+        source_server = (
+            await db.execute(select(DNSServer).where(DNSServer.id == plan.source_dns_server_id))
+        ).scalar_one_or_none()
+
+    meta: dict[str, Any] | None = None
+    source_error: str | None = None
+    if source_server is not None:
+        meta, source_error = await _pull_source_zone_meta(source_server, item.source_ref)
+
+    blockers = await evaluate_dns_item(db, plan=plan, item=item, zone=zone, source_zone_meta=meta)
+    if source_error:
+        _annotate_unreadable_source(blockers, BLOCKER_SOURCE_ZONE_MISSING, source_error)
+    return blockers
+
+
+async def _refresh_dhcp_blockers(
+    db: AsyncSession, *, plan: CutoverPlan, item: CutoverItem
+) -> list[Blocker]:
+    scope: DHCPScope | None = None
+    if item.scope_id is not None:
+        scope = (
+            await db.execute(select(DHCPScope).where(DHCPScope.id == item.scope_id))
+        ).scalar_one_or_none()
+
+    source_server: DHCPServer | None = None
+    if plan.source_dhcp_server_id is not None:
+        source_server = (
+            await db.execute(select(DHCPServer).where(DHCPServer.id == plan.source_dhcp_server_id))
+        ).scalar_one_or_none()
+
+    # The CIDR is how the source scope is matched; without the scope (and so
+    # without a subnet) we fall back to matching on the scope id alone, which
+    # ``match_source_scope`` handles.
+    subnet_cidr = ""
+    if scope is not None:
+        subnet = (
+            await db.execute(select(Subnet).where(Subnet.id == scope.subnet_id))
+        ).scalar_one_or_none()
+        if subnet is not None:
+            subnet_cidr = str(subnet.network)
+
+    source: dict[str, Any] | None = None
+    source_error: str | None = None
+    if source_server is not None:
+        source, source_error = await _pull_source_scope(source_server, item.source_ref, subnet_cidr)
+
+    blockers = await evaluate_dhcp_item(db, plan=plan, item=item, scope=scope, source_scope=source)
+    if source_error:
+        _annotate_unreadable_source(blockers, BLOCKER_SOURCE_SCOPE_MISSING, source_error)
+    return blockers
+
+
+__all__ = [
+    "evaluate_dhcp_item",
+    "evaluate_dns_item",
+    "normalize_dynamic_update",
+    "refresh_blockers",
+]

--- a/backend/app/services/cutover/runbook.py
+++ b/backend/app/services/cutover/runbook.py
@@ -1,0 +1,691 @@
+"""Operator runbook generator for a cutover plan (issue #756).
+
+:func:`render_runbook` turns a plan and its items into markdown that gets
+pasted straight into a change ticket. It is deliberately not a summary of
+what SpatiumDDI already did — it is the document the operator works from
+during the window, so it carries the Windows-side PowerShell we deliberately
+do **not** run for them, the exact order of operations, and a rollback with a
+number attached.
+
+Two things here are load-bearing rather than decorative:
+
+* **The Windows-side TTL block.** SpatiumDDI lowers TTLs on its own copy of a
+  zone during pre-flight, but the currently-authoritative TTLs — the ones
+  resolvers are actually caching — belong to the Windows server. Lowering only
+  our side is worse than lowering neither, because it produces a runbook that
+  claims a five-minute rollback while the world still holds hour-long answers.
+  So the block is emitted, with the item's real target TTL baked in.
+* **The stated recovery time.** Every rollback section names a concrete number
+  derived from that item's actual pre-flight TTL (or lease time), and says so
+  when no pre-flight has been run — an unquantified "roll back if it goes
+  wrong" is what turns a bad cutover into a long one.
+
+Nothing is escaped: the output is markdown for humans, and zone names / scope
+ids are DNS labels and IP addresses.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, NamedTuple
+
+from app.models.cutover import CutoverItem, CutoverPlan
+from app.services.cutover.canonical import ParityReport
+from app.services.cutover.preflight import windows_ttl_powershell
+
+#: Used when an item has no TTL evidence at all — matches ``DNSZone.ttl``'s
+#: model default, so it is the value a freshly-created zone really carries.
+#: Always rendered with an explicit "assumed" caveat.
+_ASSUMED_ZONE_TTL = 3600
+
+#: What to tell an operator to lower to when no pre-flight has run yet. Inside
+#: the pre-flight's documented 30..86400 bound, and the conventional migration
+#: value: short enough that a rollback lands in minutes, long enough that the
+#: authoritative servers aren't answering every query twice.
+_RECOMMENDED_TARGET_TTL = 300
+
+#: Same idea for DHCP: ``DHCPScope`` leases default to a day in every driver we
+#: ship, and clients first attempt renewal at T1 (half the lease).
+_ASSUMED_LEASE_SECONDS = 86400
+
+_PLACEHOLDER_DNS_HOST = "WINDOWS-DNS-SERVER"
+_PLACEHOLDER_DHCP_HOST = "WINDOWS-DHCP-SERVER"
+
+
+def _humanise(seconds: int) -> str:
+    """``300`` → ``"5 minutes"``. Whole units only; this is prose, not a clock."""
+    if seconds < 60:
+        return f"{seconds} second{'s' if seconds != 1 else ''}"
+    if seconds < 3600:
+        minutes = seconds // 60
+        rest = seconds % 60
+        head = f"{minutes} minute{'s' if minutes != 1 else ''}"
+        return head if rest == 0 else f"{head} {rest}s"
+    if seconds < 86400:
+        hours = seconds // 3600
+        rest = (seconds % 3600) // 60
+        head = f"{hours} hour{'s' if hours != 1 else ''}"
+        return head if rest == 0 else f"{head} {rest}m"
+    days = seconds // 86400
+    rest = (seconds % 86400) // 3600
+    head = f"{days} day{'s' if days != 1 else ''}"
+    return head if rest == 0 else f"{head} {rest}h"
+
+
+def _as_int(value: Any) -> int | None:
+    """Coerce a JSONB-sourced number to ``int``, or ``None`` if it isn't one."""
+    if isinstance(value, bool):  # bool is an int subclass; not a TTL
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _sort_key(item: CutoverItem) -> tuple[int, str]:
+    """DNS first, then DHCP, each alphabetical.
+
+    DNS leads because it is the half with a multi-hour lead time: TTLs have to
+    be dropped and then *waited out* before the window opens, while a DHCP
+    scope switch is instant.
+    """
+    return (0 if item.kind == "dns_zone" else 1, item.source_ref)
+
+
+# ── evidence extraction ────────────────────────────────────────────────
+
+
+def _parity_facts(
+    item: CutoverItem, reports: Mapping[str, ParityReport] | None
+) -> dict[str, Any] | None:
+    """Best available parity evidence for an item, as a flat dict.
+
+    A freshly-run :class:`ParityReport` passed by the caller wins; otherwise
+    the persisted ``item.last_parity`` blob is used, so a runbook generated
+    without re-running the checks still reports the last known state rather
+    than silently claiming nothing is known.
+    """
+    if reports is not None:
+        report = reports.get(str(item.id))
+        if report is not None:
+            return {
+                "status": report.status,
+                "error": report.error,
+                "in_sync": report.in_sync,
+                "difference_count": report.difference_count,
+                "counts_by_class": report.counts_by_class(),
+                "fresh": True,
+            }
+    stored = item.last_parity
+    if isinstance(stored, dict):
+        return {
+            "status": stored.get("status"),
+            "error": stored.get("error"),
+            "in_sync": stored.get("in_sync"),
+            "difference_count": stored.get("difference_count"),
+            "counts_by_class": stored.get("counts_by_class") or {},
+            "fresh": False,
+        }
+    return None
+
+
+class _DnsTtls(NamedTuple):
+    """The two different TTLs a DNS item's section needs.
+
+    They are only the same number once the pre-flight has run: before that,
+    ``target`` is what the operator is being told to lower *to* and ``recovery``
+    is the long value still governing a rollback. Conflating them produces the
+    two worst possible instructions — "lower this zone to 3600s" (it already is)
+    and "recovery is ~5 minutes" (it is an hour).
+    """
+
+    #: What the TTL pre-flight lowers records to.
+    target: int
+    #: What actually governs rollback convergence right now.
+    recovery: int
+    lowered: bool
+    #: Where ``recovery`` came from, in prose.
+    provenance: str
+
+
+def _dns_ttl(item: CutoverItem, propagation_seconds: Mapping[str, int] | None) -> _DnsTtls:
+    """Resolve a DNS item's pre-flight target and current recovery TTL.
+
+    Evidence, most authoritative first: an explicit ``propagation_seconds``
+    entry (the caller read the live ``DNSZone.ttl``, i.e. what records are
+    genuinely being served with); ``ttl_snapshot["target_ttl"]``, stamped by
+    the pre-flight apply; ``ttl_snapshot["zone"]["ttl"]``, the original
+    pre-lowering value; then the zone-model default, labelled as an assumption.
+    """
+    override = (propagation_seconds or {}).get(str(item.id))
+    snapshot = item.ttl_snapshot if isinstance(item.ttl_snapshot, dict) else {}
+    applied = _as_int(snapshot.get("target_ttl"))
+    zone_before = snapshot.get("zone")
+    original = _as_int(zone_before.get("ttl")) if isinstance(zone_before, dict) else None
+
+    if item.ttl_lowered_at is not None:
+        # Pre-flight applied: records are being served with the lowered value,
+        # so target and recovery are the same number.
+        if applied is not None:
+            return _DnsTtls(applied, applied, True, "the TTL applied by the pre-flight")
+        if override is not None:
+            return _DnsTtls(override, override, True, "the zone's current TTL")
+        return _DnsTtls(
+            _RECOMMENDED_TARGET_TTL,
+            _RECOMMENDED_TARGET_TTL,
+            True,
+            "an assumed value (the pre-flight recorded no target TTL)",
+        )
+
+    # No pre-flight: recovery is still governed by the long, current TTL.
+    if override is not None:
+        return _DnsTtls(_RECOMMENDED_TARGET_TTL, override, False, "the zone's current TTL")
+    if original is not None:
+        return _DnsTtls(_RECOMMENDED_TARGET_TTL, original, False, "the zone's pre-migration TTL")
+    return _DnsTtls(
+        _RECOMMENDED_TARGET_TTL,
+        _ASSUMED_ZONE_TTL,
+        False,
+        "an assumed zone default, because nothing recorded the real one",
+    )
+
+
+def _dhcp_lease(
+    item: CutoverItem, propagation_seconds: Mapping[str, int] | None
+) -> tuple[int, str]:
+    """``(lease_seconds, provenance)`` for a DHCP item's recovery time."""
+    override = (propagation_seconds or {}).get(str(item.id))
+    if override is not None:
+        return override, "the scope's configured lease time"
+    return _ASSUMED_LEASE_SECONDS, "an assumed 24-hour lease (supply the real one to sharpen this)"
+
+
+# ── document sections ──────────────────────────────────────────────────
+
+
+def _header(plan: CutoverPlan, items: Sequence[CutoverItem]) -> list[str]:
+    generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    dns_count = sum(1 for i in items if i.kind == "dns_zone")
+    dhcp_count = len(items) - dns_count
+    out = [
+        f"# Cutover runbook — {plan.name}",
+        "",
+        (
+            f"Generated {generated} · plan status `{plan.status}` · "
+            f"{dns_count} DNS zone(s), {dhcp_count} DHCP scope(s)"
+        ),
+        "",
+    ]
+    if plan.description.strip():
+        out += [plan.description.strip(), ""]
+    out += [
+        "Read this end to end before the change window opens. Each item below is",
+        "independent: they can be cut over one at a time, on different days, and each",
+        "one rolls back on its own. There is no big-bang step anywhere in this plan.",
+        "",
+    ]
+    if plan.notes.strip():
+        out += ["**Plan notes**", "", plan.notes.strip(), ""]
+    return out
+
+
+def _summary_table(items: Sequence[CutoverItem]) -> list[str]:
+    out = [
+        "## Items",
+        "",
+        "| # | Kind | Windows source | Stage | Blockers |",
+        "|---|---|---|---|---|",
+    ]
+    for n, item in enumerate(items, start=1):
+        blockers = item.blockers if isinstance(item.blockers, list) else []
+        blocking = sum(1 for b in blockers if isinstance(b, dict) and b.get("severity") == "block")
+        warns = len(blockers) - blocking
+        if blocking:
+            verdict = f"**{blocking} blocking**" + (f", {warns} warning" if warns else "")
+        elif warns:
+            verdict = f"{warns} warning(s)"
+        else:
+            verdict = "none"
+        kind = "DNS zone" if item.kind == "dns_zone" else "DHCP scope"
+        out.append(f"| {n} | {kind} | `{item.source_ref}` | `{item.stage}` | {verdict} |")
+    out.append("")
+    return out
+
+
+def _blocker_block(item: CutoverItem) -> list[str]:
+    blockers = item.blockers if isinstance(item.blockers, list) else []
+    if not blockers:
+        return ["**Readiness** — no blockers recorded at generation time.", ""]
+    out = ["**Readiness**", ""]
+    has_block = False
+    for raw in blockers:
+        if not isinstance(raw, dict):
+            continue
+        severity = str(raw.get("severity") or "warn")
+        has_block = has_block or severity == "block"
+        marker = "⛔ BLOCK" if severity == "block" else "⚠️ warn"
+        out.append(f"- {marker} `{raw.get('code')}` — {raw.get('message')}")
+    if has_block:
+        out += [
+            "",
+            "The `BLOCK` entries above are refused by the API and cannot be forced. "
+            "Clear them before the window; `force` only acknowledges warnings.",
+        ]
+    else:
+        out += [
+            "",
+            "Warnings do not stop the cutover, but the API asks you to acknowledge "
+            "them with `force`. Read each one first — that is the entire point of "
+            "making you pass the flag.",
+        ]
+    out.append("")
+    return out
+
+
+def _parity_block(facts: dict[str, Any] | None) -> list[str]:
+    if facts is None:
+        return [
+            "**Parity** — never checked. Run the parity check before the window; a "
+            "cutover from an unverified copy is a guess.",
+            "",
+        ]
+    status = facts.get("status")
+    if status == "error":
+        return [f"**Parity** — last check failed: {facts.get('error')}", ""]
+    if status == "unmatched":
+        return [
+            f"**Parity** — the object exists on one side only ({facts.get('error')}).",
+            "",
+        ]
+    diffs = facts.get("difference_count") or 0
+    freshness = "checked for this runbook" if facts.get("fresh") else "last recorded check"
+    if not diffs:
+        return [f"**Parity** — in sync ({facts.get('in_sync')} objects matched, {freshness}).", ""]
+    counts = facts.get("counts_by_class") or {}
+    detail = ", ".join(f"{v} {k}" for k, v in counts.items() if v)
+    out = [f"**Parity** — {diffs} difference(s) ({freshness}).", ""]
+    if detail:
+        out += [f"Breakdown: {detail}.", ""]
+    out += [
+        "Reconcile these before cutting over, or accept them explicitly — each one is "
+        "an answer that changes the moment traffic moves.",
+        "",
+    ]
+    return out
+
+
+def _ps_lower_ttls(host: str, zone: str, ttl: int, current_ttl: int) -> list[str]:
+    """Fence the canonical Windows-side TTL script for the runbook.
+
+    The script itself lives in :func:`app.services.cutover.preflight.windows_ttl_powershell`
+    and is *not* duplicated here: the same commands are also returned inline on
+    every pre-flight preview and apply, and handing an operator two subtly
+    different versions of the same step is how one of them ends up wrong.
+    """
+    block = windows_ttl_powershell(zone, ttl, current_ttl, computer_name=host)
+    return ["```powershell", *block.rstrip("\n").split("\n"), "```", ""]
+
+
+def _ps_disable_scavenging(host: str, zone: str) -> list[str]:
+    return [
+        "```powershell",
+        "# Scavenging deletes 'stale' dynamically-registered records. Once clients",
+        "# start registering against SpatiumDDI instead, Windows sees its own copies",
+        "# stop refreshing and begins deleting them — during a parallel run that",
+        "# silently empties the zone you are still falling back to. Turn it off",
+        "# BEFORE the parallel run starts, not after.",
+        f"$Server = '{host}'",
+        "",
+        "Set-DnsServerScavenging -ComputerName $Server -ScavengingState $false -ApplyOnAllZones",
+        f"Set-DnsServerZoneAging -ComputerName $Server -Name '{zone}' -Aging $false",
+        "",
+        "# Verify",
+        "Get-DnsServerScavenging -ComputerName $Server",
+        f"Get-DnsServerZoneAging -ComputerName $Server -Name '{zone}'",
+        "```",
+        "",
+    ]
+
+
+def _ps_scope_state(host: str, scope_id: str, *, active: bool) -> list[str]:
+    state = "Active" if active else "InActive"
+    return [
+        "```powershell",
+        "# Manual equivalent of what SpatiumDDI does for you. The Windows enum value",
+        "# is 'InActive' — one word, capital A.",
+        f"Set-DhcpServerv4Scope -ComputerName '{host}' -ScopeId {scope_id} -State {state}",
+        f"Get-DhcpServerv4Scope -ComputerName '{host}' -ScopeId {scope_id} |",
+        "    Select-Object ScopeId, Name, State, LeaseDuration",
+        "```",
+        "",
+    ]
+
+
+def _ps_deauthorize_dhcp(host: str) -> list[str]:
+    return [
+        "```powershell",
+        "# Deauthorize the Windows DHCP server in Active Directory. Until this runs,",
+        "# the server is still an authorized DHCP source in the forest and will",
+        "# happily start serving again after a reboot or a service restart.",
+        "# Needs Enterprise Admins, or delegated rights on the NetServices container.",
+        "",
+        "Get-DhcpServerInDC      # what AD authorizes today — note the exact DnsName/IPAddress",
+        "",
+        f"Remove-DhcpServerInDC -DnsName '{host}' -IPAddress '<the IP listed above>'",
+        "",
+        "Get-DhcpServerInDC      # confirm it is gone",
+        "```",
+        "",
+    ]
+
+
+# ── per-item sections ──────────────────────────────────────────────────
+
+
+def _dns_section(
+    n: int,
+    item: CutoverItem,
+    *,
+    facts: dict[str, Any] | None,
+    host: str,
+    ttls: _DnsTtls,
+) -> list[str]:
+    zone = item.source_ref
+    out = [f"### {n}. DNS zone `{zone}`", ""]
+    out += _parity_block(facts)
+    out += _blocker_block(item)
+
+    applied_note = (
+        " (already applied — re-running is a no-op for records at or below the target)"
+        if ttls.lowered
+        else ""
+    )
+    out += [
+        "#### Pre-flight",
+        "",
+        "1. Confirm parity (above). Reconcile or consciously accept every difference.",
+        "2. Turn off scavenging and aging on the Windows side, if it is on.",
+        "",
+    ]
+    out += _ps_disable_scavenging(host, zone)
+    out += [
+        f"3. Run the TTL pre-flight in SpatiumDDI to lower this zone to {ttls.target}s"
+        f"{applied_note}. The original values are snapshotted, so the restore is exact.",
+        f"4. Lower the **Windows-side** TTLs to the same {ttls.target}s. SpatiumDDI does "
+        "not do this for you — the Windows copy is the one resolvers are caching right "
+        "now, and lowering only our side buys nothing.",
+        "",
+    ]
+    out += _ps_lower_ttls(host, zone, ttls.target, ttls.recovery)
+    if ttls.lowered:
+        step5 = (
+            "5. Confirm the short TTL is actually being served before you rely on it — "
+            f"`dig +noall +answer {zone} SOA` against both sides should show {ttls.target}. "
+            "A cache that fetched an answer just before step 4 still holds the old value "
+            "until that older TTL elapses."
+        )
+    else:
+        step5 = (
+            f"5. Wait out the **old** TTL ({_humanise(ttls.recovery)}) before continuing. "
+            "Caches that fetched an answer just before step 4 keep it for the old "
+            f"duration; until that has elapsed, the {_humanise(ttls.target)} recovery "
+            "time below is not real yet."
+        )
+    out += [
+        step5,
+        "6. Run the shadow comparison and confirm the managed servers answer identically "
+        "to Windows for real production query names.",
+        "",
+        "#### The switch",
+        "",
+        "SpatiumDDI owns no server-side switch for DNS — the switch is the delegation "
+        "or forwarder change, and it lives on the parent zone or on the resolvers.",
+        "",
+        "1. Point the delegation (parent-zone NS records) or the resolver forwarders at "
+        "the SpatiumDDI servers for this zone.",
+        "2. Record the transition in SpatiumDDI (the item's **Cut over** action). It "
+        "stamps the item, writes the audit + timeline rows, and refuses if any blocking "
+        "readiness issue is still present.",
+        "3. Verify from a client subnet, not just from the DNS host:",
+        "",
+        "```bash",
+        f"dig +norecurse @<spatiumddi-server-ip> {zone} SOA",
+        f"dig {zone} NS      # resolved through the production resolver path",
+        "```",
+        "",
+        "#### Rollback",
+        "",
+        "1. Revert the delegation / forwarder change made in step 1 of the switch.",
+        "2. Restore the TTLs from the snapshot (the item's **Restore TTLs** action).",
+        "",
+    ]
+    if ttls.lowered:
+        applied_at = (
+            item.ttl_lowered_at.strftime("%Y-%m-%d %H:%M UTC")
+            if item.ttl_lowered_at is not None
+            else "an unrecorded time"
+        )
+        out += [
+            f"**Recovery time: ~{_humanise(ttls.recovery)} ({ttls.recovery}s)** once the "
+            f"delegation is reverted — that is {ttls.provenance}, and the pre-flight was "
+            f"applied at {applied_at}. Every resolver holding an answer from the "
+            "SpatiumDDI servers drops it within that window and re-queries.",
+            "",
+        ]
+    else:
+        out += [
+            f"**Recovery time: up to {_humanise(ttls.recovery)} ({ttls.recovery}s)** — the "
+            "TTL pre-flight has NOT been run for this item, so recovery is governed by "
+            f"{ttls.provenance}. That number is the real length of a bad cutover. Run the "
+            f"pre-flight (step 3) and wait out the old TTL, and it drops to "
+            f"~{_humanise(ttls.target)}.",
+            "",
+        ]
+    return out
+
+
+def _dhcp_section(
+    n: int,
+    item: CutoverItem,
+    *,
+    facts: dict[str, Any] | None,
+    host: str,
+    lease_seconds: int,
+    lease_provenance: str,
+) -> list[str]:
+    scope = item.source_ref
+    t1 = max(lease_seconds // 2, 1)
+    out = [f"### {n}. DHCP scope `{scope}`", ""]
+    out += _parity_block(facts)
+    out += _blocker_block(item)
+
+    handover = item.lease_handover if isinstance(item.lease_handover, dict) else None
+    out += ["#### Pre-flight", ""]
+    out += [
+        "1. Confirm parity (above): pools, exclusions, reservations, lease time and "
+        "options must all match before any client is asked to renew against Kea.",
+        "2. Confirm the managed scope is still **inactive**. During the parallel run the "
+        "SpatiumDDI scope must be structurally unreachable — two DHCP servers answering "
+        "on one broadcast domain is a coin flip, not a migration.",
+        "3. Run the **lease handover**. It turns every live Windows lease into a "
+        "reservation on the managed scope, so a client renewing against Kea gets back the "
+        "address it already holds instead of a fresh one from an empty pool.",
+        "",
+    ]
+    if handover:
+        out += [
+            (
+                f"   Last handover: {handover.get('created', 0)} created, "
+                f"{handover.get('skipped', 0)} skipped, {handover.get('failed', 0)} failed "
+                f"({handover.get('at', 'time not recorded')})."
+            ),
+            "",
+        ]
+    else:
+        out += ["   Not run yet for this item.", ""]
+
+    out += [
+        "#### The switch",
+        "",
+        "This one SpatiumDDI performs, atomically and in this order:",
+        "",
+        f"1. Deactivate the scope on the Windows server (`{host}`).",
+        "2. Activate the managed scope and wake the DHCP agents.",
+        "",
+        "The order is the whole point — the old server stops answering before the new one "
+        "starts, so the two never race. If step 2 fails, step 1 is reversed automatically.",
+        "",
+    ]
+    out += _ps_scope_state(host, scope, active=False)
+    out += [
+        "Verify by watching a real client renew (`ipconfig /renew`, or `dhclient -v`), and "
+        "confirm the offered address matches the reservation carried over in pre-flight.",
+        "",
+        "#### Rollback",
+        "",
+        "1. Deactivate the managed scope.",
+        f"2. Reactivate the Windows scope on `{host}`.",
+        "",
+    ]
+    out += _ps_scope_state(host, scope, active=True)
+    out += [
+        f"**Recovery time: ~{_humanise(t1)} ({t1}s), up to {_humanise(lease_seconds)} "
+        f"({lease_seconds}s)** — derived from {lease_provenance}. Clients first try to "
+        "renew at T1, half the lease, and a client that renewed moments before the "
+        "rollback waits until then. Nothing breaks in the meantime: an already-issued "
+        "lease stays valid for its full duration regardless of which server issued it, "
+        "which is why the lease handover in pre-flight matters so much — the addresses "
+        "are identical on both sides, so a rollback is invisible to the client.",
+        "",
+    ]
+    return out
+
+
+def _decommission_section(dns_host: str, dhcp_host: str, *, has_dhcp: bool) -> list[str]:
+    out = [
+        "## After the window — decommission",
+        "",
+        "Work the plan's decommission checklist in the UI; it tracks the ticks and notes "
+        "per plan. Two steps are worth having the exact command for.",
+        "",
+        "### Deauthorize the Windows DHCP server in AD",
+        "",
+    ]
+    if has_dhcp:
+        out += _ps_deauthorize_dhcp(dhcp_host)
+    else:
+        out += ["This plan migrates no DHCP scopes; nothing to deauthorize.", ""]
+    out += [
+        "### Stop the Windows services (only after a full soak)",
+        "",
+        "```powershell",
+        "# Stop and disable rather than uninstall — the role, its zone data and its",
+        "# scope database stay on disk, which is what makes a late rollback possible.",
+        "Stop-Service -Name DNS -Force ; Set-Service -Name DNS -StartupType Disabled",
+        "Stop-Service -Name DHCPServer -Force ; Set-Service -Name DHCPServer "
+        "-StartupType Disabled",
+        "```",
+        "",
+        f"Run those on `{dns_host}` / `{dhcp_host}` respectively. Do not uninstall the "
+        "roles until the checklist is complete and the plan has soaked for at least one "
+        "full DHCP lease cycle.",
+        "",
+    ]
+    return out
+
+
+# ── public entry point ─────────────────────────────────────────────────
+
+
+def render_runbook(
+    plan: CutoverPlan,
+    items: Sequence[CutoverItem],
+    reports: Mapping[str, ParityReport] | None = None,
+    *,
+    source_dns_host: str | None = None,
+    source_dhcp_host: str | None = None,
+    propagation_seconds: Mapping[str, int] | None = None,
+) -> str:
+    """Render the operator runbook for ``plan`` as markdown.
+
+    ``reports`` maps ``str(item.id)`` to a freshly-computed
+    :class:`~app.services.cutover.canonical.ParityReport`. It is optional: any
+    item without a fresh report falls back to its persisted ``last_parity``
+    blob, so a runbook generated without re-running the checks still states the
+    last known parity rather than claiming nothing is known.
+
+    ``source_dns_host`` / ``source_dhcp_host`` are interpolated into the
+    PowerShell blocks. When omitted, an obvious placeholder is emitted instead
+    — the plan row carries only FK ids, so the caller is the one that knows the
+    hostnames.
+
+    ``propagation_seconds`` maps ``str(item.id)`` to the item's real
+    propagation constant: the zone's currently-served TTL for a DNS item, the
+    scope's lease time for a DHCP item. Supplying it is what makes the stated
+    recovery time exact rather than derived from the pre-flight snapshot.
+    """
+    ordered = sorted(items, key=_sort_key)
+    dns_host = source_dns_host or _PLACEHOLDER_DNS_HOST
+    dhcp_host = source_dhcp_host or _PLACEHOLDER_DHCP_HOST
+
+    lines: list[str] = []
+    lines += _header(plan, ordered)
+
+    if not ordered:
+        lines += [
+            "This plan has no items yet. Run **Discover** against the source Windows "
+            "servers and add the zones / scopes you intend to migrate, then regenerate "
+            "this runbook.",
+            "",
+        ]
+        return "\n".join(lines).rstrip() + "\n"
+
+    lines += _summary_table(ordered)
+
+    blocked = [
+        i
+        for i in ordered
+        if any(
+            isinstance(b, dict) and b.get("severity") == "block"
+            for b in (i.blockers if isinstance(i.blockers, list) else [])
+        )
+    ]
+    if blocked:
+        lines += [
+            "> **Do not open the change window yet.** "
+            f"{len(blocked)} item(s) carry a blocking readiness issue and the cutover "
+            "endpoint will refuse them. See the Readiness list under each item.",
+            "",
+        ]
+
+    lines += ["## Per-item procedure", ""]
+    for n, item in enumerate(ordered, start=1):
+        facts = _parity_facts(item, reports)
+        if item.kind == "dns_zone":
+            lines += _dns_section(
+                n,
+                item,
+                facts=facts,
+                host=dns_host,
+                ttls=_dns_ttl(item, propagation_seconds),
+            )
+        else:
+            lease_seconds, lease_provenance = _dhcp_lease(item, propagation_seconds)
+            lines += _dhcp_section(
+                n,
+                item,
+                facts=facts,
+                host=dhcp_host,
+                lease_seconds=lease_seconds,
+                lease_provenance=lease_provenance,
+            )
+
+    lines += _decommission_section(
+        dns_host, dhcp_host, has_dhcp=any(i.kind == "dhcp_scope" for i in ordered)
+    )
+    return "\n".join(lines).rstrip() + "\n"

--- a/backend/app/services/cutover/runbook.py
+++ b/backend/app/services/cutover/runbook.py
@@ -273,15 +273,19 @@ def _blocker_block(item: CutoverItem) -> list[str]:
     if has_block:
         out += [
             "",
-            "The `BLOCK` entries above are refused by the API and cannot be forced. "
-            "Clear them before the window; `force` only acknowledges warnings.",
+            (
+                "The `BLOCK` entries above are refused by the API and cannot be forced. "
+                "Clear them before the window; `force` only acknowledges warnings."
+            ),
         ]
     else:
         out += [
             "",
-            "Warnings do not stop the cutover, but the API asks you to acknowledge "
-            "them with `force`. Read each one first — that is the entire point of "
-            "making you pass the flag.",
+            (
+                "Warnings do not stop the cutover, but the API asks you to acknowledge "
+                "them with `force`. Read each one first — that is the entire point of "
+                "making you pass the flag."
+            ),
         ]
     out.append("")
     return out
@@ -290,8 +294,10 @@ def _blocker_block(item: CutoverItem) -> list[str]:
 def _parity_block(facts: dict[str, Any] | None) -> list[str]:
     if facts is None:
         return [
-            "**Parity** — never checked. Run the parity check before the window; a "
-            "cutover from an unverified copy is a guess.",
+            (
+                "**Parity** — never checked. Run the parity check before the window; a "
+                "cutover from an unverified copy is a guess."
+            ),
             "",
         ]
     status = facts.get("status")
@@ -312,8 +318,10 @@ def _parity_block(facts: dict[str, Any] | None) -> list[str]:
     if detail:
         out += [f"Breakdown: {detail}.", ""]
     out += [
-        "Reconcile these before cutting over, or accept them explicitly — each one is "
-        "an answer that changes the moment traffic moves.",
+        (
+            "Reconcile these before cutting over, or accept them explicitly — each one is "
+            "an answer that changes the moment traffic moves."
+        ),
         "",
     ]
     return out
@@ -438,19 +446,27 @@ def _dns_section(
         )
     out += [
         step5,
-        "6. Run the shadow comparison and confirm the managed servers answer identically "
-        "to Windows for real production query names.",
+        (
+            "6. Run the shadow comparison and confirm the managed servers answer identically "
+            "to Windows for real production query names."
+        ),
         "",
         "#### The switch",
         "",
-        "SpatiumDDI owns no server-side switch for DNS — the switch is the delegation "
-        "or forwarder change, and it lives on the parent zone or on the resolvers.",
+        (
+            "SpatiumDDI owns no server-side switch for DNS — the switch is the delegation "
+            "or forwarder change, and it lives on the parent zone or on the resolvers."
+        ),
         "",
-        "1. Point the delegation (parent-zone NS records) or the resolver forwarders at "
-        "the SpatiumDDI servers for this zone.",
-        "2. Record the transition in SpatiumDDI (the item's **Cut over** action). It "
-        "stamps the item, writes the audit + timeline rows, and refuses if any blocking "
-        "readiness issue is still present.",
+        (
+            "1. Point the delegation (parent-zone NS records) or the resolver forwarders at "
+            "the SpatiumDDI servers for this zone."
+        ),
+        (
+            "2. Record the transition in SpatiumDDI (the item's **Cut over** action). It "
+            "stamps the item, writes the audit + timeline rows, and refuses if any blocking "
+            "readiness issue is still present."
+        ),
         "3. Verify from a client subnet, not just from the DNS host:",
         "",
         "```bash",
@@ -507,14 +523,20 @@ def _dhcp_section(
     handover = item.lease_handover if isinstance(item.lease_handover, dict) else None
     out += ["#### Pre-flight", ""]
     out += [
-        "1. Confirm parity (above): pools, exclusions, reservations, lease time and "
-        "options must all match before any client is asked to renew against Kea.",
-        "2. Confirm the managed scope is still **inactive**. During the parallel run the "
-        "SpatiumDDI scope must be structurally unreachable — two DHCP servers answering "
-        "on one broadcast domain is a coin flip, not a migration.",
-        "3. Run the **lease handover**. It turns every live Windows lease into a "
-        "reservation on the managed scope, so a client renewing against Kea gets back the "
-        "address it already holds instead of a fresh one from an empty pool.",
+        (
+            "1. Confirm parity (above): pools, exclusions, reservations, lease time and "
+            "options must all match before any client is asked to renew against Kea."
+        ),
+        (
+            "2. Confirm the managed scope is still **inactive**. During the parallel run the "
+            "SpatiumDDI scope must be structurally unreachable — two DHCP servers answering "
+            "on one broadcast domain is a coin flip, not a migration."
+        ),
+        (
+            "3. Run the **lease handover**. It turns every live Windows lease into a "
+            "reservation on the managed scope, so a client renewing against Kea gets back the "
+            "address it already holds instead of a fresh one from an empty pool."
+        ),
         "",
     ]
     if handover:
@@ -537,14 +559,18 @@ def _dhcp_section(
         f"1. Deactivate the scope on the Windows server (`{host}`).",
         "2. Activate the managed scope and wake the DHCP agents.",
         "",
-        "The order is the whole point — the old server stops answering before the new one "
-        "starts, so the two never race. If step 2 fails, step 1 is reversed automatically.",
+        (
+            "The order is the whole point — the old server stops answering before the new one "
+            "starts, so the two never race. If step 2 fails, step 1 is reversed automatically."
+        ),
         "",
     ]
     out += _ps_scope_state(host, scope, active=False)
     out += [
-        "Verify by watching a real client renew (`ipconfig /renew`, or `dhclient -v`), and "
-        "confirm the offered address matches the reservation carried over in pre-flight.",
+        (
+            "Verify by watching a real client renew (`ipconfig /renew`, or `dhclient -v`), and "
+            "confirm the offered address matches the reservation carried over in pre-flight."
+        ),
         "",
         "#### Rollback",
         "",
@@ -570,8 +596,10 @@ def _decommission_section(dns_host: str, dhcp_host: str, *, has_dhcp: bool) -> l
     out = [
         "## After the window — decommission",
         "",
-        "Work the plan's decommission checklist in the UI; it tracks the ticks and notes "
-        "per plan. Two steps are worth having the exact command for.",
+        (
+            "Work the plan's decommission checklist in the UI; it tracks the ticks and notes "
+            "per plan. Two steps are worth having the exact command for."
+        ),
         "",
         "### Deauthorize the Windows DHCP server in AD",
         "",
@@ -587,8 +615,10 @@ def _decommission_section(dns_host: str, dhcp_host: str, *, has_dhcp: bool) -> l
         "# Stop and disable rather than uninstall — the role, its zone data and its",
         "# scope database stay on disk, which is what makes a late rollback possible.",
         "Stop-Service -Name DNS -Force ; Set-Service -Name DNS -StartupType Disabled",
-        "Stop-Service -Name DHCPServer -Force ; Set-Service -Name DHCPServer "
-        "-StartupType Disabled",
+        (
+            "Stop-Service -Name DHCPServer -Force ; Set-Service -Name DHCPServer "
+            "-StartupType Disabled"
+        ),
         "```",
         "",
         f"Run those on `{dns_host}` / `{dhcp_host}` respectively. Do not uninstall the "
@@ -638,9 +668,11 @@ def render_runbook(
 
     if not ordered:
         lines += [
-            "This plan has no items yet. Run **Discover** against the source Windows "
-            "servers and add the zones / scopes you intend to migrate, then regenerate "
-            "this runbook.",
+            (
+                "This plan has no items yet. Run **Discover** against the source Windows "
+                "servers and add the zones / scopes you intend to migrate, then regenerate "
+                "this runbook."
+            ),
             "",
         ]
         return "\n".join(lines).rstrip() + "\n"

--- a/backend/app/services/cutover/shadow.py
+++ b/backend/app/services/cutover/shadow.py
@@ -1,0 +1,459 @@
+"""Phase 2 shadow-query comparison — ask both sides the same questions.
+
+Parity (:mod:`app.services.cutover.parity`) proves the two *configurations*
+agree. That is necessary and not sufficient: a zone can be byte-identical in
+the database and still answer differently on the wire, because of a view match
+that fires on the control plane's source address, a stale zone file an agent
+never reloaded, a CNAME the source resolves through and the target doesn't, or
+a record served from a forwarder rather than from the zone.
+
+So before the switch we replay real questions at both sides and compare the
+answers. Names come from the BIND9 query log (:class:`DNSQueryLogEntry`) when
+there is any — those are queries clients actually asked in the last 24 hours,
+which makes this a shadow run rather than a second look at our own rows — and
+fall back to the zone's ``DNSRecord`` names when the log is empty (query
+logging off, or the managed side not yet receiving traffic). ``sample_source``
+on the report says which, because the two are not equally strong evidence.
+
+Three things this module is careful about:
+
+* **Queries go to an IP literal, never a hostname.** Every low-level dnspython
+  entry point resolves the nameserver itself and raises a bare, message-less
+  ``ValueError`` for anything that is not an address. That is exactly what made
+  the #61 drift report fail 100% of the time against every hostname-addressed
+  server (#734), reporting ``""`` as the reason. Hostnames are resolved here,
+  off the event loop, and a failure becomes a per-target warning rather than
+  taking down the whole run.
+* **Recursion is disabled on the wire (RD=0).** Both sides are supposed to be
+  authoritative for the zone; letting either recurse would allow a cached
+  answer from somewhere else to stand in for the server under test.
+* **Nothing here raises for a single bad answer.** A timeout against one target
+  is data about that target, not a failed comparison.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import dns.asyncresolver
+import dns.exception
+import dns.resolver
+import structlog
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dns import CLOUD_DNS_DRIVERS
+from app.drivers.dns._axfr import resolve_server_address
+from app.models.dns import DNSRecord, DNSServer, DNSZone
+from app.models.logs import DNSQueryLogEntry
+from app.services.cutover.canonical import ShadowReport, ShadowSample
+
+logger = structlog.get_logger(__name__)
+
+#: Per-query wall clock. Short on purpose — an authoritative server on the LAN
+#: answers in single-digit milliseconds, and a whole-zone sample must not turn
+#: one dead target into a minutes-long request.
+QUERY_TIMEOUT_SECONDS = 3.0
+
+#: In-flight query ceiling across the entire run. ``sample_size`` × (1 source +
+#: N targets) queries are scheduled at once; this is what keeps that from
+#: becoming a self-inflicted flood at 200 samples.
+MAX_CONCURRENT_QUERIES = 8
+
+MIN_SAMPLE_SIZE = 1
+MAX_SAMPLE_SIZE = 200
+
+#: How far back in the query log to look for names. Matches the 24 h retention
+#: ``app.tasks.prune_log_entries`` enforces, so this never asks for rows that
+#: cannot exist.
+QUERY_LOG_WINDOW_HOURS = 24
+
+#: Types worth replaying — the wire-queryable subset of ``VALID_RECORD_TYPES``.
+#: Excludes ANY / AXFR / IXFR (meta-queries whose answers legitimately differ
+#: between implementations), the DNSSEC signing artefacts the signing daemon
+#: mints and rotates itself, and PowerDNS's ALIAS / LUA, which are authoring
+#: pseudo-types that never appear as a qtype on the wire.
+SAMPLEABLE_QTYPES: frozenset[str] = frozenset(
+    {
+        "A",
+        "AAAA",
+        "CAA",
+        "CNAME",
+        "DNAME",
+        "HTTPS",
+        "LOC",
+        "MX",
+        "NAPTR",
+        "NS",
+        "PTR",
+        "SOA",
+        "SRV",
+        "SSHFP",
+        "SVCB",
+        "TLSA",
+        "TXT",
+    }
+)
+
+
+@dataclass
+class _QueryOutcome:
+    """One server's reply to one question.
+
+    ``error`` is set only for a failure to *get* an answer (timeout, refused,
+    unreachable). NXDOMAIN and an empty answer section are both legitimate
+    answers and come back as ``answers == []`` with no error — otherwise a name
+    that is correctly absent from both sides would read as a broken comparison.
+    """
+
+    answers: list[str] = field(default_factory=list)
+    error: str | None = None
+
+
+def _clamp_sample_size(sample_size: int) -> int:
+    return max(MIN_SAMPLE_SIZE, min(MAX_SAMPLE_SIZE, int(sample_size)))
+
+
+def _zone_label(zone: DNSZone) -> str:
+    """The zone name without its trailing dot, lower-cased."""
+    return zone.name.strip().rstrip(".").lower()
+
+
+def _server_label(server: DNSServer) -> str:
+    """Human label used as the key in ``ShadowSample.target_answers``."""
+    return f"{server.name} ({server.host})"
+
+
+def normalise_answers(rendered: Iterable[str]) -> list[str]:
+    """Canonical form for comparing two answer sets.
+
+    Sorted, de-duplicated, lower-cased, trailing dot removed. RRset order is
+    not meaningful on the wire (and round-robin makes it actively unstable), so
+    comparing sorted sets is the only comparison that does not produce false
+    mismatches. The trailing dot is stripped because implementations disagree
+    about whether to render it on a CNAME/MX/NS/SRV target.
+    """
+    return sorted({r.strip().rstrip(".").lower() for r in rendered if r.strip()})
+
+
+async def _resolve_to_ip(host: str, port: int, *, what: str) -> str:
+    """Return the first IP literal for ``host``.
+
+    ``resolve_server_address`` is a blocking ``getaddrinfo`` call, so it runs
+    off the event loop. It raises ``RuntimeError`` with an operator-readable
+    message when the name does not resolve; callers turn that into a warning.
+    """
+    addrs = await asyncio.to_thread(resolve_server_address, host, port, what=what)
+    return addrs[0]
+
+
+async def _query(ip: str, qname: str, qtype: str, timeout: float) -> _QueryOutcome:
+    """Ask ``ip`` one question, authoritatively, with its own timeout.
+
+    A fresh resolver per call so a slow server cannot poison the others. The
+    exception ladder mirrors ``app.api.v1.dns_tools._query_one`` — NXDOMAIN
+    first (it subclasses ``DNSException``), then timeout, then any other DNS
+    error, then the socket-level failures dnspython lets through as ``OSError``.
+    """
+    resolver = dns.asyncresolver.Resolver(configure=False)
+    resolver.nameservers = [ip]
+    resolver.timeout = timeout
+    resolver.lifetime = timeout
+    # RD=0. Both sides should be authoritative for this zone; a recursive
+    # answer would let a cache answer for the server we are trying to test.
+    resolver.flags = 0
+
+    try:
+        answer = await resolver.resolve(qname, qtype, raise_on_no_answer=False)
+    except dns.resolver.NXDOMAIN:
+        return _QueryOutcome()
+    except dns.exception.Timeout:
+        return _QueryOutcome(error=f"timeout after {timeout:.1f}s")
+    except dns.exception.DNSException as exc:
+        return _QueryOutcome(error=str(exc) or exc.__class__.__name__)
+    except OSError as exc:
+        return _QueryOutcome(error=f"network error: {exc}")
+
+    rendered = [str(rr) for rr in answer] if answer.rrset else []
+    return _QueryOutcome(answers=normalise_answers(rendered))
+
+
+async def _sample_from_query_log(
+    db: AsyncSession, zone: DNSZone, limit: int
+) -> list[tuple[str, str]]:
+    """Recently-asked ``(qname, qtype)`` pairs inside ``zone``, newest first.
+
+    Scoped to the servers in the zone's own group: a zone name can exist in
+    more than one group (and more than one view), and replaying another group's
+    traffic would compare the wrong population of names.
+    """
+    label = _zone_label(zone)
+    cutoff = datetime.now(UTC) - timedelta(hours=QUERY_LOG_WINDOW_HOURS)
+    lowered = func.lower(DNSQueryLogEntry.qname)
+    group_server_ids = select(DNSServer.id).where(DNSServer.group_id == zone.group_id)
+
+    rows = (
+        await db.execute(
+            select(DNSQueryLogEntry.qname, DNSQueryLogEntry.qtype)
+            .where(
+                DNSQueryLogEntry.server_id.in_(group_server_ids),
+                DNSQueryLogEntry.ts >= cutoff,
+                DNSQueryLogEntry.qname.is_not(None),
+                or_(
+                    lowered == label,
+                    lowered == f"{label}.",
+                    # autoescape: a DNS label may legally contain ``_``
+                    # (``_ldap._tcp``), which is a LIKE wildcard.
+                    lowered.endswith(f".{label}", autoescape=True),
+                    lowered.endswith(f".{label}.", autoescape=True),
+                ),
+            )
+            # Over-fetch: the newest rows are dominated by whatever is being
+            # queried hardest right now, and we want ``limit`` DISTINCT names.
+            .order_by(DNSQueryLogEntry.ts.desc())
+            .limit(limit * 20)
+        )
+    ).all()
+
+    out: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for qname, qtype in rows:
+        name = (qname or "").strip().rstrip(".").lower()
+        rtype = (qtype or "").strip().upper()
+        if not name or rtype not in SAMPLEABLE_QTYPES:
+            continue
+        key = (name, rtype)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+        if len(out) >= limit:
+            break
+    return out
+
+
+async def _sample_from_records(
+    db: AsyncSession, zone: DNSZone, limit: int
+) -> list[tuple[str, str]]:
+    """Fallback name source: the zone's own records, as FQDN + type pairs."""
+    label = _zone_label(zone)
+    records = list(
+        (
+            await db.execute(
+                select(DNSRecord)
+                .where(DNSRecord.zone_id == zone.id)
+                .order_by(DNSRecord.name, DNSRecord.record_type)
+                .limit(limit * 10)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    out: list[tuple[str, str]] = []
+    seen: set[tuple[str, str]] = set()
+    for rec in records:
+        rtype = (rec.record_type or "").strip().upper()
+        if rtype not in SAMPLEABLE_QTYPES:
+            continue
+        rel = (rec.name or "@").strip().rstrip(".").lower()
+        name = label if rel in ("", "@") else f"{rel}.{label}"
+        key = (name, rtype)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(key)
+        if len(out) >= limit:
+            break
+    return out
+
+
+async def _collect_targets(
+    db: AsyncSession, zone: DNSZone, source_server: DNSServer, report: ShadowReport
+) -> list[tuple[str, str]]:
+    """Resolve the managed side of the comparison to ``(label, ip)`` pairs.
+
+    Skips the source server itself (a plan can legitimately point at a group
+    the Windows server was also registered in) and the cloud-hosted drivers,
+    whose ``host`` is a display label rather than a resolver we can query —
+    their zones are read through a provider API, not off the wire.
+    """
+    servers = list(
+        (
+            await db.execute(
+                select(DNSServer)
+                .where(DNSServer.group_id == zone.group_id, DNSServer.is_enabled.is_(True))
+                .order_by(DNSServer.is_primary.desc(), DNSServer.name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    targets: list[tuple[str, str]] = []
+    for srv in servers:
+        if srv.id == source_server.id:
+            continue
+        if srv.driver in CLOUD_DNS_DRIVERS:
+            report.warnings.append(
+                f"Skipped {srv.name!r}: the {srv.driver!r} driver is a hosted provider "
+                "reached over its API, so there is no address to send a query to."
+            )
+            continue
+        label = _server_label(srv)
+        try:
+            ip = await _resolve_to_ip(srv.host, srv.port or 53, what=f"Shadow query of {zone.name}")
+        except RuntimeError as exc:
+            report.warnings.append(f"Skipped {srv.name!r}: {exc}")
+            continue
+        targets.append((label, ip))
+        report.targets.append(label)
+    return targets
+
+
+def _score(sample: ShadowSample, report: ShadowReport) -> None:
+    """Fold one finished sample into the report's counters."""
+    if sample.verdict == "match":
+        report.matched += 1
+    elif sample.verdict == "mismatch":
+        report.mismatched += 1
+    else:
+        report.errors += 1
+
+
+async def run_shadow_comparison(
+    db: AsyncSession,
+    *,
+    source_server: DNSServer,
+    zone: DNSZone,
+    sample_size: int = 25,
+) -> ShadowReport:
+    """Replay a sample of real queries against Windows and the managed group.
+
+    Returns a :class:`ShadowReport` in every reachable-or-not case. The only
+    ways to get an empty report are: the source host does not resolve, no
+    queryable target exists in the zone's group, or there is nothing to ask —
+    each of which lands as a warning saying so, because a silent zero would
+    read as "everything matched".
+    """
+    limit = _clamp_sample_size(sample_size)
+    report = ShadowReport(zone_name=zone.name, source=_server_label(source_server))
+
+    # Answers here are read with recursion disabled, and a view-scoped zone is
+    # answered according to whichever view matches OUR source address — the
+    # same caveat #61's drift report carries, and for the same reason.
+    if zone.view_id is not None:
+        report.warnings.append(
+            "This zone belongs to a DNS view. Servers answer with whichever view "
+            "matches the control plane's source address, so differences below may "
+            "reflect a different view rather than a real difference."
+        )
+
+    try:
+        source_ip = await _resolve_to_ip(
+            source_server.host, source_server.port or 53, what=f"Shadow query of {zone.name}"
+        )
+    except RuntimeError as exc:
+        report.warnings.append(f"Source server {source_server.name!r} is not queryable: {exc}")
+        return report
+
+    targets = await _collect_targets(db, zone, source_server, report)
+    if not targets:
+        report.warnings.append(
+            "No queryable target server in this zone's group, so there was nothing "
+            "to compare against. Add or enable an agent-managed server in the group."
+        )
+        return report
+
+    samples = await _sample_from_query_log(db, zone, limit)
+    if samples:
+        report.sample_source = "query_log"
+    else:
+        samples = await _sample_from_records(db, zone, limit)
+        report.sample_source = "zone_records"
+        report.warnings.append(
+            "No recent query-log entries for this zone, so names were taken from its "
+            "records instead. Enable query logging on the managed servers and re-run "
+            "during the parallel window for a comparison against real traffic."
+        )
+    if not samples:
+        report.warnings.append("This zone has no records and no recent queries to sample.")
+        return report
+
+    semaphore = asyncio.Semaphore(MAX_CONCURRENT_QUERIES)
+
+    async def _guarded(ip: str, qname: str, qtype: str) -> _QueryOutcome:
+        async with semaphore:
+            return await _query(ip, qname, qtype, QUERY_TIMEOUT_SECONDS)
+
+    async def _one_sample(qname: str, qtype: str) -> ShadowSample:
+        sample = ShadowSample(name=qname, qtype=qtype)
+        # Trailing dot: with ``configure=False`` there is no search list, but
+        # an absolute name removes any doubt about ndots handling.
+        absolute = f"{qname}."
+        outcomes = await asyncio.gather(
+            _guarded(source_ip, absolute, qtype),
+            *(_guarded(ip, absolute, qtype) for _, ip in targets),
+        )
+
+        source_outcome = outcomes[0]
+        if source_outcome.error:
+            sample.verdict = "source_error"
+            sample.error = source_outcome.error
+            return sample
+
+        sample.source_answers = source_outcome.answers
+        target_errors: list[str] = []
+        mismatched = False
+        for (label, _ip), outcome in zip(targets, outcomes[1:], strict=True):
+            if outcome.error:
+                target_errors.append(f"{label}: {outcome.error}")
+                continue
+            sample.target_answers[label] = outcome.answers
+            if outcome.answers != source_outcome.answers:
+                mismatched = True
+
+        if target_errors:
+            # A target we could not reach outranks a mismatch we did see: the
+            # comparison is incomplete, and reporting it as a clean mismatch
+            # would understate how much is still unknown.
+            sample.verdict = "target_error"
+            sample.error = "; ".join(target_errors)
+        elif mismatched:
+            sample.verdict = "mismatch"
+        else:
+            sample.verdict = "match"
+        return sample
+
+    report.samples = list(await asyncio.gather(*(_one_sample(n, t) for n, t in samples)))
+    report.sampled = len(report.samples)
+    for sample in report.samples:
+        _score(sample, report)
+
+    logger.info(
+        "cutover.shadow.completed",
+        zone=zone.name,
+        source=source_server.host,
+        targets=len(targets),
+        sample_source=report.sample_source,
+        sampled=report.sampled,
+        matched=report.matched,
+        mismatched=report.mismatched,
+        errors=report.errors,
+    )
+    return report
+
+
+__all__ = [
+    "MAX_CONCURRENT_QUERIES",
+    "MAX_SAMPLE_SIZE",
+    "MIN_SAMPLE_SIZE",
+    "QUERY_LOG_WINDOW_HOURS",
+    "QUERY_TIMEOUT_SECONDS",
+    "SAMPLEABLE_QTYPES",
+    "normalise_answers",
+    "run_shadow_comparison",
+]

--- a/backend/app/services/cutover/shadow.py
+++ b/backend/app/services/cutover/shadow.py
@@ -127,16 +127,38 @@ def _server_label(server: DNSServer) -> str:
     return f"{server.name} ({server.host})"
 
 
-def normalise_answers(rendered: Iterable[str]) -> list[str]:
-    """Canonical form for comparing two answer sets.
+#: Types whose RDATA is entirely case- and trailing-dot-insensitive, so folding
+#: both is safe. These are the name-valued types (DNS names compare
+#: case-insensitively per RFC 4343, and implementations disagree about rendering
+#: the root dot on a target) plus the address types, where hex case in an IPv6
+#: literal carries no meaning.
+#:
+#: Everything NOT listed here is compared verbatim. TXT is the one that matters:
+#: DKIM public keys, `google-site-verification=` tokens and the like are
+#: case-sensitive payloads, and folding them would let the shadow run report a
+#: "match" between two records a resolver would treat as different. CAA tags,
+#: NAPTR flags and regexps are case-bearing for the same reason.
+_CASE_FOLDED_QTYPES: frozenset[str] = frozenset(
+    {"A", "AAAA", "CNAME", "NS", "PTR", "MX", "SRV", "SOA"}
+)
 
-    Sorted, de-duplicated, lower-cased, trailing dot removed. RRset order is
-    not meaningful on the wire (and round-robin makes it actively unstable), so
-    comparing sorted sets is the only comparison that does not produce false
-    mismatches. The trailing dot is stripped because implementations disagree
-    about whether to render it on a CNAME/MX/NS/SRV target.
+
+def normalise_answers(rendered: Iterable[str], qtype: str) -> list[str]:
+    """Canonical form for comparing two answer sets of type ``qtype``.
+
+    Always sorted and de-duplicated: RRset order is not meaningful on the wire
+    (and round-robin makes it actively unstable), so comparing sorted sets is
+    the only comparison that does not produce false mismatches.
+
+    Case and the trailing dot are folded **only** for the types in
+    :data:`_CASE_FOLDED_QTYPES`. For anything else the RDATA is compared as the
+    server rendered it — see that constant for why folding a TXT record would be
+    a correctness bug rather than a convenience.
     """
-    return sorted({r.strip().rstrip(".").lower() for r in rendered if r.strip()})
+    values = (r.strip() for r in rendered)
+    if qtype.strip().upper() in _CASE_FOLDED_QTYPES:
+        return sorted({v.rstrip(".").lower() for v in values if v})
+    return sorted({v for v in values if v})
 
 
 async def _resolve_to_ip(host: str, port: int, *, what: str) -> str:
@@ -178,7 +200,7 @@ async def _query(ip: str, qname: str, qtype: str, timeout: float) -> _QueryOutco
         return _QueryOutcome(error=f"network error: {exc}")
 
     rendered = [str(rr) for rr in answer] if answer.rrset else []
-    return _QueryOutcome(answers=normalise_answers(rendered))
+    return _QueryOutcome(answers=normalise_answers(rendered, qtype))
 
 
 async def _sample_from_query_log(

--- a/backend/app/services/cutover/switch.py
+++ b/backend/app/services/cutover/switch.py
@@ -17,6 +17,14 @@ least clever code in the package:
   answering for one subnet hand out conflicting addresses within seconds, so a
   window where both are live is worse than a window where neither is. If the
   managed side then fails to come up, the Windows scope is put back.
+* **The commit is sequenced by this module, not by the caller.** Both DHCP
+  paths pair an irreversible WinRM call with a database write, so *where* the
+  transaction commits relative to that call decides what a crash leaves behind.
+  The router hands in a ``finalize`` callable (write the audit row, commit) and
+  this module decides when to invoke it — see ``_cutover_dhcp`` /
+  ``_rollback_dhcp``. Committing at the wrong point is how a failed transaction
+  ends with both servers answering, which is the one outcome the ordering above
+  exists to prevent.
 * **DNS is not switched here at all.** There is no server-side flag we own:
   which server answers for a zone is decided by the delegation at the parent
   (or by what the resolvers forward to), and both live outside SpatiumDDI. So
@@ -27,6 +35,7 @@ least clever code in the package:
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from typing import Any
 
@@ -179,6 +188,10 @@ async def execute_cutover(
     item: CutoverItem,
     current_user: User,
     force: bool = False,
+    #: Called once the module has reached the point where the transaction is
+    #: safe to seal — writes the audit row and commits. Sequencing it is this
+    #: module's job, not the caller's; see the module docstring.
+    finalize: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Cut one item over from Windows to SpatiumDDI.
 
@@ -218,11 +231,21 @@ async def execute_cutover(
 
     if item.kind == "dhcp_scope":
         return await _cutover_dhcp(
-            db, plan=plan, item=item, current_user=current_user, acknowledged=warnings
+            db,
+            plan=plan,
+            item=item,
+            current_user=current_user,
+            acknowledged=warnings,
+            finalize=finalize,
         )
     if item.kind == "dns_zone":
         return await _cutover_dns(
-            db, plan=plan, item=item, current_user=current_user, acknowledged=warnings
+            db,
+            plan=plan,
+            item=item,
+            current_user=current_user,
+            acknowledged=warnings,
+            finalize=finalize,
         )
     raise ValueError(f"Unsupported cutover item kind {item.kind!r}")
 
@@ -234,6 +257,7 @@ async def _cutover_dhcp(
     item: CutoverItem,
     current_user: User,
     acknowledged: list[Blocker],
+    finalize: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Deactivate the Windows scope, then activate the managed one.
 
@@ -262,6 +286,13 @@ async def _cutover_dhcp(
         scope.is_active = True
         await db.flush()
         collect_wake(dhcp_group_channel(scope.group_id))
+        # Commit here, inside the guard. The Windows scope is already down; if
+        # sealing the managed scope's activation fails, the database rolls back
+        # to "managed inactive" while the subnet has no DHCP at all — so the
+        # compensation below has to cover a failed commit exactly as it covers a
+        # failed flush.
+        if finalize is not None:
+            await finalize()
     except Exception:
         # Compensate: the Windows scope is already down and the managed one did
         # not come up, so the subnet currently has no DHCP at all. Put the old
@@ -331,6 +362,7 @@ async def _cutover_dns(
     item: CutoverItem,
     current_user: User,
     acknowledged: list[Blocker],
+    finalize: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Record the DNS transition and hand back the operator instructions.
 
@@ -384,6 +416,12 @@ async def _cutover_dns(
         item_id=str(item.id),
         zone=zone.name,
     )
+    # No external side effect on the DNS side — the switch is a delegation
+    # change the operator makes elsewhere — so the commit point is simply after
+    # the DB writes.
+    if finalize is not None:
+        await finalize()
+
     return result
 
 
@@ -396,6 +434,10 @@ async def execute_rollback(
     plan: CutoverPlan,
     item: CutoverItem,
     current_user: User,
+    #: Called once the module has reached the point where the transaction is
+    #: safe to seal — writes the audit row and commits. Sequencing it is this
+    #: module's job, not the caller's; see the module docstring.
+    finalize: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Reverse a cutover.
 
@@ -407,9 +449,13 @@ async def execute_rollback(
     :class:`CutoverEvent` is appended.
     """
     if item.kind == "dhcp_scope":
-        return await _rollback_dhcp(db, plan=plan, item=item, current_user=current_user)
+        return await _rollback_dhcp(
+            db, plan=plan, item=item, current_user=current_user, finalize=finalize
+        )
     if item.kind == "dns_zone":
-        return await _rollback_dns(db, plan=plan, item=item, current_user=current_user)
+        return await _rollback_dns(
+            db, plan=plan, item=item, current_user=current_user, finalize=finalize
+        )
     raise ValueError(f"Unsupported cutover item kind {item.kind!r}")
 
 
@@ -419,6 +465,7 @@ async def _rollback_dhcp(
     plan: CutoverPlan,
     item: CutoverItem,
     current_user: User,
+    finalize: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Deactivate the managed scope, then re-activate the Windows one.
 
@@ -430,10 +477,30 @@ async def _rollback_dhcp(
     driver = WindowsDHCPReadOnlyDriver()
     actions: list[str] = []
 
+    now = datetime.now(UTC)
     scope.is_active = False
+    item.stage = "rolled_back"
+    item.rolled_back_at = now
+    # Clear the cutover stamp. ``readiness._is_cut_over`` short-circuits on it to
+    # stop a completed item looking permanently unready, so leaving it set on a
+    # rolled-back item would suppress the pre-switch blockers for good — most
+    # importantly ``managed_scope_active``, the one that refuses a retry while
+    # both servers are live on the same subnet. Mirrors the cutover path, which
+    # clears ``rolled_back_at`` for the same reason.
+    item.cut_over_at = None
     await db.flush()
     collect_wake(dhcp_group_channel(scope.group_id))
     actions.append("Deactivated the managed scope in SpatiumDDI")
+
+    # Seal the managed-side deactivation BEFORE touching Windows. This ordering
+    # is the whole point: if the commit fails now, nothing has been done to
+    # Windows and the database rolls back to the cut-over state — consistent. If
+    # we committed after the WinRM call instead, a failed commit would leave the
+    # database saying "managed active" while Windows had already been brought
+    # back up, and both would answer for the subnet. A brief window with no DHCP
+    # is survivable; an overlap is not.
+    if finalize is not None:
+        await finalize()
 
     try:
         await driver.set_scope_state(source_server, item.source_ref, active=True)
@@ -444,6 +511,10 @@ async def _rollback_dhcp(
         try:
             scope.is_active = True
             await db.flush()
+            # The managed-side deactivation was already committed above, so this
+            # correction is a new transaction and needs its own commit — a flush
+            # alone would be discarded when the request unwinds.
+            await db.commit()
             collect_wake(dhcp_group_channel(scope.group_id))
             logger.warning(
                 "cutover_rollback_compensated",
@@ -464,17 +535,6 @@ async def _rollback_dhcp(
         raise
 
     actions.append(f"Re-activated scope {item.source_ref} on {source_server.name}")
-
-    now = datetime.now(UTC)
-    item.stage = "rolled_back"
-    item.rolled_back_at = now
-    # Clear the cutover stamp. ``readiness._is_cut_over`` short-circuits on it to
-    # stop a completed item looking permanently unready, so leaving it set on a
-    # rolled-back item would suppress the pre-switch blockers for good — most
-    # importantly ``managed_scope_active``, the one that refuses a retry while
-    # both servers are live on the same subnet. Mirrors the cutover path, which
-    # clears ``rolled_back_at`` for the same reason.
-    item.cut_over_at = None
 
     result: dict[str, Any] = {
         "kind": item.kind,
@@ -510,6 +570,7 @@ async def _rollback_dns(
     plan: CutoverPlan,
     item: CutoverItem,
     current_user: User,
+    finalize: Callable[[], Awaitable[None]] | None = None,
 ) -> dict[str, Any]:
     """Restore the pre-flight TTLs and hand back the revert instructions.
 
@@ -566,4 +627,10 @@ async def _rollback_dns(
         zone=zone.name,
         records_restored=restored,
     )
+    # No external side effect on the DNS side — the switch is a delegation
+    # change the operator makes elsewhere — so the commit point is simply after
+    # the DB writes.
+    if finalize is not None:
+        await finalize()
+
     return result

--- a/backend/app/services/cutover/switch.py
+++ b/backend/app/services/cutover/switch.py
@@ -1,0 +1,569 @@
+"""The switch itself, and its reversal — Phase 3c of the cutover (issue #756).
+
+Everything up to here is reversible bookkeeping. This module is the moment the
+migration becomes visible to clients, so it is deliberately the smallest,
+least clever code in the package:
+
+* **It re-derives the blocker set before it does anything.** A parity report or
+  a readiness check from twenty minutes ago is a claim about the past. The
+  blockers are recomputed against live state and a ``severity == "block"``
+  entry refuses the switch outright, ``force`` or not. That refusal is the
+  whole reason the package exists — the headline hazard is cutting over an
+  AD-integrated zone whose dynamic updates are "Secure only", because GSS-TSIG
+  is unimplemented (#444) and a domain controller that cannot re-register its
+  SRV records turns a DNS migration into a domain outage.
+* **DHCP is switched in one order and only that order.** The Windows scope is
+  deactivated *first*, then the managed scope is activated. Two DHCP servers
+  answering for one subnet hand out conflicting addresses within seconds, so a
+  window where both are live is worse than a window where neither is. If the
+  managed side then fails to come up, the Windows scope is put back.
+* **DNS is not switched here at all.** There is no server-side flag we own:
+  which server answers for a zone is decided by the delegation at the parent
+  (or by what the resolvers forward to), and both live outside SpatiumDDI. So
+  the DNS path records the transition and returns the instructions. It never
+  touches the Windows zone — deleting or disabling the old zone before the
+  delegation has actually moved removes the thing that is still serving.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_wake import collect_wake, dhcp_group_channel
+from app.drivers.dhcp.windows import WindowsDHCPReadOnlyDriver
+from app.models.auth import User
+from app.models.cutover import CutoverEvent, CutoverItem, CutoverPlan
+from app.models.dhcp import DHCPScope, DHCPServer
+from app.models.dns import DNSZone
+from app.services.cutover.canonical import Blocker, blocking
+
+logger = structlog.get_logger(__name__)
+
+__all__ = ["CutoverBlocked", "execute_cutover", "execute_rollback"]
+
+
+class CutoverBlocked(ValueError):
+    """Raised when readiness refuses the switch. The router maps this to 409.
+
+    ``blockers`` carries the offending entries so the response can render them
+    verbatim — every :class:`~app.services.cutover.canonical.Blocker` message is
+    written to state the fix, and a bare "not ready" would throw that away.
+    """
+
+    def __init__(self, message: str, blockers: list[Blocker]) -> None:
+        super().__init__(message)
+        self.blockers = blockers
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"error": str(self), "blockers": [b.as_dict() for b in self.blockers]}
+
+
+# ── shared helpers ────────────────────────────────────────────────────
+
+
+async def _require_scope(db: AsyncSession, item: CutoverItem) -> DHCPScope:
+    if item.scope_id is None:
+        raise ValueError(
+            f"Cutover item {item.source_ref!r} is not linked to a managed DHCP scope. "
+            "Link it to the SpatiumDDI scope that will take over before cutting over."
+        )
+    scope = await db.get(DHCPScope, item.scope_id)
+    if scope is None:
+        raise ValueError(
+            f"The managed DHCP scope for {item.source_ref!r} no longer exists. "
+            "Re-link the item to a live scope."
+        )
+    return scope
+
+
+async def _require_zone(db: AsyncSession, item: CutoverItem) -> DNSZone:
+    if item.zone_id is None:
+        raise ValueError(
+            f"Cutover item {item.source_ref!r} is not linked to a managed DNS zone. "
+            "Import or create the zone in SpatiumDDI and link it before cutting over."
+        )
+    zone = await db.get(DNSZone, item.zone_id)
+    if zone is None:
+        raise ValueError(
+            f"The managed DNS zone for {item.source_ref!r} no longer exists. "
+            "Re-link the item to a live zone."
+        )
+    return zone
+
+
+async def _require_source_dhcp_server(db: AsyncSession, plan: CutoverPlan) -> DHCPServer:
+    if plan.source_dhcp_server_id is None:
+        raise ValueError(
+            "This plan has no source Windows DHCP server set, so there is nothing to deactivate. "
+            "Set it on the plan before cutting a DHCP scope over."
+        )
+    server = await db.get(DHCPServer, plan.source_dhcp_server_id)
+    if server is None:
+        raise ValueError("The plan's source Windows DHCP server row no longer exists.")
+    if server.driver != "windows_dhcp":
+        raise ValueError(
+            f"Source DHCP server {server.name!r} uses the {server.driver!r} driver. "
+            "The cutover switch only drives Windows DHCP."
+        )
+    return server
+
+
+def _record_event(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    kind: str,
+    summary: str,
+    detail: dict[str, Any],
+    current_user: User,
+) -> CutoverEvent:
+    """Append one timeline row. Not committed — the router owns the transaction."""
+    event = CutoverEvent(
+        plan_id=plan.id,
+        item_id=item.id,
+        at=datetime.now(UTC),
+        kind=kind,
+        summary=summary[:512],
+        detail=detail,
+        user_id=current_user.id,
+        user_display_name=current_user.display_name,
+    )
+    db.add(event)
+    return event
+
+
+def _dns_switch_instructions(zone: DNSZone) -> list[str]:
+    """The operator-side steps that actually move DNS traffic.
+
+    Generated here rather than pulled from :mod:`app.services.cutover.runbook`
+    because these are per-item and returned inline with the switch result; the
+    runbook renders the whole plan as a document.
+    """
+    name = zone.name.rstrip(".")
+    return [
+        f"Repoint the delegation for {name}: update the NS records at the parent zone "
+        "(or at the registrar, for a public zone) to the SpatiumDDI-managed name servers.",
+        f"If {name} is only resolved internally, update the conditional forwarder / stub zone "
+        "on every recursive resolver that currently forwards it to the Windows server.",
+        "Update any DHCP option 6 (dns-servers) values that still hand clients the Windows "
+        "server's address, and any statically-configured resolvers.",
+        f"Leave the Windows zone in place and serving. It is the fallback until the "
+        f"{zone.ttl}s TTL has expired everywhere and the new answers are confirmed.",
+        "Confirm with the shadow comparison and a spot-check from an external resolver "
+        "before ticking the decommission checklist.",
+    ]
+
+
+def _dns_rollback_instructions(zone: DNSZone) -> list[str]:
+    name = zone.name.rstrip(".")
+    return [
+        f"Revert the delegation for {name} to the Windows name servers at the parent zone "
+        "(or at the registrar).",
+        "Revert the conditional forwarder / stub zone on every recursive resolver you changed.",
+        "Revert any DHCP option 6 (dns-servers) values changed for the switch.",
+    ]
+
+
+# ── the switch ────────────────────────────────────────────────────────
+
+
+async def execute_cutover(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    current_user: User,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Cut one item over from Windows to SpatiumDDI.
+
+    Blockers are **re-evaluated against live state** first (via
+    :func:`app.services.cutover.readiness.refresh_blockers`, which also persists
+    them onto the item). Any blocker with ``severity == "block"`` raises
+    :class:`CutoverBlocked` and the switch does not happen.
+
+    ``force=True`` acknowledges the ``severity == "warn"`` entries and nothing
+    else. It can **never** bypass a ``block`` — most importantly not
+    ``ad_secure_dynamic_update``, which is refused because GSS-TSIG is
+    unimplemented (#444) and cutting such a zone over breaks AD's own dynamic
+    registration. There is no flag, anywhere, that turns that refusal off.
+
+    Does not commit and writes no ``AuditLog`` row — the calling router owns the
+    transaction and the audit trail. A :class:`CutoverEvent` *is* appended here,
+    because the timeline entry describes what this function did (including a
+    compensating rollback the router cannot see).
+    """
+    from app.services.cutover.readiness import refresh_blockers  # noqa: PLC0415
+
+    blockers = await refresh_blockers(db, plan=plan, item=item)
+    hard = blocking(blockers)
+    if hard:
+        raise CutoverBlocked(
+            f"{item.source_ref} is not ready to cut over: "
+            + "; ".join(b.message for b in hard[:3]),
+            hard,
+        )
+    warnings = [b for b in blockers if b.severity == "warn"]
+    if warnings and not force:
+        raise CutoverBlocked(
+            f"{item.source_ref} has {len(warnings)} warning(s) that must be acknowledged: "
+            + "; ".join(b.message for b in warnings[:3]),
+            warnings,
+        )
+
+    if item.kind == "dhcp_scope":
+        return await _cutover_dhcp(
+            db, plan=plan, item=item, current_user=current_user, acknowledged=warnings
+        )
+    if item.kind == "dns_zone":
+        return await _cutover_dns(
+            db, plan=plan, item=item, current_user=current_user, acknowledged=warnings
+        )
+    raise ValueError(f"Unsupported cutover item kind {item.kind!r}")
+
+
+async def _cutover_dhcp(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    current_user: User,
+    acknowledged: list[Blocker],
+) -> dict[str, Any]:
+    """Deactivate the Windows scope, then activate the managed one.
+
+    The order is the entire point. Between the two steps the subnet has *no*
+    DHCP server, which costs renewing clients nothing (they hold their lease
+    until half its lifetime elapses) and is measured in the seconds one WinRM
+    round-trip takes. The reverse order would leave both servers answering,
+    which hands two clients the same address.
+    """
+    scope = await _require_scope(db, item)
+    source_server = await _require_source_dhcp_server(db, plan)
+    driver = WindowsDHCPReadOnlyDriver()
+    actions: list[str] = []
+
+    await driver.set_scope_state(source_server, item.source_ref, active=False)
+    actions.append(f"Deactivated scope {item.source_ref} on {source_server.name}")
+    logger.info(
+        "cutover_dhcp_source_deactivated",
+        plan_id=str(plan.id),
+        item_id=str(item.id),
+        server=source_server.name,
+        scope_id=item.source_ref,
+    )
+
+    try:
+        scope.is_active = True
+        await db.flush()
+        collect_wake(dhcp_group_channel(scope.group_id))
+    except Exception:
+        # Compensate: the Windows scope is already down and the managed one did
+        # not come up, so the subnet currently has no DHCP at all. Put the old
+        # server back before surfacing the failure. Best-effort — if the
+        # compensation itself fails there is nothing further we can do from
+        # here, and the original error is the one worth reporting.
+        try:
+            await driver.set_scope_state(source_server, item.source_ref, active=True)
+            logger.warning(
+                "cutover_dhcp_compensated",
+                plan_id=str(plan.id),
+                item_id=str(item.id),
+                scope_id=item.source_ref,
+                detail="managed scope activation failed; Windows scope re-activated",
+            )
+        except Exception as comp_exc:  # noqa: BLE001 — report, never mask the original
+            logger.error(
+                "cutover_dhcp_compensation_failed",
+                plan_id=str(plan.id),
+                item_id=str(item.id),
+                scope_id=item.source_ref,
+                error=str(comp_exc),
+                detail="subnet may currently have NO active DHCP server — re-activate by hand",
+            )
+        raise
+
+    actions.append(f"Activated the managed scope for {scope.id} in SpatiumDDI")
+
+    now = datetime.now(UTC)
+    item.stage = "cut_over"
+    item.cut_over_at = now
+    item.rolled_back_at = None
+
+    result: dict[str, Any] = {
+        "kind": item.kind,
+        "source_ref": item.source_ref,
+        "stage": item.stage,
+        "cut_over_at": now.isoformat(),
+        "actions": actions,
+        "instructions": [
+            "Watch the DHCP activity log for the first renewals landing on the managed server.",
+            "Leave the Windows scope deactivated (not deleted) until the longest lease has "
+            "expired — deactivated is what makes the rollback a single call.",
+        ],
+        "recovery_estimate_seconds": scope.lease_time,
+        "acknowledged_warnings": [b.as_dict() for b in acknowledged],
+    }
+    _record_event(
+        db,
+        plan=plan,
+        item=item,
+        kind="cutover",
+        summary=(
+            f"Cut DHCP scope {item.source_ref} over: deactivated on {source_server.name}, "
+            "activated in SpatiumDDI"
+        ),
+        detail=result,
+        current_user=current_user,
+    )
+    return result
+
+
+async def _cutover_dns(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    current_user: User,
+    acknowledged: list[Blocker],
+) -> dict[str, Any]:
+    """Record the DNS transition and hand back the operator instructions.
+
+    There is no server-side switch to perform: the Windows zone keeps serving
+    (on purpose — it is the fallback), the managed zone is already serving, and
+    what decides which one clients reach is the delegation at the parent or the
+    forwarder on the resolvers. Both are outside SpatiumDDI, so the honest
+    action here is to stamp the transition and tell the operator exactly what to
+    change.
+    """
+    zone = await _require_zone(db, item)
+    now = datetime.now(UTC)
+    item.stage = "cut_over"
+    item.cut_over_at = now
+    item.rolled_back_at = None
+
+    result: dict[str, Any] = {
+        "kind": item.kind,
+        "source_ref": item.source_ref,
+        "stage": item.stage,
+        "cut_over_at": now.isoformat(),
+        "actions": [
+            f"Recorded the cutover of {zone.name} — the Windows zone was left untouched and "
+            "keeps serving as the fallback."
+        ],
+        "instructions": _dns_switch_instructions(zone),
+        # What a rollback costs: once the delegation is reverted, resolvers stop
+        # using the SpatiumDDI answers after at most the zone's current TTL —
+        # which is what the pre-flight TTL reduction exists to shrink.
+        "recovery_estimate_seconds": zone.ttl,
+        "ttl_lowered_at": item.ttl_lowered_at.isoformat() if item.ttl_lowered_at else None,
+        "acknowledged_warnings": [b.as_dict() for b in acknowledged],
+    }
+    if item.ttl_lowered_at is None:
+        result.setdefault("warnings", []).append(
+            "TTLs were never lowered for this zone, so a rollback propagates at the zone's "
+            f"full {zone.ttl}s TTL. Run the TTL pre-flight before the next item."
+        )
+    _record_event(
+        db,
+        plan=plan,
+        item=item,
+        kind="cutover",
+        summary=f"Cut DNS zone {zone.name} over — delegation change is operator-side",
+        detail=result,
+        current_user=current_user,
+    )
+    logger.info(
+        "cutover_dns_recorded",
+        plan_id=str(plan.id),
+        item_id=str(item.id),
+        zone=zone.name,
+    )
+    return result
+
+
+# ── the reversal ──────────────────────────────────────────────────────
+
+
+async def execute_rollback(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    current_user: User,
+) -> dict[str, Any]:
+    """Reverse a cutover.
+
+    Deliberately does **not** re-evaluate blockers: a rollback is the escape
+    hatch, and gating it on readiness would mean the state that made the switch
+    go wrong is also the state that stops you undoing it.
+
+    Does not commit and writes no ``AuditLog`` row — the router owns both. A
+    :class:`CutoverEvent` is appended.
+    """
+    if item.kind == "dhcp_scope":
+        return await _rollback_dhcp(db, plan=plan, item=item, current_user=current_user)
+    if item.kind == "dns_zone":
+        return await _rollback_dns(db, plan=plan, item=item, current_user=current_user)
+    raise ValueError(f"Unsupported cutover item kind {item.kind!r}")
+
+
+async def _rollback_dhcp(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    current_user: User,
+) -> dict[str, Any]:
+    """Deactivate the managed scope, then re-activate the Windows one.
+
+    Mirror image of the cutover ordering, for the same reason: a gap with no
+    DHCP server is survivable, an overlap with two is not.
+    """
+    scope = await _require_scope(db, item)
+    source_server = await _require_source_dhcp_server(db, plan)
+    driver = WindowsDHCPReadOnlyDriver()
+    actions: list[str] = []
+
+    scope.is_active = False
+    await db.flush()
+    collect_wake(dhcp_group_channel(scope.group_id))
+    actions.append("Deactivated the managed scope in SpatiumDDI")
+
+    try:
+        await driver.set_scope_state(source_server, item.source_ref, active=True)
+    except Exception:
+        # The managed scope is down and Windows did not come back up. Re-activate
+        # the managed side so *something* serves the subnet, then surface the
+        # original failure. Best-effort, same reasoning as the cutover path.
+        try:
+            scope.is_active = True
+            await db.flush()
+            collect_wake(dhcp_group_channel(scope.group_id))
+            logger.warning(
+                "cutover_rollback_compensated",
+                plan_id=str(plan.id),
+                item_id=str(item.id),
+                scope_id=item.source_ref,
+                detail="Windows re-activation failed; managed scope left active",
+            )
+        except Exception as comp_exc:  # noqa: BLE001 — report, never mask the original
+            logger.error(
+                "cutover_rollback_compensation_failed",
+                plan_id=str(plan.id),
+                item_id=str(item.id),
+                scope_id=item.source_ref,
+                error=str(comp_exc),
+                detail="subnet may currently have NO active DHCP server — re-activate by hand",
+            )
+        raise
+
+    actions.append(f"Re-activated scope {item.source_ref} on {source_server.name}")
+
+    now = datetime.now(UTC)
+    item.stage = "rolled_back"
+    item.rolled_back_at = now
+    # Clear the cutover stamp. ``readiness._is_cut_over`` short-circuits on it to
+    # stop a completed item looking permanently unready, so leaving it set on a
+    # rolled-back item would suppress the pre-switch blockers for good — most
+    # importantly ``managed_scope_active``, the one that refuses a retry while
+    # both servers are live on the same subnet. Mirrors the cutover path, which
+    # clears ``rolled_back_at`` for the same reason.
+    item.cut_over_at = None
+
+    result: dict[str, Any] = {
+        "kind": item.kind,
+        "source_ref": item.source_ref,
+        "stage": item.stage,
+        "rolled_back_at": now.isoformat(),
+        "actions": actions,
+        "instructions": [
+            "Reservations created by the lease handover are still on the managed scope. They are "
+            "stamped import_source=windows_cutover and are harmless while the scope is inactive; "
+            "delete them only if you do not intend to retry the cutover.",
+        ],
+        "recovery_estimate_seconds": 0,
+    }
+    _record_event(
+        db,
+        plan=plan,
+        item=item,
+        kind="rollback",
+        summary=(
+            f"Rolled DHCP scope {item.source_ref} back: deactivated in SpatiumDDI, "
+            f"re-activated on {source_server.name}"
+        ),
+        detail=result,
+        current_user=current_user,
+    )
+    return result
+
+
+async def _rollback_dns(
+    db: AsyncSession,
+    *,
+    plan: CutoverPlan,
+    item: CutoverItem,
+    current_user: User,
+) -> dict[str, Any]:
+    """Restore the pre-flight TTLs and hand back the revert instructions.
+
+    As with the cutover, the traffic-moving step is the delegation and lives
+    outside SpatiumDDI. What *is* ours is the TTL snapshot, which is restored
+    here so the zone goes back to the values it had before the migration
+    lowered them.
+    """
+    from app.services.cutover.preflight import restore_ttl_preflight  # noqa: PLC0415
+
+    zone = await _require_zone(db, item)
+    restored = 0
+    if item.ttl_snapshot:
+        restored = await restore_ttl_preflight(db, zone=zone, item=item, current_user=current_user)
+
+    now = datetime.now(UTC)
+    item.stage = "rolled_back"
+    item.rolled_back_at = now
+    # Clear the cutover stamp. ``readiness._is_cut_over`` short-circuits on it to
+    # stop a completed item looking permanently unready, so leaving it set on a
+    # rolled-back item would suppress the pre-switch blockers for good — most
+    # importantly ``managed_scope_active``, the one that refuses a retry while
+    # both servers are live on the same subnet. Mirrors the cutover path, which
+    # clears ``rolled_back_at`` for the same reason.
+    item.cut_over_at = None
+
+    result: dict[str, Any] = {
+        "kind": item.kind,
+        "source_ref": item.source_ref,
+        "stage": item.stage,
+        "rolled_back_at": now.isoformat(),
+        "actions": (
+            [f"Restored the pre-flight TTL snapshot ({restored} record(s)) on {zone.name}"]
+            if restored
+            else ["No TTL snapshot to restore — TTLs were never lowered for this zone."]
+        ),
+        "instructions": _dns_rollback_instructions(zone),
+        "records_restored": restored,
+        "recovery_estimate_seconds": zone.ttl,
+    }
+    _record_event(
+        db,
+        plan=plan,
+        item=item,
+        kind="rollback",
+        summary=f"Rolled DNS zone {zone.name} back — {restored} TTL(s) restored",
+        detail=result,
+        current_user=current_user,
+    )
+    logger.info(
+        "cutover_dns_rolled_back",
+        plan_id=str(plan.id),
+        item_id=str(item.id),
+        zone=zone.name,
+        records_restored=restored,
+    )
+    return result

--- a/backend/app/services/factory_reset/sections.py
+++ b/backend/app/services/factory_reset/sections.py
@@ -164,6 +164,29 @@ FACTORY_SECTIONS: tuple[FactorySection, ...] = (
         ),
     ),
     FactorySection(
+        key="migration",
+        label="Migration plans",
+        description=(
+            "Windows → SpatiumDDI cutover plans and everything hanging "
+            "off them: per-zone / per-scope items with their parity and "
+            "shadow reports, pre-flight TTL snapshots, lease-handover "
+            "results, the decommission checklist, and the plan timeline. "
+            "The zones, scopes and reservations the plans point at are "
+            "NOT touched — only the migration bookkeeping is destroyed. "
+            "Note that a plan's TTL snapshot is the only record of the "
+            "pre-migration TTLs, so destroying an in-flight plan gives up "
+            "the ability to roll its cutover back."
+        ),
+        phrase="DESTROY-MIGRATION-PLANS",
+        kind="truncate",
+        tables=(
+            "cutover_event",
+            "cutover_checklist_item",
+            "cutover_item",
+            "cutover_plan",
+        ),
+    ),
+    FactorySection(
         key="network_modeling",
         label="Network modeling",
         description=(

--- a/backend/app/services/feature_modules.py
+++ b/backend/app/services/feature_modules.py
@@ -293,6 +293,26 @@ MODULES: Final[tuple[ModuleSpec, ...]] = (
     # Default-enabled — same rationale as the DNS / DHCP importers: no
     # blast radius from the toggle (endpoints are RBAC-gated + superadmin
     # separately), operators flip it off to hide the surface.
+    # Windows → SpatiumDDI cutover (issue #756). The one-shot importers get an
+    # operator's Windows estate INTO SpatiumDDI; this is the rest of the
+    # journey — parity verification, the parallel run, the per-zone/per-scope
+    # switch, and the decommission checklist.
+    #
+    # Group is "Tools", not "DNS" or "DHCP": one plan covers both protocols
+    # (a single item list holds zones and scopes), so either protocol group
+    # would be a lie about half the surface. "Tools" is where the operator
+    # workflows live.
+    #
+    # Default-enabled, same rationale as the three importers it extends: the
+    # surface is read-mostly and every mutating step behind it is separately
+    # superadmin-gated, so there is no blast radius from the toggle being on —
+    # and an operator cannot turn off what they never knew shipped.
+    ModuleSpec(
+        id="migration.cutover",
+        label="Windows cutover",
+        group="Tools",
+        description="Guided migration from Windows DNS / DHCP onto managed BIND9 / PowerDNS / Kea — parity verification, parallel-run shadow queries, per-zone and per-scope cutover with rollback, and the decommission checklist. Configuration → Import → Windows cutover; superadmin-only.",
+    ),
     ModuleSpec(
         id="ipam.import.netbox",
         label="NetBox import",

--- a/backend/tests/test_cutover.py
+++ b/backend/tests/test_cutover.py
@@ -1,0 +1,1114 @@
+"""Windows → SpatiumDDI cutover workflow (#756).
+
+The tests that matter most here are the refusals. A cutover is the one
+operation in this codebase that can take a production estate offline while
+looking like it succeeded, and the issue names the failure mode explicitly:
+migrating an AD-integrated "Secure only" zone means domain controllers can no
+longer register their SRV records, which breaks Active Directory itself. That
+refusal — and the fact that ``force`` cannot bypass it — is asserted from three
+angles below.
+
+Everything talks to fakes: no Windows box, no WinRM, no live DNS.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.drivers.dns.base import RecordData
+from app.models.auth import User
+from app.models.cutover import CutoverItem, CutoverPlan
+from app.models.dhcp import DHCPPool, DHCPScope, DHCPServer, DHCPServerGroup, DHCPStaticAssignment
+from app.models.dns import DNSRecord, DNSServer, DNSServerGroup, DNSZone
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services.cutover import leases as leases_mod
+from app.services.cutover import parity as parity_mod
+from app.services.cutover import preflight as preflight_mod
+from app.services.cutover import readiness as readiness_mod
+from app.services.cutover import switch as switch_mod
+from app.services.cutover.canonical import BLOCKER_AD_SECURE_DDNS, blocking
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class _FakeDNSDriver:
+    """Stands in for ``WindowsDNSDriver``'s two read methods."""
+
+    def __init__(
+        self,
+        records: list[RecordData] | None = None,
+        zones: list[dict[str, Any]] | None = None,
+        raises: Exception | None = None,
+    ) -> None:
+        self._records = records or []
+        self._zones = zones or []
+        self._raises = raises
+
+    async def pull_zone_records(self, server: Any, zone_name: str) -> list[RecordData]:
+        if self._raises is not None:
+            raise self._raises
+        return list(self._records)
+
+    async def pull_zones_from_server(self, server: Any) -> list[dict[str, Any]]:
+        if self._raises is not None:
+            raise self._raises
+        return list(self._zones)
+
+
+class _FakeDHCPDriver:
+    """Stands in for ``WindowsDHCPReadOnlyDriver``.
+
+    ``state_calls`` records every ``set_scope_state`` invocation in order, which
+    is what the switch-ordering tests assert on.
+    """
+
+    def __init__(
+        self,
+        scopes: list[dict[str, Any]] | None = None,
+        leases: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._scopes = scopes or []
+        self._leases = leases or []
+        self.state_calls: list[tuple[str, bool]] = []
+
+    async def get_scopes(self, server: Any) -> list[dict[str, Any]]:
+        return list(self._scopes)
+
+    async def get_leases(self, server: Any) -> list[dict[str, Any]]:
+        return list(self._leases)
+
+    async def set_scope_state(self, server: Any, scope_id: str, *, active: bool) -> None:
+        self.state_calls.append((scope_id, active))
+
+
+def _windows_scope(
+    *,
+    cidr: str = "10.20.0.0/24",
+    scope_id: str = "10.20.0.0",
+    lease_time: int = 86400,
+    is_active: bool = True,
+    pools: list[dict[str, Any]] | None = None,
+    statics: list[dict[str, Any]] | None = None,
+    options: dict[str, Any] | None = None,
+    pools_ok: bool = True,
+    statics_ok: bool = True,
+) -> dict[str, Any]:
+    """One entry shaped like ``WindowsDHCPReadOnlyDriver.get_scopes`` returns."""
+    return {
+        "scope_id": scope_id,
+        "subnet_cidr": cidr,
+        "name": "test scope",
+        "description": "",
+        "lease_time": lease_time,
+        "is_active": is_active,
+        "options": options or {},
+        "pools": pools if pools is not None else [],
+        "statics": statics if statics is not None else [],
+        "pools_ok": pools_ok,
+        "statics_ok": statics_ok,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Seeding helpers
+# --------------------------------------------------------------------------- #
+
+
+async def _user(db: AsyncSession) -> User:
+    user = User(
+        username=f"cutover-{uuid.uuid4().hex[:8]}",
+        email=f"cutover-{uuid.uuid4().hex[:8]}@example.com",
+        display_name="cutover admin",
+        hashed_password="x",
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _dns_side(
+    db: AsyncSession, *, zone_name: str = "corp.example.", import_source: str | None = None
+) -> tuple[DNSServerGroup, DNSServer, DNSServer, DNSZone]:
+    """A target group with one managed server, plus a Windows source server."""
+    group = DNSServerGroup(name=f"grp-{uuid.uuid4().hex[:6]}")
+    db.add(group)
+    await db.flush()
+
+    managed = DNSServer(
+        group_id=group.id,
+        name="ns-managed",
+        driver="bind9",
+        host="10.0.0.53",
+        port=53,
+        is_enabled=True,
+        is_primary=True,
+    )
+    source_group = DNSServerGroup(name=f"win-{uuid.uuid4().hex[:6]}")
+    db.add_all([managed, source_group])
+    await db.flush()
+    source = DNSServer(
+        group_id=source_group.id,
+        name="win-dns",
+        driver="windows_dns",
+        host="10.0.0.10",
+        port=53,
+        is_enabled=True,
+    )
+    zone = DNSZone(
+        group_id=group.id,
+        name=zone_name,
+        zone_type="primary",
+        kind="forward",
+        ttl=3600,
+        minimum=3600,
+        import_source=import_source,
+    )
+    db.add_all([source, zone])
+    await db.flush()
+    return group, source, managed, zone
+
+
+async def _dhcp_side(
+    db: AsyncSession, *, cidr: str = "10.20.0.0/24", is_active: bool = False
+) -> tuple[DHCPServerGroup, DHCPServer, DHCPScope, Subnet]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, name="blk", network=cidr)
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, name="sub", network=cidr)
+    group = DHCPServerGroup(name=f"dgrp-{uuid.uuid4().hex[:6]}")
+    source_group = DHCPServerGroup(name=f"dwin-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, group, source_group])
+    await db.flush()
+
+    # NB: DHCPServer's FK is ``server_group_id`` — DNSServer's is ``group_id``.
+    # The two models disagree, so a copy-paste between the halves fails loudly.
+    source = DHCPServer(
+        server_group_id=source_group.id,
+        name="win-dhcp",
+        driver="windows_dhcp",
+        host="10.0.0.11",
+    )
+    scope = DHCPScope(
+        group_id=group.id,
+        subnet_id=subnet.id,
+        name="managed scope",
+        is_active=is_active,
+        lease_time=86400,
+        address_family="ipv4",
+    )
+    # The target group needs at least one server or readiness blocks the
+    # cutover — correctly, since activating a scope in an empty group would
+    # leave the subnet with nothing handing out addresses.
+    managed = DHCPServer(
+        server_group_id=group.id,
+        name="kea-managed",
+        driver="kea",
+        host="10.0.0.67",
+    )
+    db.add_all([source, scope, managed])
+    await db.flush()
+    return group, source, scope, subnet
+
+
+async def _plan_with_item(
+    db: AsyncSession,
+    *,
+    kind: str,
+    source_ref: str,
+    user: User,
+    source_dns: DNSServer | None = None,
+    source_dhcp: DHCPServer | None = None,
+    dns_group_id: uuid.UUID | None = None,
+    dhcp_group_id: uuid.UUID | None = None,
+    zone: DNSZone | None = None,
+    scope: DHCPScope | None = None,
+    stage: str = "parity_checked",
+    parity_ok: bool = False,
+) -> tuple[CutoverPlan, CutoverItem]:
+    """Seed a plan with one item.
+
+    ``parity_ok`` stamps a clean parity report onto the item. Readiness treats a
+    missing or non-``ok`` report as a hard block — an item whose parity was
+    never established cannot be cut over — so any test that exercises the switch
+    has to satisfy that first, exactly as an operator would.
+    """
+    plan = CutoverPlan(
+        name=f"plan-{uuid.uuid4().hex[:8]}",
+        status="verifying",
+        source_dns_server_id=source_dns.id if source_dns else None,
+        source_dhcp_server_id=source_dhcp.id if source_dhcp else None,
+        target_dns_group_id=dns_group_id,
+        target_dhcp_group_id=dhcp_group_id,
+        created_by_user_id=user.id,
+    )
+    db.add(plan)
+    await db.flush()
+    item = CutoverItem(
+        plan_id=plan.id,
+        kind=kind,
+        source_ref=source_ref,
+        zone_id=zone.id if zone else None,
+        scope_id=scope.id if scope else None,
+        stage=stage,
+        blockers=[],
+        last_parity=(
+            {"status": "ok", "difference_count": 0, "in_sync": 1, "is_parity": True}
+            if parity_ok
+            else None
+        ),
+        last_parity_at=datetime.now(UTC) if parity_ok else None,
+    )
+    db.add(item)
+    await db.flush()
+    return plan, item
+
+
+# =========================================================================== #
+# 1. The GSS-TSIG refusal — the hazard the issue calls out by name.
+# =========================================================================== #
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["Secure", "secure", "SECURE", 2, "2", 2.0],
+    ids=["text", "lower", "upper", "int", "numeric-string", "float"],
+)
+def test_secure_dynamic_update_recognised_in_every_wire_shape(raw: Any) -> None:
+    """``ConvertTo-Json`` emits the enum as a string on some builds and an int
+    on others. Missing either shape means the AD blocker silently never fires."""
+    assert readiness_mod.normalize_dynamic_update(raw) == "secure"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("None", "none"),
+        (0, "none"),
+        ("NonsecureAndSecure", "nonsecure_and_secure"),
+        ("nonsecure and secure", "nonsecure_and_secure"),
+        (1, "nonsecure_and_secure"),
+        (None, None),
+        ("", None),
+        ("wat", None),
+        # bool is an int subclass; True must not decode as NonsecureAndSecure.
+        (True, None),
+        (False, None),
+    ],
+)
+def test_dynamic_update_normalisation(raw: Any, expected: str | None) -> None:
+    assert readiness_mod.normalize_dynamic_update(raw) == expected
+
+
+async def test_ad_secure_zone_is_hard_blocked(db_session: AsyncSession) -> None:
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+
+    blockers = await readiness_mod.evaluate_dns_item(
+        db_session,
+        plan=plan,
+        item=item,
+        zone=zone,
+        source_zone_meta={
+            "name": "corp.example",
+            "zone_type": "Primary",
+            "is_ad_integrated": True,
+            "is_reverse_lookup": False,
+            "dynamic_update": "Secure",
+        },
+    )
+    hard = blocking(blockers)
+    assert BLOCKER_AD_SECURE_DDNS in {b.code for b in hard}
+    # The message has to tell the operator what to do about it, not just that
+    # it is refused — this is the one refusal they cannot work around.
+    msg = next(b.message for b in hard if b.code == BLOCKER_AD_SECURE_DDNS)
+    assert "GSS-TSIG" in msg and "444" in msg
+
+
+async def test_unreadable_dynamic_update_mode_fails_closed(db_session: AsyncSession) -> None:
+    """An AD-integrated zone whose mode we cannot interpret is treated as
+    Secure. "We could not check" must never resolve to "safe to migrate"."""
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+
+    blockers = await readiness_mod.evaluate_dns_item(
+        db_session,
+        plan=plan,
+        item=item,
+        zone=zone,
+        source_zone_meta={
+            "name": "corp.example",
+            "is_ad_integrated": True,
+            "dynamic_update": "SomethingNewMicrosoftAdded",
+        },
+    )
+    assert BLOCKER_AD_SECURE_DDNS in {b.code for b in blocking(blockers)}
+
+
+async def test_cutover_refuses_and_force_cannot_bypass_a_block(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The end-to-end guarantee: a blocked item does not cut over, with or
+    without ``force``."""
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+
+    monkeypatch.setattr(
+        readiness_mod,
+        "get_dns_driver",
+        lambda _d: _FakeDNSDriver(
+            zones=[
+                {
+                    "name": "corp.example",
+                    "is_ad_integrated": True,
+                    "dynamic_update": "Secure",
+                    "is_reverse_lookup": False,
+                    "zone_type": "Primary",
+                }
+            ]
+        ),
+    )
+
+    for force in (False, True):
+        with pytest.raises(switch_mod.CutoverBlocked) as exc:
+            await switch_mod.execute_cutover(
+                db_session, plan=plan, item=item, current_user=user, force=force
+            )
+        assert BLOCKER_AD_SECURE_DDNS in {b.code for b in exc.value.blockers}
+
+    await db_session.refresh(item)
+    assert item.stage != "cut_over"
+    assert item.cut_over_at is None
+
+
+# =========================================================================== #
+# 2. DNS parity classification.
+# =========================================================================== #
+
+
+async def _run_dns_parity(
+    db: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    zone: DNSZone,
+    source: DNSServer,
+    wire: list[RecordData],
+) -> Any:
+    monkeypatch.setattr(parity_mod, "get_dns_driver", lambda _d: _FakeDNSDriver(records=wire))
+    return await parity_mod.compute_dns_parity(
+        db, source_server=source, zone=zone, source_zone_name=zone.name.rstrip(".")
+    )
+
+
+async def test_dns_parity_pairs_a_changed_value_into_one_difference(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The delta over #61: same name+type with different data is ONE decision,
+    not a missing+extra pair."""
+    _group, source, _managed, zone = await _dns_side(db_session, import_source="windows_dns")
+    db_session.add(DNSRecord(zone_id=zone.id, name="www", record_type="A", value="10.0.0.1"))
+    await db_session.commit()
+
+    report = await _run_dns_parity(
+        db_session,
+        monkeypatch,
+        zone=zone,
+        source=source,
+        wire=[RecordData(name="www", record_type="A", value="10.0.0.99")],
+    )
+    assert report.status == "ok"
+    assert [d.classification for d in report.differences] == ["value_mismatch"]
+    diff = report.differences[0]
+    assert diff.source_value == "10.0.0.99"
+    assert diff.target_value == "10.0.0.1"
+
+
+async def test_dns_parity_windows_only_keys_off_import_provenance(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An imported zone that Windows has moved on from reports
+    ``drifted_since_import``; one with no provenance reports
+    ``never_imported``. Row-level provenance does not exist, so the zone's is
+    the only evidence available — assert we use it consistently."""
+    for provenance, expected in (
+        ("windows_dns", "drifted_since_import"),
+        (None, "never_imported"),
+    ):
+        _g, source, _m, zone = await _dns_side(
+            db_session,
+            zone_name=f"z{uuid.uuid4().hex[:6]}.example.",
+            import_source=provenance,
+        )
+        await db_session.commit()
+        report = await _run_dns_parity(
+            db_session,
+            monkeypatch,
+            zone=zone,
+            source=source,
+            wire=[RecordData(name="new", record_type="A", value="10.0.0.7")],
+        )
+        assert [d.classification for d in report.differences] == [expected]
+
+
+async def test_dns_parity_spatium_only_is_intentionally_diverged(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _g, source, _m, zone = await _dns_side(db_session, import_source="windows_dns")
+    db_session.add(DNSRecord(zone_id=zone.id, name="only-here", record_type="A", value="10.0.0.5"))
+    await db_session.commit()
+
+    report = await _run_dns_parity(db_session, monkeypatch, zone=zone, source=source, wire=[])
+    # Zero-on-the-wire with rows in the DB is the ambiguous case (a parse
+    # failure returns [] identically), so it must NOT read as a clean diff.
+    assert report.status == "unverified"
+    assert not report.is_parity
+
+
+async def test_dns_parity_in_sync_reports_parity(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _g, source, _m, zone = await _dns_side(db_session, import_source="windows_dns")
+    db_session.add(DNSRecord(zone_id=zone.id, name="www", record_type="A", value="10.0.0.1"))
+    await db_session.commit()
+
+    report = await _run_dns_parity(
+        db_session,
+        monkeypatch,
+        zone=zone,
+        source=source,
+        wire=[RecordData(name="www", record_type="A", value="10.0.0.1", ttl=60)],
+    )
+    # TTL-only differences are the pre-flight step's business, not parity's.
+    assert report.is_parity
+    assert report.in_sync == 1
+
+
+async def test_dns_parity_pull_failure_is_reported_not_raised(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _g, source, _m, zone = await _dns_side(db_session)
+    await db_session.commit()
+    monkeypatch.setattr(
+        parity_mod,
+        "get_dns_driver",
+        lambda _d: _FakeDNSDriver(raises=RuntimeError("WinRM transport failure")),
+    )
+    report = await parity_mod.compute_dns_parity(
+        db_session, source_server=source, zone=zone, source_zone_name="corp.example"
+    )
+    assert report.status == "error"
+    assert "WinRM" in (report.error or "")
+    assert not report.is_parity
+
+
+async def test_dns_parity_skips_types_the_read_path_cannot_see(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Path-B pull cannot emit CAA, so a CAA row in the DB must not be
+    reported as a difference — that would send the operator to "fix" a record
+    that is already correct on both sides."""
+    _g, source, _m, zone = await _dns_side(db_session, import_source="windows_dns")
+    # Path B is selected by the presence of credentials.
+    source.credentials_encrypted = b"not-really-encrypted-but-truthy"
+    db_session.add_all(
+        [
+            DNSRecord(zone_id=zone.id, name="@", record_type="CAA", value='0 issue "le.org"'),
+            DNSRecord(zone_id=zone.id, name="www", record_type="A", value="10.0.0.1"),
+        ]
+    )
+    await db_session.commit()
+
+    report = await _run_dns_parity(
+        db_session,
+        monkeypatch,
+        zone=zone,
+        source=source,
+        wire=[RecordData(name="www", record_type="A", value="10.0.0.1")],
+    )
+    assert report.is_parity, [d.as_dict() for d in report.differences]
+    assert report.not_compared == 1
+    assert any("not compared" in w for w in report.warnings)
+
+
+# =========================================================================== #
+# 3. DHCP parity.
+# =========================================================================== #
+
+
+async def test_dhcp_parity_diffs_lease_time_pools_and_reservations(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _group, source, scope, _subnet = await _dhcp_side(db_session)
+    db_session.add_all(
+        [
+            DHCPPool(
+                scope_id=scope.id, start_ip="10.20.0.100", end_ip="10.20.0.200", pool_type="dynamic"
+            ),
+            DHCPStaticAssignment(
+                scope_id=scope.id,
+                ip_address="10.20.0.50",
+                mac_address="aa:bb:cc:dd:ee:ff",
+                hostname="printer",
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    windows = _windows_scope(
+        lease_time=43200,  # differs from the scope's 86400
+        pools=[{"start_ip": "10.20.0.100", "end_ip": "10.20.0.150", "pool_type": "dynamic"}],
+        statics=[
+            # Windows reports the ClientId form with the 01- hardware-type
+            # prefix; it must fold onto the same MAC, not read as a difference.
+            {
+                "mac_address": "01-AA-BB-CC-DD-EE-FF",
+                "ip_address": "10.20.0.51",
+                "hostname": "printer",
+            }
+        ],
+    )
+    monkeypatch.setattr(parity_mod, "get_dhcp_driver", lambda _d: _FakeDHCPDriver(scopes=[windows]))
+
+    report = await parity_mod.compute_dhcp_parity(
+        db_session, source_server=source, scope=scope, source_scope_id="10.20.0.0"
+    )
+    assert report.status == "ok"
+    kinds = {(d.name, d.classification) for d in report.differences}
+    assert ("lease_time", "value_mismatch") in kinds
+    # The reservation folded onto one MAC and differs only by address.
+    assert ("aa:bb:cc:dd:ee:ff", "value_mismatch") in kinds
+    assert any(name == "pool" for name, _ in kinds)
+
+
+async def test_dhcp_parity_honours_statics_ok(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#620: an enumeration failure returns an empty ``statics`` list. Treating
+    that as "Windows has no reservations" would report every managed
+    reservation as diverged off the back of a transient PowerShell error."""
+    _group, source, scope, _subnet = await _dhcp_side(db_session)
+    db_session.add(
+        DHCPStaticAssignment(
+            scope_id=scope.id, ip_address="10.20.0.50", mac_address="aa:bb:cc:dd:ee:ff"
+        )
+    )
+    await db_session.commit()
+
+    windows = _windows_scope(lease_time=86400, statics=[], statics_ok=False)
+    monkeypatch.setattr(parity_mod, "get_dhcp_driver", lambda _d: _FakeDHCPDriver(scopes=[windows]))
+
+    report = await parity_mod.compute_dhcp_parity(
+        db_session, source_server=source, scope=scope, source_scope_id="10.20.0.0"
+    )
+    assert not any(d.name == "aa:bb:cc:dd:ee:ff" for d in report.differences)
+    assert any("could not be enumerated" in w for w in report.warnings)
+
+
+async def test_dhcp_parity_unmatched_scope(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _group, source, scope, _subnet = await _dhcp_side(db_session)
+    await db_session.commit()
+    monkeypatch.setattr(
+        parity_mod,
+        "get_dhcp_driver",
+        lambda _d: _FakeDHCPDriver(
+            scopes=[_windows_scope(cidr="192.168.9.0/24", scope_id="192.168.9.0")]
+        ),
+    )
+    report = await parity_mod.compute_dhcp_parity(
+        db_session, source_server=source, scope=scope, source_scope_id="10.20.0.0"
+    )
+    assert report.status == "unmatched"
+    assert not report.is_parity
+
+
+# =========================================================================== #
+# 4. Lease handover.
+# =========================================================================== #
+
+
+async def test_lease_handover_classifies_every_lease(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _group, source, scope, _subnet = await _dhcp_side(db_session)
+    db_session.add(
+        DHCPStaticAssignment(
+            scope_id=scope.id, ip_address="10.20.0.50", mac_address="11:11:11:11:11:11"
+        )
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(
+        leases=[
+            # Carried across.
+            {"ip_address": "10.20.0.60", "mac_address": "22:22:22:22:22:22", "hostname": "laptop"},
+            # Outside the managed scope's subnet — belongs to another scope.
+            {"ip_address": "192.168.5.10", "mac_address": "33:33:33:33:33:33", "hostname": "far"},
+            # MAC already reserved to a DIFFERENT address on this scope.
+            {"ip_address": "10.20.0.70", "mac_address": "11:11:11:11:11:11", "hostname": "dup"},
+            # No usable MAC.
+            {"ip_address": "10.20.0.80", "mac_address": "", "client_id": "not-a-mac"},
+        ]
+    )
+    monkeypatch.setattr(leases_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+
+    plan = await leases_mod.preview_lease_handover(
+        db_session, source_server=source, scope=scope, source_scope_id="10.20.0.0"
+    )
+    by_ip = {e.ip_address: e for e in plan.entries}
+    assert by_ip["10.20.0.60"].action == "create"
+    assert by_ip["192.168.5.10"].action == "skip"
+    assert by_ip["10.20.0.70"].action == "conflict"
+    assert by_ip["10.20.0.80"].action == "skip"
+    assert plan.create_count == 1
+    assert plan.conflict_count == 1
+
+
+async def test_lease_handover_commit_creates_reservations_with_provenance(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = await _user(db_session)
+    _group, source, scope, _subnet = await _dhcp_side(db_session)
+    _plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        scope=scope,
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(
+        leases=[
+            {"ip_address": "10.20.0.60", "mac_address": "22:22:22:22:22:22", "hostname": "laptop"},
+            {"ip_address": "10.20.0.61", "mac_address": "44:44:44:44:44:44", "hostname": "phone"},
+        ]
+    )
+    monkeypatch.setattr(leases_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+
+    preview = await leases_mod.preview_lease_handover(
+        db_session, source_server=source, scope=scope, source_scope_id="10.20.0.0"
+    )
+    result = await leases_mod.commit_lease_handover(
+        db_session,
+        source_server=source,
+        scope=scope,
+        item=item,
+        plan=preview,
+        current_user=user,
+    )
+    await db_session.commit()
+
+    assert result.created == 2
+    assert result.failed == 0
+    rows = (
+        (
+            await db_session.execute(
+                DHCPStaticAssignment.__table__.select().where(
+                    DHCPStaticAssignment.scope_id == scope.id
+                )
+            )
+        )
+        .mappings()
+        .all()
+    )
+    assert {str(r["ip_address"]) for r in rows} == {"10.20.0.60", "10.20.0.61"}
+    # Provenance is what makes these findable + removable once leases churn.
+    assert all(r["import_source"] == leases_mod.CUTOVER_IMPORT_SOURCE for r in rows)
+    assert item.lease_handover["created"] == 2
+
+
+async def test_lease_handover_empty_pull_warns_rather_than_reporting_success(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty lease list is indistinguishable from a failed read, so it must
+    not present as a clean handover."""
+    _group, source, scope, _subnet = await _dhcp_side(db_session)
+    await db_session.commit()
+    monkeypatch.setattr(leases_mod, "WindowsDHCPReadOnlyDriver", lambda: _FakeDHCPDriver(leases=[]))
+
+    plan = await leases_mod.preview_lease_handover(
+        db_session, source_server=source, scope=scope, source_scope_id="10.20.0.0"
+    )
+    assert plan.entries == []
+    assert any("no active leases" in w for w in plan.warnings)
+
+
+# =========================================================================== #
+# 5. TTL pre-flight.
+# =========================================================================== #
+
+
+@pytest.mark.parametrize("bad", [0, 29, 86401, 999999])
+def test_target_ttl_bounds(bad: int) -> None:
+    with pytest.raises(ValueError):
+        preflight_mod.validate_target_ttl(bad)
+
+
+async def test_ttl_preflight_snapshots_once_and_restores_exactly(
+    db_session: AsyncSession,
+) -> None:
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    explicit = DNSRecord(zone_id=zone.id, name="www", record_type="A", value="10.0.0.1", ttl=3600)
+    inherited = DNSRecord(zone_id=zone.id, name="app", record_type="A", value="10.0.0.2", ttl=None)
+    db_session.add_all([explicit, inherited])
+    _plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+
+    await preflight_mod.apply_ttl_preflight(
+        db_session, zone=zone, item=item, target_ttl=300, current_user=user
+    )
+    await db_session.commit()
+    assert zone.ttl == 300
+    assert explicit.ttl == 300
+    # An inherited TTL is pinned explicitly so the restore can put the
+    # inheritance back rather than leaving it stuck at the zone default.
+    assert inherited.ttl == 300
+    first_snapshot = dict(item.ttl_snapshot or {})
+
+    # A second, lower apply must NOT overwrite the pristine snapshot.
+    await preflight_mod.apply_ttl_preflight(
+        db_session, zone=zone, item=item, target_ttl=60, current_user=user
+    )
+    await db_session.commit()
+    assert item.ttl_snapshot["zone"] == first_snapshot["zone"]
+    assert zone.ttl == 60
+
+    await preflight_mod.restore_ttl_preflight(db_session, zone=zone, item=item, current_user=user)
+    await db_session.commit()
+    assert zone.ttl == 3600
+    assert explicit.ttl == 3600
+    assert inherited.ttl is None
+    assert item.ttl_snapshot is None
+
+
+async def test_ttl_restore_without_snapshot_is_a_no_op(db_session: AsyncSession) -> None:
+    """Rollback calls this unconditionally, so "nothing was lowered" must not
+    be an error."""
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    _plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+    assert (
+        await preflight_mod.restore_ttl_preflight(
+            db_session, zone=zone, item=item, current_user=user
+        )
+        == 0
+    )
+
+
+# =========================================================================== #
+# 6. The DHCP switch — ordering is the whole safety property.
+# =========================================================================== #
+
+
+async def test_dhcp_cutover_deactivates_windows_before_activating_kea(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = await _user(db_session)
+    group, source, scope, _subnet = await _dhcp_side(db_session, is_active=False)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        dhcp_group_id=group.id,
+        scope=scope,
+        parity_ok=True,
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(scopes=[_windows_scope()])
+    monkeypatch.setattr(switch_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+    monkeypatch.setattr(readiness_mod, "get_dhcp_driver", lambda _d: driver)
+
+    await switch_mod.execute_cutover(
+        db_session, plan=plan, item=item, current_user=user, force=True
+    )
+    await db_session.commit()
+
+    # Deactivate-then-activate. The reverse order leaves both servers handing
+    # out addresses on the same subnet.
+    assert driver.state_calls == [("10.20.0.0", False)]
+    assert scope.is_active is True
+    assert item.stage == "cut_over"
+    assert item.cut_over_at is not None
+
+
+async def test_dhcp_rollback_reverses_the_switch(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = await _user(db_session)
+    group, source, scope, _subnet = await _dhcp_side(db_session, is_active=True)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        dhcp_group_id=group.id,
+        scope=scope,
+        stage="cut_over",
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(scopes=[_windows_scope(is_active=False)])
+    monkeypatch.setattr(switch_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+
+    await switch_mod.execute_rollback(db_session, plan=plan, item=item, current_user=user)
+    await db_session.commit()
+
+    assert ("10.20.0.0", True) in driver.state_calls
+    assert scope.is_active is False
+    assert item.stage == "rolled_back"
+
+
+async def test_dhcp_cutover_reactivates_windows_when_activation_fails(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the managed side fails to come up, the subnet is left with no DHCP at
+    all — so the Windows scope must be put back before the error surfaces."""
+    user = await _user(db_session)
+    group, source, scope, _subnet = await _dhcp_side(db_session, is_active=False)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        dhcp_group_id=group.id,
+        scope=scope,
+        parity_ok=True,
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(scopes=[_windows_scope()])
+    monkeypatch.setattr(switch_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+    monkeypatch.setattr(readiness_mod, "get_dhcp_driver", lambda _d: driver)
+
+    def _boom(*_a: Any, **_kw: Any) -> None:
+        raise RuntimeError("wake bus exploded")
+
+    monkeypatch.setattr(switch_mod, "collect_wake", _boom)
+
+    with pytest.raises(RuntimeError, match="wake bus exploded"):
+        await switch_mod.execute_cutover(
+            db_session, plan=plan, item=item, current_user=user, force=True
+        )
+    await db_session.rollback()
+
+    assert driver.state_calls == [("10.20.0.0", False), ("10.20.0.0", True)]
+
+
+# =========================================================================== #
+# 7. Regressions from the #756 code review.
+# =========================================================================== #
+
+
+async def test_rollback_clears_cut_over_at_so_pre_switch_blockers_return(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A rolled-back item must be treated as *not* cut over.
+
+    ``readiness._is_cut_over`` short-circuits the pre-switch checks so a
+    completed item does not look permanently unready. If a rollback left
+    ``cut_over_at`` set, that suppression would persist — and the next attempt
+    would skip ``managed_scope_active``, the blocker that refuses a retry while
+    both servers are live on the same subnet.
+    """
+    user = await _user(db_session)
+    group, source, scope, _subnet = await _dhcp_side(db_session, is_active=True)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        dhcp_group_id=group.id,
+        scope=scope,
+        stage="cut_over",
+        parity_ok=True,
+    )
+    item.cut_over_at = datetime.now(UTC)
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(scopes=[_windows_scope(is_active=False)])
+    monkeypatch.setattr(switch_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+    await switch_mod.execute_rollback(db_session, plan=plan, item=item, current_user=user)
+    await db_session.commit()
+
+    assert item.cut_over_at is None
+    assert readiness_mod._is_cut_over(item) is False
+
+    # Now simulate the operator re-activating the managed scope by hand while
+    # Windows is serving again: the hard block must be back.
+    scope.is_active = True
+    await db_session.commit()
+    blockers = await readiness_mod.evaluate_dhcp_item(
+        db_session, plan=plan, item=item, scope=scope, source_scope=_windows_scope(is_active=True)
+    )
+    assert "managed_scope_active" in {b.code for b in blocking(blockers)}
+
+
+async def test_match_source_scope_does_not_match_on_empty_cidr() -> None:
+    """An item with no linked subnet passes ``subnet_cidr=""``. That must match
+    nothing — matching a scope whose own ``subnet_cidr`` is missing would hand
+    readiness an unrelated Windows scope and suppress ``source_scope_missing``."""
+    scopes = [{"scope_id": "192.168.9.0", "subnet_cidr": ""}]
+    assert parity_mod.match_source_scope(scopes, subnet_cidr="", source_scope_id="") is None
+    # A real id still matches by scope_id.
+    assert (
+        parity_mod.match_source_scope(scopes, subnet_cidr="", source_scope_id="192.168.9.0")
+        is not None
+    )
+
+
+async def test_ttl_preflight_refuses_when_the_group_primary_is_agentless(
+    db_session: AsyncSession,
+) -> None:
+    """The pre-flight promises never to write to the Windows source. If the
+    target group's primary IS an agentless server, ``enqueue_record_ops_batch``
+    would dispatch straight at it — so the apply refuses instead."""
+    user = await _user(db_session)
+    group = DNSServerGroup(name=f"grp-{uuid.uuid4().hex[:6]}")
+    db_session.add(group)
+    await db_session.flush()
+    db_session.add(
+        DNSServer(
+            group_id=group.id,
+            name="win-dns-primary",
+            driver="windows_dns",
+            host="10.0.0.10",
+            is_enabled=True,
+            is_primary=True,
+        )
+    )
+    zone = DNSZone(group_id=group.id, name="risky.example.", zone_type="primary", kind="forward")
+    db_session.add(zone)
+    await db_session.flush()
+    _plan, item = await _plan_with_item(
+        db_session, kind="dns_zone", source_ref="risky.example", user=user, zone=zone
+    )
+    await db_session.commit()
+
+    with pytest.raises(ValueError, match="agentless"):
+        await preflight_mod.apply_ttl_preflight(
+            db_session, zone=zone, item=item, target_ttl=300, current_user=user
+        )
+
+
+async def test_checklist_read_is_read_only_and_patch_creates_the_row(
+    db_session: AsyncSession,
+) -> None:
+    """Reading a checklist must not write — a GET that seeds rows would owe an
+    audit entry and would slip past the maintenance-mode gate."""
+    from sqlalchemy import func as sa_func
+
+    from app.models.cutover import CutoverChecklistItem
+    from app.services.cutover import checklist as checklist_mod
+
+    user = await _user(db_session)
+    plan, _item = await _plan_with_item(
+        db_session, kind="dns_zone", source_ref="corp.example", user=user
+    )
+    await db_session.commit()
+
+    views = await checklist_mod.read_checklist(db_session, plan=plan)
+    assert len(views) == len(checklist_mod.DECOMMISSION_CHECKLIST)
+    assert all(v.is_done is False for v in views)
+    stored = (
+        await db_session.execute(
+            select(sa_func.count())
+            .select_from(CutoverChecklistItem)
+            .where(CutoverChecklistItem.plan_id == plan.id)
+        )
+    ).scalar_one()
+    assert stored == 0, "read_checklist must not create rows"
+
+    key = checklist_mod.DECOMMISSION_CHECKLIST[0].key
+    row = await checklist_mod.upsert_checklist_row(db_session, plan=plan, key=key)
+    assert row is not None
+    row.is_done = True
+    await db_session.commit()
+
+    views = await checklist_mod.read_checklist(db_session, plan=plan)
+    assert next(v for v in views if v.key == key).is_done is True
+    # An unknown key must not mint a row.
+    assert await checklist_mod.upsert_checklist_row(db_session, plan=plan, key="nope") is None
+
+
+def test_runbook_and_preflight_share_one_powershell_generator() -> None:
+    """Two hand-maintained copies of the same operator command is how one of
+    them ends up wrong. The runbook fences the preflight generator's output."""
+    from app.services.cutover import runbook as runbook_mod
+
+    fenced = runbook_mod._ps_lower_ttls("dc01.corp.example", "corp.example", 300, 3600)
+    body = "\n".join(fenced)
+    assert body.startswith("```powershell")
+    assert "-ComputerName $Server" in body
+    # The same generator, without a computer name, is what the API returns.
+    inline = preflight_mod.windows_ttl_powershell("corp.example", 300, 3600)
+    assert "-ComputerName" not in inline
+    for marker in ("MinimumTimeToLive", "Set-DnsServerResourceRecord", "$NewTtl"):
+        assert marker in body and marker in inline

--- a/backend/tests/test_cutover.py
+++ b/backend/tests/test_cutover.py
@@ -1258,3 +1258,101 @@ async def test_ttl_restore_sends_the_zone_default_for_inheriting_records(
     # ...and the wire carries the zone's own default, not the agent's 3600.
     restore_ops = captured[-1]
     assert [o["record"]["ttl"] for o in restore_ops] == [7200]
+
+
+async def test_failed_commit_during_cutover_puts_the_windows_scope_back(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The commit is sequenced inside the switch, so a commit failure is
+    compensated like any other.
+
+    The Windows scope is already down by the time the transaction is sealed. If
+    sealing fails, the database rolls back to "managed inactive" and the subnet
+    would have no DHCP at all — so the same compensation that covers a failed
+    flush has to cover a failed commit.
+    """
+    user = await _user(db_session)
+    group, source, scope, _subnet = await _dhcp_side(db_session, is_active=False)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        dhcp_group_id=group.id,
+        scope=scope,
+        parity_ok=True,
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(scopes=[_windows_scope()])
+    monkeypatch.setattr(switch_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+    monkeypatch.setattr(readiness_mod, "get_dhcp_driver", lambda _d: driver)
+
+    async def _boom() -> None:
+        raise RuntimeError("commit failed")
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        await switch_mod.execute_cutover(
+            db_session,
+            plan=plan,
+            item=item,
+            current_user=user,
+            force=True,
+            finalize=_boom,
+        )
+    await db_session.rollback()
+
+    # Down, then back up — never left with no DHCP server on the subnet.
+    assert driver.state_calls == [("10.20.0.0", False), ("10.20.0.0", True)]
+
+
+async def test_rollback_commits_before_reactivating_windows(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The managed-side deactivation must be sealed *before* Windows comes back.
+
+    Committing afterwards would mean a failed commit rolls the managed scope
+    back to active while Windows is already active — both answering for one
+    subnet, which is the single outcome the switch ordering exists to prevent.
+    """
+    user = await _user(db_session)
+    group, source, scope, _subnet = await _dhcp_side(db_session, is_active=True)
+    plan, item = await _plan_with_item(
+        db_session,
+        kind="dhcp_scope",
+        source_ref="10.20.0.0",
+        user=user,
+        source_dhcp=source,
+        dhcp_group_id=group.id,
+        scope=scope,
+        stage="cut_over",
+        parity_ok=True,
+    )
+    await db_session.commit()
+
+    driver = _FakeDHCPDriver(scopes=[_windows_scope(is_active=False)])
+    monkeypatch.setattr(switch_mod, "WindowsDHCPReadOnlyDriver", lambda: driver)
+
+    order: list[str] = []
+
+    async def _finalize() -> None:
+        order.append(f"commit(managed_active={scope.is_active})")
+        await db_session.commit()
+
+    original = driver.set_scope_state
+
+    async def _tracked(server: Any, scope_id: str, *, active: bool) -> None:
+        order.append(f"winrm(active={active})")
+        await original(server, scope_id, active=active)
+
+    monkeypatch.setattr(driver, "set_scope_state", _tracked)
+
+    await switch_mod.execute_rollback(
+        db_session, plan=plan, item=item, current_user=user, finalize=_finalize
+    )
+
+    assert order == ["commit(managed_active=False)", "winrm(active=True)"], order
+    assert scope.is_active is False
+    assert item.stage == "rolled_back"
+    assert item.cut_over_at is None

--- a/backend/tests/test_cutover.py
+++ b/backend/tests/test_cutover.py
@@ -1112,3 +1112,65 @@ def test_runbook_and_preflight_share_one_powershell_generator() -> None:
     assert "-ComputerName" not in inline
     for marker in ("MinimumTimeToLive", "Set-DnsServerResourceRecord", "$NewTtl"):
         assert marker in body and marker in inline
+
+
+async def test_ttl_preflight_does_not_collapse_a_multi_value_rrset(
+    db_session: AsyncSession,
+) -> None:
+    """Three A records at one name must survive a TTL change.
+
+    The BIND9 agent renders a record op as an RFC 2136 ``replace``, which swaps
+    the whole RRset for that op's single value. Emitting one plain update per
+    record would therefore leave the zone serving only the last one — a TTL
+    change silently costing the operator two thirds of their addresses.
+    """
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    for addr in ("10.0.0.1", "10.0.0.2", "10.0.0.3"):
+        db_session.add(
+            DNSRecord(zone_id=zone.id, name="pool", record_type="A", value=addr, ttl=3600)
+        )
+    db_session.add(DNSRecord(zone_id=zone.id, name="solo", record_type="A", value="10.0.0.9"))
+    _plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+
+    captured: list[list[dict[str, Any]]] = []
+
+    async def _capture(db: Any, z: Any, ops: list[dict[str, Any]]) -> list[Any]:
+        captured.append(ops)
+        return [None] * len(ops)
+
+    import pytest as _pytest
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr(preflight_mod, "enqueue_record_ops_batch", _capture)
+    try:
+        await preflight_mod.apply_ttl_preflight(
+            db_session, zone=zone, item=item, target_ttl=300, current_user=user
+        )
+    finally:
+        monkeypatch.undo()
+
+    ops = captured[0]
+    pool_ops = [o for o in ops if o["record"]["name"] == "pool"]
+    solo_ops = [o for o in ops if o["record"]["name"] == "solo"]
+
+    assert len(pool_ops) == 3
+    # First clears the RRset, the other two append onto it — so all three values
+    # end up served at the new TTL.
+    assert "rrset_action" not in pool_ops[0]["record"]
+    assert [o["record"].get("rrset_action") for o in pool_ops[1:]] == ["add", "add"]
+    assert {o["record"]["value"] for o in pool_ops} == {"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+    assert all(o["record"]["ttl"] == 300 for o in pool_ops)
+
+    # A single-value RRset is emitted exactly as before.
+    assert len(solo_ops) == 1
+    assert "rrset_action" not in solo_ops[0]["record"]

--- a/backend/tests/test_cutover.py
+++ b/backend/tests/test_cutover.py
@@ -1174,3 +1174,87 @@ async def test_ttl_preflight_does_not_collapse_a_multi_value_rrset(
     # A single-value RRset is emitted exactly as before.
     assert len(solo_ops) == 1
     assert "rrset_action" not in solo_ops[0]["record"]
+
+
+# =========================================================================== #
+# 8. Regressions from the PR #775 review.
+# =========================================================================== #
+
+
+def test_shadow_does_not_case_fold_txt_rdata() -> None:
+    """Folding case on a TXT record would report a match between two values a
+    resolver treats as different — DKIM keys and verification tokens are
+    case-bearing payloads, not names."""
+    from app.services.cutover import shadow as shadow_mod
+
+    lower = shadow_mod.normalise_answers(['"google-site-verification=abc123"'], "TXT")
+    upper = shadow_mod.normalise_answers(['"google-site-verification=AbC123"'], "TXT")
+    assert lower != upper, "TXT rdata must be compared verbatim"
+
+    # Name-valued and address types still fold, so a rendering difference in
+    # case or the root dot is not reported as drift.
+    assert shadow_mod.normalise_answers(["Mail.Example.COM."], "CNAME") == (
+        shadow_mod.normalise_answers(["mail.example.com"], "CNAME")
+    )
+    assert shadow_mod.normalise_answers(["2001:DB8::1"], "AAAA") == (
+        shadow_mod.normalise_answers(["2001:db8::1"], "AAAA")
+    )
+    # Order is never meaningful.
+    assert shadow_mod.normalise_answers(["10.0.0.2", "10.0.0.1"], "A") == ["10.0.0.1", "10.0.0.2"]
+
+
+async def test_ttl_restore_sends_the_zone_default_for_inheriting_records(
+    db_session: AsyncSession,
+) -> None:
+    """A record whose TTL is NULL inherits ``zone.ttl``. The BIND9 agent's
+    record-op branch falls back to a hardcoded 3600 rather than the zone's own
+    default, so shipping the null would write 3600 onto every inheriting record
+    of a zone whose default is anything else. The row must stay NULL; the wire
+    must carry the resolved value."""
+    user = await _user(db_session)
+    group, source, _managed, zone = await _dns_side(db_session)
+    zone.ttl = 7200  # deliberately NOT the agent's 3600 fallback
+    zone.minimum = 7200
+    inherited = DNSRecord(zone_id=zone.id, name="app", record_type="A", value="10.0.0.1", ttl=None)
+    db_session.add(inherited)
+    _plan, item = await _plan_with_item(
+        db_session,
+        kind="dns_zone",
+        source_ref="corp.example",
+        user=user,
+        source_dns=source,
+        dns_group_id=group.id,
+        zone=zone,
+    )
+    await db_session.commit()
+
+    captured: list[list[dict[str, Any]]] = []
+
+    async def _capture(db: Any, z: Any, ops: list[dict[str, Any]]) -> list[Any]:
+        captured.append(ops)
+        return [None] * len(ops)
+
+    import pytest as _pytest
+
+    monkeypatch = _pytest.MonkeyPatch()
+    monkeypatch.setattr(preflight_mod, "enqueue_record_ops_batch", _capture)
+    try:
+        await preflight_mod.apply_ttl_preflight(
+            db_session, zone=zone, item=item, target_ttl=300, current_user=user
+        )
+        await db_session.commit()
+        assert inherited.ttl == 300
+
+        await preflight_mod.restore_ttl_preflight(
+            db_session, zone=zone, item=item, current_user=user
+        )
+        await db_session.commit()
+    finally:
+        monkeypatch.undo()
+
+    # The row is back to NULL, so inheritance is preserved...
+    assert inherited.ttl is None
+    assert zone.ttl == 7200
+    # ...and the wire carries the zone's own default, not the agent's 3600.
+    restore_ops = captured[-1]
+    assert [o["record"]["ttl"] for o in restore_ops] == [7200]

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -931,6 +931,12 @@ Full config-push to Windows DHCP (analogous to Windows DNS Path B) would unlock:
 
 The per-object CRUD methods are already in place (`apply_scope`, `apply_reservation`, `apply_exclusion`) — what's missing is the API-side wiring that routes write events from the scope / pool / static endpoints into those methods for agentless drivers.
 
+### 15.7 Migrating off Windows DHCP entirely (issue #756)
+
+Everything above treats Windows as a supported *backend*. When the goal is to stop using it, the guided **Windows cutover** surface (feature module `migration.cutover`, default-on, `/api/v1/migration/cutover`, superadmin) drives the switch per scope: parity against the live server (lease time, pools, reservations, options), the lease handover, the switch itself, and a decommission checklist.
+
+Two things matter here. The **lease handover** exists because the DHCP importer (§8) deliberately skips live leases — so a naive switch hands clients to a Kea with an empty lease database, and the first renewal offers a fresh pool address to a client still using the one Windows gave it. The handover promotes each live Windows lease to a reservation (stamped `import_source="windows_cutover"`) so a renewing client keeps the address it already holds. And the **switch is ordered**: the Windows scope is deactivated *before* the managed scope is activated, so the two never answer the same subnet at once; if the managed side then fails to come up, the Windows scope is re-activated. Rollback reverses it, with the recovery-time expectation stated as the scope's lease time. See [MIGRATION.md](MIGRATION.md#windows--spatiumddi-cutover-756).
+
 ## 16. Rules & constraints
 
 Server-side validations that reject requests with a human-readable

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -775,6 +775,12 @@ If AXFR is refused, the per-zone sync in step 4 of "Sync with Servers" shows `Zo
 
 See [WINDOWS.md](../deployment/WINDOWS.md) for full Windows-side prerequisites including WinRM enablement, service account creation, and firewall rules.
 
+### 13.6 Migrating off Windows DNS entirely (issue #756)
+
+Path A / B make Windows a supported *backend*. When the goal is to stop using it, the guided **Windows cutover** surface (feature module `migration.cutover`, default-on, `/api/v1/migration/cutover`, superadmin) walks the four phases: per-zone parity against the live server, a shadow-query parallel run replaying real BIND9 query-log traffic at both sides, a TTL pre-flight plus the switch with per-zone rollback, and a decommission checklist.
+
+Note especially that it **refuses** any zone whose Windows dynamic-update mode is AD "Secure only" — a hard block `force` cannot bypass, for the reason in §13.4: GSS-TSIG is unimplemented ([#444](https://github.com/spatiumddi/spatiumddi/issues/444)), and a DC that cannot register its SRV records breaks AD itself. See [MIGRATION.md](MIGRATION.md#windows--spatiumddi-cutover-756).
+
 ---
 
 ## 14. IPAM ↔ DNS synchronization jobs

--- a/docs/features/MIGRATION.md
+++ b/docs/features/MIGRATION.md
@@ -15,16 +15,23 @@ source-agnostic two-phase **preview → commit** pipeline. Each lives
 behind a togglable feature module so operators who don't need the
 surface can hide it (Settings → Features).
 
-| | DNS importer (#128) | DHCP importer (#129) | NetBox / IPAM importer (#36) |
-|---|---|---|---|
-| Feature module | `dns.import` | `dhcp.import` | `ipam.import.netbox` |
-| Admin surface | DNS Import (sidebar) | DHCP Import (sidebar) | Import → NetBox |
-| Sources | BIND9 archive · Windows DNS live-pull · PowerDNS REST · Cloud DNS live-pull (Cloudflare / Route 53 / Azure DNS / Google Cloud DNS) | Kea JSON file · Windows DHCP live-pull · ISC `dhcpd.conf` | NetBox REST live-pull (v3.x–4.6+) |
-| Target | DNS server group (+ optional view) | DHCP server group (+ IPAM linkage) | native IPAM rows (space / block / subnet / address + VRF / VLAN / Customer / Site) |
-| Provenance columns | `dns_zone` / `dns_record` `import_source` + `imported_at` | `dhcp_scope` / `dhcp_pool` / `dhcp_static_assignment` / `dhcp_client_class` `import_source` + `imported_at` | IPAM / network rows `import_source` + `imported_at` + `netbox_id` (in `custom_fields` / `tags`) |
-| Conflict actions | skip / overwrite / rename (per zone) | skip / overwrite (per scope) | skip / overwrite (per entity) |
-| API prefix | `/api/v1/dns/import/{source}/…` | `/api/v1/dhcp/import/{source}/…` | `/api/v1/ipam/import/netbox/…` |
-| RBAC | superadmin | superadmin | superadmin |
+The fourth column below is **not** an importer. The Windows cutover
+(#756) picks up where they stop — the estate is already in
+SpatiumDDI, the Windows server is still the one clients talk to, and
+what is left is proving the two agree and then moving the traffic. It
+shares the family's superadmin posture, provenance columns and
+preview → commit idiom, so it sits in the same table.
+
+| | DNS importer (#128) | DHCP importer (#129) | NetBox / IPAM importer (#36) | Windows cutover (#756) |
+|---|---|---|---|---|
+| Feature module | `dns.import` | `dhcp.import` | `ipam.import.netbox` | `migration.cutover` |
+| Admin surface | DNS Import (sidebar) | DHCP Import (sidebar) | Import → NetBox | Import → Windows cutover |
+| Sources | BIND9 archive · Windows DNS live-pull · PowerDNS REST · Cloud DNS live-pull (Cloudflare / Route 53 / Azure DNS / Google Cloud DNS) | Kea JSON file · Windows DHCP live-pull · ISC `dhcpd.conf` | NetBox REST live-pull (v3.x–4.6+) | live Windows DNS + Windows DHCP over WinRM |
+| Target | DNS server group (+ optional view) | DHCP server group (+ IPAM linkage) | native IPAM rows (space / block / subnet / address + VRF / VLAN / Customer / Site) | zones + scopes that already exist here — it creates none |
+| Provenance columns | `dns_zone` / `dns_record` `import_source` + `imported_at` | `dhcp_scope` / `dhcp_pool` / `dhcp_static_assignment` / `dhcp_client_class` `import_source` + `imported_at` | IPAM / network rows `import_source` + `imported_at` + `netbox_id` (in `custom_fields` / `tags`) | `dhcp_static_assignment` `import_source="windows_cutover"` + `imported_at` (lease handover only) |
+| Conflict actions | skip / overwrite / rename (per zone) | skip / overwrite (per scope) | skip / overwrite (per entity) | — parity report + readiness blockers instead |
+| API prefix | `/api/v1/dns/import/{source}/…` | `/api/v1/dhcp/import/{source}/…` | `/api/v1/ipam/import/netbox/…` | `/api/v1/migration/cutover/…` |
+| RBAC | superadmin | superadmin | superadmin | superadmin |
 
 The provenance columns are nullable + non-default: pre-existing,
 hand-created rows look "not imported" to the matcher, so a re-import
@@ -262,6 +269,408 @@ hard-blocked). The surface is superadmin-only; the feature module
 `ipam.import.netbox` is **default-on** (importers are default-on for
 discovery per non-negotiable #13/#14 — only continuous integration
 *mirrors* default off).
+
+---
+
+## Windows → SpatiumDDI cutover (#756)
+
+The importers land a *copy* of the Windows estate. They prove nothing
+about what happens next: the Windows server is still running, still
+authoritative, and still the thing clients actually talk to. This
+surface is the other half — verify the two sides agree, run them in
+parallel, perform the switch, and track the decommission.
+
+It is emphatically not a fifth importer. It creates no zones, scopes,
+pools or records. Its only writes are TTL reductions on a zone
+SpatiumDDI already owns, reservations synthesised from live Windows
+leases, and the `is_active` flag on a managed scope.
+
+Behind the **default-on** `migration.cutover` feature module (Settings
+→ Features, group **Tools**); router at `/api/v1/migration/cutover`,
+**superadmin on every endpoint**. That matches the three importers, on
+the grounds that a cutover is strictly more dangerous than an import —
+inventing a grantable permission for it would be a *weaker* posture
+than the surface it extends. Four MCP tools ship with it:
+`find_cutover_plans`, `find_cutover_plan_status` and
+`count_cutover_blockers` (DB-only, default-enabled) plus
+`find_cutover_parity_check`, which is default-**off** because it runs a
+live WinRM pull.
+
+### The plan
+
+The unit of work is a **plan**: a name, a source Windows DNS and/or
+DHCP server, a target DNS and/or DHCP server group, and a list of
+**items**. One item is one zone or one scope
+(`kind = dns_zone | dhcp_scope`). Items are independent — they can be
+cut over on different days, and each one rolls back on its own. There
+is no big-bang step anywhere.
+
+`POST …/plans/{id}/discover` live-pulls both source servers and hands
+back pickable candidates already matched against the target group
+(zones by name with the trailing dot and case normalised away, scopes
+by canonical subnet CIDR) with their readiness blockers pre-computed,
+so nobody types a zone name. The two halves are independent: a WinRM
+failure on the DHCP side is reported as an `error` string on that side
+while the DNS candidates still come back.
+
+Every mutating endpoint writes an `audit_log` row *and* a per-plan
+timeline event (`GET …/events`) — the audit row is the compliance
+record, the timeline is the operator's narrative of what was done to
+this plan and by whom. `GET …/runbook` renders the whole plan as
+markdown for a change ticket, built from persisted state so it does
+not re-pull the source.
+
+Plan status walks `draft` → `verifying` → `parallel` → `cutting_over`
+→ `completed`, with `rolled_back` and `abandoned` as terminal states.
+Item stage walks `pending` → `parity_checked` → `preflight_done` →
+`cut_over` / `rolled_back`.
+
+### Phase 1 — parity
+
+*Do we answer the same as Windows does right now?*
+
+`POST …/items/{id}/parity` runs one item; `POST …/plans/{id}/parity`
+runs every item on the plan. The fan-out is **sequential** on purpose:
+one `AsyncSession` cannot serve concurrent operations, and every parity
+computation reads from the DB before it touches the wire. A slow
+Windows box makes the request slow; it does not corrupt the session.
+Each report is persisted onto the item and refreshes its blockers.
+
+**DNS** diffs the live `pull_zone_records` result against the zone's
+`DNSRecord` rows. Identity and value normalisation are reused verbatim
+from `app.services.dns.pull_from_server._key`, so relative-vs-FQDN
+storage and TTL-only noise never register as failures. Records bucket
+on `(name, type)` **first**, which is the delta over the #61 drift
+report: a changed record surfaces as one difference rather than the
+missing+extra pair keying on `(name, type, value)` produces. TTLs are
+the pre-flight's business, not parity's.
+
+**DHCP** diffs `get_scopes()` against the managed scope — lease time,
+the pool set as `(start, end, type)` triples, reservations keyed by
+MAC, and scope options by canonical name. Activation posture is
+reported as a *warning*, never as a difference: through the parallel
+run the two sides are deliberately never both active, so a mismatch
+there is the expected posture, and recording it as a difference would
+make "in parity" structurally unreachable.
+
+Every difference is classified by *why* the two sides differ, because
+during a migration that is the decision, not the fact that they do:
+
+| Classification | What it means |
+|---|---|
+| `in_sync` | Both sides hold the same record or fact. Carried as the report's `in_sync` **count**, not as a difference row. |
+| `value_mismatch` | Same `(name, type)` on both sides, different data. One difference, not an add plus a remove — "the value changed" is a different decision from "a record appeared". |
+| `drifted_since_import` | Windows has it, SpatiumDDI doesn't, **and** the SpatiumDDI object carries import provenance. It came across once and Windows has moved on since; re-import or add it here. |
+| `never_imported` | Windows has it, SpatiumDDI doesn't, and there is no import provenance. Nothing drifted — it was simply never brought across. |
+| `intentionally_diverged` | SpatiumDDI has it, Windows doesn't. Almost always an operator addition made after the import; it starts being served at cutover. Surfaced, never auto-reconciled. |
+
+Report `status` is one of `ok`, `unmatched` (the object exists on one
+side only, so there is nothing to diff), `error` (the pull failed — a
+per-item failure never raises, so one dead host cannot take down a
+whole-plan run), or `unverified`. That last status, and the
+`not_compared` counter beside it, both exist because the *reader* can
+be wrong about the source — and saying so beats guessing.
+
+**`not_compared` — records the reader physically cannot see.** The
+Windows DNS driver picks its read path from whether the server has
+WinRM credentials, and the two paths are blind to different things.
+Path B (`Get-DnsServerResourceRecord`) maps only the types in
+`_PULL_RECORD_TYPES`; anything else reaches the parser as a raw
+`.ToString()` it refuses to guess at, so a CAA / TLSA / SSHFP / NAPTR /
+LOC row held here would read as "Windows does not have it" purely
+because the PowerShell walker cannot emit it. Path A (AXFR) has no
+type allowlist but strips DNSSEC artefacts. Both drop the SOA and the
+apex NS set, which SpatiumDDI models as zone-level fields rather than
+as records. Those rows are counted into `not_compared` and surfaced as
+a warning instead of falling out as `intentionally_diverged` — a
+difference there says something about the reader, not about the two
+servers, and chasing it means "fixing" records that are already
+correct on both sides.
+
+**`unverified` — the pull returned, and the answer cannot be trusted.**
+`WindowsDNSDriver._parse_records` logs a warning and returns an **empty
+list** when the PowerShell output does not parse, which is
+byte-identical to a genuinely empty zone. So a pull that comes back
+with no records at all while SpatiumDDI holds some gets
+`status="unverified"` rather than reporting every row as
+SpatiumDDI-only: calling that "everything diverged" would be actively
+misleading, and calling it "in parity" would be dangerous. Readiness
+treats `unverified` exactly like never-checked — a hard block.
+
+### Phase 2 — parallel run (shadow queries)
+
+Parity proves the two *configurations* agree. That is necessary and not
+sufficient: a zone can be byte-identical in the database and still
+answer differently on the wire — a view that matches on the control
+plane's source address, a stale zone file an agent never reloaded, a
+name served from a forwarder rather than from the zone.
+
+`POST …/items/{id}/shadow` (DNS items only; a DHCP item 422s) replays a
+sample of real questions at the Windows source **and** at every
+enabled, queryable server in the target group, then compares the
+answers.
+
+Names come from the BIND9 query log (`dns_query_log_entry`, scoped to
+the zone's own group, over a 24 h window matching what
+`prune_log_entries` retains). Those are questions clients actually
+asked, and that is what makes this a *shadow* run rather than a second
+look at our own rows. When the log is empty — query logging off, or the
+managed side not receiving traffic yet — it falls back to the zone's
+`DNSRecord` names. `sample_source` on the report says which, and it
+matters: parity demonstrated against production traffic is a
+materially stronger claim than parity against the rows being tested.
+The fallback also emits a warning telling the operator to enable query
+logging and re-run during the parallel window.
+
+Mechanics worth knowing:
+
+- Queries go to an **IP literal**; hostnames are resolved first. Every
+  low-level dnspython entry point resolves the nameserver itself and
+  raises a bare, message-less `ValueError` for anything that is not an
+  address — the exact reason #61's drift report failed 100% of the time
+  against hostname-addressed servers (#734).
+- Recursion is disabled (RD=0). Both sides are supposed to be
+  authoritative, and letting either recurse would let a cached answer
+  from somewhere else stand in for the server under test.
+- Answers compare as sorted, de-duplicated, lower-cased,
+  trailing-dot-stripped sets — RRset order is not meaningful on the
+  wire, and round-robin makes it actively unstable.
+- Sample size 1–200 (default 25), 3 s per query, at most 8 in flight.
+- Cloud-hosted DNS drivers are skipped with a warning: their `host` is
+  a display label reached over a provider API, not a resolver.
+
+Per-sample verdicts are `match`, `mismatch`, `source_error` and
+`target_error`. A target that could not be reached outranks a mismatch
+that was seen — the comparison is incomplete, and reporting it as a
+clean mismatch would understate how much is still unknown.
+
+### Readiness blockers — and the GSS-TSIG refusal
+
+Every reason an item is not ready is a **blocker** with a stable code
+and one of two severities. `warn` is advisory and can be acknowledged
+by passing `force=true`; `block` refuses the cutover outright and
+**cannot be forced, ever**. Unacknowledged warnings also refuse, so
+`force` is an explicit "I have read these" rather than a bypass.
+
+Blockers are re-derived against **live** source state at the moment of
+the switch, not read from the last parity run. A report from twenty
+minutes ago is a claim about the past, and the whole guard is worthless
+if an operator can flip a zone on Windows afterwards and still be
+allowed through.
+
+> **The one that matters is `ad_secure_dynamic_update`.** A Windows
+> zone set to Active Directory **"Secure only"** dynamic updates
+> accepts registrations exclusively over GSS-TSIG. SpatiumDDI does not
+> implement GSS-TSIG (#444), so the moment that zone is served from
+> here instead, every domain controller and domain-joined client
+> silently fails to register — no error the operator will see, just an
+> Active Directory that stops resolving itself. That is the difference
+> between a DNS migration and a domain outage, so it is a hard block
+> and there is no flag anywhere that turns it off. Fix it on the
+> Windows side (set the zone to "Nonsecure and secure"), or leave that
+> zone on Windows and migrate the rest.
+
+The detection **fails closed**. Windows' `DynamicUpdate` arrives from
+`ConvertTo-Json` either as a string (`None` / `NonsecureAndSecure` /
+`Secure`) or as the raw enum integer (`0` / `1` / `2`), depending on
+the build, and both shapes are decoded — case-insensitively, and with
+punctuation squashed. An **AD-integrated** zone whose mode cannot be
+interpreted at all is treated as `Secure` and blocked, because "we
+could not tell" must not read as "it is fine".
+
+The rest, in brief. Blocking: no source server; the source zone /
+scope could not be read (so it is unverified — the message is rewritten
+to name the transport error when that is what happened); no target zone
+/ scope linked; the target group has no servers; parity never verified
+or not trustworthy; and `managed_scope_active`, which refuses a DHCP
+item whose managed scope is already active while Windows is still
+serving — the parallel run must be structurally unreachable to clients.
+Warnings: parity differences, a missing reverse zone, nonsecure dynamic
+updates, an AD-integrated source zone, a view-scoped target zone, an
+already-inactive source scope, and a pending lease handover.
+
+### Phase 3a — TTL pre-flight (DNS)
+
+The DNS switch is a delegation or forwarder change made outside
+SpatiumDDI, so its blast radius is governed entirely by how long
+resolvers keep serving the old answers — the TTL. A zone sitting on the
+common 3600 default means a bad cutover stays visible for an hour after
+it is reverted; lowered to 300 well ahead of the window, the same
+mistake clears in five minutes. Nothing else in the cutover buys as
+much safety for as little effort.
+
+`POST …/items/{id}/ttl-preflight/preview` describes the change;
+`…/commit` applies it; `…/restore` puts it back. `target_ttl` is
+bounded 30–86400 s (default 300) — the ceiling exists so an operator
+cannot quietly *raise* every TTL in the zone through a screen labelled
+"lower TTLs".
+
+Commit snapshots the zone SOA (`ttl` / `minimum` / `refresh` / `retry`)
+and **every** record's TTL into `cutover_item.ttl_snapshot`, then
+lowers `zone.ttl`, `zone.minimum` and every record above the target.
+Records with `ttl IS NULL` inherit the zone TTL, so they are given an
+explicit value and snapshotted as `null` — that is what lets a restore
+put the *inheritance* back rather than pinning them to whatever the
+zone default happened to be. Changes ride the ordinary record pipeline:
+one `bump_zone_serial` for the whole batch, then
+`enqueue_record_ops_batch`. The snapshot is written **once**; a second
+apply at a lower target still lowers TTLs but keeps the pristine
+snapshot, so a restore always returns the true pre-migration values.
+
+> **SpatiumDDI does not lower the TTLs on the Windows side, and that is
+> deliberate** — even though those are the values resolvers are
+> actually caching today, and therefore the ones that matter. Record
+> writes to a Windows DNS server ride RFC 2136, where "change the TTL"
+> is expressed as a **delete of the rrset followed by an add**, and
+> SpatiumDDI will not issue an unattended delete against a zone that is
+> still live and authoritative for production. The WinRM Path B
+> alternative is no better here: it is a clone-and-`Set` per record
+> against that same live zone. So the preview and commit responses both
+> carry `source_side_instructions` — a copy-pasteable PowerShell block
+> for the operator to run there — and the runbook repeats it. **A TTL
+> drop applied to only one side is worse than none at all**: it looks
+> done and buys nothing, which is why the instructions are part of
+> every response rather than an optional extra.
+
+Both sides then need waiting out. The preview warns with the real
+number: resolvers may keep serving the previous values for up to the
+zone's *current* TTL, so the drop has to happen at least that long
+before the window.
+
+### Phase 3b — DHCP lease handover
+
+The DHCP importer deliberately skips live leases (see "Not imported"
+above) — they are transient state, and an importer that invented
+reservations out of them would be lying about operator intent. A
+cutover is the one moment where that trade flips.
+
+At the instant the managed scope starts answering, **Kea's lease
+database is empty**. The first client to renew is handed a fresh
+address out of the pool while it is still using, and still answering
+on, the one Windows gave it. On a busy subnet a naive switch is
+therefore a wave of duplicate-address complaints during the exact
+window an operator is least able to absorb them.
+
+`POST …/items/{id}/lease-handover/preview` reads the live Windows lease
+table (`get_leases` already filters to the states Windows considers
+live) and classifies every lease; `…/commit` writes the `create`
+entries as `DHCPStaticAssignment` rows on the managed scope, so a
+renewing client is offered **the address it already holds**. Same
+stateless preview → commit contract as the importers: the plan comes
+back from the client, and every entry is re-classified against live DB
+state on the way in.
+
+- `create` — becomes a reservation.
+- `skip` — outside the managed scope's subnet (leases are selected by
+  subnet containment, because the driver's neutral lease dict carries
+  no scope id), already reserved with that address, or carrying a
+  client id that is not a MAC.
+- `conflict` — the MAC is already reserved to a *different* address on
+  this scope, or the address is already reserved to a different MAC.
+  Never overwritten; resolve those by hand.
+
+Rows are stamped `import_source="windows_cutover"` + `imported_at`,
+which is distinct from the importer's `windows_dhcp` on purpose: these
+were synthesised from *leases* at cutover, not read from the server's
+config, and an operator who later wants the addresses back in the
+dynamic pool can find and drop exactly this set. Each row is written in
+its **own savepoint** together with its IPAM mirror, so one failure
+fails exactly one entry — the same ledger idiom the importers use — and
+the rollup lands on `cutover_item.lease_handover`.
+
+### Phase 3c — the switch, and rollback
+
+`POST …/items/{id}/cutover` re-evaluates blockers first and returns
+**409** with the blocker list when it refuses (409 rather than 422:
+the request is well-formed, the *state* is what refuses it).
+
+**DHCP is a real switch, and the order is the entire point.** The
+Windows scope is deactivated **first**
+(`Set-DhcpServerv4Scope -State InActive` over WinRM), and only then is
+the managed scope activated. Between the two steps the subnet has *no*
+DHCP server, which costs renewing clients nothing — they hold their
+lease until half its lifetime elapses — and lasts about one WinRM
+round-trip. The reverse order would leave **both** servers answering
+the same subnet, which hands two clients the same address within
+seconds. If activating the managed scope then fails, the Windows scope
+is put back (best-effort, logged); if that compensation also fails, the
+log says in so many words that the subnet may currently have no active
+DHCP server.
+
+**DNS is not switched here at all**, because there is no server-side
+flag SpatiumDDI owns: which server answers for a zone is decided by the
+delegation at the parent (or by what the resolvers forward to), and
+both live outside SpatiumDDI. So the DNS path stamps the transition,
+returns the operator instructions — repoint the delegation, repoint
+conditional forwarders and stub zones, update DHCP option 6, leave the
+Windows zone serving as the fallback — and **never touches the Windows
+zone**. Deleting or disabling it before the delegation has actually
+moved removes the thing that is still serving.
+
+`POST …/items/{id}/rollback` reverses it. DHCP: deactivate the managed
+scope, re-activate the Windows one — the mirror image of the cutover
+ordering, with its own compensation. DNS: restore the TTL snapshot and
+return the revert instructions. Rollback deliberately does **not**
+re-evaluate blockers — it is the escape hatch, and gating it on
+readiness would mean the state that made the switch go wrong is also
+the state that stops you undoing it.
+
+Both cutover and rollback return `recovery_estimate_seconds`, so the
+recovery-time expectation is a number rather than a hope: the zone's
+current TTL for DNS (which is exactly what the pre-flight exists to
+shrink — cutting over without it earns a warning saying a rollback will
+propagate at the zone's full TTL), and the scope's lease time for DHCP.
+The generated runbook states the same figure in prose per item, derived
+from that item's real pre-flight TTL or lease time, and says so
+explicitly when it is falling back to an assumed default.
+
+### Phase 4 — decommission checklist
+
+The switch is the visible part of a migration; the decommission is the
+part that bites weeks later. A Windows DNS server left running with
+scavenging on quietly deletes the fallback copy of the zone. A DHCP
+server left *authorized in Active Directory* starts answering again the
+first time it is patched and rebooted, racing the managed scope for the
+same subnet. A conditional forwarder on one resolver in one branch
+office keeps a whole site resolving from a box everybody believes is
+retired.
+
+None of that is discoverable from the cutover state, so it is a
+checklist. `GET …/plans/{id}/checklist` seeds it on first read from a
+static catalog and returns it; `PATCH …/checklist/{key}` ticks an item
+or annotates it. Fifteen entries across four categories — `ad`, `dns`,
+`dhcp`, `general` — covering DC SRV re-registration, forced Netlogon
+re-registration, scavenging, dynamic-update sources and permissions,
+AD deauthorization of the DHCP server, conditional forwarders and stub
+zones, reverse-zone ownership, zone-transfer ACLs, WINS / GlobalNames,
+the Windows DHCP failover relationship, DHCP option 6, monitoring and
+alerting, a retained final export, and stopping (not uninstalling) each
+Windows service.
+
+The catalog is versioned code and the ticks are data: seeding is an
+idempotent upsert on `(plan, key)` that refreshes an item's wording and
+ordering while leaving `is_done` / `done_at` / notes strictly alone, and
+a key dropped from the catalog keeps its row rather than silently
+discarding an operator's tick.
+
+**Three items are auto-evaluated, and none of them is ever
+auto-ticked.** `dc_srv_registration` looks for `_ldap._tcp` /
+`_kerberos._tcp` / `_gc._tcp` / `_kpasswd._tcp` SRV records still
+living in the plan's zones; `reverse_zone_ownership` derives the `/24`
+`in-addr.arpa` companions implied by those zones' A records and reports
+which are missing from the plan or absent from SpatiumDDI entirely
+(IPv6 is deliberately not derived — an AAAA record's reverse boundary
+is a site convention, so guessing it would report companions that were
+never supposed to exist); `zone_transfer_acls` resolves each zone's
+effective `allow-transfer` (zone value, else the server group's
+default, the same precedence the renderer uses) and flags anything that
+lands on `any`. Each comes back as `ok` / `attention` /
+`not_applicable` / `manual` with a detail line beside the item. Every
+other entry is `manual`, because it is about the state of a Windows
+box, a resolver in a branch office, or a monitoring system — none of
+which SpatiumDDI can see. **A checklist that ticks itself is a
+checklist nobody reads**, so the operator is always the one who decides
+an item is done.
 
 ---
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -221,6 +221,10 @@ export default function App() {
           path="admin/netbox-import"
           element={<ImportPage initialTab="netbox" />}
         />
+        <Route
+          path="admin/cutover"
+          element={<ImportPage initialTab="cutover" />}
+        />
         <Route path="admin/backup" element={<BackupPage />} />
         <Route
           path="admin/diagnostics/errors"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -344,15 +344,20 @@ const adminConfigurationNav = [
   },
   { label: "Custom Fields", icon: Tags, to: "/admin/custom-fields" },
   // Import hub (#36) — the one-shot DHCP (#129) / DNS (#128) / NetBox (#36)
-  // importers share a single Configuration entry with a left sub-nav (see
-  // ImportPage), mirroring Appliance → Fleet. ``anyModule`` hides the entry
-  // only when ALL three importer modules are off; the sub-nav inside gates
-  // each family individually.
+  // importers plus the guided Windows cutover (#756) share a single
+  // Configuration entry with a left sub-nav (see ImportPage), mirroring
+  // Appliance → Fleet. ``anyModule`` hides the entry only when ALL of those
+  // modules are off; the sub-nav inside gates each family individually.
   {
     label: "Import",
     icon: Upload,
     to: "/admin/import",
-    anyModule: ["dhcp.import", "dns.import", "ipam.import.netbox"],
+    anyModule: [
+      "dhcp.import",
+      "dns.import",
+      "ipam.import.netbox",
+      "migration.cutover",
+    ],
   },
   // ``Features`` lives in the footer next to Settings — it's a
   // platform-wide control, not a per-area config, and ops teams expect

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6626,6 +6626,448 @@ export const netboxImportApi = {
       .then((r) => r.data),
 };
 
+// ── Windows → SpatiumDDI cutover (issue #756) ──────────────────────────
+//
+// The migration family's guided workflow: a plan holds one item per Windows
+// zone / scope and walks it through four phases — parity (does SpatiumDDI
+// hold what Windows holds?), parallel run (do both sides answer the same?),
+// the switch (TTL pre-flight / DHCP lease handover / cut over / roll back),
+// and the decommission checklist. Every endpoint is superadmin-gated and
+// lives behind the ``migration.cutover`` feature module.
+//
+// Wire shapes match backend/app/api/v1/cutover/router.py; the JSONB payloads
+// that ride inside the item columns (last_parity, last_shadow, …) match the
+// ``as_dict()`` of the dataclasses in
+// backend/app/services/cutover/canonical.py.
+
+export type CutoverItemKind = "dns_zone" | "dhcp_scope";
+
+/** ``block`` refuses the switch outright; ``warn`` can be acknowledged with
+ *  ``force``. Messages are written to state the fix — render them verbatim. */
+export interface CutoverBlocker {
+  code: string;
+  severity: "block" | "warn";
+  message: string;
+}
+
+/** One explained difference between SpatiumDDI and the live Windows object.
+ *  ``classification`` is a DiffClass: in_sync | value_mismatch |
+ *  drifted_since_import | never_imported | intentionally_diverged. */
+export interface CutoverParityDifference {
+  classification: string;
+  name: string;
+  detail: string;
+  source_value: string | null;
+  target_value: string | null;
+  record_type: string | null;
+}
+
+export interface CutoverParityReport {
+  kind: string;
+  source_ref: string;
+  // ok | unmatched | error | unverified
+  status: string;
+  error: string | null;
+  in_sync: number;
+  not_compared: number;
+  difference_count: number;
+  is_parity: boolean;
+  counts_by_class: Record<string, number>;
+  differences: CutoverParityDifference[];
+  warnings: string[];
+}
+
+export interface CutoverShadowSample {
+  name: string;
+  qtype: string;
+  source_answers: string[];
+  // Keyed by target server label.
+  target_answers: Record<string, string[]>;
+  // match | mismatch | source_error | target_error
+  verdict: string;
+  error: string | null;
+}
+
+export interface CutoverShadowReport {
+  zone_name: string;
+  source: string;
+  targets: string[];
+  // "query_log" = replayed production traffic; "zone_records" = our own rows.
+  sample_source: string;
+  sampled: number;
+  matched: number;
+  mismatched: number;
+  errors: number;
+  samples: CutoverShadowSample[];
+  warnings: string[];
+}
+
+export interface CutoverTTLRecordChange {
+  record_id: string;
+  name: string;
+  record_type: string;
+  current_ttl: number | null;
+  new_ttl: number;
+}
+
+export interface CutoverTTLPreflightPlan {
+  target_ttl: number;
+  zone_current: Record<string, number>;
+  zone_after: Record<string, number>;
+  records: CutoverTTLRecordChange[];
+  changed: number;
+  unchanged: number;
+  warnings: string[];
+  // PowerShell the operator runs on the Windows side — SpatiumDDI never
+  // writes TTLs there, and an unexplained one-sided drop is worse than none.
+  source_side_instructions: string;
+}
+
+export interface CutoverLeaseEntry {
+  ip_address: string;
+  mac_address: string;
+  hostname: string;
+  action: "create" | "skip" | "conflict";
+  reason: string;
+  // Set on commit: created | skipped | failed.
+  result: string | null;
+  error: string | null;
+}
+
+/** What ``CutoverItem.lease_handover`` actually holds after a commit. */
+export interface CutoverLeaseHandoverSummary {
+  created: number;
+  skipped: number;
+  failed: number;
+  at: string;
+}
+
+export interface CutoverLeaseHandoverPlan {
+  scope_cidr: string;
+  source_scope_id: string;
+  entries: CutoverLeaseEntry[];
+  create_count: number;
+  skip_count: number;
+  conflict_count: number;
+  created: number;
+  skipped: number;
+  failed: number;
+  warnings: string[];
+}
+
+export interface CutoverItem {
+  id: string;
+  plan_id: string;
+  kind: string;
+  source_ref: string;
+  zone_id: string | null;
+  scope_id: string | null;
+  // pending | parity_checked | preflight_done | cut_over | rolled_back
+  stage: string;
+  blockers: CutoverBlocker[];
+  last_parity: CutoverParityReport | null;
+  last_parity_at: string | null;
+  last_shadow: CutoverShadowReport | null;
+  last_shadow_at: string | null;
+  ttl_snapshot: Record<string, unknown> | null;
+  ttl_lowered_at: string | null;
+  /**
+   * The persisted *summary* of the last handover, NOT a full plan — the backend
+   * stores only ``{created, skipped, failed, at}`` on the item
+   * (``services/cutover/leases.commit_lease_handover``). Typing it as the full
+   * plan would let a component reach for ``.entries`` / ``.warnings`` that are
+   * never there.
+   */
+  lease_handover: CutoverLeaseHandoverSummary | null;
+  cut_over_at: string | null;
+  rolled_back_at: string | null;
+  notes: string;
+}
+
+export interface CutoverPlan {
+  id: string;
+  name: string;
+  description: string;
+  // draft | verifying | parallel | cutting_over | completed | rolled_back |
+  // abandoned
+  status: string;
+  source_dns_server_id: string | null;
+  source_dhcp_server_id: string | null;
+  target_dns_group_id: string | null;
+  target_dhcp_group_id: string | null;
+  notes: string;
+  created_at: string;
+  modified_at: string;
+  completed_at: string | null;
+  rolled_back_at: string | null;
+  item_count: number;
+  stage_counts: Record<string, number>;
+  blocked_count: number;
+}
+
+export interface CutoverPlanDetail extends CutoverPlan {
+  items: CutoverItem[];
+}
+
+export interface CutoverPlanCreate {
+  name: string;
+  description?: string;
+  source_dns_server_id?: string | null;
+  source_dhcp_server_id?: string | null;
+  target_dns_group_id?: string | null;
+  target_dhcp_group_id?: string | null;
+  notes?: string;
+}
+
+export interface CutoverChecklistItem {
+  key: string;
+  // dns | dhcp | ad | general
+  category: string;
+  label: string;
+  description: string;
+  applies_to: string;
+  is_done: boolean;
+  done_at: string | null;
+  notes: string;
+  sort_order: number;
+  // ok | attention | not_applicable | manual — advisory only, never ticks.
+  auto_state: string;
+  auto_detail: string;
+}
+
+export interface CutoverEvent {
+  id: string;
+  item_id: string | null;
+  at: string;
+  kind: string;
+  summary: string;
+  detail: Record<string, unknown> | null;
+  user_display_name: string;
+}
+
+export interface CutoverCandidate {
+  kind: CutoverItemKind;
+  source_ref: string;
+  display_name: string;
+  matched_id: string | null;
+  matched_display: string | null;
+  already_in_plan: boolean;
+  blockers: CutoverBlocker[];
+  source: Record<string, unknown>;
+}
+
+// One half of the discover result. ``available: false`` means the plan simply
+// has no source server of that kind — a DNS-only plan is not an error state.
+export interface CutoverDiscoverSide {
+  available: boolean;
+  error: string | null;
+  source_server: string | null;
+  target_group_id: string | null;
+  candidates: CutoverCandidate[];
+}
+
+export interface CutoverDiscoverResult {
+  dns: CutoverDiscoverSide;
+  dhcp: CutoverDiscoverSide;
+}
+
+export interface CutoverItemIn {
+  kind: CutoverItemKind;
+  source_ref: string;
+  zone_id?: string | null;
+  scope_id?: string | null;
+  notes?: string;
+}
+
+// Per-item row of the whole-plan parity run: the report fields inlined, or
+// ``status: "error"`` with the wiring problem that stopped it.
+export type CutoverPlanParityRow = Partial<CutoverParityReport> & {
+  item_id: string;
+  source_ref: string;
+  kind: string;
+  status: string;
+  error?: string | null;
+};
+
+export interface CutoverPlanParityResult {
+  items: CutoverPlanParityRow[];
+  in_parity: number;
+  total: number;
+}
+
+// Result of a cutover / rollback. ``actions`` is what SpatiumDDI did;
+// ``instructions`` is what the operator still has to do (for DNS, the
+// delegation change — which lives outside SpatiumDDI entirely).
+export interface CutoverSwitchResult {
+  kind: string;
+  source_ref: string;
+  stage: string;
+  cut_over_at?: string;
+  rolled_back_at?: string;
+  actions: string[];
+  instructions: string[];
+  recovery_estimate_seconds: number | null;
+  acknowledged_warnings?: CutoverBlocker[];
+  records_restored?: number;
+  ttl_lowered_at?: string | null;
+  warnings?: string[];
+}
+
+// 409 body of POST …/cutover — ``CutoverBlocked.as_dict()``. Note the key is
+// ``error``, not ``message``.
+export interface CutoverBlockedDetail {
+  error: string;
+  blockers: CutoverBlocker[];
+}
+
+const CUTOVER_BASE = "/migration/cutover";
+
+export const cutoverApi = {
+  listPlans: () =>
+    api.get<CutoverPlan[]>(`${CUTOVER_BASE}/plans`).then((r) => r.data),
+  createPlan: (body: CutoverPlanCreate) =>
+    api
+      .post<CutoverPlanDetail>(`${CUTOVER_BASE}/plans`, body)
+      .then((r) => r.data),
+  getPlan: (planId: string) =>
+    api
+      .get<CutoverPlanDetail>(`${CUTOVER_BASE}/plans/${planId}`)
+      .then((r) => r.data),
+  updatePlan: (
+    planId: string,
+    body: Partial<CutoverPlanCreate> & {
+      status?: string;
+    },
+  ) =>
+    api
+      .patch<CutoverPlanDetail>(`${CUTOVER_BASE}/plans/${planId}`, body)
+      .then((r) => r.data),
+  deletePlan: (planId: string) => api.delete(`${CUTOVER_BASE}/plans/${planId}`),
+
+  // Live WinRM pull of the source estate — read-only, matches each Windows
+  // object against the target group and pre-computes its blockers.
+  discover: (planId: string) =>
+    api
+      .post<CutoverDiscoverResult>(`${CUTOVER_BASE}/plans/${planId}/discover`)
+      .then((r) => r.data),
+  addItems: (planId: string, items: CutoverItemIn[]) =>
+    api
+      .post<CutoverItem[]>(`${CUTOVER_BASE}/plans/${planId}/items`, { items })
+      .then((r) => r.data),
+  deleteItem: (planId: string, itemId: string) =>
+    api.delete(`${CUTOVER_BASE}/plans/${planId}/items/${itemId}`),
+
+  // Phase 1 — parity.
+  runItemParity: (planId: string, itemId: string) =>
+    api
+      .post<{
+        report: CutoverParityReport;
+        blockers: CutoverBlocker[];
+      }>(`${CUTOVER_BASE}/plans/${planId}/items/${itemId}/parity`)
+      .then((r) => r.data),
+  runPlanParity: (planId: string) =>
+    api
+      .post<CutoverPlanParityResult>(`${CUTOVER_BASE}/plans/${planId}/parity`)
+      .then((r) => r.data),
+
+  // Phase 2 — parallel run (DNS items only; a dhcp_scope item 422s).
+  runShadow: (planId: string, itemId: string, sampleSize: number) =>
+    api
+      .post<CutoverShadowReport>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/shadow`,
+        { sample_size: sampleSize },
+      )
+      .then((r) => r.data),
+
+  // Phase 3a — TTL pre-flight (DNS items only).
+  previewTtl: (planId: string, itemId: string, targetTtl: number) =>
+    api
+      .post<CutoverTTLPreflightPlan>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/ttl-preflight/preview`,
+        { target_ttl: targetTtl },
+      )
+      .then((r) => r.data),
+  commitTtl: (planId: string, itemId: string, targetTtl: number) =>
+    api
+      .post<CutoverTTLPreflightPlan>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/ttl-preflight/commit`,
+        { target_ttl: targetTtl },
+      )
+      .then((r) => r.data),
+  restoreTtl: (planId: string, itemId: string) =>
+    api
+      .post<{
+        records_restored: number;
+        zone: string;
+      }>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/ttl-preflight/restore`,
+      )
+      .then((r) => r.data),
+
+  // Phase 3b — DHCP lease handover (DHCP items only). Stateless between
+  // preview and commit: the previewed entries are handed straight back, and
+  // the server re-classifies every one against live DB state.
+  previewLeases: (planId: string, itemId: string) =>
+    api
+      .post<CutoverLeaseHandoverPlan>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/lease-handover/preview`,
+      )
+      .then((r) => r.data),
+  commitLeases: (
+    planId: string,
+    itemId: string,
+    entries: CutoverLeaseEntry[],
+  ) =>
+    api
+      .post<CutoverLeaseHandoverPlan>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/lease-handover/commit`,
+        { entries },
+      )
+      .then((r) => r.data),
+
+  // Phase 3c — the switch. 409 carries CutoverBlockedDetail; ``force`` only
+  // ever acknowledges warn-severity blockers.
+  cutOver: (planId: string, itemId: string, force = false) =>
+    api
+      .post<CutoverSwitchResult>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/cutover`,
+        { force },
+      )
+      .then((r) => r.data),
+  rollback: (planId: string, itemId: string) =>
+    api
+      .post<CutoverSwitchResult>(
+        `${CUTOVER_BASE}/plans/${planId}/items/${itemId}/rollback`,
+      )
+      .then((r) => r.data),
+
+  // Phase 4 — decommission checklist. The GET seeds on first read.
+  getChecklist: (planId: string) =>
+    api
+      .get<CutoverChecklistItem[]>(`${CUTOVER_BASE}/plans/${planId}/checklist`)
+      .then((r) => r.data),
+  patchChecklistItem: (
+    planId: string,
+    key: string,
+    body: { is_done?: boolean; notes?: string },
+  ) =>
+    api
+      .patch<CutoverChecklistItem>(
+        `${CUTOVER_BASE}/plans/${planId}/checklist/${key}`,
+        body,
+      )
+      .then((r) => r.data),
+
+  listEvents: (planId: string, params?: { limit?: number; offset?: number }) =>
+    api
+      .get<CutoverEvent[]>(`${CUTOVER_BASE}/plans/${planId}/events`, { params })
+      .then((r) => r.data),
+  runbook: (planId: string) =>
+    api
+      .get<{ markdown: string }>(`${CUTOVER_BASE}/plans/${planId}/runbook`)
+      .then((r) => r.data),
+};
+
 export const dnsBlocklistApi = {
   list: () => api.get<DNSBlockList[]>("/dns/blocklists").then((r) => r.data),
   catalog: () =>

--- a/frontend/src/pages/admin/CutoverPage.tsx
+++ b/frontend/src/pages/admin/CutoverPage.tsx
@@ -1,0 +1,2683 @@
+import { Fragment, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRightLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ClipboardList,
+  Copy,
+  FileText,
+  History,
+  Loader2,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Search,
+  ShieldAlert,
+  Timer,
+  Trash2,
+} from "lucide-react";
+
+import {
+  cutoverApi,
+  dhcpApi,
+  dnsApi,
+  formatApiError,
+  type CutoverBlocker,
+  type CutoverCandidate,
+  type CutoverChecklistItem,
+  type CutoverItem,
+  type CutoverItemIn,
+  type CutoverLeaseHandoverPlan,
+  type CutoverParityReport,
+  type CutoverPlan,
+  type CutoverPlanDetail,
+  type CutoverPlanParityResult,
+  type CutoverShadowReport,
+  type CutoverSwitchResult,
+  type CutoverTTLPreflightPlan,
+  type DHCPServer,
+  type DNSServer,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { useSessionState } from "@/lib/useSessionState";
+import { HeaderButton } from "@/components/ui/header-button";
+import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+
+/**
+ * Configuration → Import → Windows cutover (issue #756).
+ *
+ * The guided migration off Windows DNS / DHCP. A plan holds one item per
+ * Windows zone or scope, and the four tabs are the four phases the backend
+ * models: parity (Items), the parallel run (shadow queries), the switch (TTL
+ * pre-flight / lease handover / cut over / roll back), and the decommission
+ * checklist.
+ *
+ * Two things drive most of the layout decisions here:
+ *
+ * * **Blockers are the point.** Every ``Blocker.message`` the API returns is
+ *   written to state the fix, so they are rendered verbatim — in the item
+ *   table, in the cutover confirmation, and in the 409 body when the switch is
+ *   refused. The Cut over button is disabled outright while any blocker has
+ *   ``severity: "block"``; that refusal (notably the AD "Secure only" one) is
+ *   not something a UI affordance may talk its way past.
+ * * **Everything expensive is on demand.** Parity, the shadow run and discover
+ *   all make live WinRM / DNS calls against the operator's estate, so nothing
+ *   here polls: results are read back from the persisted ``last_parity`` /
+ *   ``last_shadow`` columns and only re-run when the operator asks.
+ *
+ * Wire shapes come from ``cutoverApi`` in lib/api.ts.
+ */
+
+const MODULE_ID = "migration.cutover";
+
+const PLAN_STATUSES = [
+  "draft",
+  "verifying",
+  "parallel",
+  "cutting_over",
+  "completed",
+  "rolled_back",
+  "abandoned",
+] as const;
+
+type DetailTab = "items" | "parallel" | "cutover" | "decommission";
+
+const DETAIL_TABS: { key: DetailTab; label: string; hint: string }[] = [
+  { key: "items", label: "Items", hint: "Phase 1 — parity" },
+  { key: "parallel", label: "Parallel run", hint: "Phase 2 — shadow queries" },
+  { key: "cutover", label: "Cutover", hint: "Phase 3 — pre-flight + switch" },
+  {
+    key: "decommission",
+    label: "Decommission",
+    hint: "Phase 4 — retire Windows",
+  },
+];
+
+type Tone = "success" | "amber" | "destructive" | "muted" | "info" | "violet";
+
+const TONE_CLS: Record<Tone, string> = {
+  success: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+  amber: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  destructive: "bg-destructive/15 text-destructive",
+  muted: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400",
+  info: "bg-sky-500/15 text-sky-700 dark:text-sky-400",
+  violet: "bg-violet-500/15 text-violet-700 dark:text-violet-400",
+};
+
+const STAGE_TONES: Record<string, Tone> = {
+  pending: "muted",
+  parity_checked: "info",
+  preflight_done: "violet",
+  cut_over: "success",
+  rolled_back: "amber",
+};
+
+const DIFF_TONES: Record<string, Tone> = {
+  in_sync: "success",
+  value_mismatch: "amber",
+  drifted_since_import: "amber",
+  never_imported: "info",
+  intentionally_diverged: "violet",
+};
+
+const PARITY_STATUS_TONES: Record<string, Tone> = {
+  ok: "success",
+  unmatched: "amber",
+  unverified: "amber",
+  error: "destructive",
+};
+
+const AUTO_STATE_TONES: Record<string, Tone> = {
+  ok: "success",
+  attention: "amber",
+  not_applicable: "muted",
+  manual: "muted",
+};
+
+const CATEGORY_LABELS: Record<string, string> = {
+  ad: "Active Directory",
+  dns: "DNS",
+  dhcp: "DHCP",
+  general: "General decommission",
+};
+
+// ── error helpers ─────────────────────────────────────────────────────
+
+type ErrorDetail = { detail?: unknown };
+
+function errorDetail(err: unknown): unknown {
+  return (err as { response?: { data?: ErrorDetail } })?.response?.data?.detail;
+}
+
+/** The 409 from POST …/cutover is ``CutoverBlocked.as_dict()``: an ``error``
+ *  string plus the blockers. Everything else falls through to the shared
+ *  formatter. */
+function extractError(err: unknown): string {
+  const detail = errorDetail(err);
+  if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+    const msg = (detail as { error?: unknown }).error;
+    if (typeof msg === "string" && msg.trim()) return msg;
+  }
+  return formatApiError(err);
+}
+
+function extractBlockers(err: unknown): CutoverBlocker[] {
+  const detail = errorDetail(err);
+  if (detail && typeof detail === "object" && !Array.isArray(detail)) {
+    const raw = (detail as { blockers?: unknown }).blockers;
+    if (Array.isArray(raw)) return raw as CutoverBlocker[];
+  }
+  return [];
+}
+
+function hasBlocking(blockers: CutoverBlocker[] | null | undefined): boolean {
+  return (blockers ?? []).some((b) => b.severity === "block");
+}
+
+function warnOnly(blockers: CutoverBlocker[] | null | undefined) {
+  return (blockers ?? []).filter((b) => b.severity === "warn");
+}
+
+function shortDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? value : d.toLocaleString();
+}
+
+// ── presentational primitives ─────────────────────────────────────────
+
+function Chip({
+  tone,
+  children,
+  title,
+}: {
+  tone: Tone;
+  children: React.ReactNode;
+  title?: string;
+}) {
+  return (
+    <span
+      title={title}
+      className={cn(
+        "inline-flex rounded-full px-2 py-0.5 text-[10px] font-medium",
+        TONE_CLS[tone],
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-xs text-destructive">
+      <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+      <div className="min-w-0 break-all">{message}</div>
+    </div>
+  );
+}
+
+function WarningList({ warnings }: { warnings: string[] }) {
+  if (warnings.length === 0) return null;
+  return (
+    <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+      <div className="font-medium text-amber-700 dark:text-amber-400">
+        Warnings
+      </div>
+      {warnings.map((w, i) => (
+        <div
+          key={i}
+          className="break-all text-amber-700/90 dark:text-amber-300/90"
+        >
+          {w}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Full blocker rendering — code, severity and the message verbatim. */
+function BlockerList({ blockers }: { blockers: CutoverBlocker[] }) {
+  if (blockers.length === 0) return null;
+  return (
+    <ul className="space-y-1.5">
+      {blockers.map((b, i) => (
+        <li
+          key={`${b.code}:${i}`}
+          className={cn(
+            "flex items-start gap-2 rounded-md border p-2 text-xs",
+            b.severity === "block"
+              ? "border-destructive/40 bg-destructive/5"
+              : "border-amber-500/40 bg-amber-500/5",
+          )}
+        >
+          {b.severity === "block" ? (
+            <ShieldAlert className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-destructive" />
+          ) : (
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+          )}
+          <div className="min-w-0">
+            <span className="break-all font-mono text-[10px] text-muted-foreground">
+              {b.code}
+            </span>
+            <p className="break-words text-foreground">{b.message}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Compact form for a table cell. */
+function BlockerChips({ blockers }: { blockers: CutoverBlocker[] }) {
+  if (blockers.length === 0)
+    return <span className="text-xs text-muted-foreground">none</span>;
+  return (
+    <span className="flex flex-wrap gap-1">
+      {blockers.map((b, i) => (
+        <Chip
+          key={`${b.code}:${i}`}
+          tone={b.severity === "block" ? "destructive" : "amber"}
+          title={b.message}
+        >
+          {b.code}
+        </Chip>
+      ))}
+    </span>
+  );
+}
+
+function StageChip({ stage }: { stage: string }) {
+  return <Chip tone={STAGE_TONES[stage] ?? "muted"}>{stage}</Chip>;
+}
+
+function ParityCell({ item }: { item: CutoverItem }) {
+  const report = item.last_parity;
+  if (!report)
+    return <span className="text-xs text-muted-foreground">not checked</span>;
+  return (
+    <span className="flex flex-wrap items-center gap-1">
+      <Chip tone={PARITY_STATUS_TONES[report.status] ?? "muted"}>
+        {report.status}
+      </Chip>
+      {report.is_parity ? (
+        <Chip tone="success">in parity</Chip>
+      ) : (
+        <Chip tone="amber">{report.difference_count} diff</Chip>
+      )}
+      <span className="text-[11px] text-muted-foreground">
+        {report.in_sync} in sync · {shortDate(item.last_parity_at)}
+      </span>
+    </span>
+  );
+}
+
+/** Read-only markdown / PowerShell block with a copy button.
+ *
+ * Deliberately a ``<pre>`` and not a rendered document: the runbook and the
+ * Windows-side instructions exist to be pasted into a change ticket or a
+ * PowerShell prompt, and rendering them would lose the exact text. */
+function CopyBlock({
+  text,
+  label,
+  className,
+}: {
+  text: string;
+  label: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const t = window.setTimeout(() => setCopied(false), 2000);
+    return () => window.clearTimeout(t);
+  }, [copied]);
+
+  return (
+    <div className={cn("rounded-md border bg-muted/30", className)}>
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b px-3 py-1.5">
+        <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+          {label}
+        </span>
+        <HeaderButton
+          icon={copied ? CheckCircle2 : Copy}
+          className="px-2 py-1 text-xs"
+          onClick={() => {
+            navigator.clipboard
+              ?.writeText(text)
+              .then(() => setCopied(true))
+              // Clipboard access can be denied (insecure origin, permission
+              // policy); the text stays selectable, so there is nothing to fix.
+              .catch(() => setCopied(false));
+          }}
+        >
+          {copied ? "Copied" : "Copy"}
+        </HeaderButton>
+      </div>
+      <pre className="max-h-[28rem] overflow-auto p-3 text-xs leading-relaxed">
+        {text}
+      </pre>
+    </div>
+  );
+}
+
+// ── root ──────────────────────────────────────────────────────────────
+
+export function CutoverPage() {
+  const { ready, enabled } = useFeatureModules();
+  // ``enabled`` is optimistic while the module set loads, so a hard page load
+  // would otherwise fire a gated query that 404s before the real state lands.
+  const canQuery = ready && enabled(MODULE_ID);
+  const [planId, setPlanId] = useSessionState<string | null>(
+    "admin.cutover.plan",
+    null,
+  );
+
+  if (ready && !enabled(MODULE_ID)) {
+    return (
+      <div className="p-6">
+        <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+          The <strong>Windows cutover</strong> module is turned off. Enable{" "}
+          <code>{MODULE_ID}</code> under Settings → Features to use it.
+        </div>
+      </div>
+    );
+  }
+
+  return planId ? (
+    <PlanDetailView
+      planId={planId}
+      canQuery={canQuery}
+      onBack={() => setPlanId(null)}
+    />
+  ) : (
+    <PlanListView canQuery={canQuery} onOpen={(id) => setPlanId(id)} />
+  );
+}
+
+// ── master list ───────────────────────────────────────────────────────
+
+function PlanListView({
+  canQuery,
+  onOpen,
+}: {
+  canQuery: boolean;
+  onOpen: (id: string) => void;
+}) {
+  const qc = useQueryClient();
+  const [newOpen, setNewOpen] = useState(false);
+  const [deleting, setDeleting] = useState<CutoverPlan | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const plansQ = useQuery({
+    queryKey: ["cutover", "plans"],
+    queryFn: cutoverApi.listPlans,
+    enabled: canQuery,
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => cutoverApi.deletePlan(id),
+    onSuccess: () => {
+      setDeleting(null);
+      setError(null);
+      qc.invalidateQueries({ queryKey: ["cutover", "plans"] });
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const plans = plansQ.data ?? [];
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-wrap items-center gap-3 border-b p-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <ArrowRightLeft className="h-5 w-5 flex-shrink-0 text-primary" />
+          <div className="min-w-0">
+            <h1 className="text-lg font-semibold">Windows cutover</h1>
+            <p className="text-xs text-muted-foreground">
+              Guided migration off Windows DNS / DHCP — verify parity, run both
+              sides in parallel, cut over one item at a time with a rollback,
+              then work the decommission checklist.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+          <HeaderButton
+            icon={plansQ.isFetching ? Loader2 : RefreshCw}
+            iconClassName={plansQ.isFetching ? "animate-spin" : undefined}
+            onClick={() => plansQ.refetch()}
+            disabled={!canQuery}
+          >
+            Refresh
+          </HeaderButton>
+          <HeaderButton
+            variant="primary"
+            icon={Plus}
+            onClick={() => setNewOpen(true)}
+            disabled={!canQuery}
+          >
+            New plan
+          </HeaderButton>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="space-y-4">
+          {error && <ErrorBanner message={error} />}
+          {plansQ.isError && (
+            <ErrorBanner message={formatApiError(plansQ.error)} />
+          )}
+
+          {plansQ.isLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading plans…
+            </div>
+          ) : plans.length === 0 ? (
+            <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+              No cutover plans yet. Create one, point it at the Windows DNS /
+              DHCP servers you are migrating away from and the SpatiumDDI groups
+              taking over, then run <strong>Discover</strong> to pull the zones
+              and scopes off the live source.
+            </div>
+          ) : (
+            <div className="overflow-x-auto rounded-md border bg-background">
+              <table className="w-full min-w-[52rem] text-sm">
+                <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Plan</th>
+                    <th className="px-3 py-2 text-left">Status</th>
+                    <th className="px-3 py-2 text-left">Items</th>
+                    <th className="px-3 py-2 text-left">Stages</th>
+                    <th className="px-3 py-2 text-left">Blocked</th>
+                    <th className="px-3 py-2 text-left">Created</th>
+                    <th className="px-3 py-2 text-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {plans.map((p) => (
+                    <tr key={p.id} className="border-t hover:bg-muted/20">
+                      <td className="px-3 py-2 align-top">
+                        <button
+                          type="button"
+                          onClick={() => onOpen(p.id)}
+                          className="break-all text-left font-medium text-primary hover:underline"
+                        >
+                          {p.name}
+                        </button>
+                        {p.description && (
+                          <p className="break-words text-[11px] text-muted-foreground">
+                            {p.description}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <Chip
+                          tone={
+                            p.status === "completed"
+                              ? "success"
+                              : p.status === "rolled_back" ||
+                                  p.status === "abandoned"
+                                ? "amber"
+                                : "info"
+                          }
+                        >
+                          {p.status}
+                        </Chip>
+                      </td>
+                      <td className="px-3 py-2 align-top tabular-nums">
+                        {p.item_count}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <span className="flex flex-wrap gap-1">
+                          {Object.entries(p.stage_counts).map(([s, n]) => (
+                            <Chip key={s} tone={STAGE_TONES[s] ?? "muted"}>
+                              {s} {n}
+                            </Chip>
+                          ))}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        {p.blocked_count > 0 ? (
+                          <Chip tone="destructive">{p.blocked_count}</Chip>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            0
+                          </span>
+                        )}
+                      </td>
+                      <td className="whitespace-nowrap px-3 py-2 align-top text-xs text-muted-foreground">
+                        {shortDate(p.created_at)}
+                      </td>
+                      <td className="px-3 py-2 align-top text-right">
+                        <div className="flex flex-wrap justify-end gap-2">
+                          <HeaderButton
+                            className="px-2 py-1 text-xs"
+                            onClick={() => onOpen(p.id)}
+                          >
+                            Open
+                          </HeaderButton>
+                          <HeaderButton
+                            variant="destructive"
+                            icon={Trash2}
+                            className="px-2 py-1 text-xs"
+                            onClick={() => setDeleting(p)}
+                          >
+                            Delete
+                          </HeaderButton>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {newOpen && (
+        <NewPlanModal
+          canQuery={canQuery}
+          onClose={() => setNewOpen(false)}
+          onCreated={(plan) => {
+            setNewOpen(false);
+            qc.invalidateQueries({ queryKey: ["cutover", "plans"] });
+            onOpen(plan.id);
+          }}
+        />
+      )}
+
+      <ConfirmModal
+        open={deleting !== null}
+        tone="destructive"
+        title="Delete cutover plan?"
+        message={
+          <span>
+            Deletes <strong className="break-all">{deleting?.name}</strong> with
+            its items, checklist and timeline. Nothing the plan points at is
+            touched — zones, scopes and reservations are owned by their own
+            tables. It does throw away any pre-flight TTL snapshot, which is the
+            only record of the pre-migration TTLs.
+          </span>
+        }
+        confirmLabel="Delete plan"
+        loading={deleteMut.isPending}
+        onConfirm={() => deleting && deleteMut.mutate(deleting.id)}
+        onClose={() => setDeleting(null)}
+      />
+    </div>
+  );
+}
+
+// ── new plan ──────────────────────────────────────────────────────────
+
+function NewPlanModal({
+  canQuery,
+  onClose,
+  onCreated,
+}: {
+  canQuery: boolean;
+  onClose: () => void;
+  onCreated: (plan: CutoverPlanDetail) => void;
+}) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [dnsSource, setDnsSource] = useState("");
+  const [dhcpSource, setDhcpSource] = useState("");
+  const [dnsTarget, setDnsTarget] = useState("");
+  const [dhcpTarget, setDhcpTarget] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const dnsGroupsQ = useQuery({
+    queryKey: ["dns-groups"],
+    queryFn: dnsApi.listGroups,
+    enabled: canQuery,
+  });
+  const dhcpGroupsQ = useQuery({
+    queryKey: ["dhcp-groups"],
+    queryFn: dhcpApi.listGroups,
+    enabled: canQuery,
+  });
+  // DNS servers are only listable per group, so the picker fans out over the
+  // groups it just loaded.
+  const dnsGroupIds = (dnsGroupsQ.data ?? []).map((g) => g.id);
+  const dnsServersQ = useQuery({
+    queryKey: ["cutover", "dns-servers", dnsGroupIds.join(",")],
+    queryFn: async () => {
+      const perGroup = await Promise.all(
+        dnsGroupIds.map((id) => dnsApi.listServers(id)),
+      );
+      return perGroup.flat();
+    },
+    enabled: canQuery && dnsGroupIds.length > 0,
+  });
+  const dhcpServersQ = useQuery({
+    queryKey: ["cutover", "dhcp-servers"],
+    queryFn: () => dhcpApi.listServers(),
+    enabled: canQuery,
+  });
+
+  const windowsDns = (dnsServersQ.data ?? []).filter(
+    (s: DNSServer) => s.driver === "windows_dns",
+  );
+  const windowsDhcp = (dhcpServersQ.data ?? []).filter(
+    (s: DHCPServer) => s.driver === "windows_dhcp",
+  );
+
+  const createMut = useMutation({
+    mutationFn: () =>
+      cutoverApi.createPlan({
+        name: name.trim(),
+        description,
+        source_dns_server_id: dnsSource || null,
+        source_dhcp_server_id: dhcpSource || null,
+        target_dns_group_id: dnsTarget || null,
+        target_dhcp_group_id: dhcpTarget || null,
+      }),
+    onSuccess: onCreated,
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  return (
+    <Modal title="New cutover plan" onClose={onClose} wide>
+      <div className="space-y-4">
+        {error && <ErrorBanner message={error} />}
+
+        <div>
+          <label className="block text-sm font-medium">Name</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Retire DC01 — corp.example + 10.0.20.0/24"
+            className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium">Description</label>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="mt-1 w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label className="block text-sm font-medium">
+              Source Windows DNS server
+            </label>
+            <p className="mb-1 text-[11px] text-muted-foreground">
+              What zones are pulled from. Needs the <code>windows_dns</code>{" "}
+              driver.
+            </p>
+            <select
+              value={dnsSource}
+              onChange={(e) => setDnsSource(e.target.value)}
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— none —</option>
+              {windowsDns.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name} ({s.host})
+                </option>
+              ))}
+            </select>
+            {!dnsServersQ.isLoading && windowsDns.length === 0 && (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                No Windows DNS servers are configured.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium">
+              Target DNS server group
+            </label>
+            <p className="mb-1 text-[11px] text-muted-foreground">
+              The SpatiumDDI group taking the zones over.
+            </p>
+            <select
+              value={dnsTarget}
+              onChange={(e) => setDnsTarget(e.target.value)}
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— none —</option>
+              {(dnsGroupsQ.data ?? []).map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium">
+              Source Windows DHCP server
+            </label>
+            <p className="mb-1 text-[11px] text-muted-foreground">
+              What scopes and leases are pulled from. Needs the{" "}
+              <code>windows_dhcp</code> driver.
+            </p>
+            <select
+              value={dhcpSource}
+              onChange={(e) => setDhcpSource(e.target.value)}
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— none —</option>
+              {windowsDhcp.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name} ({s.host})
+                </option>
+              ))}
+            </select>
+            {!dhcpServersQ.isLoading && windowsDhcp.length === 0 && (
+              <p className="mt-1 text-[11px] text-muted-foreground">
+                No Windows DHCP servers are configured.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium">
+              Target DHCP server group
+            </label>
+            <p className="mb-1 text-[11px] text-muted-foreground">
+              The SpatiumDDI group taking the scopes over.
+            </p>
+            <select
+              value={dhcpTarget}
+              onChange={(e) => setDhcpTarget(e.target.value)}
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">— none —</option>
+              {(dhcpGroupsQ.data ?? []).map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-2">
+          <HeaderButton onClick={onClose}>Cancel</HeaderButton>
+          <HeaderButton
+            variant="primary"
+            icon={createMut.isPending ? Loader2 : Plus}
+            iconClassName={createMut.isPending ? "animate-spin" : undefined}
+            onClick={() => {
+              setError(null);
+              createMut.mutate();
+            }}
+            disabled={!name.trim() || createMut.isPending}
+          >
+            Create plan
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// ── plan detail ───────────────────────────────────────────────────────
+
+function PlanDetailView({
+  planId,
+  canQuery,
+  onBack,
+}: {
+  planId: string;
+  canQuery: boolean;
+  onBack: () => void;
+}) {
+  const qc = useQueryClient();
+  const [tab, setTab] = useSessionState<DetailTab>(
+    "admin.cutover.detailTab",
+    "items",
+  );
+  const [discoverOpen, setDiscoverOpen] = useState(false);
+  const [runbookOpen, setRunbookOpen] = useState(false);
+  const [timelineOpen, setTimelineOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const planQ = useQuery({
+    queryKey: ["cutover", "plan", planId],
+    queryFn: () => cutoverApi.getPlan(planId),
+    enabled: canQuery,
+  });
+
+  const statusMut = useMutation({
+    mutationFn: (status: string) => cutoverApi.updatePlan(planId, { status }),
+    onSuccess: () => {
+      setError(null);
+      qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+      qc.invalidateQueries({ queryKey: ["cutover", "plans"] });
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const plan = planQ.data;
+  const items = useMemo(() => plan?.items ?? [], [plan]);
+
+  const refresh = () => {
+    qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+    qc.invalidateQueries({ queryKey: ["cutover", "checklist", planId] });
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex flex-wrap items-center gap-3 border-b p-4">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <HeaderButton icon={ArrowLeft} onClick={onBack} className="px-2">
+            Plans
+          </HeaderButton>
+          <div className="min-w-0">
+            <h1 className="break-all text-lg font-semibold">
+              {plan?.name ?? "Cutover plan"}
+            </h1>
+            <p className="text-xs text-muted-foreground">
+              {plan
+                ? `${plan.item_count} item(s) · ${plan.blocked_count} blocked`
+                : "Loading…"}
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+          {plan && (
+            <select
+              value={plan.status}
+              onChange={(e) => statusMut.mutate(e.target.value)}
+              disabled={statusMut.isPending}
+              className="rounded-md border bg-background px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              aria-label="Plan status"
+            >
+              {PLAN_STATUSES.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          )}
+          <HeaderButton
+            icon={planQ.isFetching ? Loader2 : RefreshCw}
+            iconClassName={planQ.isFetching ? "animate-spin" : undefined}
+            onClick={refresh}
+            disabled={!canQuery}
+          >
+            Refresh
+          </HeaderButton>
+          <HeaderButton icon={History} onClick={() => setTimelineOpen(true)}>
+            Timeline
+          </HeaderButton>
+          <HeaderButton icon={FileText} onClick={() => setRunbookOpen(true)}>
+            Runbook
+          </HeaderButton>
+        </div>
+      </div>
+
+      {/* Phase tabs. */}
+      <div className="flex flex-wrap gap-1 border-b px-4">
+        {DETAIL_TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            title={t.hint}
+            className={cn(
+              "-mb-px border-b-2 px-3 py-2 text-sm transition-colors",
+              tab === t.key
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="space-y-4">
+          {error && <ErrorBanner message={error} />}
+          {planQ.isError && (
+            <ErrorBanner message={formatApiError(planQ.error)} />
+          )}
+
+          {planQ.isLoading && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" /> Loading plan…
+            </div>
+          )}
+
+          {plan && tab === "items" && (
+            <ItemsTab
+              planId={planId}
+              items={items}
+              onDiscover={() => setDiscoverOpen(true)}
+            />
+          )}
+          {plan && tab === "parallel" && (
+            <ParallelTab planId={planId} items={items} />
+          )}
+          {plan && tab === "cutover" && (
+            <CutoverTab planId={planId} items={items} />
+          )}
+          {plan && tab === "decommission" && (
+            <DecommissionTab planId={planId} canQuery={canQuery} />
+          )}
+        </div>
+      </div>
+
+      {discoverOpen && (
+        <DiscoverModal
+          planId={planId}
+          onClose={() => setDiscoverOpen(false)}
+          onAdded={() => {
+            setDiscoverOpen(false);
+            qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+            qc.invalidateQueries({ queryKey: ["cutover", "plans"] });
+          }}
+        />
+      )}
+      {runbookOpen && (
+        <RunbookModal
+          planId={planId}
+          canQuery={canQuery}
+          onClose={() => setRunbookOpen(false)}
+        />
+      )}
+      {timelineOpen && (
+        <TimelineModal
+          planId={planId}
+          canQuery={canQuery}
+          onClose={() => setTimelineOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Phase 1 — Items ───────────────────────────────────────────────────
+
+function ItemsTab({
+  planId,
+  items,
+  onDiscover,
+}: {
+  planId: string;
+  items: CutoverItem[];
+  onDiscover: () => void;
+}) {
+  const qc = useQueryClient();
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [removing, setRemoving] = useState<CutoverItem | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [planParity, setPlanParity] = useState<CutoverPlanParityResult | null>(
+    null,
+  );
+  const [runningItem, setRunningItem] = useState<string | null>(null);
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+    qc.invalidateQueries({ queryKey: ["cutover", "plans"] });
+  };
+
+  const itemParityMut = useMutation({
+    mutationFn: (itemId: string) => cutoverApi.runItemParity(planId, itemId),
+    onSuccess: () => {
+      setError(null);
+      setRunningItem(null);
+      invalidate();
+    },
+    onError: (err: unknown) => {
+      setRunningItem(null);
+      setError(extractError(err));
+    },
+  });
+
+  const planParityMut = useMutation({
+    mutationFn: () => cutoverApi.runPlanParity(planId),
+    onSuccess: (result) => {
+      setError(null);
+      setPlanParity(result);
+      invalidate();
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const removeMut = useMutation({
+    mutationFn: (itemId: string) => cutoverApi.deleteItem(planId, itemId),
+    onSuccess: () => {
+      setRemoving(null);
+      setError(null);
+      invalidate();
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+          Parity answers one question per item: does SpatiumDDI hold what
+          Windows is actually serving? A failed or unmatched pull is never
+          treated as parity.
+        </div>
+        <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+          <HeaderButton
+            icon={planParityMut.isPending ? Loader2 : CheckCircle2}
+            iconClassName={planParityMut.isPending ? "animate-spin" : undefined}
+            onClick={() => planParityMut.mutate()}
+            disabled={planParityMut.isPending || items.length === 0}
+          >
+            {planParityMut.isPending ? "Running parity…" : "Run parity on all"}
+          </HeaderButton>
+          <HeaderButton variant="primary" icon={Search} onClick={onDiscover}>
+            Discover
+          </HeaderButton>
+        </div>
+      </div>
+
+      {error && <ErrorBanner message={error} />}
+
+      {planParity && (
+        <div className="rounded-md border bg-muted/20 p-3 text-xs">
+          <span className="font-medium">
+            {planParity.in_parity} of {planParity.total} item(s) in parity.
+          </span>{" "}
+          {planParity.items
+            .filter((r) => r.status !== "ok")
+            .map((r) => (
+              <span key={r.item_id} className="mr-2 break-all">
+                <Chip tone={PARITY_STATUS_TONES[r.status] ?? "muted"}>
+                  {r.source_ref}: {r.status}
+                </Chip>
+              </span>
+            ))}
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+          This plan has no items. Run <strong>Discover</strong> to pull the
+          zones and scopes off the live Windows source — each candidate comes
+          back already matched against the target group, with its blockers
+          computed.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border bg-background">
+          <table className="w-full min-w-[64rem] text-sm">
+            <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="w-8 px-2 py-2" />
+                <th className="px-3 py-2 text-left">Kind</th>
+                <th className="px-3 py-2 text-left">Source ref</th>
+                <th className="px-3 py-2 text-left">Matched target</th>
+                <th className="px-3 py-2 text-left">Stage</th>
+                <th className="px-3 py-2 text-left">Blockers</th>
+                <th className="px-3 py-2 text-left">Last parity</th>
+                <th className="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => {
+                const target = item.zone_id ?? item.scope_id;
+                const open = expanded === item.id;
+                const busy = itemParityMut.isPending && runningItem === item.id;
+                return (
+                  <Fragment key={item.id}>
+                    <tr className="border-t hover:bg-muted/20">
+                      <td className="px-2 py-2 align-top">
+                        <button
+                          type="button"
+                          aria-label={open ? "Collapse" : "Expand"}
+                          onClick={() => setExpanded(open ? null : item.id)}
+                          className="rounded p-1 text-muted-foreground hover:text-foreground"
+                        >
+                          {open ? (
+                            <ChevronDown className="h-4 w-4" />
+                          ) : (
+                            <ChevronRight className="h-4 w-4" />
+                          )}
+                        </button>
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <Chip
+                          tone={item.kind === "dns_zone" ? "info" : "violet"}
+                        >
+                          {item.kind}
+                        </Chip>
+                      </td>
+                      <td className="break-all px-3 py-2 align-top font-mono text-xs">
+                        {item.source_ref}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        {target ? (
+                          <span className="break-all font-mono text-[10px] text-muted-foreground">
+                            {target}
+                          </span>
+                        ) : (
+                          <Chip tone="destructive">not linked</Chip>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <StageChip stage={item.stage} />
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <BlockerChips blockers={item.blockers} />
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <ParityCell item={item} />
+                      </td>
+                      <td className="px-3 py-2 align-top text-right">
+                        <div className="flex flex-wrap justify-end gap-2">
+                          <HeaderButton
+                            className="px-2 py-1 text-xs"
+                            icon={busy ? Loader2 : CheckCircle2}
+                            iconClassName={busy ? "animate-spin" : undefined}
+                            onClick={() => {
+                              setRunningItem(item.id);
+                              itemParityMut.mutate(item.id);
+                            }}
+                            disabled={itemParityMut.isPending}
+                          >
+                            Run parity
+                          </HeaderButton>
+                          <HeaderButton
+                            variant="destructive"
+                            className="px-2 py-1 text-xs"
+                            icon={Trash2}
+                            onClick={() => setRemoving(item)}
+                          >
+                            Remove
+                          </HeaderButton>
+                        </div>
+                      </td>
+                    </tr>
+                    {open && (
+                      <tr className="border-t bg-muted/10">
+                        <td colSpan={8} className="px-3 py-3">
+                          <ItemParityDetail item={item} />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <ConfirmModal
+        open={removing !== null}
+        tone="destructive"
+        title="Remove item from plan?"
+        message={
+          <span>
+            Removes{" "}
+            <strong className="break-all">{removing?.source_ref}</strong> and
+            its parity / shadow history from this plan. An item that has already
+            been cut over cannot be removed — roll it back first.
+          </span>
+        }
+        confirmLabel="Remove item"
+        loading={removeMut.isPending}
+        onConfirm={() => removing && removeMut.mutate(removing.id)}
+        onClose={() => setRemoving(null)}
+      />
+    </div>
+  );
+}
+
+function ItemParityDetail({ item }: { item: CutoverItem }) {
+  const report: CutoverParityReport | null = item.last_parity;
+  return (
+    <div className="space-y-3">
+      {item.blockers.length > 0 && (
+        <div>
+          <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Readiness
+          </div>
+          <BlockerList blockers={item.blockers} />
+        </div>
+      )}
+
+      {!report ? (
+        <p className="text-xs text-muted-foreground">
+          No parity report yet — run one to compare this item against the live
+          Windows object.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <Chip tone={PARITY_STATUS_TONES[report.status] ?? "muted"}>
+              {report.status}
+            </Chip>
+            <span>
+              <strong className="text-foreground">{report.in_sync}</strong> in
+              sync
+            </span>
+            <span>
+              <strong className="text-foreground">
+                {report.difference_count}
+              </strong>{" "}
+              difference(s)
+            </span>
+            {report.not_compared > 0 && (
+              <span title="Records the source's read path cannot report — excluded from both counts.">
+                <strong className="text-foreground">
+                  {report.not_compared}
+                </strong>{" "}
+                not compared
+              </span>
+            )}
+            {Object.entries(report.counts_by_class)
+              .filter(([, n]) => n > 0)
+              .map(([cls, n]) => (
+                <Chip key={cls} tone={DIFF_TONES[cls] ?? "muted"}>
+                  {cls} {n}
+                </Chip>
+              ))}
+          </div>
+
+          {report.error && <ErrorBanner message={report.error} />}
+          <WarningList warnings={report.warnings} />
+
+          {report.differences.length > 0 && (
+            <div className="overflow-x-auto rounded-md border bg-background">
+              <table className="w-full min-w-[48rem] text-sm">
+                <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Classification</th>
+                    <th className="px-3 py-2 text-left">Name</th>
+                    <th className="px-3 py-2 text-left">Type</th>
+                    <th className="px-3 py-2 text-left">Detail</th>
+                    <th className="px-3 py-2 text-left">Windows</th>
+                    <th className="px-3 py-2 text-left">SpatiumDDI</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.differences.map((d, i) => (
+                    <tr key={`${d.name}:${i}`} className="border-t">
+                      <td className="px-3 py-2 align-top">
+                        <Chip tone={DIFF_TONES[d.classification] ?? "muted"}>
+                          {d.classification}
+                        </Chip>
+                      </td>
+                      <td className="break-all px-3 py-2 align-top font-mono text-xs">
+                        {d.name || "—"}
+                      </td>
+                      <td className="px-3 py-2 align-top text-xs">
+                        {d.record_type ?? "—"}
+                      </td>
+                      <td className="break-words px-3 py-2 align-top text-xs text-muted-foreground">
+                        {d.detail}
+                      </td>
+                      <td className="break-all px-3 py-2 align-top font-mono text-[11px]">
+                        {d.source_value ?? "—"}
+                      </td>
+                      <td className="break-all px-3 py-2 align-top font-mono text-[11px]">
+                        {d.target_value ?? "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Phase 2 — parallel run ────────────────────────────────────────────
+
+function ParallelTab({
+  planId,
+  items,
+}: {
+  planId: string;
+  items: CutoverItem[];
+}) {
+  const dnsItems = items.filter((i) => i.kind === "dns_zone");
+  if (dnsItems.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+        The shadow comparison is DNS-only — this plan has no{" "}
+        <code>dns_zone</code> items. DHCP is verified by parity and by the lease
+        handover on the Cutover tab.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Each run replays a sample of names at the Windows source and at every
+        enabled server in the target group, then compares the answers. Names
+        come from the recorded query log when there is one — that is what makes
+        it a shadow of production traffic rather than a second config diff.
+      </p>
+      {dnsItems.map((item) => (
+        <ShadowCard key={item.id} planId={planId} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function ShadowCard({ planId, item }: { planId: string; item: CutoverItem }) {
+  const qc = useQueryClient();
+  const [sampleSize, setSampleSize] = useState(25);
+  const [error, setError] = useState<string | null>(null);
+  const [fresh, setFresh] = useState<CutoverShadowReport | null>(null);
+
+  const shadowMut = useMutation({
+    mutationFn: () => cutoverApi.runShadow(planId, item.id, sampleSize),
+    onSuccess: (report) => {
+      setError(null);
+      setFresh(report);
+      qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const report = fresh ?? item.last_shadow;
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="break-all font-mono text-sm font-medium">
+            {item.source_ref}
+          </div>
+          <div className="text-[11px] text-muted-foreground">
+            Last run {shortDate(item.last_shadow_at)}
+          </div>
+        </div>
+        <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+          <label className="flex items-center gap-1 text-xs text-muted-foreground">
+            Samples
+            <input
+              type="number"
+              min={1}
+              max={200}
+              value={sampleSize}
+              onChange={(e) =>
+                setSampleSize(
+                  Math.max(1, Math.min(200, Number(e.target.value) || 1)),
+                )
+              }
+              className="w-20 rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+          <HeaderButton
+            icon={shadowMut.isPending ? Loader2 : ArrowRightLeft}
+            iconClassName={shadowMut.isPending ? "animate-spin" : undefined}
+            onClick={() => shadowMut.mutate()}
+            disabled={shadowMut.isPending}
+          >
+            {shadowMut.isPending ? "Querying…" : "Run shadow comparison"}
+          </HeaderButton>
+        </div>
+      </div>
+
+      {error && <ErrorBanner message={error} />}
+
+      {!report ? (
+        <p className="text-xs text-muted-foreground">
+          No shadow comparison recorded for this zone yet.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <SampleSourceBanner source={report.sample_source} />
+
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <span>
+              <strong className="text-foreground">{report.sampled}</strong>{" "}
+              sampled
+            </span>
+            <Chip tone="success">{report.matched} matched</Chip>
+            {report.mismatched > 0 && (
+              <Chip tone="destructive">{report.mismatched} mismatched</Chip>
+            )}
+            {report.errors > 0 && (
+              <Chip tone="amber">{report.errors} error</Chip>
+            )}
+            <span className="break-all">
+              source{" "}
+              <strong className="text-foreground">{report.source}</strong>
+              {report.targets.length > 0 && (
+                <> · targets {report.targets.join(", ")}</>
+              )}
+            </span>
+          </div>
+
+          <WarningList warnings={report.warnings} />
+
+          {report.samples.length > 0 && (
+            <div className="overflow-x-auto rounded-md border bg-background">
+              <table className="w-full min-w-[52rem] text-sm">
+                <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left">Name</th>
+                    <th className="px-3 py-2 text-left">Type</th>
+                    <th className="px-3 py-2 text-left">Verdict</th>
+                    <th className="px-3 py-2 text-left">Windows answer</th>
+                    <th className="px-3 py-2 text-left">SpatiumDDI answer</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.samples.map((s, i) => (
+                    <tr key={`${s.name}:${s.qtype}:${i}`} className="border-t">
+                      <td className="break-all px-3 py-2 align-top font-mono text-xs">
+                        {s.name}
+                      </td>
+                      <td className="px-3 py-2 align-top text-xs">{s.qtype}</td>
+                      <td className="px-3 py-2 align-top">
+                        <Chip
+                          tone={
+                            s.verdict === "match"
+                              ? "success"
+                              : s.verdict === "mismatch"
+                                ? "destructive"
+                                : "amber"
+                          }
+                          title={s.error ?? undefined}
+                        >
+                          {s.verdict}
+                        </Chip>
+                      </td>
+                      <td className="break-all px-3 py-2 align-top font-mono text-[11px]">
+                        {s.source_answers.length
+                          ? s.source_answers.join(", ")
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2 align-top font-mono text-[11px]">
+                        {Object.keys(s.target_answers).length === 0 ? (
+                          "—"
+                        ) : (
+                          <ul className="space-y-0.5">
+                            {Object.entries(s.target_answers).map(
+                              ([target, answers]) => (
+                                <li key={target} className="break-all">
+                                  <span className="text-muted-foreground">
+                                    {target}:
+                                  </span>{" "}
+                                  {answers.length ? answers.join(", ") : "—"}
+                                </li>
+                              ),
+                            )}
+                          </ul>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Where the sampled names came from decides how much the run proves. */
+function SampleSourceBanner({ source }: { source: string }) {
+  const isTraffic = source === "query_log";
+  return (
+    <div
+      className={cn(
+        "flex items-start gap-2 rounded-md border p-3 text-xs",
+        isTraffic
+          ? "border-emerald-500/40 bg-emerald-500/5"
+          : "border-amber-500/40 bg-amber-500/5",
+      )}
+    >
+      {isTraffic ? (
+        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-600 dark:text-emerald-400" />
+      ) : (
+        <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+      )}
+      <div className="min-w-0">
+        <div className="font-medium text-foreground">
+          Sample source: <code>{source}</code>
+        </div>
+        {isTraffic ? (
+          <p className="text-muted-foreground">
+            Names were replayed from names clients actually asked for, so a
+            clean run is evidence about production traffic.
+          </p>
+        ) : (
+          <p className="text-muted-foreground">
+            Names came from SpatiumDDI&apos;s own zone records, not from
+            observed traffic — this proves the two servers agree about what we
+            hold, not that they agree about what clients ask for. Turn the query
+            log on for the source zone to get a real shadow run.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Phase 3 — the switch ──────────────────────────────────────────────
+
+function CutoverTab({
+  planId,
+  items,
+}: {
+  planId: string;
+  items: CutoverItem[];
+}) {
+  if (items.length === 0) {
+    return (
+      <div className="rounded-md border bg-muted/20 p-4 text-sm text-muted-foreground">
+        This plan has no items to cut over yet.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-4">
+      <p className="text-xs text-muted-foreground">
+        Pre-flight first, switch second. For DNS the pre-flight is the TTL drop
+        and the switch is a delegation change SpatiumDDI does not own — it
+        records the transition and hands back the steps. For DHCP the handover
+        mints reservations from the live Windows leases, and the switch is real:
+        the Windows scope is deactivated before the managed scope is activated.
+      </p>
+      {items.map((item) =>
+        item.kind === "dns_zone" ? (
+          <DnsCutoverCard key={item.id} planId={planId} item={item} />
+        ) : (
+          <DhcpCutoverCard key={item.id} planId={planId} item={item} />
+        ),
+      )}
+    </div>
+  );
+}
+
+/** Header + switch controls shared by the DNS and DHCP cards. */
+function SwitchControls({
+  planId,
+  item,
+}: {
+  planId: string;
+  item: CutoverItem;
+}) {
+  const qc = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [rollbackOpen, setRollbackOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refused, setRefused] = useState<CutoverBlocker[]>([]);
+  const [result, setResult] = useState<CutoverSwitchResult | null>(null);
+
+  const blocked = hasBlocking(item.blockers);
+  const warnings = warnOnly(item.blockers);
+
+  const invalidate = () => {
+    qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+    qc.invalidateQueries({ queryKey: ["cutover", "plans"] });
+  };
+
+  const cutMut = useMutation({
+    mutationFn: (force: boolean) => cutoverApi.cutOver(planId, item.id, force),
+    onSuccess: (res) => {
+      setConfirmOpen(false);
+      setError(null);
+      setRefused([]);
+      setResult(res);
+      invalidate();
+    },
+    onError: (err: unknown) => {
+      setConfirmOpen(false);
+      setError(extractError(err));
+      setRefused(extractBlockers(err));
+    },
+  });
+
+  const rollbackMut = useMutation({
+    mutationFn: () => cutoverApi.rollback(planId, item.id),
+    onSuccess: (res) => {
+      setRollbackOpen(false);
+      setError(null);
+      setRefused([]);
+      setResult(res);
+      invalidate();
+    },
+    onError: (err: unknown) => {
+      setRollbackOpen(false);
+      setError(extractError(err));
+      setRefused(extractBlockers(err));
+    },
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-0 flex-1 text-xs text-muted-foreground">
+          {blocked
+            ? "Cutting over is refused while a blocking readiness check fails. Fix the blocker below — there is no override."
+            : warnings.length > 0
+              ? "Warnings must be acknowledged before the switch."
+              : "No blockers outstanding."}
+        </div>
+        <div className="flex flex-shrink-0 flex-wrap gap-2">
+          <HeaderButton
+            variant="primary"
+            icon={cutMut.isPending ? Loader2 : ArrowRightLeft}
+            iconClassName={cutMut.isPending ? "animate-spin" : undefined}
+            onClick={() => setConfirmOpen(true)}
+            disabled={blocked || cutMut.isPending || item.stage === "cut_over"}
+            title={
+              blocked
+                ? "A blocking readiness check refuses this cutover."
+                : undefined
+            }
+          >
+            Cut over
+          </HeaderButton>
+          <HeaderButton
+            icon={rollbackMut.isPending ? Loader2 : RotateCcw}
+            iconClassName={rollbackMut.isPending ? "animate-spin" : undefined}
+            onClick={() => setRollbackOpen(true)}
+            disabled={rollbackMut.isPending || item.stage !== "cut_over"}
+          >
+            Roll back
+          </HeaderButton>
+        </div>
+      </div>
+
+      {error && <ErrorBanner message={error} />}
+      {/* A refusal rolls its transaction back, so the freshly-evaluated
+          blockers in the 409 body are the only copy of them — prefer those
+          over the ones persisted on the item. */}
+      <BlockerList blockers={refused.length > 0 ? refused : item.blockers} />
+      {result && <SwitchResultPanel result={result} />}
+
+      <ConfirmModal
+        open={confirmOpen}
+        tone="destructive"
+        title={`Cut over ${item.source_ref}?`}
+        message={
+          <div className="space-y-3">
+            <p>
+              {item.kind === "dhcp_scope"
+                ? "Deactivates the Windows scope, then activates the managed scope. Between the two the subnet has no DHCP server for one WinRM round-trip — that gap is deliberate, because two servers answering at once hand out conflicting addresses."
+                : "Records the transition and returns the delegation steps. The Windows zone is left untouched and keeps serving as the fallback until you move the delegation."}
+            </p>
+            {item.blockers.length > 0 && (
+              <div>
+                <div className="mb-1 text-[11px] font-semibold uppercase tracking-wider">
+                  Outstanding readiness checks
+                </div>
+                <BlockerList blockers={item.blockers} />
+              </div>
+            )}
+          </div>
+        }
+        confirmLabel="Cut over"
+        requireCheckboxLabel={
+          warnings.length > 0
+            ? `I acknowledge the ${warnings.length} warning(s) above and want to proceed.`
+            : undefined
+        }
+        loading={cutMut.isPending}
+        onConfirm={() => cutMut.mutate(warnings.length > 0)}
+        onClose={() => setConfirmOpen(false)}
+      />
+
+      <ConfirmModal
+        open={rollbackOpen}
+        title={`Roll ${item.source_ref} back?`}
+        message={
+          item.kind === "dhcp_scope"
+            ? "Deactivates the managed scope, then re-activates the Windows scope. Reservations minted by the lease handover stay in place — they are harmless while the scope is inactive."
+            : "Restores the pre-flight TTL snapshot and returns the steps for reverting the delegation."
+        }
+        confirmLabel="Roll back"
+        loading={rollbackMut.isPending}
+        onConfirm={() => rollbackMut.mutate()}
+        onClose={() => setRollbackOpen(false)}
+      />
+    </div>
+  );
+}
+
+function SwitchResultPanel({ result }: { result: CutoverSwitchResult }) {
+  return (
+    <div className="space-y-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-xs">
+      <div className="font-medium text-emerald-700 dark:text-emerald-400">
+        {result.stage === "rolled_back" ? "Rolled back" : "Cut over"} —{" "}
+        <span className="break-all">{result.source_ref}</span>
+      </div>
+      {result.actions.length > 0 && (
+        <ul className="list-inside list-disc space-y-0.5">
+          {result.actions.map((a, i) => (
+            <li key={i} className="break-words">
+              {a}
+            </li>
+          ))}
+        </ul>
+      )}
+      {result.instructions.length > 0 && (
+        <div>
+          <div className="mt-1 font-medium text-foreground">
+            Operator-side steps
+          </div>
+          <ol className="list-inside list-decimal space-y-0.5">
+            {result.instructions.map((s, i) => (
+              <li key={i} className="break-words">
+                {s}
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+      {result.recovery_estimate_seconds != null && (
+        <div className="text-muted-foreground">
+          Expected recovery once reversed: ~{result.recovery_estimate_seconds}s.
+        </div>
+      )}
+      <WarningList warnings={result.warnings ?? []} />
+    </div>
+  );
+}
+
+function DnsCutoverCard({
+  planId,
+  item,
+}: {
+  planId: string;
+  item: CutoverItem;
+}) {
+  const qc = useQueryClient();
+  const [targetTtl, setTargetTtl] = useState(300);
+  const [preview, setPreview] = useState<CutoverTTLPreflightPlan | null>(null);
+  const [committed, setCommitted] = useState<CutoverTTLPreflightPlan | null>(
+    null,
+  );
+  const [restored, setRestored] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const invalidate = () =>
+    qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+
+  const previewMut = useMutation({
+    mutationFn: () => cutoverApi.previewTtl(planId, item.id, targetTtl),
+    onSuccess: (plan) => {
+      setError(null);
+      setCommitted(null);
+      setRestored(null);
+      setPreview(plan);
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const commitMut = useMutation({
+    mutationFn: () => cutoverApi.commitTtl(planId, item.id, targetTtl),
+    onSuccess: (plan) => {
+      setError(null);
+      setRestored(null);
+      setCommitted(plan);
+      invalidate();
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const restoreMut = useMutation({
+    mutationFn: () => cutoverApi.restoreTtl(planId, item.id),
+    onSuccess: (res) => {
+      setError(null);
+      setPreview(null);
+      setCommitted(null);
+      setRestored(res.records_restored);
+      invalidate();
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const shown = committed ?? preview;
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Chip tone="info">dns_zone</Chip>
+        <span className="min-w-0 flex-1 break-all font-mono text-sm font-medium">
+          {item.source_ref}
+        </span>
+        <StageChip stage={item.stage} />
+      </div>
+
+      <div className="space-y-3">
+        <div className="rounded-md border bg-background p-3">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <Timer className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              TTL pre-flight
+            </span>
+            <label className="flex items-center gap-1 text-xs text-muted-foreground">
+              Target TTL (s)
+              <input
+                type="number"
+                min={30}
+                max={86400}
+                value={targetTtl}
+                onChange={(e) => setTargetTtl(Number(e.target.value) || 0)}
+                className="w-24 rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <HeaderButton
+                className="px-2 py-1 text-xs"
+                icon={previewMut.isPending ? Loader2 : Search}
+                iconClassName={
+                  previewMut.isPending ? "animate-spin" : undefined
+                }
+                onClick={() => previewMut.mutate()}
+                disabled={previewMut.isPending}
+              >
+                Preview
+              </HeaderButton>
+              <HeaderButton
+                variant="primary"
+                className="px-2 py-1 text-xs"
+                icon={commitMut.isPending ? Loader2 : Timer}
+                iconClassName={commitMut.isPending ? "animate-spin" : undefined}
+                onClick={() => commitMut.mutate()}
+                disabled={commitMut.isPending}
+              >
+                Commit
+              </HeaderButton>
+              <HeaderButton
+                className="px-2 py-1 text-xs"
+                icon={restoreMut.isPending ? Loader2 : RotateCcw}
+                iconClassName={
+                  restoreMut.isPending ? "animate-spin" : undefined
+                }
+                onClick={() => restoreMut.mutate()}
+                disabled={restoreMut.isPending || !item.ttl_snapshot}
+              >
+                Restore
+              </HeaderButton>
+            </div>
+          </div>
+
+          <div className="mb-2 text-[11px] text-muted-foreground">
+            {item.ttl_lowered_at
+              ? `TTLs lowered ${shortDate(item.ttl_lowered_at)} — the snapshot taken before the first commit is what Restore replays.`
+              : "TTLs have not been lowered for this zone. A rollback then propagates at the zone's full TTL."}
+          </div>
+
+          {error && <ErrorBanner message={error} />}
+          {restored !== null && (
+            <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-2 text-xs text-emerald-700 dark:text-emerald-400">
+              Restored {restored} record TTL(s) from the pre-flight snapshot.
+            </div>
+          )}
+
+          {shown && (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                <Chip tone={committed ? "success" : "info"}>
+                  {committed ? "committed" : "preview"}
+                </Chip>
+                <span>
+                  target{" "}
+                  <strong className="text-foreground">
+                    {shown.target_ttl}s
+                  </strong>
+                </span>
+                <span>
+                  <strong className="text-foreground">{shown.changed}</strong>{" "}
+                  changed
+                </span>
+                <span>
+                  <strong className="text-foreground">{shown.unchanged}</strong>{" "}
+                  already at or below
+                </span>
+                <span className="break-all">
+                  SOA{" "}
+                  {Object.entries(shown.zone_current)
+                    .map(([k, v]) => `${k} ${v}`)
+                    .join(" · ")}{" "}
+                  →{" "}
+                  {Object.entries(shown.zone_after)
+                    .map(([k, v]) => `${k} ${v}`)
+                    .join(" · ")}
+                </span>
+              </div>
+
+              <WarningList warnings={shown.warnings} />
+
+              {shown.source_side_instructions && (
+                <CopyBlock
+                  label="Run this on the Windows source — SpatiumDDI does not write its TTLs"
+                  text={shown.source_side_instructions}
+                />
+              )}
+
+              {shown.records.length > 0 && (
+                <div className="overflow-x-auto rounded-md border bg-background">
+                  <table className="w-full min-w-[36rem] text-sm">
+                    <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+                      <tr>
+                        <th className="px-3 py-2 text-left">Record</th>
+                        <th className="px-3 py-2 text-left">Type</th>
+                        <th className="px-3 py-2 text-left">Current TTL</th>
+                        <th className="px-3 py-2 text-left">New TTL</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {shown.records.map((r) => (
+                        <tr key={r.record_id} className="border-t">
+                          <td className="break-all px-3 py-2 align-top font-mono text-xs">
+                            {r.name || "@"}
+                          </td>
+                          <td className="px-3 py-2 align-top text-xs">
+                            {r.record_type}
+                          </td>
+                          <td className="px-3 py-2 align-top text-xs tabular-nums">
+                            {r.current_ttl ?? "inherit"}
+                          </td>
+                          <td className="px-3 py-2 align-top text-xs tabular-nums">
+                            {r.new_ttl}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <SwitchControls planId={planId} item={item} />
+      </div>
+    </div>
+  );
+}
+
+function DhcpCutoverCard({
+  planId,
+  item,
+}: {
+  planId: string;
+  item: CutoverItem;
+}) {
+  const qc = useQueryClient();
+  const [preview, setPreview] = useState<CutoverLeaseHandoverPlan | null>(null);
+  const [committed, setCommitted] = useState<CutoverLeaseHandoverPlan | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const previewMut = useMutation({
+    mutationFn: () => cutoverApi.previewLeases(planId, item.id),
+    onSuccess: (plan) => {
+      setError(null);
+      setCommitted(null);
+      setPreview(plan);
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const commitMut = useMutation({
+    mutationFn: () => {
+      if (!preview) throw new Error("Preview the lease handover first");
+      return cutoverApi.commitLeases(planId, item.id, preview.entries);
+    },
+    onSuccess: (plan) => {
+      setError(null);
+      setCommitted(plan);
+      qc.invalidateQueries({ queryKey: ["cutover", "plan", planId] });
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  // Only a real plan (from this session's preview or commit) has entries and
+  // warnings to render. ``item.lease_handover`` is the persisted summary —
+  // four counters and a timestamp — so it gets its own compact line below
+  // rather than being fed to the table renderer.
+  const shown = committed ?? preview;
+  const lastRun = item.lease_handover;
+
+  return (
+    <div className="rounded-md border bg-muted/20 p-4">
+      <div className="mb-3 flex flex-wrap items-center gap-2">
+        <Chip tone="violet">dhcp_scope</Chip>
+        <span className="min-w-0 flex-1 break-all font-mono text-sm font-medium">
+          {item.source_ref}
+        </span>
+        <StageChip stage={item.stage} />
+      </div>
+
+      <div className="space-y-3">
+        <div className="rounded-md border bg-background p-3">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <ClipboardList className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+            <span className="min-w-0 flex-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              Lease handover
+            </span>
+            <div className="flex flex-wrap gap-2">
+              <HeaderButton
+                className="px-2 py-1 text-xs"
+                icon={previewMut.isPending ? Loader2 : Search}
+                iconClassName={
+                  previewMut.isPending ? "animate-spin" : undefined
+                }
+                onClick={() => previewMut.mutate()}
+                disabled={previewMut.isPending}
+              >
+                Preview
+              </HeaderButton>
+              <HeaderButton
+                variant="primary"
+                className="px-2 py-1 text-xs"
+                icon={commitMut.isPending ? Loader2 : ClipboardList}
+                iconClassName={commitMut.isPending ? "animate-spin" : undefined}
+                onClick={() => commitMut.mutate()}
+                disabled={commitMut.isPending || !preview}
+              >
+                Commit
+              </HeaderButton>
+            </div>
+          </div>
+
+          <p className="mb-2 text-[11px] text-muted-foreground">
+            Turns each live Windows lease into a reservation on the managed
+            scope, so a client renewing against Kea keeps the address it already
+            holds instead of drawing a fresh one from an empty pool. Rows are
+            re-classified against live data at commit, so a reservation added
+            between the two calls is skipped rather than failing the batch.
+          </p>
+
+          {error && <ErrorBanner message={error} />}
+
+          {lastRun && (
+            <p className="mb-2 text-xs text-muted-foreground">
+              Last handover{" "}
+              <span className="text-foreground">
+                {new Date(lastRun.at).toLocaleString()}
+              </span>
+              : <strong className="text-foreground">{lastRun.created}</strong>{" "}
+              created ·{" "}
+              <strong className="text-foreground">{lastRun.skipped}</strong>{" "}
+              skipped ·{" "}
+              <strong className="text-foreground">{lastRun.failed}</strong>{" "}
+              failed. Preview again to see the current lease table.
+            </p>
+          )}
+
+          {!shown ? (
+            <p className="text-xs text-muted-foreground">
+              No handover previewed yet.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                {shown.scope_cidr && (
+                  <span className="break-all font-mono">
+                    {shown.scope_cidr}
+                  </span>
+                )}
+                <Chip tone="success">{shown.create_count} create</Chip>
+                <Chip tone="muted">{shown.skip_count} skip</Chip>
+                {shown.conflict_count > 0 && (
+                  <Chip tone="destructive">
+                    {shown.conflict_count} conflict
+                  </Chip>
+                )}
+                {shown.created + shown.skipped + shown.failed > 0 && (
+                  <span>
+                    committed:{" "}
+                    <strong className="text-foreground">{shown.created}</strong>{" "}
+                    created ·{" "}
+                    <strong className="text-foreground">{shown.skipped}</strong>{" "}
+                    skipped ·{" "}
+                    <strong className="text-foreground">{shown.failed}</strong>{" "}
+                    failed
+                  </span>
+                )}
+              </div>
+
+              <WarningList warnings={shown.warnings} />
+
+              {shown.entries.length > 0 && (
+                <div className="overflow-x-auto rounded-md border bg-background">
+                  <table className="w-full min-w-[52rem] text-sm">
+                    <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+                      <tr>
+                        <th className="px-3 py-2 text-left">IP</th>
+                        <th className="px-3 py-2 text-left">MAC</th>
+                        <th className="px-3 py-2 text-left">Hostname</th>
+                        <th className="px-3 py-2 text-left">Action</th>
+                        <th className="px-3 py-2 text-left">Reason</th>
+                        <th className="px-3 py-2 text-left">Result</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {shown.entries.map((e, i) => (
+                        <tr
+                          key={`${e.mac_address}:${e.ip_address}:${i}`}
+                          className="border-t"
+                        >
+                          <td className="break-all px-3 py-2 align-top font-mono text-xs">
+                            {e.ip_address}
+                          </td>
+                          <td className="break-all px-3 py-2 align-top font-mono text-xs">
+                            {e.mac_address}
+                          </td>
+                          <td className="break-all px-3 py-2 align-top text-xs">
+                            {e.hostname || "—"}
+                          </td>
+                          <td className="px-3 py-2 align-top">
+                            <Chip
+                              tone={
+                                e.action === "create"
+                                  ? "success"
+                                  : e.action === "conflict"
+                                    ? "destructive"
+                                    : "muted"
+                              }
+                            >
+                              {e.action}
+                            </Chip>
+                          </td>
+                          <td className="break-words px-3 py-2 align-top text-xs text-muted-foreground">
+                            {e.reason || "—"}
+                          </td>
+                          <td className="break-words px-3 py-2 align-top text-xs">
+                            {e.result ? (
+                              <Chip
+                                tone={
+                                  e.result === "created"
+                                    ? "success"
+                                    : e.result === "failed"
+                                      ? "destructive"
+                                      : "muted"
+                                }
+                                title={e.error ?? undefined}
+                              >
+                                {e.result}
+                              </Chip>
+                            ) : (
+                              "—"
+                            )}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        <SwitchControls planId={planId} item={item} />
+      </div>
+    </div>
+  );
+}
+
+// ── Phase 4 — decommission checklist ──────────────────────────────────
+
+function DecommissionTab({
+  planId,
+  canQuery,
+}: {
+  planId: string;
+  canQuery: boolean;
+}) {
+  const qc = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const checklistQ = useQuery({
+    queryKey: ["cutover", "checklist", planId],
+    queryFn: () => cutoverApi.getChecklist(planId),
+    enabled: canQuery,
+  });
+
+  const patchMut = useMutation({
+    mutationFn: (args: {
+      key: string;
+      body: { is_done?: boolean; notes?: string };
+    }) => cutoverApi.patchChecklistItem(planId, args.key, args.body),
+    onSuccess: () => {
+      setError(null);
+      qc.invalidateQueries({ queryKey: ["cutover", "checklist", planId] });
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const rows = checklistQ.data ?? [];
+  const grouped = useMemo(() => {
+    const m = new Map<string, CutoverChecklistItem[]>();
+    for (const r of rows) {
+      const arr = m.get(r.category) ?? [];
+      arr.push(r);
+      m.set(r.category, arr);
+    }
+    return Array.from(m.entries());
+  }, [rows]);
+
+  const done = rows.filter((r) => r.is_done).length;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <p className="min-w-0 flex-1 text-xs text-muted-foreground">
+          The switch is the visible part; the decommission is the part that
+          bites weeks later. Auto-checks are advisory — they never tick a box.
+        </p>
+        <Chip
+          tone={done === rows.length && rows.length > 0 ? "success" : "muted"}
+        >
+          {done} / {rows.length} done
+        </Chip>
+      </div>
+
+      {error && <ErrorBanner message={error} />}
+      {checklistQ.isError && (
+        <ErrorBanner message={formatApiError(checklistQ.error)} />
+      )}
+
+      {checklistQ.isLoading ? (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" /> Loading checklist…
+        </div>
+      ) : (
+        grouped.map(([category, entries]) => (
+          <div key={category} className="space-y-2">
+            <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              {CATEGORY_LABELS[category] ?? category}
+            </h2>
+            {entries.map((entry) => (
+              <ChecklistRow
+                key={entry.key}
+                entry={entry}
+                saving={patchMut.isPending}
+                onToggle={(isDone) =>
+                  patchMut.mutate({ key: entry.key, body: { is_done: isDone } })
+                }
+                onNotes={(notes) =>
+                  patchMut.mutate({ key: entry.key, body: { notes } })
+                }
+              />
+            ))}
+          </div>
+        ))
+      )}
+    </div>
+  );
+}
+
+function ChecklistRow({
+  entry,
+  saving,
+  onToggle,
+  onNotes,
+}: {
+  entry: CutoverChecklistItem;
+  saving: boolean;
+  onToggle: (isDone: boolean) => void;
+  onNotes: (notes: string) => void;
+}) {
+  const [notes, setNotes] = useState(entry.notes);
+
+  // The server row is the source of truth: re-sync the draft whenever a PATCH
+  // (or a refetch) brings back different text, so an edit elsewhere isn't
+  // silently overwritten by a stale local draft.
+  useEffect(() => {
+    setNotes(entry.notes);
+  }, [entry.notes]);
+
+  return (
+    <div
+      className={cn(
+        "rounded-md border p-3",
+        entry.is_done
+          ? "border-emerald-500/40 bg-emerald-500/5"
+          : "bg-muted/20",
+      )}
+    >
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={entry.is_done}
+          disabled={saving}
+          onChange={(e) => onToggle(e.target.checked)}
+          className="mt-1 h-4 w-4 flex-shrink-0 cursor-pointer rounded border focus:ring-2 focus:ring-ring"
+          aria-label={entry.label}
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="min-w-0 flex-1 break-words text-sm font-medium">
+              {entry.label}
+            </span>
+            <Chip tone="muted" title={`Applies to ${entry.applies_to}`}>
+              {entry.applies_to}
+            </Chip>
+            <Chip
+              tone={AUTO_STATE_TONES[entry.auto_state] ?? "muted"}
+              title={entry.auto_detail || undefined}
+            >
+              auto: {entry.auto_state}
+            </Chip>
+          </div>
+          <p className="break-words text-xs text-muted-foreground">
+            {entry.description}
+          </p>
+          {entry.auto_detail && (
+            <p
+              className={cn(
+                "break-words rounded-md border p-2 text-[11px]",
+                entry.auto_state === "attention"
+                  ? "border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-300"
+                  : "bg-background text-muted-foreground",
+              )}
+            >
+              {entry.auto_detail}
+            </p>
+          )}
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            onBlur={() => {
+              if (notes !== entry.notes) onNotes(notes);
+            }}
+            rows={2}
+            placeholder="Notes — who checked this, when, ticket reference…"
+            className="w-full rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+          {entry.done_at && (
+            <p className="text-[11px] text-muted-foreground">
+              Marked done {shortDate(entry.done_at)}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Discover ──────────────────────────────────────────────────────────
+
+function DiscoverModal({
+  planId,
+  onClose,
+  onAdded,
+}: {
+  planId: string;
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const [result, setResult] = useState<{
+    dns: CutoverCandidate[];
+    dhcp: CutoverCandidate[];
+    dnsError: string | null;
+    dhcpError: string | null;
+  } | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [error, setError] = useState<string | null>(null);
+
+  const discoverMut = useMutation({
+    mutationFn: () => cutoverApi.discover(planId),
+    onSuccess: (res) => {
+      setError(null);
+      setSelected(new Set());
+      // Each side is independent: a WinRM failure on one reports its own
+      // ``error`` string while the other still returns candidates.
+      setResult({
+        dns: res.dns.candidates,
+        dhcp: res.dhcp.candidates,
+        dnsError: res.dns.error,
+        dhcpError: res.dhcp.error,
+      });
+    },
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const addMut = useMutation({
+    mutationFn: (items: CutoverItemIn[]) => cutoverApi.addItems(planId, items),
+    onSuccess: onAdded,
+    onError: (err: unknown) => setError(extractError(err)),
+  });
+
+  const candidates = useMemo(
+    () => [...(result?.dns ?? []), ...(result?.dhcp ?? [])],
+    [result],
+  );
+
+  const toggle = (ref: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(ref)) next.delete(ref);
+      else next.add(ref);
+      return next;
+    });
+
+  const add = () => {
+    const chosen = candidates.filter(
+      (c) => selected.has(`${c.kind}:${c.source_ref}`) && !c.already_in_plan,
+    );
+    if (chosen.length === 0) return;
+    addMut.mutate(
+      chosen.map((c) => ({
+        kind: c.kind,
+        source_ref: c.source_ref,
+        zone_id: c.kind === "dns_zone" ? c.matched_id : null,
+        scope_id: c.kind === "dhcp_scope" ? c.matched_id : null,
+      })),
+    );
+  };
+
+  return (
+    <Modal
+      title="Discover candidates from the Windows source"
+      onClose={onClose}
+      wide
+    >
+      <div className="space-y-4">
+        <p className="text-xs text-muted-foreground">
+          Live-pulls the zones and scopes off the plan&apos;s source servers,
+          matches each against the target group (zones by name, scopes by subnet
+          CIDR) and pre-computes its blockers. Read-only — nothing is written
+          until you add the selected rows.
+        </p>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <HeaderButton
+            icon={discoverMut.isPending ? Loader2 : Search}
+            iconClassName={discoverMut.isPending ? "animate-spin" : undefined}
+            onClick={() => discoverMut.mutate()}
+            disabled={discoverMut.isPending}
+          >
+            {discoverMut.isPending ? "Pulling…" : "Run discovery"}
+          </HeaderButton>
+          <div className="min-w-0 flex-1" />
+          <HeaderButton
+            variant="primary"
+            icon={addMut.isPending ? Loader2 : Plus}
+            iconClassName={addMut.isPending ? "animate-spin" : undefined}
+            onClick={add}
+            disabled={addMut.isPending || selected.size === 0}
+          >
+            Add {selected.size} item(s)
+          </HeaderButton>
+        </div>
+
+        {error && <ErrorBanner message={error} />}
+        {result?.dnsError && <ErrorBanner message={result.dnsError} />}
+        {result?.dhcpError && <ErrorBanner message={result.dhcpError} />}
+
+        {result && candidates.length === 0 && (
+          <p className="text-xs text-muted-foreground">
+            No candidates came back from either source.
+          </p>
+        )}
+
+        {candidates.length > 0 && (
+          <div className="overflow-x-auto rounded-md border bg-background">
+            <table className="w-full min-w-[44rem] text-sm">
+              <thead className="bg-muted/30 text-[11px] uppercase tracking-wider text-muted-foreground">
+                <tr>
+                  <th className="w-8 px-2 py-2" />
+                  <th className="px-3 py-2 text-left">Candidate</th>
+                  <th className="px-3 py-2 text-left">Kind</th>
+                  <th className="px-3 py-2 text-left">Matched</th>
+                  <th className="px-3 py-2 text-left">Blockers</th>
+                </tr>
+              </thead>
+              <tbody>
+                {candidates.map((c) => {
+                  const key = `${c.kind}:${c.source_ref}`;
+                  return (
+                    <tr key={key} className="border-t">
+                      <td className="px-2 py-2 align-top">
+                        <input
+                          type="checkbox"
+                          checked={selected.has(key)}
+                          disabled={c.already_in_plan}
+                          onChange={() => toggle(key)}
+                          className="h-4 w-4 cursor-pointer rounded border focus:ring-2 focus:ring-ring"
+                          aria-label={`Select ${c.source_ref}`}
+                        />
+                      </td>
+                      <td className="break-all px-3 py-2 align-top">
+                        <span className="font-mono text-xs">
+                          {c.display_name}
+                        </span>
+                        {c.already_in_plan && (
+                          <span className="ml-2">
+                            <Chip tone="muted">already in plan</Chip>
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <Chip tone={c.kind === "dns_zone" ? "info" : "violet"}>
+                          {c.kind}
+                        </Chip>
+                      </td>
+                      <td className="break-all px-3 py-2 align-top text-xs">
+                        {c.matched_display ?? (
+                          <Chip tone="destructive">no target</Chip>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 align-top">
+                        <BlockerChips blockers={c.blockers} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+// ── Runbook + timeline ────────────────────────────────────────────────
+
+function RunbookModal({
+  planId,
+  canQuery,
+  onClose,
+}: {
+  planId: string;
+  canQuery: boolean;
+  onClose: () => void;
+}) {
+  const runbookQ = useQuery({
+    queryKey: ["cutover", "runbook", planId],
+    queryFn: () => cutoverApi.runbook(planId),
+    enabled: canQuery,
+  });
+
+  return (
+    <Modal title="Cutover runbook" onClose={onClose} wide>
+      <div className="space-y-3">
+        <p className="text-xs text-muted-foreground">
+          Generated from the plan&apos;s persisted state — it does not re-pull
+          the Windows source, so it is safe to produce for a change ticket.
+          Markdown, verbatim.
+        </p>
+        {runbookQ.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Rendering…
+          </div>
+        ) : runbookQ.isError ? (
+          <ErrorBanner message={formatApiError(runbookQ.error)} />
+        ) : (
+          <CopyBlock label="runbook.md" text={runbookQ.data?.markdown ?? ""} />
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function TimelineModal({
+  planId,
+  canQuery,
+  onClose,
+}: {
+  planId: string;
+  canQuery: boolean;
+  onClose: () => void;
+}) {
+  const eventsQ = useQuery({
+    queryKey: ["cutover", "events", planId],
+    queryFn: () => cutoverApi.listEvents(planId, { limit: 200 }),
+    enabled: canQuery,
+  });
+
+  const events = eventsQ.data ?? [];
+
+  return (
+    <Modal title="Plan timeline" onClose={onClose} wide>
+      <div className="space-y-3">
+        {eventsQ.isLoading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" /> Loading timeline…
+          </div>
+        ) : eventsQ.isError ? (
+          <ErrorBanner message={formatApiError(eventsQ.error)} />
+        ) : events.length === 0 ? (
+          <p className="text-xs text-muted-foreground">
+            Nothing has happened on this plan yet.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {events.map((e) => (
+              <li key={e.id} className="rounded-md border bg-muted/20 p-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Chip tone="muted">{e.kind}</Chip>
+                  <span className="text-[11px] text-muted-foreground">
+                    {shortDate(e.at)}
+                  </span>
+                  <span className="text-[11px] text-muted-foreground">
+                    {e.user_display_name}
+                  </span>
+                </div>
+                <p className="mt-1 break-words text-xs">{e.summary}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/admin/ImportPage.tsx
+++ b/frontend/src/pages/admin/ImportPage.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { useSessionState } from "@/lib/useSessionState";
+import { CutoverPage } from "./CutoverPage";
 import { DHCPImportPage } from "./DHCPImportPage";
 import { DNSImportPage } from "./DNSImportPage";
 import { NetBoxImportPage } from "./NetBoxImportPage";
@@ -11,18 +12,20 @@ import { NetBoxImportPage } from "./NetBoxImportPage";
  * Configuration → Import hub.
  *
  * Consolidates the three one-shot importers (DHCP #129 / DNS #128 / NetBox
- * #36) under a single Configuration nav entry with a left sub-nav, mirroring
- * the Appliance → Fleet left-sidebar pattern. Each importer keeps its own
- * page component (and its own source sub-tabs); this shell just picks which
- * family is active and gates each section on its feature module.
+ * #36) plus the guided Windows cutover (#756) under a single Configuration
+ * nav entry with a left sub-nav, mirroring the Appliance → Fleet left-sidebar
+ * pattern. Each section keeps its own page component (and its own source
+ * sub-tabs); this shell just picks which family is active and gates each
+ * section on its feature module.
  *
  * Mounted at /admin/import plus the legacy per-importer routes
- * (/admin/{dhcp,dns,netbox}-import) so existing deep-links — notably the DNS
- * page's "Sync from provider" navigate("/admin/dns-import", {state}) — keep
- * working: the legacy route renders this shell with the matching initialTab,
- * and the embedded page still reads its router state.
+ * (/admin/{dhcp,dns,netbox}-import, /admin/cutover) so existing deep-links —
+ * notably the DNS page's "Sync from provider"
+ * navigate("/admin/dns-import", {state}) — keep working: the legacy route
+ * renders this shell with the matching initialTab, and the embedded page still
+ * reads its router state.
  */
-export type ImportTab = "dhcp" | "dns" | "netbox";
+export type ImportTab = "dhcp" | "dns" | "netbox" | "cutover";
 
 const SECTIONS: {
   key: ImportTab;
@@ -47,6 +50,12 @@ const SECTIONS: {
     label: "NetBox",
     summary: "One-shot IPAM migration from a NetBox install",
     module: "ipam.import.netbox",
+  },
+  {
+    key: "cutover",
+    label: "Windows cutover",
+    summary: "Guided migration off Windows DNS / DHCP",
+    module: "migration.cutover",
   },
 ];
 
@@ -111,6 +120,8 @@ export function ImportPage({ initialTab }: { initialTab?: ImportTab }) {
           <DNSImportPage />
         ) : active?.key === "netbox" ? (
           <NetBoxImportPage />
+        ) : active?.key === "cutover" ? (
+          <CutoverPage />
         ) : null}
       </main>
     </div>


### PR DESCRIPTION
The importers (#128 / #129) load a Windows DNS / DHCP estate into native rows and stop there. Nothing took an operator the rest of the way: proving the imported rows still match what Windows is serving, running both sides in parallel, performing the switch per zone / per scope, and knowing what is safe to turn off afterwards.

Ships as an extension of the migration family, not a parallel subsystem — same preview → commit idiom, same provenance columns, fourth tab in the existing Import hub.

Closes #756

## The four phases

**Phase 1 — parity.** Diffs each SpatiumDDI object against what Windows is serving *now*, classifying by *why* the two sides differ: `drifted_since_import` / `never_imported` / `intentionally_diverged`, plus `value_mismatch`, which pairs a changed record into **one** decision rather than the missing+extra pair #61's drift report produces.

Two traps are handled explicitly, because both would otherwise manufacture drift out of nothing:

- A Path-B pull maps only `_PULL_RECORD_TYPES`, so CAA / TLSA / SSHFP are counted as `not_compared` with a warning rather than reported as missing.
- `_parse_records` logs a warning and returns `[]` on unparseable PowerShell output — indistinguishable from an empty zone. Zero-on-the-wire with rows in the DB reports `status="unverified"` instead of "everything diverged".

DHCP parity honours the driver's `pools_ok` / `statics_ok` flags (#620), which the importer does not.

**Phase 2 — parallel run.** Replays recently-observed queries from the BIND9 query log against both sides and compares answers, so parity is demonstrated against production traffic rather than asserted from config equality. `sample_source` says whether the names came from real traffic or from our own records, because the two are not equally strong evidence.

**Phase 3 — the switch, per item.** A TTL pre-flight that snapshots the originals **once** and restores them exactly (including putting `ttl IS NULL` inheritance back). A DHCP lease handover that promotes live Windows leases to reservations, so a renewing client keeps the address it already holds instead of meeting a Kea with an empty lease database. And the switch itself, which deactivates the Windows scope **before** activating the managed one and puts the old one back if the new side fails to come up.

**Phase 4 —** a 15-item decommission checklist; three items advisory-evaluated from our own data, none ever auto-ticked.

## The load-bearing refusal

An AD-integrated zone with **"Secure only"** dynamic updates is a hard block that `force` cannot bypass, because GSS-TSIG is unimplemented (#444) and a domain controller that cannot register its SRV records turns a DNS migration into a domain outage.

It **fails closed**: an AD-integrated zone whose dynamic-update mode cannot be interpreted is treated as `Secure`. Windows emits that enum as a string on some builds and an integer on others; both are decoded.

## Field-verified against a real domain controller

Not just mocks — the whole workflow was driven against a live AD DC with DNS + DHCP:

```
AD-secure cutover force=False -> HTTP 409  blockers=['ad_secure_dynamic_update', ...]
AD-secure cutover force=True  -> HTTP 409  blockers=['ad_secure_dynamic_update', ...]
```

`corp.lab.local`, `_msdcs.corp.lab.local` and the reverse zone all reported `Secure` and were refused; `windows.lab.local` (`NonsecureAndSecure`) was allowed with warnings.

Parity classified real drift correctly after changing one record on Windows, adding one on each side, and adding a CAA that Path B cannot see:

```
in_sync=9  not_compared=1  diffs=3
  value_mismatch: www src=10.20.7.99 tgt=10.20.7.20
  drifted_since_import: newhost
  intentionally_diverged: added-here
```

And the **live DHCP switch and rollback both ran against the real server**:

```
posture:        windows_active=True   spatium_active=False
CUTOVER  -> 200   deactivated on dc1, activated in SpatiumDDI
                windows_active=False  spatium_active=True
ROLLBACK -> 200   deactivated in SpatiumDDI, re-activated on dc1
                windows_active=True   spatium_active=False
```

The estate finished exactly where it started. Ordering held in both directions — there is no moment where both servers answer for the subnet.

## Shape

- Feature module `migration.cutover`, **default-on**, group Tools. Cross-cutting (one plan holds both zones and scopes), so neither protocol group would be honest.
- Router at `/api/v1/migration/cutover`, **superadmin on every endpoint** — matching the three importers this extends, on the grounds that a cutover is strictly more dangerous than an import. Delegation via a grantable permission is a deliberate follow-up, not a side effect of shipping.
- Four MCP tools; three DB-only and default-on, `find_cutover_parity_check` default-**off** because it makes a live WinRM pull.
- Four new tables, registered in **both** the backup and factory-reset catalogs.
- Every mutation writes an `audit_log` row and a per-plan timeline event.

## Bugs found along the way

Two filed rather than fixed here, both pre-existing and outside this issue's scope:

- **#773** — the BIND9 agent renders every record op as an RFC 2136 `replace`, so any multi-value RRset (round-robin A, multiple MX/TXT) collapses to its last value. Affects the importers and normal record CRUD. This is what made the shadow comparison disagree with a parity report that said "in sync" — exactly the case Phase 2 exists to catch.
- **#774** — `PUT /dhcp/scopes/{id}` lets `enabled` shadow `is_active`, so a read-modify-write deactivation returns 200 and does nothing.

`d5e6efb7` in this branch works around #773 locally so that lowering a TTL cannot destroy addresses; that workaround should be deleted once #773 is fixed centrally.

## Verification

- 46 tests in `backend/tests/test_cutover.py`, including the GSS-TSIG refusal from three angles and the switch ordering.
- `make ci` green; full `mypy` clean over 807 files; ruff / black / prettier clean.
- Migration `a4f1c93d7e28` applied and rolled back against a scratch database, diffed column-for-column against the models.
- Docs: `docs/features/MIGRATION.md` gains the full section; DNS.md and DHCP.md cross-reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)