### PR TITLE
fix(docs): collapse the site nav into a hamburger on small screens

### DIFF
--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -4,15 +4,17 @@
       <img src="{{ include.root }}assets/logo-icon.svg" alt="">
       <span>Spatium<span class="ddi">DDI</span></span>
     </a>
-    <div class="nav-links">
-      <a class="hide-sm" href="{{ include.root }}index.html#features">Features</a>
+    <div class="nav-links" id="nav-links">
+      <a href="{{ include.root }}index.html#features">Features</a>
       <a href="{{ include.root }}docs.html">Docs</a>
-      <a class="hide-sm" href="{{ include.root }}index.html#install">Install</a>
-      <a class="hide-sm" href="{{ site.links.discord }}">Community</a>
+      <a href="{{ include.root }}index.html#install">Install</a>
+      <a href="{{ site.links.discord }}">Community</a>
       <a class="nav-cta" href="{{ site.links.github }}">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.4 7.4 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
         GitHub
       </a>
+    </div>
+    <div class="nav-actions">
       <button class="theme-toggle" type="button" id="theme-toggle"
               aria-label="Toggle dark mode" title="Toggle dark mode">
         <svg class="icon-light" width="17" height="17" viewBox="0 0 24 24" fill="none"
@@ -24,6 +26,22 @@
              stroke="currentColor" stroke-width="2" stroke-linecap="round"
              stroke-linejoin="round" aria-hidden="true">
           <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z"/>
+        </svg>
+      </button>
+      <!-- Shown only under the nav breakpoint (see site.css). Rendered
+           unconditionally rather than injected by script so the control exists
+           for a reader with JavaScript disabled; the script below is what makes
+           it do anything, and the links stay reachable either way because the
+           panel is only hidden once the script marks the nav as enhanced. -->
+      <button class="nav-toggle" type="button" id="nav-toggle"
+              aria-label="Menu" aria-expanded="false" aria-controls="nav-links">
+        <svg class="icon-open" width="20" height="20" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+          <path d="M3 6h18M3 12h18M3 18h18"/>
+        </svg>
+        <svg class="icon-close" width="20" height="20" viewBox="0 0 24 24" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+          <path d="M6 6l12 12M18 6L6 18"/>
         </svg>
       </button>
     </div>
@@ -52,5 +70,59 @@
         // this page view, it just will not survive navigation.
       }
     });
+  })();
+
+  // Mobile nav. Before this runs the links are a plain wrapping row, which is
+  // usable without JavaScript; `data-nav-enhanced` is what switches the CSS to
+  // the collapsed panel, so the menu can only be hidden once something exists
+  // to open it again.
+  (function () {
+    var nav = document.querySelector(".nav");
+    var toggle = document.getElementById("nav-toggle");
+    var links = document.getElementById("nav-links");
+    if (!nav || !toggle || !links) return;
+
+    nav.setAttribute("data-nav-enhanced", "true");
+
+    function setOpen(open) {
+      nav.setAttribute("data-nav-open", open ? "true" : "false");
+      toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    }
+    setOpen(false);
+
+    toggle.addEventListener("click", function (e) {
+      e.stopPropagation();
+      setOpen(nav.getAttribute("data-nav-open") !== "true");
+    });
+
+    // Following a link closes the panel. Same-page anchors (#features,
+    // #install) do not reload, so without this the panel would stay open over
+    // the section the reader just jumped to.
+    links.addEventListener("click", function (e) {
+      if (e.target.closest("a")) setOpen(false);
+    });
+
+    document.addEventListener("click", function (e) {
+      if (!e.target.closest(".nav")) setOpen(false);
+    });
+
+    document.addEventListener("keydown", function (e) {
+      if (e.key !== "Escape") return;
+      if (nav.getAttribute("data-nav-open") !== "true") return;
+      setOpen(false);
+      toggle.focus();
+    });
+
+    // Leaving the breakpoint while open would otherwise strand the panel state:
+    // the desktop rules ignore data-nav-open, so the menu would silently
+    // reappear expanded on the next rotation back to a narrow viewport.
+    if (window.matchMedia) {
+      var wide = window.matchMedia("(min-width: 821px)");
+      var onChange = function (ev) {
+        if (ev.matches) setOpen(false);
+      };
+      if (wide.addEventListener) wide.addEventListener("change", onChange);
+      else if (wide.addListener) wide.addListener(onChange);
+    }
   })();
 </script>

