### PR TITLE
fix(appliance): resolve in-cluster Service names absolutely (#777)

### DIFF
--- a/agent/supervisor/spatium_supervisor/__main__.py
+++ b/agent/supervisor/spatium_supervisor/__main__.py
@@ -114,7 +114,15 @@ def _self_bootstrap_or_skip(
     # Hardcoded here so the supervisor doesn't need an extra env var
     # for the discovery URL — multi-node HA (#272 later phases) can
     # generalise this when we add real promotion-flow plumbing.
-    api_url = "http://spatium-control-spatiumddi-api.spatium.svc.cluster.local:8000"
+    # Trailing dot is load-bearing (#777). Without it the name has 4 dots, which
+    # is under the pod's ``ndots:5``, so the resolver walks its search list first —
+    # and kubelet appends the NODE's own DHCP search domain to every pod's list. If
+    # that domain's zone answers NOERROR/NODATA (rather than NXDOMAIN) for a
+    # nonexistent name — Cloudflare-hosted zones do, among others — musl stops the
+    # walk there and returns EAI_NODATA without ever trying the bare name. The
+    # supervisor then never registers, on a network it has no control over. The dot
+    # makes the name absolute and skips the search list entirely.
+    api_url = "http://spatium-control-spatiumddi-api.spatium.svc.cluster.local.:8000"
     log.info("supervisor.self_bootstrap.attempting", variant=variant, api_url=api_url)
     try:
         with httpx.Client(timeout=10.0) as client:

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -98,8 +98,16 @@ _NFT_APPLIED_HASH_PATH = Path(
 # CONTROL_PLANE_URL — ideally the MetalLB VIP — since they have no
 # in-cluster DNS to resolve the .svc name. See
 # ``_effective_control_plane_url`` for the member-vs-remote split.
+# Trailing dot is load-bearing (#777). Without it the name has 4 dots, which
+# is under the pod's ``ndots:5``, so the resolver walks its search list first —
+# and kubelet appends the NODE's own DHCP search domain to every pod's list. If
+# that domain's zone answers NOERROR/NODATA (rather than NXDOMAIN) for a
+# nonexistent name — Cloudflare-hosted zones do, among others — musl stops the
+# walk there and returns EAI_NODATA without ever trying the bare name. The
+# supervisor then never registers, on a network it has no control over. The dot
+# makes the name absolute and skips the search list entirely.
 _IN_CLUSTER_CONTROL_PLANE_URL = (
-    "http://spatium-control-spatiumddi-api.spatium.svc.cluster.local:8000"
+    "http://spatium-control-spatiumddi-api.spatium.svc.cluster.local.:8000"
 )
 
 

--- a/charts/spatiumddi-appliance/templates/supervisor.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor.yaml
@@ -26,6 +26,26 @@ spec:
     spec:
       nodeSelector:
         {{- toYaml .Values.global.nodeSelector | nindent 8 }}
+      # Pin the resolver so the supervisor's own bootstrap can't be broken by
+      # the network the appliance happens to be plugged into (#777).
+      #
+      # kubelet appends the NODE's DHCP-supplied search domains to every pod's
+      # resolv.conf. With the default ndots:5, any in-cluster name shorter than
+      # five dots is resolved by walking that list first — and if the inherited
+      # domain's zone answers NOERROR/NODATA instead of NXDOMAIN for a name that
+      # does not exist (Cloudflare-hosted zones do), musl stops the walk there
+      # and reports EAI_NODATA without ever trying the bare name. The supervisor
+      # then retries forever and the appliance never registers itself.
+      #
+      # ndots:1 means the four-dot Service names resolve as absolute on the
+      # first try, so the inherited domain is never consulted. The URLs are also
+      # written with a trailing dot, which fixes the same thing at the caller;
+      # this is the belt to that pair of braces, and covers every other name the
+      # supervisor may come to resolve.
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       # Issue #183 Phase 3 — in-cluster auth via the SA the matching
       # supervisor-rbac template provisions. The auto-mounted SA
       # token + ca.crt give the supervisor's k8s_api module enough

--- a/charts/spatiumddi/templates/dhcp-agent.yaml
+++ b/charts/spatiumddi/templates/dhcp-agent.yaml
@@ -66,7 +66,11 @@ spec:
           imagePullPolicy: {{ $root.Values.dhcpAgents.image.pullPolicy }}
           env:
             - name: SPATIUM_API_URL
-              value: "http://{{ include "spatiumddi.fullname" $root }}-api.{{ $root.Release.Namespace }}.svc.cluster.local:{{ $root.Values.api.service.port }}"
+              # Trailing dot on the Service name: the pod inherits the node's
+              # DHCP search domains, and under ndots:5 a NODATA-answering
+              # inherited zone aborts the resolver's search walk before the
+              # bare name is ever tried (#777). Absolute skips the list.
+              value: "http://{{ include "spatiumddi.fullname" $root }}-api.{{ $root.Release.Namespace }}.svc.cluster.local.:{{ $root.Values.api.service.port }}"
             - name: SPATIUM_SERVER_NAME
               valueFrom:
                 fieldRef:

--- a/charts/spatiumddi/templates/dns-agent.yaml
+++ b/charts/spatiumddi/templates/dns-agent.yaml
@@ -85,7 +85,11 @@ spec:
           imagePullPolicy: {{ $root.Values.dnsAgents.image.pullPolicy }}
           env:
             - name: CONTROL_PLANE_URL
-              value: "http://{{ include "spatiumddi.fullname" $root }}-api.{{ $root.Release.Namespace }}.svc.cluster.local:{{ $root.Values.api.service.port }}"
+              # Trailing dot on the Service name: the pod inherits the node's
+              # DHCP search domains, and under ndots:5 a NODATA-answering
+              # inherited zone aborts the resolver's search walk before the
+              # bare name is ever tried (#777). Absolute skips the list.
+              value: "http://{{ include "spatiumddi.fullname" $root }}-api.{{ $root.Release.Namespace }}.svc.cluster.local.:{{ $root.Values.api.service.port }}"
             - name: SERVER_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
The supervisor never registers on a network whose DHCP hands out a domain whose zone answers NODATA, so the founding node never appears in the Fleet UI and no `appliance_id` is ever issued.

Reproduced on a live appliance, on the supervisor's own image.

Closes #777

## The root cause is narrower than the report

The issue describes `ndots:5` plus a host-inherited search domain. That is necessary and **not sufficient** — the test appliance has exactly that (`search home.northco.net`, `ndots:5`, byte-for-byte the same resolv.conf shape) and its supervisor registers fine.

The missing third condition: **the inherited zone must answer `NOERROR`/NODATA rather than `NXDOMAIN`.**

* kubelet appends the node's DHCP search domains to every pod's `resolv.conf`.
* Under `ndots:5`, a four-dot Service name is resolved by walking that list *before* the bare name is tried.
* musl stops the walk on a NODATA answer and returns `EAI_NODATA` — never reaching the bare name.

Confirmed on both sides:

```
zzrandom98765.monnich.info                          -> NOERROR/NODATA   (Cloudflare, 172.64.80.1)
kubernetes.default.svc.cluster.local.home.northco.net -> NXDOMAIN        (walk continues; resolves)
```

That is why this reproduces for the reporter and not in our lab. It is not lab-specific, but it is not universal either: it hits anyone whose DHCP domain is Cloudflare-hosted (or served by anything else that NODATAs) and silently spares everyone else. Fixing this against the issue text alone and testing on our own network would have shown a pass **before and after**.

It also answers the reporter's open question: the supervisor image is **Alpine/musl, not glibc**. That matters, because the two resolvers differ on precisely this behaviour.

## Verified on the real image

The reporter's domain was injected into a pod's search list on `ghcr.io/spatiumddi/spatium-supervisor`, reproducing the failing condition without touching the appliance's real DNS config:

| pod spec | unqualified lookup |
|---|---|
| `ndots:5` (ships today) | **FAILS, exit 2** |
| `ndots:5`, trailing dot | `10.43.102.63` |
| `ndots:1` | `10.43.102.63` |

The live DaemonSet was then patched with `ndots:1`; the supervisor came back resolving both forms and heartbeating (`supervisor.heartbeat.role_env_rendered`, `supervisor.identity.loaded`).

## The fix

Both layers, because they cover different things:

* **Trailing dot** on the two hardcoded URLs (`heartbeat.py`, `__main__.py`) — fixes the names that actually broke, and is immune to whatever the node's DNS config happens to be.
* **`dnsConfig` `ndots:1`** on the supervisor DaemonSet — covers every *other* name the supervisor may come to resolve, and cannot be forgotten by a future caller.

The **DNS and DHCP agent charts** carried the identical unqualified name and are fixed the same way. They run with `ClusterFirstWithHostNet` and inherit the same search list, so they would fail on exactly the networks the supervisor does.

Safety check on the trailing dot: `TrustedHostMiddleware` is active on the API, but `trusted_hosts` defaults to `"*"`, which Starlette short-circuits — so a `Host: …cluster.local.:8000` header is accepted. Worth knowing, since this would break on a deploy that had locked that allow-list down.

## Scope of verification

The *mechanism* is verified end to end on real hardware, and both fixes are verified to resolve on the shipped image. What has **not** been done is rebuilding the supervisor image with the trailing-dot change and booting an appliance from it — the trailing dot is validated as DNS behaviour, not as a shipped code path. The `ndots:1` half *was* exercised against a live DaemonSet.

## Not in this PR — #776

Investigated together; it needs no code change. The missing `tcp dport 443` rule was already fixed by `e2fd65cf` (#768), which postdates the `2026.07.30-1` tag the reporter is running:

```
git cat-file -e 2026.07.30-1:appliance/mkosi.extra/etc/nftables.d/00-spatium-webui.nft  ->  ABSENT
```

Confirmed live on a current build: 443 reachable from another host, with both the `web-ui-bootstrap` sentinel and the supervisor's `web-ui` rule present. It needs a release, not a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)