--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -237,9 +237,116 @@ kbd {
   display: block;
 }
 
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+}
+
+/* Hamburger. Hidden above the breakpoint; the rule that shows it lives in the
+   media query below so the desktop bar is unchanged. */
+.nav-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-soft);
+  color: var(--fg-muted);
+  cursor: pointer;
+  flex: none;
+}
+.nav-toggle:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.nav-toggle svg {
+  display: block;
+}
+/* One button, two glyphs: which one shows is driven by the same
+   ``data-nav-open`` attribute the panel reads, so they cannot disagree. */
+.nav-toggle .icon-close,
+.nav[data-nav-open="true"] .nav-toggle .icon-open {
+  display: none;
+}
+.nav[data-nav-open="true"] .nav-toggle .icon-close {
+  display: block;
+}
+
 @media (max-width: 820px) {
-  .nav-links .hide-sm {
+  .nav-inner {
+    gap: 12px;
+  }
+
+  /* Push the controls to the right edge. On desktop that happens for free —
+     .nav-links carries margin-left:auto and sits before .nav-actions in the
+     flow. Here .nav-links is taken out of flow (it becomes the dropdown panel
+     below), so nothing is left to push, and the buttons would otherwise sit
+     tucked against the brand with the whole right half of the bar empty. */
+  .nav-actions {
+    margin-left: auto;
+  }
+
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  /* Collapsed panel. Gated on ``data-nav-enhanced``, which the nav script sets
+     on load: without JavaScript the links stay a plain wrapping row under the
+     brand rather than being hidden behind a button that cannot open. */
+  .nav[data-nav-enhanced="true"] .nav-links {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin-left: 0;
     display: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    padding: 8px 16px 14px;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    /* The bar itself is translucent; the panel is not. Text scrolling under a
+       see-through dropdown is unreadable, and this one covers real content. */
+    box-shadow: 0 10px 24px rgb(0 0 0 / 12%);
+    /* Long menus stay reachable on a short landscape viewport. */
+    max-height: calc(100dvh - 62px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .nav[data-nav-enhanced="true"][data-nav-open="true"] .nav-links {
+    display: flex;
+  }
+
+  /* Comfortable tap targets — 44px is the usual floor, and these are the only
+     way to reach Features / Install / Community on a phone. */
+  .nav[data-nav-enhanced="true"] .nav-links a {
+    padding: 12px 4px;
+    border-bottom: 1px solid var(--border);
+    font-size: 1rem;
+  }
+  .nav[data-nav-enhanced="true"] .nav-links a:last-child {
+    border-bottom: 0;
+  }
+
+  .nav[data-nav-enhanced="true"] .nav-links .nav-cta {
+    justify-content: center;
+    margin-top: 12px;
+    padding: 11px 14px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+  }
+
+  /* The bar needs a positioning context for the panel, and must sit above it
+     so the shadow falls behind the bar rather than across it. */
+  .nav-inner {
+    position: relative;
   }
 }
 


### PR DESCRIPTION
Reported: the top menu bar on spatiumddi.com does not work on mobile.

## What was actually wrong

The nav had **no collapsed mode at all**. Below 820px, `hide-sm` set `display: none` on Features, Install and Community:

```css
@media (max-width: 820px) {
  .nav-links .hide-sm { display: none; }
}
```

That left Docs, the GitHub button and the theme toggle. Three of the five destinations were simply unreachable on a phone, with nothing to indicate they existed.

## The change

A real collapsed menu — hamburger in the bar, full-width panel holding every link. Desktop is unchanged: the toggle is `display: none` above the breakpoint and the links stay the inline row they were.

Details worth keeping, since each is a bug avoided rather than a preference:

* **The panel is gated on `data-nav-enhanced`**, set by the script on load. Without JavaScript the links stay a plain wrapping row rather than being hidden behind a button that cannot open them — which would be the same defect as before, not a fix.
* **The panel is opaque, with a shadow.** The bar itself is translucent (`backdrop-filter`), and a see-through dropdown over real content is unreadable.
* **Closes on link click, outside click, and Escape** (returning focus to the toggle). The `#features` / `#install` anchors do not reload, so without the first the panel would sit over the section just jumped to.
* **Crossing back above the breakpoint while open resets the state**, or the menu would silently reappear expanded on the next rotation to portrait.
* **One button, two glyphs**, both driven by the same `data-nav-open` attribute the panel reads, so the icon cannot disagree with the state.
* **`max-height` + `overflow-y`** on the panel so a long menu stays usable in landscape.
* **`.nav-actions` gets `margin-left: auto` inside the media query.** On desktop that happens for free — `.nav-links` carries the auto margin and sits before `.nav-actions` in the flow. On mobile `.nav-links` becomes absolutely positioned, leaving nothing to push, so without this the controls sat tucked against the brand with the right half of the bar empty.

## Verification

Headless Chromium against the Jekyll preview, measuring computed styles rather than eyeballing a screenshot — a hamburger that renders but does not open is the failure worth catching:

| | < 820px | at 820px | 1280px |
|---|---|---|---|
| hamburger visible | yes | yes | hidden |
| panel hidden when closed | yes | yes | links inline |
| opens on click, `aria-expanded` tracks | yes | yes | n/a |
| Escape closes | yes | yes | n/a |
| all 5 links present | yes | yes | yes |

Tap targets measure 51px (the usual floor is 44). The toggle sits 24px from the bar's right edge at 390/600/820px, matching `.nav-inner`'s padding so it lines up with the content column. Screenshots confirm appearance closed and open, in dark and light. Both layouts (`home`, `default`) render the toggle, and nested pages still resolve `include.root` correctly (`../index.html`) — the relative-prefix mechanism CLAUDE.md flags as easy to break.

## Note on merging

`docs/` publishes on every `main` push (`docs-publish.yml`), so this goes live on spatiumddi.com as soon as it lands — not at the next release. Worth a look on a real device first; the measurements are sound but tap-target feel is a judgement call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)