### PR TITLE
fix: multi-value RRset collapse (#773), coredns single-node deadlock (#750), scope alias shadowing (#774)

### DIFF
--- a/agent/dns/spatium_dns_agent/drivers/base.py
+++ b/agent/dns/spatium_dns_agent/drivers/base.py
@@ -11,6 +11,12 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+# Record-op kinds that describe an RRset, and so can carry the complete
+# desired ``record["rrset"]`` the control plane stamps on them (#773).
+# Everything else on the queue is zone-level (the ``dnssec_*`` ops) and
+# branches off before any of the record machinery runs.
+RRSET_OP_KINDS = frozenset({"create", "update", "delete"})
+
 
 class DriverBase(ABC):
     def __init__(self, state_dir: Path):

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -22,13 +22,16 @@ import structlog
 
 try:
     import dns.query
+    import dns.rdata
+    import dns.rdataclass
+    import dns.rdatatype
     import dns.tsigkeyring
     import dns.update
 except ImportError:  # pragma: no cover - runtime-optional
     dns = None  # type: ignore[assignment]
 
 from ._process import find_running_daemon, is_zombie
-from .base import DriverBase
+from .base import RRSET_OP_KINDS, DriverBase
 
 log = structlog.get_logger(__name__)
 
@@ -359,6 +362,47 @@ def _format_master(entry: str) -> str:
             return f"{ip} port {port}"
         return ip
     return entry
+
+
+def _parses_as_rdata(rtype: str, wire: str) -> bool:
+    """Whether dnspython can read ``wire`` as rdata of ``rtype``.
+
+    Used to keep one unreadable sibling from failing a whole-RRset write. Any
+    exception counts as "no" — ``from_text`` raises a different type per rdata
+    class (SyntaxError, ValueError, dns.exception.*), and the only thing worth
+    knowing here is whether the value is usable.
+    """
+    try:
+        dns.rdata.from_text(dns.rdataclass.IN, dns.rdatatype.from_text(rtype), wire)
+    except Exception:  # noqa: BLE001 — see docstring: any failure means unusable
+        return False
+    return True
+
+
+def _wire_value(rtype: str, value: str, fields: dict[str, Any]) -> str:
+    """Compose one RR's presentation form from a record-op payload.
+
+    MX / SRV wire-format requires the priority (and weight+port) to appear
+    inline before the target. The control plane stores those as separate
+    columns and, historically, only forwarded ``value``. Prefer the explicit
+    fields; fall back to the raw value if an already-composed wire string came
+    through (legacy path + future-proofing).
+
+    Shared by the op's own record and by every member of the RRset that op
+    carries (#773), so a multi-value MX or SRV composes identically either way.
+    """
+    rtype_u = rtype.upper()
+    if rtype_u == "MX":
+        pri = fields.get("priority")
+        if pri is not None and not value.lstrip().split(" ", 1)[0].isdigit():
+            return f"{pri} {value}"
+    elif rtype_u == "SRV":
+        pri = fields.get("priority")
+        wt = fields.get("weight")
+        prt = fields.get("port")
+        if pri is not None and wt is not None and prt is not None and len(value.split()) < 4:
+            return f"{pri} {wt} {prt} {value}"
+    return value
 
 
 # DNSSEC algorithm name → IANA number (issue #49). Used when parsing
@@ -1073,59 +1117,87 @@ class Bind9Driver(DriverBase):
             if m:
                 keyring = dns.tsigkeyring.from_text({m.group(1): m.group(2)})
 
-        # MX / SRV wire-format requires the priority (and weight+port) to
-        # appear inline before the target. The control plane stores those
-        # as separate columns and, historically, only forwarded `value`.
-        # Prefer explicit fields; fall back to the raw value if an already-
-        # composed wire string came through (legacy path + future-proofing).
-        wire_value = value
-        rtype_u = rtype.upper()
-        if rtype_u == "MX":
-            pri = rec.get("priority")
-            if pri is not None and not value.lstrip().split(" ", 1)[0].isdigit():
-                wire_value = f"{pri} {value}"
-        elif rtype_u == "SRV":
-            pri = rec.get("priority")
-            wt = rec.get("weight")
-            prt = rec.get("port")
-            if (
-                pri is not None
-                and wt is not None
-                and prt is not None
-                and len(value.split()) < 4
-            ):
-                wire_value = f"{pri} {wt} {prt} {value}"
+        wire_value = _wire_value(rtype, value, rec)
 
-        # ``rrset_action`` is set by callers that need precise multi-RR
-        # semantics (most notably DNS pools, where N A records share a
-        # single name and ``replace`` would clobber siblings every time
-        # a member is added). When unset (the legacy default) the
-        # existing replace/wildcard-delete behaviour applies, matching
-        # the single-RR-per-name case the operator-facing record CRUD
-        # path was originally written for.
-        rrset_action = (rec.get("rrset_action") or "").lower()
+        # #773 — the control plane ships the complete desired RRset for the
+        # (name, type) this op touches, so the update is expressed as one
+        # atomic whole-RRset write: dnspython's ``replace`` with N rdatas emits
+        # a single delete-RRset followed by N adds in ONE message. That is what
+        # makes a name with several values — round-robin A, a backup MX, SPF
+        # beside a verification TXT — survive. Applying the same RRset twice is
+        # a no-op, so ops are idempotent and replay-safe rather than
+        # order-dependent.
+        #
+        # An empty member list means the RRset should not exist at all (the op
+        # deleted its last value).
+        rrset = rec.get("rrset") if isinstance(rec.get("rrset"), dict) else None
+        members = rrset.get("members") if rrset is not None else None
 
         upd = dns.update.Update(zone, keyring=keyring)
-        if op["op"] in ("create", "update"):
-            if rrset_action == "add":
-                upd.add(name, ttl, rtype, wire_value)
+        if rrset is not None and members is not None and op["op"] in RRSET_OP_KINDS:
+            # ``or ttl`` would swallow a legitimate TTL of 0 (RFC 2181 allows
+            # it and it is how "never cache this" is expressed), so test for
+            # absence rather than falsiness.
+            rrset_ttl = rrset.get("ttl")
+            # Parse each member on its own before handing the list to
+            # ``replace``, which parses internally and would fail the WHOLE op
+            # on one bad value. That matters because the members are siblings
+            # the op did not ask about: one legacy or imported row dnspython
+            # cannot read would otherwise block every future write to the name,
+            # not just its own. Skip it with a warning instead — an rdata that
+            # will not parse cannot be served either way, and the value the
+            # operator is actually changing still lands. The op's OWN value is
+            # not skipped: a failure there is the operator's edit failing, and
+            # must surface as one.
+            own_wire = wire_value
+            wire_members: list[str] = []
+            for m in members:
+                candidate = _wire_value(rtype, m.get("value") or "", m)
+                if candidate == own_wire or _parses_as_rdata(rtype, candidate):
+                    wire_members.append(candidate)
+                else:
+                    log.warning(
+                        "rrset_member_unparseable_skipped",
+                        zone=zone,
+                        name=name,
+                        type=rtype,
+                        value=candidate,
+                    )
+            if wire_members:
+                upd.replace(
+                    name,
+                    int(ttl if rrset_ttl is None else rrset_ttl),
+                    rtype,
+                    *wire_members,
+                )
             else:
-                upd.replace(name, ttl, rtype, wire_value)
-        elif op["op"] == "delete":
-            if rrset_action == "delete_value":
-                # Remove the specific RR only; sibling RRs at the same
-                # (name, rtype) survive. Used by pool member removal so
-                # taking one member out doesn't drop the rest.
-                upd.delete(name, rtype, wire_value)
-            else:
-                # Some BIND configurations reject the RR-specific delete
-                # form (value must exactly match a live RR) when the
-                # running daemon has drifted from the zone file. Delete
-                # by (name, rtype) so any matching RR gets cleared.
-                # Idempotent.
                 upd.delete(name, rtype)
         else:
-            raise ValueError(f"unknown op: {op['op']}")
+            # Fallback for an op enqueued by a control plane that predates the
+            # ``rrset`` payload. ``rrset_action`` is the older, per-op override
+            # for these semantics — DNS pools set it because N A records share
+            # one name there and a bare ``replace`` clobbers siblings.
+            rrset_action = (rec.get("rrset_action") or "").lower()
+            if op["op"] in ("create", "update"):
+                if rrset_action == "add":
+                    upd.add(name, ttl, rtype, wire_value)
+                else:
+                    upd.replace(name, ttl, rtype, wire_value)
+            elif op["op"] == "delete":
+                if rrset_action == "delete_value":
+                    # Remove the specific RR only; sibling RRs at the same
+                    # (name, rtype) survive. Used by pool member removal so
+                    # taking one member out doesn't drop the rest.
+                    upd.delete(name, rtype, wire_value)
+                else:
+                    # Some BIND configurations reject the RR-specific delete
+                    # form (value must exactly match a live RR) when the
+                    # running daemon has drifted from the zone file. Delete
+                    # by (name, rtype) so any matching RR gets cleared.
+                    # Idempotent.
+                    upd.delete(name, rtype)
+            else:
+                raise ValueError(f"unknown op: {op['op']}")
         resp = dns.query.tcp(upd, "127.0.0.1", timeout=10)
         rcode = resp.rcode()
         if rcode != 0:  # NOERROR

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -41,7 +41,7 @@ import httpx
 import structlog
 
 from ._process import find_running_daemon, is_zombie
-from .base import DriverBase
+from .base import RRSET_OP_KINDS, DriverBase
 
 log = structlog.get_logger(__name__)
 
@@ -661,7 +661,11 @@ class PowerDNSDriver(DriverBase):
         rec = op["record"]
         name = _qualified_name(zone, rec.get("name") or "@")
         rtype = rec["type"].upper()
-        ttl = rec.get("ttl") or 3600
+        # Absence, not falsiness — a TTL of 0 is legal ("never cache this") and
+        # ``or`` silently turned it into an hour. Matches bind9's driver, which
+        # has always tested for None here.
+        _op_ttl = rec.get("ttl")
+        ttl = 3600 if _op_ttl is None else _op_ttl
 
         url = f"{_PDNS_API_BASE}/zones/{zone}"
         headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
@@ -671,12 +675,71 @@ class PowerDNSDriver(DriverBase):
         # rrset contents and ``DELETE`` drops it. There is no
         # ``INSERT`` / ``REMOVE-MEMBER`` granularity. Multiple records
         # at the same (name, type) — round-robin A pools, multi-MX
-        # priorities, multi-NS apex — therefore require a
-        # GET-merge-PATCH dance: read the current rrset, splice the
-        # new content in (or out), and PATCH the merged set back.
-        # Without this, two consecutive ``create www A`` calls
-        # collide (the second overwrites the first), which broke
-        # GSLB pool fan-out among other things.
+        # priorities, multi-NS apex — therefore need the whole set in
+        # hand before the PATCH.
+        #
+        # #773 — the control plane now ships that set on the op, because it
+        # is the only place the complete desired state is known. When it is
+        # present the write is one PATCH, no read: no zone GET, no merge, and
+        # an ``update`` that CHANGES a value no longer strands the old one
+        # (the fallback below could not remove it, and says so).
+        #
+        # Every member goes out as ``disabled: False``. The control plane has
+        # no notion of a disabled record, so its desired set means "these
+        # values, served" — a record an operator disabled in PowerDNS's own UI
+        # is re-enabled by the next write to that name. The merge below used to
+        # preserve the flag on members it did not touch; a full-zone reconcile
+        # would have clobbered it regardless, so this makes the behaviour
+        # consistent rather than introducing a new way to lose it.
+        rrset_payload = rec.get("rrset") if isinstance(rec.get("rrset"), dict) else None
+        rrset_members = (
+            rrset_payload.get("members") if rrset_payload is not None else None
+        )
+        if (
+            rrset_payload is not None
+            and rrset_members is not None
+            and op_kind in RRSET_OP_KINDS
+        ):
+            if rrset_members:
+                # Absence, not falsiness — a TTL of 0 is legal and meaningful.
+                _rrset_ttl = rrset_payload.get("ttl")
+                desired: dict[str, Any] = {
+                    "name": name,
+                    "type": rtype,
+                    "ttl": int(ttl if _rrset_ttl is None else _rrset_ttl),
+                    "changetype": "REPLACE",
+                    "records": [
+                        {
+                            "content": _record_content({**m, "type": rtype}),
+                            "disabled": False,
+                        }
+                        for m in rrset_members
+                    ],
+                }
+            else:
+                desired = {"name": name, "type": rtype, "changetype": "DELETE"}
+            with httpx.Client(timeout=_PDNS_API_TIMEOUT) as client:
+                resp = client.patch(url, headers=headers, json={"rrsets": [desired]})
+            if resp.status_code >= 400:
+                raise RuntimeError(
+                    f"PowerDNS PATCH {zone}/{name}/{rtype} returned "
+                    f"{resp.status_code}: {resp.text[:200]}"
+                )
+            log.info(
+                "powerdns_rrset_applied",
+                zone=zone,
+                name=name,
+                type=rtype,
+                op=op_kind,
+                members=len(rrset_members),
+            )
+            return None
+
+        # Fallback for an op enqueued by a control plane that predates the
+        # ``rrset`` payload: read the current rrset, splice the new content in
+        # (or out), and PATCH the merged set back. Without this, two
+        # consecutive ``create www A`` calls collide (the second overwrites
+        # the first), which broke GSLB pool fan-out among other things.
         with httpx.Client(timeout=_PDNS_API_TIMEOUT) as client:
             zone_resp = client.get(url, headers=headers)
             existing_records: list[dict[str, Any]] = []
@@ -696,15 +759,13 @@ class PowerDNSDriver(DriverBase):
                                     }
                                 )
                         break
-            # update = delete-the-old-content + add-the-new-content;
-            # we don't know the previous value here so update is
-            # treated as "ensure the new value is present + remove
-            # any duplicate of the same content". A separate explicit
-            # remove for the OLD value would need the upstream op
-            # payload to carry it; today the control plane sends
-            # update as a fresh-value-only payload, so if the operator
-            # *changes* the value we leave the old IP in the rrset
-            # until a delete op fires for the prior content.
+            # update = delete-the-old-content + add-the-new-content; we don't
+            # know the previous value here so update is treated as "ensure the
+            # new value is present + remove any duplicate of the same
+            # content". A separate explicit remove for the OLD value would
+            # need the op payload to carry it, so without ``rrset`` a value
+            # *change* leaves the old IP in the rrset until a delete op fires
+            # for the prior content.
             merged: list[dict[str, Any]] = []
             if op_kind == "delete":
                 merged = [r for r in existing_records if r["content"] != new_content]

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -69,7 +69,7 @@ import httpx
 import structlog
 
 from ._process import find_running_daemon, is_zombie
-from .base import DriverBase
+from .base import RRSET_OP_KINDS, DriverBase
 
 log = structlog.get_logger(__name__)
 
@@ -895,11 +895,20 @@ class TechnitiumDriver(DriverBase):
         updates the TTL of a value-identical record rather than erroring.
         Only the value-change case needs the REPLACE.)
 
-        ``rrset_action`` is the project-wide per-op override for that
-        default (see ``bind9.py``): DNS pools set ``"add"`` because N
-        A records share one name there and a REPLACE would clobber
-        siblings every time a member is added. Honour it here too, or
-        pool members would delete each other.
+        The op payload now carries the complete desired ``rrset`` (#773) —
+        the control plane knows the whole set, which is the only place that
+        knowledge exists — so the normal path replays it as N calls: member 0
+        with ``overwrite=true`` to clear, the rest with ``overwrite=false`` to
+        append. That is a whole-RRset replace expressed in the vocabulary this
+        API has, and it is what keeps a name with several values (round-robin
+        A, a backup MX, SPF beside a verification TXT) from collapsing to
+        whichever op landed last.
+
+        ``rrset_action`` is the older project-wide per-op override (see
+        ``bind9.py``) and remains the fallback for an op enqueued by a control
+        plane that predates ``rrset``: DNS pools set ``"add"`` because N A
+        records share one name there and a REPLACE would clobber siblings
+        every time a member is added.
         """
         token = self._get_api_token()
         if token is None:
@@ -919,7 +928,11 @@ class TechnitiumDriver(DriverBase):
         rec = op["record"]
         rtype = (rec.get("type") or "").upper()
         name = _qualified_name(zone, rec.get("name") or "@")
-        ttl = rec.get("ttl") or 3600
+        # Absence, not falsiness — a TTL of 0 is legal ("never cache this") and
+        # ``or`` silently turned it into an hour. Matches bind9's driver, which
+        # has always tested for None here.
+        _op_ttl = rec.get("ttl")
+        ttl = 3600 if _op_ttl is None else _op_ttl
         params = {
             "domain": name,
             "zone": zone,
@@ -927,6 +940,67 @@ class TechnitiumDriver(DriverBase):
             **_record_params(rtype, rec.get("value") or "", rec),
         }
 
+        # #773 — the control plane ships the complete desired RRset. Technitium's
+        # REST API is one record per call, so there is no way to install N
+        # values atomically; the shape below picks the least destructive
+        # sequence available for each op kind.
+        #
+        # A ``delete`` is expressed as a value-scoped delete of the op's OWN
+        # value — the survivors in ``members`` are already on the server, so
+        # touching them would be a wipe-and-rebuild with a window where the
+        # name serves less than it should. One call, nothing at risk. (Rebuilding
+        # from the set would be more self-healing, and is not worth trading a
+        # guaranteed-safe delete for.)
+        #
+        # A ``create`` / ``update`` has no such option: the op may be changing a
+        # value, and this API cannot say "replace THIS RR" — so it is member 0
+        # with ``overwrite=true`` (which clears) followed by appends. Member 0
+        # always lands, so a mid-sequence failure leaves a subset containing it
+        # rather than an empty name, and the op is replayed. A member the server
+        # permanently rejects strands the rest of the set once the retry budget
+        # runs out — still strictly more than the single value the pre-#773 path
+        # left behind.
+        rrset = rec.get("rrset") if isinstance(rec.get("rrset"), dict) else None
+        members = rrset.get("members") if rrset is not None else None
+        if rrset is not None and members is not None and op_kind in RRSET_OP_KINDS:
+            # Absence, not falsiness — a TTL of 0 is legal and meaningful.
+            _rrset_ttl = rrset.get("ttl")
+            rrset_ttl = int(ttl if _rrset_ttl is None else _rrset_ttl)
+            if op_kind == "delete":
+                # Both the "siblings survive" and the "last value gone" cases:
+                # the op's own params identify exactly the RR to remove, and
+                # Technitium drops the rrset once its last record goes.
+                self._record_call(token, "delete", params, zone, name, rtype, op_kind)
+            else:
+                for index, member in enumerate(members):
+                    self._record_call(
+                        token,
+                        "add",
+                        {
+                            "domain": name,
+                            "zone": zone,
+                            "type": rtype,
+                            "ttl": rrset_ttl,
+                            "overwrite": "true" if index == 0 else "false",
+                            **_record_params(rtype, member.get("value") or "", member),
+                        },
+                        zone,
+                        name,
+                        rtype,
+                        op_kind,
+                    )
+            log.info(
+                "technitium_rrset_applied",
+                zone=zone,
+                name=name,
+                type=rtype,
+                op=op_kind,
+                members=len(members),
+            )
+            return None
+
+        # Fallback for an op enqueued by a control plane that predates the
+        # ``rrset`` payload. ``rrset_action`` is the older per-op override.
         rrset_action = (rec.get("rrset_action") or "").lower()
         endpoint = "delete" if op_kind == "delete" else "add"
         if op_kind != "delete":
@@ -936,30 +1010,57 @@ class TechnitiumDriver(DriverBase):
             # explicitly asks for sibling-preserving semantics.
             params["overwrite"] = "false" if rrset_action == "add" else "true"
 
-        resp = self._call(token, "POST", f"zones/records/{endpoint}", params)
-        body = resp.json()
-        if body.get("status") == "error":
-            msg = (body.get("errorMessage") or "").lower()
-            # Idempotent no-ops: retried create of an identical record, or
-            # a delete of a record that's already gone.
-            if "already exists" in msg or "no such record" in msg:
-                log.info(
-                    "technitium_record_op_idempotent_noop",
-                    zone=zone,
-                    name=name,
-                    type=rtype,
-                    op=op_kind,
-                    detail=body.get("errorMessage"),
-                )
-                return None
-            raise RuntimeError(
-                f"Technitium {endpoint} {zone}/{name}/{rtype} failed: "
-                f"{body.get('errorMessage')}"
+        if self._record_call(token, endpoint, params, zone, name, rtype, op_kind):
+            log.info(
+                "technitium_record_op_applied",
+                zone=zone,
+                name=name,
+                type=rtype,
+                op=op_kind,
             )
-        log.info(
-            "technitium_record_op_applied", zone=zone, name=name, type=rtype, op=op_kind
-        )
         return None
+
+    def _record_call(
+        self,
+        token: str,
+        endpoint: str,
+        params: dict[str, Any],
+        zone: str,
+        name: str,
+        rtype: str,
+        op_kind: str,
+    ) -> bool:
+        """POST one ``zones/records/{add,delete}`` call, raising on a real error.
+
+        Returns False for an idempotent no-op so a caller can skip its
+        "applied" log line, True when the server accepted the change.
+
+        Technitium answers HTTP 200 with ``{"status": "error"}`` for a rejected
+        record, so the body has to be inspected. Two of those are not failures:
+        a retried create of an identical record, and a delete of a record that
+        is already gone — both mean the server is already in the state the op
+        asks for, which is exactly what a replayed op should find. Crucially
+        they must NOT abort a multi-member RRset write half way — one member
+        the server already has does not make the remaining members optional.
+        """
+        body = self._call(token, "POST", f"zones/records/{endpoint}", params).json()
+        if body.get("status") != "error":
+            return True
+        msg = (body.get("errorMessage") or "").lower()
+        if "already exists" in msg or "no such record" in msg:
+            log.info(
+                "technitium_record_op_idempotent_noop",
+                zone=zone,
+                name=name,
+                type=rtype,
+                op=op_kind,
+                detail=body.get("errorMessage"),
+            )
+            return False
+        raise RuntimeError(
+            f"Technitium {endpoint} {zone}/{name}/{rtype} failed: "
+            f"{body.get('errorMessage')}"
+        )
 
     # ── Blocklists (issue #744) ─────────────────────────────────────────
 

--- a/agent/dns/tests/test_rrset_ops.py
+++ b/agent/dns/tests/test_rrset_ops.py
@@ -1,0 +1,1110 @@
+"""Whole-RRset record ops across all three agent drivers (issue #773).
+
+A record op carries ONE record, but each driver turned that into a
+whole-RRset write — so a name holding several values (round-robin A, a
+backup MX, SPF beside a verification TXT) collapsed to whichever op landed
+last. The fix has the control plane — the only place the complete desired
+state is known — stamp the full set onto the op::
+
+    "rrset": {"ttl": 3600, "members": [{"value": "10.20.7.22"},
+                                       {"value": "10.20.7.21"}]}
+
+``members`` is the desired set for that ``(name, type)`` AFTER the op, so a
+delete ships the survivors and an empty list means "this RRset should not
+exist". When ``rrset`` is absent entirely the drivers keep their previous
+``rrset_action`` behaviour, because an op enqueued before the control plane
+was upgraded is still sitting in the queue when the agent restarts.
+
+The three drivers express the same semantics in three different
+vocabularies, and each has a different way to get it wrong, so each is
+pinned against its own wire:
+
+* **BIND9** — RFC 2136. One ``dns.update.Update`` message carrying a
+  delete-RRset followed by N adds. Asserted against the message's UPDATE
+  section, not a rendered string.
+* **Technitium** — one record per REST call, so an RRset write is N calls:
+  member 0 with ``overwrite=true`` (which clears), the rest ``false``.
+* **PowerDNS** — one ``changetype: REPLACE`` PATCH, and critically no zone
+  GET: the merge the fallback needs is pointless once the desired set is
+  known.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import dns.query
+import dns.rdataclass
+import dns.rdatatype
+import pytest
+
+from spatium_dns_agent.drivers import powerdns as powerdns_mod
+from spatium_dns_agent.drivers.bind9 import Bind9Driver
+from spatium_dns_agent.drivers.powerdns import PowerDNSDriver
+from spatium_dns_agent.drivers.technitium import TechnitiumDriver
+
+# The Technitium fakes already exist and are the established idiom for this
+# driver (see the module they live in); re-declaring them here would let the
+# two copies drift.
+from tests.test_technitium_render import _install_fake_request, _seed_token
+
+# ── BIND9: RFC 2136 wire interception ───────────────────────────────────────
+
+
+class _FakeDnsResponse:
+    """Stand-in for the ``dns.message.Message`` ``dns.query.tcp`` returns —
+    the driver only ever calls ``.rcode()`` on it.
+
+    Always NOERROR: these tests are about what the driver SENDS. How it
+    reacts to a refusal is a separate concern and has its own path.
+    """
+
+    def rcode(self) -> int:
+        return 0
+
+
+def _send(
+    monkeypatch: pytest.MonkeyPatch,
+    driver: Bind9Driver,
+    op: dict[str, Any],
+) -> list[tuple[Any, str]]:
+    """Apply ``op`` with the RFC 2136 wire intercepted.
+
+    Returns the ``(update_message, destination)`` pairs the driver handed to
+    ``dns.query.tcp`` — one entry per DNS message actually sent, which is
+    itself part of what these tests assert (a whole-RRset write must be ONE
+    message, or it is not atomic).
+    """
+    sent: list[tuple[Any, str]] = []
+
+    def _fake_tcp(q: Any, where: str, timeout: float | None = None, **kw: Any):
+        sent.append((q, where))
+        return _FakeDnsResponse()
+
+    monkeypatch.setattr(dns.query, "tcp", _fake_tcp)
+    driver.apply_record_op(op)
+    return sent
+
+
+def _wire_sections(update: Any) -> list[tuple[str, str, str, int, list[str]]]:
+    """Flatten an Update's UPDATE section into readable tuples.
+
+    ``(kind, name, rdtype, ttl, values)`` where kind is one of:
+
+    * ``delete-rrset``  — RFC 2136 §2.5.2, class ANY: drop every RR at
+      ``(name, type)``.
+    * ``delete-value``  — §2.5.4, class NONE: drop one specific RR,
+      siblings survive.
+    * ``add``           — §2.5.1.
+
+    dnspython builds each add as its own RRset object (``force_unique``), so
+    the order here is the order the driver asked for.
+
+    Names and rdata are derelativized against the message origin. dnspython
+    stores both relative to the zone internally and absolutizes them only
+    when it renders the wire, so reading them raw would show ``10 mail1``
+    for an MX and make a correct payload look truncated.
+    """
+    origin = update.origin
+    out: list[tuple[str, str, str, int, list[str]]] = []
+    for rrset in update.update:
+        if rrset.deleting == dns.rdataclass.ANY:
+            kind = "delete-rrset"
+        elif rrset.deleting == dns.rdataclass.NONE:
+            kind = "delete-value"
+        else:
+            kind = "add"
+        out.append(
+            (
+                kind,
+                rrset.name.derelativize(origin).to_text(),
+                dns.rdatatype.to_text(rrset.rdtype),
+                rrset.ttl,
+                [rd.to_text(origin=origin, relativize=False) for rd in rrset],
+            )
+        )
+    return out
+
+
+def test_bind9_multi_value_a_survives_a_single_record_op(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression test for #773 — the exact repro.
+
+    ``app`` holds two A records. Editing/creating either one used to send a
+    bare ``upd.replace(name, ttl, "A", <this one value>)``, whose
+    delete-RRset wiped the sibling that the op never mentioned: the zone
+    ended up answering with a single address and nothing self-healed,
+    because record CRUD bumps the bundle ``etag`` but not its
+    ``structural_etag``, so the full-zone reconcile never fires.
+
+    With the desired set on the op, ONE message carries a delete of the
+    whole RRset plus an add for BOTH values — RFC 2136 §3.4.2.6 applies an
+    update section in order, so the deletion and the re-adds land together
+    and no client ever observes the name half-populated.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 3600,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [{"value": "10.20.7.22"}, {"value": "10.20.7.21"}],
+                },
+            },
+        },
+    )
+
+    # One message, to the loopback daemon. Splitting the delete and the adds
+    # across two messages would reintroduce a window where ``app`` resolves
+    # to nothing.
+    assert len(sent) == 1
+    assert sent[0][1] == "127.0.0.1"
+
+    assert _wire_sections(sent[0][0]) == [
+        ("delete-rrset", "app.example.com.", "A", 0, []),
+        ("add", "app.example.com.", "A", 3600, ["10.20.7.22"]),
+        ("add", "app.example.com.", "A", 3600, ["10.20.7.21"]),
+    ]
+
+
+def test_bind9_empty_members_deletes_the_whole_rrset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty member list is the control plane saying "this RRset should
+    not exist" — the op removed its last value. That has to become a
+    delete of ``(name, type)`` with no adds; emitting a zero-value
+    ``replace`` would leave the name intact, and adding anything back would
+    resurrect the record the operator just deleted.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {
+                "name": "gone",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 3600,
+                "rrset": {"ttl": 3600, "members": []},
+            },
+        },
+    )
+
+    assert _wire_sections(sent[0][0]) == [
+        ("delete-rrset", "gone.example.com.", "A", 0, [])
+    ]
+
+
+def test_bind9_delete_with_survivors_reinstalls_the_siblings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Deleting one member of a multi-value RRset must keep the rest.
+
+    This is the destructive half of #773: the old delete path ran
+    ``upd.delete(name, rtype)`` — delete the whole RRset, by (name, type),
+    with no re-add — so removing one address from a three-address
+    round-robin took the other two down with it. The survivors the control
+    plane ships are re-installed in the same message.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 3600,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [{"value": "10.20.7.22"}, {"value": "10.20.7.23"}],
+                },
+            },
+        },
+    )
+
+    sections = _wire_sections(sent[0][0])
+    assert sections[0] == ("delete-rrset", "app.example.com.", "A", 0, [])
+    assert [s[4] for s in sections[1:]] == [["10.20.7.22"], ["10.20.7.23"]]
+    # The deleted value must not come back.
+    assert all("10.20.7.21" not in s[4] for s in sections)
+
+
+def test_bind9_rrset_ttl_wins_over_the_ops_own_record_ttl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """RFC 2181 §5.2: every RR in an RRset carries the same TTL, and a
+    resolver receiving a mismatched set is entitled to pick any of them.
+
+    So the TTL that lands on the wire is the RRset's, not the individual
+    op record's — the op record is one member's row and its TTL may be
+    mid-edit or simply stale relative to its siblings. All members share it.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 30,  # the op's own row — deliberately different
+                "rrset": {
+                    "ttl": 600,
+                    "members": [{"value": "10.20.7.21"}, {"value": "10.20.7.22"}],
+                },
+            },
+        },
+    )
+
+    adds = [s for s in _wire_sections(sent[0][0]) if s[0] == "add"]
+    assert len(adds) == 2
+    assert {s[3] for s in adds} == {600}
+
+
+def test_bind9_rrset_ttl_of_zero_is_honoured_not_treated_as_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A TTL of 0 is legal (RFC 2181 §8) and is how "do not cache this"
+    is expressed — DDNS-driven names are the usual reason to want it.
+
+    The natural way to write the fallback, ``rrset["ttl"] or ttl``, quietly
+    turns that into the op record's TTL instead, and the resulting bug is
+    invisible until someone wonders why a record that must not be cached
+    is being cached. The test exists because the correct spelling is the
+    less obvious one.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 300,
+                "rrset": {"ttl": 0, "members": [{"value": "10.20.7.21"}]},
+            },
+        },
+    )
+
+    adds = [s for s in _wire_sections(sent[0][0]) if s[0] == "add"]
+    assert [s[3] for s in adds] == [0]
+
+
+def test_bind9_multi_member_mx_composes_priority_per_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``_wire_value`` must be applied to every member, not just to the op's
+    own record.
+
+    MX presentation format puts the preference inline before the exchange,
+    and the control plane stores it in a separate column — so a member whose
+    priority was left as a bare field would be handed to dnspython as
+    ``mail2.example.com.`` and raise, or (worse, on a driver that doesn't
+    parse) install a mail route with the wrong preference. Each member
+    carries its own priority and each must be composed from it.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "@",
+                "type": "MX",
+                "value": "mail2.example.com.",
+                "priority": 20,
+                "ttl": 3600,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [
+                        {"value": "mail1.example.com.", "priority": 10},
+                        {"value": "mail2.example.com.", "priority": 20},
+                    ],
+                },
+            },
+        },
+    )
+
+    sections = _wire_sections(sent[0][0])
+    # Apex: ``@`` resolves to the zone itself, which is where a multi-MX
+    # RRset actually lives.
+    assert sections[0] == ("delete-rrset", "example.com.", "MX", 0, [])
+    assert [s[4] for s in sections[1:]] == [
+        ["10 mail1.example.com."],
+        ["20 mail2.example.com."],
+    ]
+
+
+def test_bind9_multi_member_srv_composes_priority_weight_port_per_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Same rule as MX, with three inline fields instead of one.
+
+    A pair of SRV records at ``_sip._tcp`` is the normal shape (primary +
+    backup), which is exactly the case #773 destroyed, so the composition
+    has to survive the RRset path rather than only the single-record one.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "_sip._tcp",
+                "type": "SRV",
+                "value": "sip2.example.com.",
+                "priority": 20,
+                "weight": 10,
+                "port": 5060,
+                "ttl": 3600,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [
+                        {
+                            "value": "sip1.example.com.",
+                            "priority": 10,
+                            "weight": 60,
+                            "port": 5060,
+                        },
+                        {
+                            "value": "sip2.example.com.",
+                            "priority": 20,
+                            "weight": 10,
+                            "port": 5060,
+                        },
+                    ],
+                },
+            },
+        },
+    )
+
+    sections = _wire_sections(sent[0][0])
+    assert [s[4] for s in sections[1:]] == [
+        ["10 60 5060 sip1.example.com."],
+        ["20 10 5060 sip2.example.com."],
+    ]
+
+
+def test_bind9_without_rrset_falls_back_to_replace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``rrset`` key ⇒ the pre-#773 behaviour, byte-identical.
+
+    Ops enqueued by an older control plane are still in the queue when the
+    agent picks up the new code, so the old semantics have to keep working
+    exactly as they did — a value edit replaces the RRset with the single
+    new value.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {"name": "www", "type": "A", "value": "10.0.0.2", "ttl": 300},
+        },
+    )
+
+    assert _wire_sections(sent[0][0]) == [
+        ("delete-rrset", "www.example.com.", "A", 0, []),
+        ("add", "www.example.com.", "A", 300, ["10.0.0.2"]),
+    ]
+
+
+def test_bind9_without_rrset_honours_rrset_action_add(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``rrset_action="add"`` is the older per-op override, set by DNS pools
+    because N A records share one name there and a bare replace clobbers
+    the siblings on every member add. On the fallback path it must still
+    append — no delete-RRset at all.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "pool",
+                "type": "A",
+                "value": "10.0.0.7",
+                "ttl": 60,
+                "rrset_action": "add",
+            },
+        },
+    )
+
+    assert _wire_sections(sent[0][0]) == [
+        ("add", "pool.example.com.", "A", 60, ["10.0.0.7"])
+    ]
+
+
+def test_bind9_without_rrset_delete_value_keeps_siblings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``rrset_action="delete_value"`` is the pool-member-removal override:
+    drop this one RR (RFC 2136 class NONE) and leave the rest of the RRset
+    standing. The value has to ride along in the delete, since that is what
+    identifies which RR to remove.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {
+                "name": "pool",
+                "type": "A",
+                "value": "10.0.0.7",
+                "rrset_action": "delete_value",
+            },
+        },
+    )
+
+    assert _wire_sections(sent[0][0]) == [
+        ("delete-value", "pool.example.com.", "A", 0, ["10.0.0.7"])
+    ]
+
+
+def test_bind9_without_rrset_delete_drops_whole_rrset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plain delete with no override clears by ``(name, type)``.
+
+    Deliberately value-blind: BIND rejects the RR-specific delete form when
+    the running daemon has drifted from the zone file, and this form is
+    idempotent, so a replayed op finds the state it asks for rather than an
+    error.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+    sent = _send(
+        monkeypatch,
+        driver,
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {"name": "www", "type": "A", "value": "10.0.0.1"},
+        },
+    )
+
+    assert _wire_sections(sent[0][0]) == [
+        ("delete-rrset", "www.example.com.", "A", 0, [])
+    ]
+
+
+def test_bind9_dnssec_op_never_reaches_the_record_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DNSSEC ops ride the same queue but are zone-level, not RRset-shaped.
+
+    BIND9 signs from the rendered config (inline-signing), so sign/unsign
+    need no per-op action — and their synthetic ``DNSSEC_OP`` record type
+    would raise inside ``dns.rdatatype`` if it ever reached the update
+    builder. The branch must return before any of the RRset machinery,
+    including the new ``rrset`` lookup, runs.
+    """
+    driver = Bind9Driver(state_dir=tmp_path)
+
+    def _fake_tcp(q: Any, where: str, timeout: float | None = None, **kw: Any):
+        raise AssertionError("a DNSSEC op must not send an RFC 2136 update")
+
+    monkeypatch.setattr(dns.query, "tcp", _fake_tcp)
+
+    result = driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "dnssec_sign",
+            "record": {"name": "@", "type": "DNSSEC_OP"},
+        }
+    )
+
+    assert result is None
+
+
+# ── Technitium: N REST calls, first one clears ──────────────────────────────
+
+
+def test_technitium_rrset_writes_every_member_first_one_overwriting(
+    tmp_path: Path,
+) -> None:
+    """Technitium's REST API is one record per call, so a whole-RRset write
+    is N calls and the ordering carries the semantics: member 0 with
+    ``overwrite=true`` wipes the existing RRset and installs itself, and
+    every later member appends with ``overwrite=false``.
+
+    Get it backwards — all ``true`` — and the set collapses to the last
+    member, which is the #773 bug wearing a different hat. All members
+    share the RRset TTL (RFC 2181 §5.2).
+    """
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 60,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [
+                        {"value": "10.20.7.21"},
+                        {"value": "10.20.7.22"},
+                        {"value": "10.20.7.23"},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert len(calls) == 3
+    assert {path for (_, _, path, _) in calls} == {"zones/records/add"}
+    assert [params["overwrite"] for (_, _, _, params) in calls] == [
+        "true",
+        "false",
+        "false",
+    ]
+    assert [params["ipAddress"] for (_, _, _, params) in calls] == [
+        "10.20.7.21",
+        "10.20.7.22",
+        "10.20.7.23",
+    ]
+    # The RRset TTL, not the op record's own 60.
+    assert {params["ttl"] for (_, _, _, params) in calls} == {3600}
+    assert {params["domain"] for (_, _, _, params) in calls} == {"app.example.com"}
+
+
+def test_technitium_rrset_members_compose_their_own_structured_fields(
+    tmp_path: Path,
+) -> None:
+    """Each member goes through ``_record_params`` in its own right, so a
+    multi-MX RRset carries a per-member ``preference``.
+
+    This driver rebuilds the param dict inside the loop rather than reusing
+    the op's own — reading ``rec`` instead of ``member`` for the priority
+    would give every member the op record's preference and silently rewrite
+    the operator's mail routing.
+    """
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "@",
+                "type": "MX",
+                "value": "mail1.example.com.",
+                "priority": 10,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [
+                        {"value": "mail1.example.com.", "priority": 10},
+                        {"value": "mail2.example.com.", "priority": 20},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert [
+        (params["exchange"], params["preference"]) for (_, _, _, params) in calls
+    ] == [("mail1.example.com", 10), ("mail2.example.com", 20)]
+
+
+def test_technitium_delete_with_survivors_is_one_surgical_call(
+    tmp_path: Path,
+) -> None:
+    """A delete removes ONLY its own value — it does not wipe and rebuild.
+
+    The survivors in ``members`` are already on the server. Clearing the
+    RRset to re-add them would open a window, one HTTP call wide, where the
+    name serves less than it should, and a failure inside that window would
+    leave it truncated until the retry budget ran out. This API has a
+    value-scoped delete; there is no reason to reach past it.
+    """
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {
+                "name": "pool",
+                "type": "A",
+                "value": "10.20.7.21",
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [{"value": "10.20.7.22"}, {"value": "10.20.7.23"}],
+                },
+            },
+        }
+    )
+
+    assert len(calls) == 1
+    _, _, path, params = calls[0]
+    assert path == "zones/records/delete"
+    assert params["ipAddress"] == "10.20.7.21"
+
+
+def test_technitium_rrset_ttl_of_zero_is_honoured_not_treated_as_missing(
+    tmp_path: Path,
+) -> None:
+    """Same "absence, not falsiness" rule as the BIND9 driver — each of the
+    three drivers spells the fallback out separately, so each one can
+    independently regress to ``rrset["ttl"] or ttl``."""
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 300,
+                "rrset": {"ttl": 0, "members": [{"value": "10.20.7.21"}]},
+            },
+        }
+    )
+
+    assert [params["ttl"] for (_, _, _, params) in calls] == [0]
+
+
+def test_technitium_empty_members_calls_the_delete_endpoint(
+    tmp_path: Path,
+) -> None:
+    """Last value gone ⇒ delete the record, don't add anything.
+
+    ``zones/records/delete`` needs the exact value params to identify what
+    it is removing, which is why the op's own record payload (not the empty
+    member list) supplies them.
+    """
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {
+                "name": "gone",
+                "type": "A",
+                "value": "10.20.7.21",
+                "rrset": {"ttl": 3600, "members": []},
+            },
+        }
+    )
+
+    assert len(calls) == 1
+    _, _, path, params = calls[0]
+    assert path == "zones/records/delete"
+    assert params["ipAddress"] == "10.20.7.21"
+    assert "overwrite" not in params
+
+
+def test_technitium_idempotent_noop_does_not_abandon_later_members(
+    tmp_path: Path,
+) -> None:
+    """An "already exists" answer mid-sequence must not end the write.
+
+    Technitium answers HTTP 200 with ``{"status": "error"}`` for a record
+    that is already present, and a replayed op hits that on any member that
+    landed before the retry. The pre-fix code returned early on it, which
+    on a multi-member RRset means every member after the first duplicate is
+    silently never written — a partially-applied set that looks like a
+    success. Every remaining member must still be attempted.
+    """
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+
+    def _responder(path: str, params: dict[str, Any], n: int) -> dict[str, Any]:
+        if n == 2:
+            return {"status": "error", "errorMessage": "Record already exists."}
+        return {"status": "ok"}
+
+    calls = _install_fake_request(driver, _responder)
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 3600,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [
+                        {"value": "10.20.7.21"},
+                        {"value": "10.20.7.22"},
+                        {"value": "10.20.7.23"},
+                    ],
+                },
+            },
+        }
+    )
+
+    assert [params["ipAddress"] for (_, _, _, params) in calls] == [
+        "10.20.7.21",
+        "10.20.7.22",
+        "10.20.7.23",
+    ]
+
+
+def test_technitium_without_rrset_falls_back_to_single_overwriting_add(
+    tmp_path: Path,
+) -> None:
+    """No ``rrset`` ⇒ exactly one call, the pre-#773 REPLACE.
+
+    The count matters as much as the flag: an op from an older control
+    plane must not accidentally engage the multi-call RRset path with a
+    one-element set it never declared.
+    """
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {"name": "www", "type": "A", "value": "10.0.0.2", "ttl": 300},
+        }
+    )
+
+    assert len(calls) == 1
+    _, _, path, params = calls[0]
+    assert path == "zones/records/add"
+    assert params["overwrite"] == "true"
+    assert params["ttl"] == 300
+
+
+def test_technitium_without_rrset_honours_rrset_action_add(tmp_path: Path) -> None:
+    """The older per-op override still appends on the fallback path — DNS
+    pools depend on it, and they are exactly the multi-value RRsets that
+    would otherwise lose siblings on every member add."""
+    driver = TechnitiumDriver(state_dir=tmp_path)
+    _seed_token(driver)
+    calls = _install_fake_request(driver, lambda *_: {"status": "ok"})
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "pool",
+                "type": "A",
+                "value": "10.0.0.7",
+                "ttl": 60,
+                "rrset_action": "add",
+            },
+        }
+    )
+
+    assert len(calls) == 1
+    assert calls[0][3]["overwrite"] == "false"
+
+
+# ── PowerDNS: one REPLACE PATCH, no zone GET ────────────────────────────────
+
+
+class _FakePdnsResponse:
+    def __init__(self, status_code: int = 200, body: Any = None) -> None:
+        self.status_code = status_code
+        self.text = ""
+        self._body = body if body is not None else {}
+
+    def json(self) -> Any:
+        return self._body
+
+
+class _FakePdnsClient:
+    """Context-manager stand-in for ``httpx.Client``, recording every call
+    as ``(method, url, json_body)``."""
+
+    def __init__(self, calls: list[tuple[str, str, Any]], zone_doc: Any) -> None:
+        self._calls = calls
+        self._zone_doc = zone_doc
+
+    def __enter__(self) -> _FakePdnsClient:
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+    def get(self, url: str, headers: Any = None) -> _FakePdnsResponse:
+        self._calls.append(("GET", url, None))
+        return _FakePdnsResponse(200, self._zone_doc)
+
+    def patch(
+        self, url: str, headers: Any = None, json: Any = None
+    ) -> _FakePdnsResponse:
+        self._calls.append(("PATCH", url, json))
+        return _FakePdnsResponse(200, {})
+
+
+def _install_fake_pdns_client(
+    monkeypatch: pytest.MonkeyPatch, zone_doc: Any = None
+) -> list[tuple[str, str, Any]]:
+    """Swap the driver module's ``httpx`` for a namespace exposing only the
+    fake ``Client``.
+
+    Scoped to the powerdns module rather than patching ``httpx.Client``
+    itself, so the fake can't leak into any other module that imports httpx.
+    """
+    calls: list[tuple[str, str, Any]] = []
+    monkeypatch.setattr(
+        powerdns_mod,
+        "httpx",
+        SimpleNamespace(
+            Client=lambda **kw: _FakePdnsClient(calls, zone_doc or {"rrsets": []})
+        ),
+    )
+    return calls
+
+
+def test_powerdns_rrset_sends_one_replace_patch_and_no_zone_get(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The desired set makes the read-merge-write cycle unnecessary.
+
+    PowerDNS has no INSERT/REMOVE-MEMBER granularity — ``REPLACE`` swaps
+    the whole RRset — so before #773 the driver had to GET the zone, splice
+    the op's value into whatever it found, and PATCH the merge back. That
+    read is both a per-op round trip against the full zone document and a
+    lost-update race between two concurrent ops. With the complete set on
+    the op it is one PATCH and no GET, which is what this pins: the absence
+    of the GET is the point, not an incidental detail.
+    """
+    driver = PowerDNSDriver(state_dir=tmp_path)
+    calls = _install_fake_pdns_client(monkeypatch)
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 60,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [{"value": "10.20.7.22"}, {"value": "10.20.7.21"}],
+                },
+            },
+        }
+    )
+
+    assert [method for (method, _, _) in calls] == ["PATCH"]
+    _, url, body = calls[0]
+    assert url.endswith("/zones/example.com.")
+    assert body["rrsets"] == [
+        {
+            "name": "app.example.com.",
+            "type": "A",
+            "ttl": 3600,  # the RRset's TTL, not the op record's 60
+            "changetype": "REPLACE",
+            "records": [
+                {"content": "10.20.7.22", "disabled": False},
+                {"content": "10.20.7.21", "disabled": False},
+            ],
+        }
+    ]
+
+
+def test_powerdns_rrset_ttl_of_zero_is_honoured_not_treated_as_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Third copy of the "absence, not falsiness" TTL rule — see the BIND9
+    test of the same name for why 0 is the value that gets lost."""
+    driver = PowerDNSDriver(state_dir=tmp_path)
+    calls = _install_fake_pdns_client(monkeypatch)
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "update",
+            "record": {
+                "name": "app",
+                "type": "A",
+                "value": "10.20.7.21",
+                "ttl": 300,
+                "rrset": {"ttl": 0, "members": [{"value": "10.20.7.21"}]},
+            },
+        }
+    )
+
+    assert calls[0][2]["rrsets"][0]["ttl"] == 0
+
+
+def test_powerdns_multi_member_mx_composes_content_per_member(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Each member's content is stitched from its own fields.
+
+    PowerDNS stores MX preference inline in ``content``, and the member
+    dicts carry the priority as a separate key — so the driver has to run
+    every member through the content builder, not just the op's own record.
+    A member handed through raw would install ``mail1.example.com.`` with
+    no preference and PowerDNS would reject the PATCH.
+    """
+    driver = PowerDNSDriver(state_dir=tmp_path)
+    calls = _install_fake_pdns_client(monkeypatch)
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {
+                "name": "@",
+                "type": "MX",
+                "value": "mail2.example.com.",
+                "priority": 20,
+                "ttl": 3600,
+                "rrset": {
+                    "ttl": 3600,
+                    "members": [
+                        {"value": "mail1.example.com.", "priority": 10},
+                        {"value": "mail2.example.com.", "priority": 20},
+                    ],
+                },
+            },
+        }
+    )
+
+    _, _, body = calls[0]
+    rrset = body["rrsets"][0]
+    assert rrset["name"] == "example.com."  # apex
+    assert [r["content"] for r in rrset["records"]] == [
+        "10 mail1.example.com.",
+        "20 mail2.example.com.",
+    ]
+
+
+def test_powerdns_empty_members_sends_a_delete_changetype(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Empty set ⇒ ``changetype: DELETE`` and nothing else.
+
+    A ``REPLACE`` with an empty ``records`` list is not the same request —
+    PowerDNS treats it as a malformed replace rather than a removal — so
+    the empty case has to switch changetype, not just ship zero records.
+    Still no zone GET: there is nothing to merge with.
+    """
+    driver = PowerDNSDriver(state_dir=tmp_path)
+    calls = _install_fake_pdns_client(monkeypatch)
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "delete",
+            "record": {
+                "name": "gone",
+                "type": "A",
+                "value": "10.20.7.21",
+                "rrset": {"ttl": 3600, "members": []},
+            },
+        }
+    )
+
+    assert [method for (method, _, _) in calls] == ["PATCH"]
+    assert calls[0][2]["rrsets"] == [
+        {"name": "gone.example.com.", "type": "A", "changetype": "DELETE"}
+    ]
+
+
+def test_powerdns_without_rrset_still_does_the_get_merge_patch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No ``rrset`` ⇒ the pre-#773 read-merge-write survives unchanged.
+
+    It is the only thing standing between an op from an older control plane
+    and a clobbered sibling: two consecutive ``create www A`` calls would
+    otherwise have the second overwrite the first, which is how GSLB pool
+    fan-out broke. The merge de-duplicates the incoming content and appends
+    it to whatever the zone already holds.
+    """
+    driver = PowerDNSDriver(state_dir=tmp_path)
+    calls = _install_fake_pdns_client(
+        monkeypatch,
+        zone_doc={
+            "rrsets": [
+                {
+                    "name": "www.example.com.",
+                    "type": "A",
+                    "records": [{"content": "10.0.0.1", "disabled": False}],
+                }
+            ]
+        },
+    )
+
+    driver.apply_record_op(
+        {
+            "zone_name": "example.com.",
+            "op": "create",
+            "record": {"name": "www", "type": "A", "value": "10.0.0.2", "ttl": 300},
+        }
+    )
+
+    assert [method for (method, _, _) in calls] == ["GET", "PATCH"]
+    assert calls[1][2]["rrsets"] == [
+        {
+            "name": "www.example.com.",
+            "type": "A",
+            "ttl": 300,
+            "changetype": "REPLACE",
+            "records": [
+                {"content": "10.0.0.1", "disabled": False},
+                {"content": "10.0.0.2", "disabled": False},
+            ],
+        }
+    ]

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -1085,10 +1085,13 @@ def heartbeat_once(
         # longer than the whole recovery budget. Re-converged every
         # heartbeat because k3s re-applies its bundled manifest (replicas
         # back to 1) on every restart.
-        dns_changed, dns_err = k8s_api.ensure_coredns_ha()
-        if dns_changed:
-            log.info("supervisor.heartbeat.coredns_ha_applied")
-        elif dns_err:
+        #
+        # #750 — the reconciler now targets the HA shape only once a second
+        # node exists, and reverts a single-node box to stock; applying it to
+        # one node deadlocked the rollout permanently. So a "changed" here can
+        # mean either direction, and the reconciler logs which.
+        _dns_changed, dns_err = k8s_api.ensure_coredns_ha()
+        if dns_err:
             log.warning("supervisor.heartbeat.coredns_ha_failed", error=dns_err)
 
     # #170 Wave C2 — render the role-driven compose env. C3 will

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -844,43 +844,178 @@ def patch_node_labels(
     return False, f"kubeapi status {status}: {resp[:200]!r}"
 
 
-def ensure_coredns_ha(replicas: int = 2) -> tuple[bool, str | None]:
-    """Keep the k3s-bundled CoreDNS able to survive a node loss —
-    returns (changed, error); ``(False, None)`` means already converged.
+def count_nodes(timeout: float = 5.0) -> tuple[int, int, str | None]:
+    """``(registered, ready_and_schedulable, error)`` over ``/api/v1/nodes``.
+
+    Two counts because they answer two different questions.
+
+    ``registered`` counts every Node object regardless of condition — it is
+    how many ``kubernetes.io/hostname`` domains a required anti-affinity can
+    ever spread over. A Node object survives NotReady; it only disappears on
+    an explicit :func:`delete_node` (the #272 eviction path) or a cluster
+    reset. Sizing the replica target off it is what stops a node *outage*
+    from scaling cluster DNS down at the exact moment #590 needs it up, and
+    it does not flap the way a Ready count does across a kubelet restart.
+
+    ``ready_and_schedulable`` (Ready=True, not cordoned) is the stricter
+    count, used only to decide whether a pod-template rollout can land right
+    now. It may defer a change; it never shrinks one.
+    """
+    try:
+        status, body = _request("GET", "/api/v1/nodes", timeout=timeout)
+    except (RuntimeError, OSError) as exc:
+        # OSError is NOT redundant: _request builds its HTTPSConnection (and
+        # reads the CA via _ssl_context) OUTSIDE the try that converts
+        # transport errors to RuntimeError, so a missing/unreadable ca.crt
+        # raises straight through. Same catch as its sibling readers in
+        # firewall_peer_audit.
+        return 0, 0, str(exc)
+    if status != 200:
+        return 0, 0, f"kubeapi status {status}: {body[:200]!r}"
+    try:
+        data = json.loads(body)
+    except (json.JSONDecodeError, ValueError):
+        return 0, 0, "unparseable node list"
+    if not isinstance(data, dict):
+        return 0, 0, "unparseable node list"
+    items = data.get("items") or []
+    schedulable = 0
+    for node in items:
+        if (node.get("spec") or {}).get("unschedulable"):
+            continue
+        for cond in (node.get("status") or {}).get("conditions") or []:
+            if cond.get("type") == "Ready" and cond.get("status") == "True":
+                schedulable += 1
+                break
+    return len(items), schedulable, None
+
+
+_COREDNS_PATH = "/apis/apps/v1/namespaces/kube-system/deployments/coredns"
+_FAST_EVICT_KEYS = ("node.kubernetes.io/unreachable", "node.kubernetes.io/not-ready")
+_FAST_EVICT_TOLERATIONS = [
+    {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
+     "effect": "NoExecute", "tolerationSeconds": 20},
+    {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
+     "effect": "NoExecute", "tolerationSeconds": 20},
+]
+_COREDNS_SPREAD = {
+    "podAntiAffinity": {
+        "requiredDuringSchedulingIgnoredDuringExecution": [{
+            "topologyKey": "kubernetes.io/hostname",
+            "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
+        }],
+    },
+}
+
+
+def _merge_patch(target: Any, patch: Any) -> Any:
+    """Apply an RFC 7386 JSON merge-patch and return the result.
+
+    Only used to predict what a PATCH would produce, so the reconciler can tell
+    a real pod-template rewrite (which starts a rollout, and on one node is how
+    #750 happens) from a no-op patch. Objects merge key by key and a ``null``
+    member DELETES its key — the two behaviours the coredns affinity patch
+    depends on.
+    """
+    if not isinstance(patch, dict):
+        return patch
+    merged = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = _merge_patch(merged.get(key), value)
+    return merged
+
+
+def ensure_coredns_ha(max_replicas: int = 2) -> tuple[bool, str | None]:
+    """Match the k3s-bundled CoreDNS to the cluster's NODE COUNT — returns
+    (changed, error); ``(False, None)`` means converged or deferred.
 
     #590 — k3s ships CoreDNS as a SINGLE replica with the default 300 s
-    unreachable toleration, and on an appliance it deterministically
-    lands on the seed (single-node install; members join later; the pod
-    never moves). Hard-kill the seed and cluster DNS is gone for 5
-    minutes — and *everything* the api readiness gate touches resolves
-    through it (the Postgres ``-rw`` Service, the Redis sentinel
-    FQDNs), so every api pod goes NotReady cluster-wide until CoreDNS
-    finally reschedules. Observed live 2026-07-12: kill_leader failed
-    identically across four builds while postgres/redis fixes landed,
-    because DNS was the common upstream casualty.
+    unreachable toleration, and on an appliance it deterministically lands on
+    the seed. Hard-kill the seed and cluster DNS is gone for 5 minutes — and
+    *everything* the api readiness gate touches resolves through it (the
+    Postgres ``-rw`` Service, the Redis sentinel FQDNs), so every api pod
+    goes NotReady cluster-wide until CoreDNS finally reschedules. Hence 2
+    replicas + fast-evict tolerations + REQUIRED (not preferred)
+    anti-affinity on a real cluster; #633 has the live evidence for why
+    preferred was wrong — it parked BOTH replicas on the seed, and
+    Kubernetes never rebalances running pods, so the "HA" DNS died with the
+    seed anyway.
 
-    Reconciled from the seed's heartbeat (idempotent GET-then-patch):
-    k3s re-applies its bundled manifest on every restart, which resets
-    replicas to 1 — a one-shot patch would silently regress, the
-    heartbeat re-converges it. The toleration list is REPLACED by the
-    merge-patch, so the stock entries ride along with the fast-evict
-    pair (same 20 s rationale as api/frontend/worker/postgresql/redis).
+    #750 — but that shape is only correct once a SECOND NODE EXISTS.
+    Applying it to a single-node box deadlocks the rollout permanently: the
+    patch rewrites the pod template, so a NEW ReplicaSet is created whose
+    pods can never schedule (required anti-affinity, one node, occupied),
+    while the old ReplicaSet's pod can never drain (``maxUnavailable: 1`` at
+    ``replicas: 2`` ⇒ minAvailable 1, and zero new pods are Ready). Three
+    coredns pods forever, and every later coredns change queues behind a
+    rollout that cannot finish. The previous docstring anticipated a single
+    Pending *spare* and judged it harmless; that is true of the steady state
+    but not of the transition, which is where the template rewrite bites.
 
-    REQUIRED (not preferred) anti-affinity, deliberately: the reconciler
-    first fires while the appliance is still a single node (firstboot —
-    members join minutes later), and preferred anti-affinity happily
-    parked BOTH replicas on the seed; Kubernetes never rebalances
-    running pods, so the "HA" DNS died with the seed anyway (observed
-    live 2026-07-12: both coredns replicas Terminating in the same
-    kill_leader window the fix was meant to survive). Under required
-    anti-affinity the second replica sits Pending until a member joins
-    and then schedules there — a Pending spare on a genuinely
-    single-node box is harmless (the first replica serves), a
-    co-located spare is worthless."""
-    path = "/apis/apps/v1/namespaces/kube-system/deployments/coredns"
+    So the target is a function of the node count, with two states:
+
+    * **1 registered node → STOCK.** replicas 1, fast-evict tolerations
+      REMOVED, pod anti-affinity REMOVED. Both buy exactly nothing with one
+      hostname domain — worse, a 20 s unreachable toleration means a kubelet
+      blip evicts the only DNS pod with nowhere to put it.
+    * **≥2 registered nodes → HA.** ``min(registered, max_replicas)``
+      replicas + fast-evict + required spread. The cap is 2 by default
+      because required anti-affinity places at most one pod per node, and
+      two is what surviving a node loss needs — a third on a 3-node cluster
+      costs memory for no extra failure tolerance.
+
+    The count is *registered* Node objects, deliberately, and deliberately
+    NOT the ``control_plane_size`` that sizes every other appliance workload
+    (the ``# spatium:cp-size`` markers in ``spatiumddi-firstboot``). That
+    number is the COMMITTED member count and can lead reality — a member
+    committed but not yet joined would give a target of 2 against one real
+    node, which is precisely this bug. Node objects are ground truth for how
+    many hostname domains exist, and they survive NotReady, so a node
+    *outage* cannot scale cluster DNS down at the moment #590 needs it up.
+
+    Consequences worth knowing:
+
+    * A fresh single-node install is now a total no-op. Stock already *is*
+      the target, so there is no patch, no second ReplicaSet and no pod
+      churn — which is also why the deadlock cannot be re-created.
+    * An appliance already stuck in the deadlock heals in one patch, usually
+      with no DNS gap: the pod still Running is normally the one from the
+      stock-template ReplicaSet, so reverting the template makes that
+      ReplicaSet current again and the unschedulable one is scaled to zero
+      underneath it. Worst case the hash does not match — a reboot let an
+      HA-ReplicaSet pod win the single node and the stock ReplicaSet was
+      garbage-collected — and it degrades to an ordinary ``replicas: 1``
+      rollout, where ``maxUnavailable: 1`` leaves minAvailable 0 so the old
+      pod drains immediately. A few seconds of gap, still converged.
+    * The replica check moved from ``>=`` (a ratchet that could only ever
+      raise the count, which is why nothing could undo the deadlock) to
+      equality. The supervisor now owns this field in both directions: a
+      manual ``kubectl scale deploy/coredns`` is reverted on the next
+      heartbeat.
+
+    Still reconciled from every seed heartbeat rather than once, because k3s
+    re-applies its bundled manifest on restart and would silently revert an
+    HA cluster to a single replica.
+    """
+    registered, schedulable, node_err = count_nodes()
+    if node_err is not None:
+        return False, f"node count unavailable: {node_err}"
+    if registered <= 0:
+        # A cluster we are running inside always has at least one Node. A
+        # zero here means an authorization or field-selector surprise, not a
+        # nodeless cluster — patching to the single-node target off a
+        # reading we do not trust is how you turn a bad read into an outage.
+        return False, "kubeapi reported no nodes"
+
+    want_ha = registered >= 2
+    desired = min(registered, max_replicas) if want_ha else 1
+
     try:
-        status, resp = _request("GET", path)
-    except RuntimeError as exc:
+        status, resp = _request("GET", _COREDNS_PATH)
+    except (RuntimeError, OSError) as exc:
         return False, str(exc)
     if status != 200:
         return False, f"kubeapi status {status}: {resp[:200]!r}"
@@ -888,55 +1023,91 @@ def ensure_coredns_ha(replicas: int = 2) -> tuple[bool, str | None]:
         dep = json.loads(resp)
     except ValueError:
         return False, "unparseable coredns deployment"
+    if not isinstance(dep, dict):
+        return False, "unparseable coredns deployment"
     spec = dep.get("spec") or {}
     tmpl_spec = (spec.get("template") or {}).get("spec") or {}
     tolerations = tmpl_spec.get("tolerations") or []
-    has_fast_evict = any(
-        t.get("key") == "node.kubernetes.io/unreachable"
-        and (t.get("tolerationSeconds") or 10**9) <= 30
-        for t in tolerations
-    )
-    has_required_spread = bool(
-        ((tmpl_spec.get("affinity") or {}).get("podAntiAffinity") or {})
-        .get("requiredDuringSchedulingIgnoredDuringExecution")
-    )
-    if (int(spec.get("replicas") or 0) >= replicas and has_fast_evict
-            and has_required_spread):
+    affinity = tmpl_spec.get("affinity") or {}
+    current_replicas = int(spec.get("replicas") or 0)
+
+    # Convergence is decided by comparing the template we WOULD send against
+    # the one that is live, rather than by a set of "close enough" predicates.
+    # That makes the reconciler own this template outright: a half-applied
+    # toleration pair, a leftover preferred anti-affinity from a pre-#633
+    # build, and a fast-evict entry someone hand-edited to 25 s are all just
+    # "not what we send", and all get repaired. Tolerations we do not manage
+    # ride along in ``keep``, so this never fights another controller.
+    keep = [t for t in tolerations if t.get("key") not in _FAST_EVICT_KEYS]
+    if want_ha:
+        affinity_patch: Any = _COREDNS_SPREAD
+    elif set(affinity) <= {"podAntiAffinity"}:
+        # ``null`` DELETES the key under a JSON merge-patch, restoring the
+        # stock pod template exactly — which is what lets the still-Running
+        # stock-hash ReplicaSet become current again and heal without a DNS
+        # gap. Only safe when podAntiAffinity is all there is.
+        affinity_patch = None
+    else:
+        # A merge-patch recurses into objects, so nulling one key removes just
+        # that key and leaves the siblings (a stock nodeAffinity, say) intact —
+        # which is also the stock shape, so this heals as cleanly as the branch
+        # above. Nulling the whole ``affinity`` here would take the operator's
+        # other scheduling constraints with it.
+        affinity_patch = {"podAntiAffinity": None}
+    want_tolerations = (keep + _FAST_EVICT_TOLERATIONS) if want_ha else keep
+
+    # Whether the PATCH would actually rewrite the pod template, computed from
+    # the body we are about to send rather than from ``template_ok``. The two
+    # are not the same question: ``template_ok`` accepts any fast-evict
+    # toleration at <=30 s, so a template sitting at 25 s satisfies it while
+    # still differing from the canonical body — and that difference is a new
+    # pod-template hash, i.e. a rollout. Deciding the gate on the loose
+    # predicate would let exactly that rollout skip the guard it exists to be.
+    want_affinity = None if affinity_patch is None else _merge_patch(affinity, affinity_patch)
+    rewrites_template = want_tolerations != tolerations or want_affinity != (affinity or None)
+
+    if current_replicas == desired and not rewrites_template:
         return False, None
-    fast = [
-        {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
-         "effect": "NoExecute", "tolerationSeconds": 20},
-        {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
-         "effect": "NoExecute", "tolerationSeconds": 20},
-    ]
-    keep = [t for t in tolerations
-            if t.get("key") not in ("node.kubernetes.io/unreachable",
-                                    "node.kubernetes.io/not-ready")]
-    spread = {
-        "podAntiAffinity": {
-            "requiredDuringSchedulingIgnoredDuringExecution": [{
-                "topologyKey": "kubernetes.io/hostname",
-                "labelSelector": {"matchLabels": {"k8s-app": "kube-dns"}},
-            }],
-        },
-    }
+
+    if rewrites_template and schedulable < desired:
+        # Defer while fewer nodes are Ready+uncordoned than the target: a
+        # pod-template change there is how the #750 deadlock is authored in
+        # the first place. A coarse proxy — it does not model taints or
+        # coredns' own nodeSelector — but it catches the case that actually
+        # occurs on an appliance, a peer that is registered and down. Not an
+        # error: nothing is wrong, it retries next heartbeat, and reporting a
+        # failure every 30 s across a node reboot would be noise.
+        log.info(
+            "supervisor.k8s_api.coredns_deferred",
+            registered_nodes=registered,
+            schedulable_nodes=schedulable,
+            desired_replicas=desired,
+        )
+        return False, None
+
     payload = json.dumps({
         "spec": {
-            "replicas": replicas,
+            "replicas": desired,
             "template": {"spec": {
-                "tolerations": keep + fast,
-                "affinity": spread,
+                "tolerations": want_tolerations,
+                "affinity": affinity_patch,
             }},
         },
     }).encode("utf-8")
     try:
         status, resp = _request(
-            "PATCH", path, body=payload,
+            "PATCH", _COREDNS_PATH, body=payload,
             content_type="application/merge-patch+json",
         )
-    except RuntimeError as exc:
+    except (RuntimeError, OSError) as exc:
         return False, str(exc)
     if status in (200, 201):
+        log.info(
+            "supervisor.k8s_api.coredns_reconciled",
+            registered_nodes=registered,
+            replicas=desired,
+            shape="ha" if want_ha else "stock",
+        )
         return True, None
     return False, f"kubeapi status {status}: {resp[:200]!r}"
 

--- a/agent/supervisor/tests/test_coredns_ha.py
+++ b/agent/supervisor/tests/test_coredns_ha.py
@@ -1,30 +1,76 @@
-"""#590 — ensure_coredns_ha keeps cluster DNS able to survive a node loss.
+"""#590 / #750 — ensure_coredns_ha matches cluster DNS to the node count.
 
 k3s ships CoreDNS as a single replica that deterministically lands on the
 seed and takes the k8s-default 300s to evict — a hard seed kill silences
 all Service/pod-FQDN resolution (the api readiness gate's Postgres and
-Redis lookups included) for longer than any recovery budget. These tests
-pin the reconciler's contract: patch a stock deployment to 2 replicas +
-fast-evict tolerations (stock entries preserved) + REQUIRED anti-affinity;
-converge idempotently; upgrade a preferred-affinity patch from an earlier
-build; and surface kubeapi errors.
+Redis lookups included) for longer than any recovery budget. #590 answered
+that with 2 replicas + fast-evict tolerations + REQUIRED anti-affinity.
+
+#750 is the other half: that shape only works once a second node exists.
+On a single node the patch rewrites the pod template, so a new ReplicaSet
+appears whose pods cannot schedule (required anti-affinity, one node)
+while the old one cannot drain (minAvailable 1, zero new pods Ready) —
+a rollout stuck forever, blocking every later coredns change.
+
+These tests pin both halves: stock stays stock on one node (no patch at
+all), an already-deadlocked appliance is reverted to stock, a real cluster
+still gets the full HA shape, the count is capped at 2, a rollout that
+could not land is deferred rather than authored, and kubeapi errors
+surface.
 """
 
 from __future__ import annotations
 
 import json
 
+import pytest
+
 from spatium_supervisor import k8s_api
+
+_NODES_PATH = "/api/v1/nodes"
 
 
 class _Recorder:
-    def __init__(self, get_status: int, get_body: str, patch_status: int = 200):
+    """Fake ``_request`` that answers the node list and the coredns GET.
+
+    ``ensure_coredns_ha`` reads ``/api/v1/nodes`` before it reads the
+    Deployment, so the fake has to route on path rather than method.
+    """
+
+    def __init__(
+        self,
+        get_status: int,
+        get_body: str,
+        patch_status: int = 200,
+        *,
+        nodes: int = 1,
+        schedulable: int | None = None,
+        nodes_status: int = 200,
+    ):
         self._get = (get_status, get_body)
         self._patch_status = patch_status
+        self._nodes = nodes
+        self._schedulable = nodes if schedulable is None else schedulable
+        self._nodes_status = nodes_status
         self.calls: list[tuple[str, str, bytes | None]] = []
 
-    def __call__(self, method, path, body=None, content_type=None):
+    def _node_list(self) -> str:
+        items = []
+        for i in range(self._nodes):
+            ready = "True" if i < self._schedulable else "False"
+            items.append({
+                "metadata": {"name": f"n{i}"},
+                "spec": {},
+                "status": {"conditions": [{"type": "Ready", "status": ready}]},
+            })
+        return json.dumps({"items": items})
+
+    def __call__(self, method, path, body=None, content_type=None, timeout=None):
         self.calls.append((method, path, body))
+        if method == "GET" and path == _NODES_PATH:
+            if self._nodes_status != 200:
+                return (self._nodes_status, "forbidden")
+            return (200, self._node_list())
         if method == "GET":
             return self._get
         return (self._patch_status, "{}")
@@ -63,6 +109,11 @@ _REQUIRED_SPREAD = {
     },
 }
 
+_PREFERRED_SPREAD = {
+    "podAntiAffinity": {
+        "preferredDuringSchedulingIgnoredDuringExecution": [{"weight": 100}]}
+}
+
 
 def _deploy(replicas: int, tolerations: list, affinity: dict | None = None) -> str:
     tmpl_spec: dict = {"tolerations": tolerations}
@@ -72,24 +123,113 @@ def _deploy(replicas: int, tolerations: list, affinity: dict | None = None) -> s
                                 "template": {"spec": tmpl_spec}}})
 
 
-def test_stock_manifest_gets_replicas_tolerations_and_required_spread(monkeypatch) -> None:
-    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS))
+# ── Single node: stock is the target ────────────────────────────────────────
+
+def test_single_node_stock_manifest_is_left_alone(monkeypatch) -> None:
+    """The #750 fix in one assertion: on one node the stock manifest already
+    IS the target, so a fresh install never patches, never creates a second
+    ReplicaSet, and therefore cannot deadlock."""
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS), nodes=1)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (False, None)
+    assert not rec.patched
+
+
+def test_single_node_deadlock_is_reverted_to_stock(monkeypatch) -> None:
+    """An appliance already stuck in the deadlock — replicas 2 + required
+    anti-affinity on one node — heals: back to one replica, fast-evict
+    tolerations dropped, affinity removed (``null`` deletes the key under a
+    merge-patch, restoring the stock template and its hash)."""
+    rec = _Recorder(
+        200,
+        _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _REQUIRED_SPREAD),
+        nodes=1,
+    )
     monkeypatch.setattr(k8s_api, "_request", rec)
 
     changed, err = k8s_api.ensure_coredns_ha()
 
     assert (changed, err) == (True, None)
-    body = rec.patch_body
-    assert body["spec"]["replicas"] == 2
+    spec = rec.patch_body["spec"]
+    assert spec["replicas"] == 1
+    assert spec["template"]["spec"]["tolerations"] == _STOCK_TOLERATIONS
+    assert spec["template"]["spec"]["affinity"] is None
+
+
+def test_single_node_keeps_sibling_affinity_terms(monkeypatch) -> None:
+    """A merge-patch recurses into objects, so nulling the whole ``affinity``
+    would take a stock ``nodeAffinity`` with it. Null just the one key when
+    there are siblings — the heal then costs a rollout, which is the cheaper
+    of the two prices."""
+    mixed = {
+        "nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {}},
+        **_REQUIRED_SPREAD,
+    }
+    rec = _Recorder(
+        200, _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, mixed), nodes=1
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["template"]["spec"]["affinity"] == {
+        "podAntiAffinity": None
+    }
+
+
+def test_single_node_reverts_a_half_applied_fast_evict_template(monkeypatch) -> None:
+    """One leftover fast-evict toleration is still a fast-evict toleration on a
+    box with nowhere to reschedule the evicted pod."""
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS + _FAST_TOLERATIONS[:1]), nodes=1)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["template"]["spec"]["tolerations"] == _STOCK_TOLERATIONS
+
+
+def test_single_node_preferred_spread_is_also_reverted(monkeypatch) -> None:
+    """A pre-#633 build's preferred anti-affinity is not the required one, so
+    it must not read as "stock" and be left behind on a single node."""
+    rec = _Recorder(
+        200, _deploy(1, _STOCK_TOLERATIONS, _PREFERRED_SPREAD), nodes=1
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["template"]["spec"]["affinity"] is None
+
+
+# ── Two or more nodes: the #590 HA shape ────────────────────────────────────
+
+def test_two_nodes_stock_manifest_gets_the_ha_shape(monkeypatch) -> None:
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS), nodes=2)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    spec = rec.patch_body["spec"]
+    assert spec["replicas"] == 2
     # Stock tolerations ride along — the merge-patch REPLACES the list.
-    assert body["spec"]["template"]["spec"]["tolerations"] == (
+    assert spec["template"]["spec"]["tolerations"] == (
         _STOCK_TOLERATIONS + _FAST_TOLERATIONS)
-    assert body["spec"]["template"]["spec"]["affinity"] == _REQUIRED_SPREAD
+    assert spec["template"]["spec"]["affinity"] == _REQUIRED_SPREAD
 
 
 def test_idempotent_when_converged(monkeypatch) -> None:
-    rec = _Recorder(200, _deploy(
-        2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _REQUIRED_SPREAD))
+    rec = _Recorder(
+        200,
+        _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _REQUIRED_SPREAD),
+        nodes=2,
+    )
     monkeypatch.setattr(k8s_api, "_request", rec)
 
     changed, err = k8s_api.ensure_coredns_ha()
@@ -104,10 +244,11 @@ def test_preferred_spread_from_earlier_build_is_upgraded(monkeypatch) -> None:
     # firstboot (k8s never rebalances running pods) — the "HA" DNS died
     # with the seed anyway. A cluster patched by that build must be
     # re-patched to the required form, not short-circuited as converged.
-    preferred = {"podAntiAffinity": {
-        "preferredDuringSchedulingIgnoredDuringExecution": [{"weight": 100}]}}
-    rec = _Recorder(200, _deploy(
-        2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, preferred))
+    rec = _Recorder(
+        200,
+        _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _PREFERRED_SPREAD),
+        nodes=2,
+    )
     monkeypatch.setattr(k8s_api, "_request", rec)
 
     changed, err = k8s_api.ensure_coredns_ha()
@@ -116,8 +257,161 @@ def test_preferred_spread_from_earlier_build_is_upgraded(monkeypatch) -> None:
     assert rec.patch_body["spec"]["template"]["spec"]["affinity"] == _REQUIRED_SPREAD
 
 
+def test_half_applied_fast_evict_is_repaired_on_a_real_cluster(monkeypatch) -> None:
+    """``unreachable`` alone is not the #590 shape — ``not-ready`` carries the
+    other 300 s default. A template missing one must not read as converged."""
+    rec = _Recorder(
+        200,
+        _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS[:1], _REQUIRED_SPREAD),
+        nodes=2,
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["template"]["spec"]["tolerations"] == (
+        _STOCK_TOLERATIONS + _FAST_TOLERATIONS)
+
+
+def test_replicas_capped_at_two_on_a_larger_cluster(monkeypatch) -> None:
+    """Required anti-affinity puts at most one pod per node; a third replica
+    on a 3-node cluster costs memory for no extra failure tolerance."""
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS), nodes=3)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["replicas"] == 2
+
+
+# ── Feasibility gate ────────────────────────────────────────────────────────
+
+def test_template_change_deferred_while_a_node_is_down(monkeypatch) -> None:
+    """Two registered nodes but only one schedulable: patching the template to
+    the HA shape now would author exactly the #750 deadlock. Defer — not an
+    error, and retried on the next heartbeat."""
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS), nodes=2, schedulable=1)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (False, None)
+    assert not rec.patched
+
+
+def test_scale_up_with_correct_template_is_not_deferred(monkeypatch) -> None:
+    """A pure replica change creates no new ReplicaSet, so it cannot deadlock:
+    the extra pod just sits Pending until the peer is back."""
+    rec = _Recorder(
+        200,
+        _deploy(1, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _REQUIRED_SPREAD),
+        nodes=2,
+        schedulable=1,
+    )
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["replicas"] == 2
+
+
+# ── Convergence: the patch must settle, in one round ────────────────────────
+
+def _apply(deploy_json: str, patch_body: dict) -> str:
+    """Apply the reconciler's merge-patch to a fake deployment, the way the
+    apiserver would, so a test can feed the result straight back in."""
+    dep = json.loads(deploy_json)
+    tmpl = dep["spec"]["template"]["spec"]
+    patch_spec = patch_body["spec"]
+    dep["spec"]["replicas"] = patch_spec["replicas"]
+    patch_tmpl = patch_spec["template"]["spec"]
+    tmpl["tolerations"] = patch_tmpl["tolerations"]
+    merged = k8s_api._merge_patch(tmpl.get("affinity"), patch_tmpl["affinity"])
+    if patch_tmpl["affinity"] is None or merged is None:
+        tmpl.pop("affinity", None)
+    else:
+        tmpl["affinity"] = merged
+    return json.dumps(dep)
+
+
+@pytest.mark.parametrize(
+    "nodes,deployment",
+    [
+        # Fresh install on a real cluster.
+        (2, _deploy(1, _STOCK_TOLERATIONS)),
+        # The #750 deadlock, on one node.
+        (1, _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _REQUIRED_SPREAD)),
+        # Sibling scheduling constraints we must not delete.
+        (1, _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, {
+            "nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {}},
+            **_REQUIRED_SPREAD,
+        })),
+        (2, _deploy(1, _STOCK_TOLERATIONS, {
+            "nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {}},
+        })),
+        # A pre-#633 build's preferred spread.
+        (2, _deploy(2, _STOCK_TOLERATIONS + _FAST_TOLERATIONS, _PREFERRED_SPREAD)),
+        # Someone hand-edited the eviction delay.
+        (2, _deploy(2, _STOCK_TOLERATIONS + [
+            {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
+             "effect": "NoExecute", "tolerationSeconds": 25},
+            {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
+             "effect": "NoExecute", "tolerationSeconds": 25},
+        ], _REQUIRED_SPREAD)),
+    ],
+)
+def test_one_patch_reaches_a_fixed_point(monkeypatch, nodes, deployment) -> None:
+    """Patch, feed the result back, and the reconciler must report converged.
+
+    This is the patch-storm guard. The reconciler runs on every 30 s heartbeat,
+    so any state where it patches, the apiserver accepts, and it still says
+    "not converged" is an endless rollout — far worse than the deadlock #750
+    fixed. Each case below is one that a looser convergence check could get
+    wrong.
+    """
+    first = _Recorder(200, deployment, nodes=nodes)
+    monkeypatch.setattr(k8s_api, "_request", first)
+    changed, err = k8s_api.ensure_coredns_ha()
+    assert (changed, err) == (True, None)
+
+    settled = _Recorder(200, _apply(deployment, first.patch_body), nodes=nodes)
+    monkeypatch.setattr(k8s_api, "_request", settled)
+
+    assert k8s_api.ensure_coredns_ha() == (False, None)
+    assert not settled.patched
+
+
+def test_hand_edited_eviction_delay_is_normalised(monkeypatch) -> None:
+    """A 25 s fast-evict toleration is not the shape we ship.
+
+    Convergence is "the template equals what we would send", not "it looks
+    close enough" — and the loose version of that check was what let a
+    template satisfy it while still differing from the canonical body, so the
+    resulting pod-template rewrite skipped the deadlock gate entirely.
+    """
+    near_miss = _STOCK_TOLERATIONS + [
+        {"key": "node.kubernetes.io/unreachable", "operator": "Exists",
+         "effect": "NoExecute", "tolerationSeconds": 25},
+        {"key": "node.kubernetes.io/not-ready", "operator": "Exists",
+         "effect": "NoExecute", "tolerationSeconds": 25},
+    ]
+    rec = _Recorder(200, _deploy(2, near_miss, _REQUIRED_SPREAD), nodes=2)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert (changed, err) == (True, None)
+    assert rec.patch_body["spec"]["template"]["spec"]["tolerations"] == (
+        _STOCK_TOLERATIONS + _FAST_TOLERATIONS)
+
+
+# ── Error paths ─────────────────────────────────────────────────────────────
+
 def test_missing_deployment_reports(monkeypatch) -> None:
-    rec = _Recorder(404, "not found")
+    rec = _Recorder(404, "not found", nodes=1)
     monkeypatch.setattr(k8s_api, "_request", rec)
 
     changed, err = k8s_api.ensure_coredns_ha()
@@ -125,3 +419,61 @@ def test_missing_deployment_reports(monkeypatch) -> None:
     assert changed is False
     assert err is not None and "404" in err
     assert not rec.patched
+
+
+def test_unreadable_node_list_defers_rather_than_guessing(monkeypatch) -> None:
+    """Without a node count there is no way to know which target applies, and
+    guessing the single-node one would scale a real cluster's DNS down."""
+    rec = _Recorder(200, _deploy(1, _STOCK_TOLERATIONS), nodes_status=403)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert changed is False
+    assert err is not None and "node count" in err
+    assert not rec.patched
+
+
+def test_transport_error_on_the_node_list_is_caught(monkeypatch) -> None:
+    """``_request`` builds its connection (and reads the CA) outside the try
+    that converts transport errors, so a bare OSError can reach us. It must
+    not escape into the heartbeat loop."""
+
+    def boom(method, path, body=None, content_type=None, timeout=None):
+        raise OSError("ca.crt: permission denied")
+
+    monkeypatch.setattr(k8s_api, "_request", boom)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert changed is False
+    assert err is not None and "permission denied" in err
+
+
+def test_zero_nodes_is_treated_as_a_bad_read(monkeypatch) -> None:
+    rec = _Recorder(200, _deploy(2, _STOCK_TOLERATIONS), nodes=0)
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    changed, err = k8s_api.ensure_coredns_ha()
+
+    assert changed is False
+    assert err is not None and "no nodes" in err
+    assert not rec.patched
+
+
+def test_count_nodes_ignores_cordoned_and_notready_for_schedulable(monkeypatch) -> None:
+    """``registered`` counts Node objects (flap-free, survives NotReady);
+    ``ready_and_schedulable`` is the stricter count the feasibility gate uses."""
+    listing = json.dumps({"items": [
+        {"spec": {}, "status": {"conditions": [{"type": "Ready", "status": "True"}]}},
+        {"spec": {"unschedulable": True},
+         "status": {"conditions": [{"type": "Ready", "status": "True"}]}},
+        {"spec": {}, "status": {"conditions": [{"type": "Ready", "status": "False"}]}},
+    ]})
+    monkeypatch.setattr(
+        k8s_api,
+        "_request",
+        lambda method, path, body=None, content_type=None, timeout=None: (200, listing),
+    )
+
+    assert k8s_api.count_nodes() == (3, 1, None)

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -7,12 +7,13 @@ from __future__ import annotations
 
 import ipaddress
 import uuid
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
@@ -49,6 +50,7 @@ NULLABLE_CLEARABLE_SCOPE_FIELDS = {
 }
 # DHCPv6 operating modes (issue #52). Only meaningful for ipv6 scopes.
 VALID_V6_MODES = {"stateful", "stateless", "slaac"}
+
 
 _CODE_TO_NAME: dict[int, str] = {
     2: "time-offset",
@@ -147,6 +149,72 @@ def _normalize_sync_mode(v: str | None) -> str:
     return legacy.get(v, v)
 
 
+# Fields the scope write models accept under two names, as
+# ``(name ScopeResponse emits, alias also accepted, comparison normaliser)``.
+# Both aliases are the underlying column name, which is why they are accepted
+# and why a script reaches for them first: they are what the model, the DHCP
+# services layer and docs/features/DHCP.md all call the field.
+_SCOPE_FIELD_ALIASES: tuple[tuple[str, str, Callable[[Any], Any]], ...] = (
+    ("enabled", "is_active", lambda v: v),
+    ("hostname_sync_mode", "hostname_to_ipam_sync", _normalize_sync_mode),
+)
+
+
+def _assert_aliases_agree(values: dict[str, Any], fields_set: set[str]) -> None:
+    """Refuse a body that sets one field twice, under both its names, and
+    disagrees with itself (#774).
+
+    ``ScopeResponse`` emits only one name of each pair, so the natural
+    read-modify-write — GET, edit, PUT the whole representation back — produces
+    a body carrying BOTH as soon as the caller reaches for the column name.
+    Whichever name the handler happened to prefer then won, and for the active
+    flag that was the stale one the GET supplied: "deactivate this scope"
+    answering 200 while the scope kept handing out addresses.
+
+    A precedence rule *could* be built — the response never emits the alias, so
+    an ``is_active`` in a body is always a deliberate keystroke while an
+    ``enabled`` may be GET residue. We refuse anyway: silently picking between
+    two contradictory instructions is the wrong posture for the flag that
+    decides whether a DHCP server hands out addresses, and the entire cost of
+    this bug was that it was silent. A refusal names the problem where it
+    happens. Sending exactly one name is unambiguous, is what every client in
+    the repo already does, and still works untouched.
+
+    Nothing counts as a disagreement unless both names carry a real value:
+    ``null`` and ``""`` mean "not supplied", and values that normalise to the
+    same thing — ``learned`` and ``on_lease`` — agree. ``False`` is a real
+    value and is compared as one.
+
+    The empty-string carve-out exists because ``create_scope`` resolves this
+    pair with ``a or b``, so an empty ``hostname_sync_mode`` has always fallen
+    through to the other name and must not start 422-ing. ``update_scope``
+    branches on key presence instead, so there an empty string still wins and
+    resolves to the default — pre-existing, and unreachable from the flow this
+    guard is about, because ``ScopeResponse`` reads the field from a NOT-NULL
+    column that only ever holds a canonical value, so a fetched body cannot
+    carry an empty one.
+    """
+
+    def _unsupplied(value: Any) -> bool:
+        return value is None or (isinstance(value, str) and not value)
+
+    for public, alias, normalize in _SCOPE_FIELD_ALIASES:
+        if public not in fields_set or alias not in fields_set:
+            continue
+        public_value, alias_value = values.get(public), values.get(alias)
+        if _unsupplied(public_value) or _unsupplied(alias_value):
+            continue
+        if normalize(public_value) == normalize(alias_value):
+            continue
+        raise ValueError(
+            f"{public!r} and {alias!r} are two names for the same field and this "
+            f"request sets them to different values ({public}={public_value!r}, "
+            f"{alias}={alias_value!r}). Send only one of them — {public!r} is the "
+            f"name the scope endpoints return, so a read-modify-write should edit "
+            f"that one."
+        )
+
+
 def _validate_relay_addresses(v: list[str] | None) -> list[str]:
     """Validate + de-dupe relay-agent IPs (issue #337).
 
@@ -201,6 +269,11 @@ class ScopeCreate(BaseModel):
     group_id: uuid.UUID | None = None
     name: str = ""
     description: str = ""
+    # Two names for one column — see ``_SCOPE_FIELD_ALIASES``. ``enabled`` is
+    # the public one (it is what ``ScopeResponse`` emits) and ``is_active`` is
+    # the accepted alias, kept because it is the column / model-attribute name
+    # and therefore the one scripts reach for first. Sending both with
+    # different values is refused rather than silently resolved (#774).
     is_active: bool = True
     enabled: bool | None = None
     lease_time: int = 86400
@@ -235,6 +308,19 @@ class ScopeCreate(BaseModel):
     relay_addresses: list[str] = Field(default_factory=list)
     tags: dict[str, Any] = Field(default_factory=dict)
 
+    @model_validator(mode="after")
+    def _field_aliases(self) -> ScopeCreate:
+        _assert_aliases_agree(
+            {
+                "enabled": self.enabled,
+                "is_active": self.is_active,
+                "hostname_sync_mode": self.hostname_sync_mode,
+                "hostname_to_ipam_sync": self.hostname_to_ipam_sync,
+            },
+            self.model_fields_set,
+        )
+        return self
+
     @field_validator("relay_addresses")
     @classmethod
     def _relay(cls, v: list[str] | None) -> list[str]:
@@ -266,6 +352,9 @@ class ScopeUpdate(BaseModel):
 
     name: str | None = None
     description: str | None = None
+    # See ScopeCreate: ``enabled`` is the public name, ``is_active`` the
+    # accepted alias for the same column, and a body that sets both to
+    # different values is refused instead of silently resolved (#774).
     is_active: bool | None = None
     enabled: bool | None = None
     lease_time: int | None = None
@@ -276,6 +365,8 @@ class ScopeUpdate(BaseModel):
     options: Any = None
     ddns_enabled: bool | None = None
     ddns_hostname_policy: str | None = None
+    # The second dual-named field (#774): ``hostname_sync_mode`` is what
+    # ``ScopeResponse`` emits, ``hostname_to_ipam_sync`` is the column name.
     hostname_to_ipam_sync: str | None = None
     hostname_sync_mode: str | None = None
     dns_track_dynamic_leases: bool | None = None
@@ -306,6 +397,19 @@ class ScopeUpdate(BaseModel):
     # scope's relay set (empty list clears it); omit to leave unchanged.
     relay_addresses: list[str] | None = None
     tags: dict[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def _field_aliases(self) -> ScopeUpdate:
+        _assert_aliases_agree(
+            {
+                "enabled": self.enabled,
+                "is_active": self.is_active,
+                "hostname_sync_mode": self.hostname_sync_mode,
+                "hostname_to_ipam_sync": self.hostname_to_ipam_sync,
+            },
+            self.model_fields_set,
+        )
+        return self
 
     @field_validator("v6_address_mode")
     @classmethod
@@ -488,6 +592,8 @@ async def create_scope(
     sync_mode = _normalize_sync_mode(body.hostname_sync_mode or body.hostname_to_ipam_sync)
     if sync_mode not in VALID_SYNC_MODES - {"ipam", "learned"}:
         raise HTTPException(status_code=422, detail=f"invalid hostname sync mode: {sync_mode}")
+    # Same alias resolution as update: ``enabled`` wins when supplied, and
+    # ``ScopeCreate`` has already refused a body where the two disagree (#774).
     is_active = body.enabled if body.enabled is not None else body.is_active
     try:
         _net = ipaddress.ip_network(str(subnet.network), strict=False)
@@ -590,8 +696,15 @@ async def update_scope(
         for k, v in body.model_dump(exclude_unset=True).items()
         if v is not None or k in NULLABLE_CLEARABLE_SCOPE_FIELDS
     }
+    # ``enabled`` is the public alias for the ``is_active`` column. Safe to let
+    # it win unconditionally now: ``ScopeUpdate`` refuses a body that sets both
+    # to different values, so this can no longer overwrite a deliberate
+    # ``is_active`` with the stale ``enabled`` a GET supplied (#774).
     if "enabled" in changes:
         changes["is_active"] = changes.pop("enabled")
+    # Same alias resolution, same guarantee: the write model refuses a body
+    # where the two names disagree, so preferring one can no longer shadow a
+    # deliberate edit to the other (#774).
     if "hostname_sync_mode" in changes:
         changes["hostname_to_ipam_sync"] = _normalize_sync_mode(changes.pop("hostname_sync_mode"))
     elif "hostname_to_ipam_sync" in changes:

--- a/backend/app/services/cutover/preflight.py
+++ b/backend/app/services/cutover/preflight.py
@@ -129,13 +129,20 @@ async def _assert_target_is_not_the_source(db: AsyncSession, zone: DNSZone) -> N
 def _ttl_ops(records: list[DNSRecord], zone: DNSZone) -> list[dict[str, Any]]:
     """Build the record-op batch for a TTL rewrite, RRset-aware.
 
-    The BIND9 agent turns a ``create`` / ``update`` op into an RFC 2136
-    ``replace`` by default, which swaps the **whole RRset** for the single value
-    in that op. That is right for the one-value-per-name case the record CRUD
-    path was written for, and silently destructive for anything else: a name
-    with three round-robin A records would be rewritten three times and end up
-    serving only the last one. Lowering a TTL must not cost the operator two
-    thirds of their addresses.
+    #773 stamps the complete desired RRset onto ordinary record ops, which
+    would cover this too — but setting ``rrset_action`` opts an op out of that
+    stamping, and this path keeps doing so on purpose. The grouping below is
+    what protects an agent that predates the ``rrset`` field, and agents deploy
+    on their own schedule; this is the one path where getting it wrong costs
+    the operator addresses at exactly the moment they are migrating.
+
+    The hazard it guards: an agent that knows only ``rrset_action`` turns a
+    ``create`` / ``update`` op into an RFC 2136 ``replace``, which swaps the
+    **whole RRset** for the single value in that op. That is right for the
+    one-value-per-name case the record CRUD path was written for, and silently
+    destructive for anything else: a name with three round-robin A records
+    would be rewritten three times and end up serving only the last one.
+    Lowering a TTL must not cost the operator two thirds of their addresses.
 
     So ops are grouped by ``(name, type)``. The first op in a group keeps the
     default ``replace`` — which clears the old RRset — and every sibling carries
@@ -145,10 +152,12 @@ def _ttl_ops(records: list[DNSRecord], zone: DNSZone) -> list[dict[str, Any]]:
 
     A ``None`` TTL is resolved to ``zone.ttl`` **on the wire**. The row keeps its
     NULL — that is how "inherit the zone default" is stored, and the restore path
-    depends on it — but the agent's record-op branch falls back to a hardcoded
-    3600 rather than the zone's own default, so shipping the null would silently
-    write 3600 onto every inheriting record of a zone whose default is anything
-    else. Resolving here keeps the wire honest without touching the row.
+    depends on it — but an older agent's record-op branch falls back to a
+    hardcoded 3600 rather than the zone's own default, so shipping the null
+    would silently write 3600 onto every inheriting record of a zone whose
+    default is anything else. Resolving here keeps the wire honest without
+    touching the row — and since these ops opt out of #773's stamping, this
+    is still the only place it happens for them.
     """
     grouped: dict[tuple[str, str], list[DNSRecord]] = {}
     for rec in records:

--- a/backend/app/services/dns/pool_apply.py
+++ b/backend/app/services/dns/pool_apply.py
@@ -219,6 +219,12 @@ async def _delete_pool_record(db: AsyncSession, zone: DNSZone, rec: DNSRecord) -
     # ``delete_value`` removes only this specific RR — sibling pool
     # members at the same (name, rtype) survive. Without this, removing
     # one unhealthy member would wipe every healthy member's record too.
+    # #773 ships the complete desired RRset on ordinary record ops, but pool
+    # ops opt out by carrying this flag: a pool re-points a member as a
+    # delete-then-create pair on ONE serial, and a whole-RRset write would make
+    # that pair order-dependent (the delete's set is computed before the row is
+    # mutated, so applying it after the create would drop the new address).
+    # Per-RR semantics are order-independent, which is what this path needs.
     snapshot = {
         "name": rec.name,
         "type": rec.record_type,
@@ -238,6 +244,9 @@ def _record_payload(pool: DNSPool, member: DNSPoolMember, ttl: int | None) -> di
     # The default RFC 2136 ``replace`` would clobber siblings on every
     # create, so the BIND9 driver only ever has one record live at the
     # pool's name regardless of how many members exist.
+    # Setting it also opts these ops out of #773's whole-RRset stamping, which
+    # is deliberate — see ``_delete_pool_record`` for why per-RR semantics are
+    # the right shape for the delete-then-create pair this module emits.
     return {
         "name": pool.record_name,
         "type": pool.record_type,

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -22,6 +22,7 @@ from app.core.agent_wake import collect_wake, dns_group_channel
 from app.drivers.dns import get_driver, is_agentless
 from app.drivers.dns.base import RecordChange, RecordData
 from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSZone
+from app.services.dns.rrset import stamp_rrsets_for_ops
 from app.services.dns.serial import bump_zone_serial
 
 logger = structlog.get_logger(__name__)
@@ -218,6 +219,17 @@ async def enqueue_record_op(
         )
         return None
 
+    # #773 — ship the complete desired RRset alongside the op. Every agent
+    # driver has to apply a record change as a whole-RRset write, so without
+    # this a second value at an existing (name, type) silently retired the
+    # first. Skipped when the payload already carries one, because the batch
+    # path folds and stamps its whole list in a single query before delegating
+    # here — restamping per op would undo the fold. (An op carrying an explicit
+    # ``rrset_action`` opts out entirely; ``stamp_rrsets_for_ops`` handles it.)
+    if "rrset" not in record:
+        record = dict(record)
+        await stamp_rrsets_for_ops(db, zone, [{"op": op, "record": record}])
+
     primary_op: DNSRecordOp | None = None
     first_op: DNSRecordOp | None = None
     for srv in agent_servers:
@@ -331,6 +343,12 @@ async def enqueue_record_ops_batch(
     # Agent-based: DB rows only; agent will batch at poll time. Delegates to
     # enqueue_record_op per op, which fans out to every ENABLED agent-based
     # server regardless of whether the designated primary is disabled (#481).
+    # The RRsets are resolved for the whole batch first (#773) — one query
+    # instead of one per op, and every op at a shared (name, type) then carries
+    # the same complete set, so none of them depends on the order the agent
+    # drains them in.
+    ops = [{**o, "record": dict(o["record"])} for o in ops]
+    await stamp_rrsets_for_ops(db, zone, ops)
     return [
         await enqueue_record_op(db, zone, o["op"], o["record"], o.get("target_serial")) for o in ops
     ]
@@ -400,6 +418,10 @@ async def enqueue_record_ops_bulk(
     agent_servers = [s for s in agent_rows if not is_agentless(s.driver)]
     if not agent_servers:
         return 0
+    # #773 — one query resolves every touched RRset for the whole batch, so the
+    # seed/import fast-path stays a fast path.
+    ops = [{**o, "record": dict(o["record"])} for o in ops]
+    await stamp_rrsets_for_ops(db, zone, ops)
     for srv in agent_servers:
         db.add_all(
             [

--- a/backend/app/services/dns/rrset.py
+++ b/backend/app/services/dns/rrset.py
@@ -1,0 +1,272 @@
+"""Resolve the complete desired RRset for a record op (#773).
+
+A record op carries one record. Every agent-side driver has to turn that into a
+whole-RRset write, because none of the three wire protocols can express "change
+this one RR and leave its siblings alone" from a payload that only names the
+NEW value:
+
+* BIND9 (RFC 2136) used ``upd.replace(...)``, which swaps the entire RRset for
+  the single value in the op.
+* Technitium used ``overwrite=true``, which does the same thing.
+* PowerDNS read the live RRset and spliced the new value in — so it did not
+  lose siblings, but it could not remove the *old* value on an edit either, and
+  its own comment says so.
+
+The result was that a name with more than one value at the same type served
+only whichever op landed last: round-robin A records, a backup MX, SPF beside a
+verification TXT, multiple apex NS. The database held every value and the
+agent's rendered zone file held every value; only the incremental update path
+lost them. ``rrset_action="add"`` existed as a per-op escape hatch but exactly
+two callers ever set it, so everything else — operator record CRUD, the DNS
+importers, IPAM→DNS sync, DDNS, ACME, trash restore — was affected.
+
+The fix is to stop asking the wire protocol a question it cannot answer. The
+control plane already knows the complete desired RRset — it is the source of
+truth — so it ships that with the op, and each driver applies it as one atomic
+whole-RRset write. Ops become idempotent and self-healing (replaying one
+converges the server to the database) instead of order-dependent.
+
+Wire shape, added to the op's ``record`` payload::
+
+    "rrset": {"ttl": 3600,
+              "members": [{"value": "10.0.0.1"},
+                          {"value": "10.0.0.2"}]}
+
+``members`` carries the structured fields too (``priority`` / ``weight`` /
+``port``) so a driver composes each member's wire form exactly as it composes
+the op's own. An EMPTY member list means the RRset should not exist at all.
+
+Backward compatibility runs both ways. An agent that predates this field
+ignores it and behaves exactly as it does today (the bug is not fixed for it,
+but nothing is made worse). A current agent handed an op from an older control
+plane sees no ``rrset`` and falls back to the previous ``rrset_action``
+semantics.
+
+The two callers that set ``rrset_action`` themselves — DNS pools and the
+Windows-cutover TTL pre-flight — are deliberately NOT stamped, and keep the
+per-RR semantics they already had. See :func:`stamp_rrsets_for_ops` for why a
+whole-RRset write is the wrong shape for the pool re-point pair specifically.
+
+Known bound: an op carries the RRset as of the moment it was ENQUEUED. Ops
+enqueued together carry the same set, so a batch converges whichever order the
+agent drains it in and however many times an op is replayed. Ops enqueued
+minutes apart do not: if an older op fails, is reset to ``pending`` by
+``ack_op`` and re-ships after a newer one has already applied, it reinstalls
+the older set. That is the same outcome the previous single-value ``replace``
+produced in that situation — no worse — and the next write to the name, or a
+structural re-render, converges it. Making it airtight would mean re-resolving
+the set at dispatch time in ``agent_config``, which costs a query per op per
+bundle for a failure-path edge.
+
+This is the agent path only. The agentless drivers (Windows DNS, and the cloud
+providers) never see the field: ``enqueue_record_op`` stamps after it has
+branched, so their op rows do not claim an RRset write nobody performed.
+Windows DNS has its own whole-RRset collapse in ``drivers/dns/windows.py``;
+that is a separate fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dns import DNSRecord, DNSZone
+
+# Ops that describe an RRset. Everything else on the record-op queue is
+# zone-level (``dnssec_sign`` / ``dnssec_unsign`` / ``dnssec_rollover``) and
+# carries a placeholder record payload with no value to reason about.
+RRSET_OPS = frozenset({"create", "update", "delete"})
+
+# Fields that make up a member's wire form beyond the value itself.
+_STRUCT_FIELDS = ("priority", "weight", "port")
+
+# Names per ``IN`` clause. asyncpg refuses a statement with more than 32 767
+# bind parameters, and the bulk path can touch far more names than that.
+_NAME_CHUNK = 5000
+
+
+def rrset_key(record: dict[str, Any]) -> tuple[str, str] | None:
+    """The ``(name, type)`` an op's payload addresses, normalised, or None when
+    the payload is not RRset-shaped (a DNSSEC op's placeholder record)."""
+    rtype = record.get("type")
+    if not rtype or rtype == "DNSSEC_OP":
+        return None
+    return ((record.get("name") or "@").lower(), str(rtype).upper())
+
+
+def rrset_target(op: str, record: dict[str, Any]) -> tuple[str, str] | None:
+    """The ``(name, type)`` this op performs an RRset write against, or None
+    when it does not perform one.
+
+    A payload with no ``value`` is refused as well as a non-RRset op: the whole
+    scheme is "here is the set the server should end up with", and a set
+    computed without knowing which RR the op is about would be wrong in the
+    dangerous direction — a delete would ship the untouched set and quietly do
+    nothing. Falling back to the legacy single-value semantics is the safe
+    answer for a payload we cannot reason about.
+    """
+    if op not in RRSET_OPS or record.get("value") is None:
+        return None
+    return rrset_key(record)
+
+
+def _member(value: str, ttl: int | None, src: Any) -> dict[str, Any]:
+    """One RRset member. ``src`` is either a ``DNSRecord`` or an op payload
+    dict — both expose the structured fields under the same names."""
+    getter = src.get if isinstance(src, dict) else lambda f: getattr(src, f, None)
+    out: dict[str, Any] = {"value": value, "ttl": ttl}
+    for field in _STRUCT_FIELDS:
+        val = getter(field)
+        if val is not None:
+            out[field] = val
+    return out
+
+
+def _same_rr(a: dict[str, Any], b: dict[str, Any]) -> bool:
+    """Whether two members are the same resource record.
+
+    Value plus the structured fields, because two MX members at one name differ
+    only by priority and two SRV members only by weight/port. TTL is excluded —
+    it is a property of the RRset, not of a member, so a TTL-only edit must
+    match its own record rather than adding a second copy of it.
+    """
+    if str(a.get("value") or "").strip() != str(b.get("value") or "").strip():
+        return False
+    return all(a.get(f) == b.get(f) for f in _STRUCT_FIELDS)
+
+
+async def resolve_rrsets(
+    db: AsyncSession,
+    zone: DNSZone,
+    keys: set[tuple[str, str]],
+) -> dict[tuple[str, str], list[dict[str, Any]]]:
+    """Load the live members of every requested ``(name, type)``.
+
+    Names are matched case-insensitively because DNS is; the database stores
+    whatever the operator typed. Soft-deleted rows are excluded by the
+    session-wide ``deleted_at IS NULL`` criterion in ``app.db``, and the SELECT
+    autoflushes, so a row created / edited / soft-deleted earlier in the same
+    request is already reflected here.
+
+    The name list is chunked. ``enqueue_record_ops_bulk`` is the seed / import
+    fast path and can hand over tens of thousands of distinct names in one call;
+    a single ``IN`` would blow asyncpg's 32 767-bind-parameter ceiling and fail
+    the whole commit, which for an import means losing the entire zone rather
+    than one record.
+
+    View-scoped records (``view_id``) are not filtered: a server whose group has
+    views never receives incremental ops at all — ``agent_config`` retires them
+    and re-renders the whole zone per view instead — so an op that reaches a
+    driver is always from a group where every record lands in one namespace.
+    """
+    if not keys:
+        return {}
+    out: dict[tuple[str, str], list[dict[str, Any]]] = {key: [] for key in keys}
+    names = sorted({name for name, _ in keys})
+    for start in range(0, len(names), _NAME_CHUNK):
+        rows = (
+            (
+                await db.execute(
+                    select(DNSRecord).where(
+                        DNSRecord.zone_id == zone.id,
+                        func.lower(DNSRecord.name).in_(names[start : start + _NAME_CHUNK]),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            key = ((row.name or "@").lower(), (row.record_type or "").upper())
+            if key in out:
+                out[key].append(_member(row.value, row.ttl, row))
+    return out
+
+
+def _fold(
+    op: str,
+    record: dict[str, Any],
+    members: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """The RRset that should exist after ``op`` is applied to ``members``.
+
+    * ``create`` / ``update`` — the op's value is present exactly once. It is
+      spliced over any identical member rather than appended, so replaying an
+      op cannot duplicate an RR, and an op whose row has not been flushed yet
+      still lands.
+    * ``delete`` — the op's value is absent. Removing by value matters for the
+      callers that enqueue the retraction *before* the row leaves the database
+      (``bulk_delete_records`` gates its DB delete on the wire result, so at
+      stamp time every victim is still live), where the rows the query returns
+      include the very values being retracted.
+    """
+    own = _member(record.get("value") or "", record.get("ttl"), record)
+    desired = [m for m in members if not _same_rr(m, own)]
+    if op != "delete":
+        desired.append(own)
+    return desired
+
+
+def _rrset_payload(members: list[dict[str, Any]], zone_ttl: int | None) -> dict[str, Any]:
+    """The wire form: one TTL plus the member list, TTLs stripped per member.
+
+    A null TTL means "inherit the zone default", which is how the zone file
+    renders it; resolving it here keeps the wire consistent with the file
+    instead of letting each driver fall back to a hardcoded 3600. Per RFC 2181
+    an RRset has ONE TTL, so members that disagree resolve to the lowest — the
+    conservative direction, since it only shortens caching.
+    """
+    default_ttl = 3600 if zone_ttl is None else zone_ttl
+    ttls = [default_ttl if m.get("ttl") is None else m["ttl"] for m in members]
+    return {
+        "ttl": min(ttls) if ttls else default_ttl,
+        "members": [{k: v for k, v in m.items() if k != "ttl"} for m in members],
+    }
+
+
+async def stamp_rrsets_for_ops(
+    db: AsyncSession,
+    zone: DNSZone,
+    ops: list[dict[str, Any]],
+) -> None:
+    """Stamp every op in a batch with the RRset that should exist once the
+    WHOLE batch has been applied. Payloads are mutated in place.
+
+    Folding the batch matters, and computing each op against the raw database
+    snapshot instead is actively wrong. ``bulk_delete_records`` builds its ops
+    from live rows and only deletes them after the wire result comes back, so
+    deleting two of three values at one name resolves to ``[A, B, C]`` for both
+    ops; reconciling each against that snapshot in isolation ships ``[B, C]``
+    for one and ``[A, C]`` for the other, and whichever lands last reinstates a
+    value the operator deleted.
+
+    Stamping every op with the FINAL set — rather than a running prefix — is
+    what keeps them order-independent as well as correct. Each op says "this
+    name should end up exactly like this", so the agent may drain them in any
+    order, and replaying one after the others is a no-op instead of a
+    regression to an earlier state.
+
+    Ops that carry an explicit ``rrset_action`` are left alone. Those callers
+    (DNS pools, the Windows-cutover TTL pre-flight) already express precise
+    per-RR semantics, and theirs are order-independent in a way a whole-RRset
+    write cannot be across SEPARATE enqueue calls: a pool re-points a member
+    with a ``delete_value`` of the old address and an ``add`` of the new, two
+    calls on one serial. Stamping those would make the pair order-dependent —
+    the delete's set is computed before the row is mutated, so applying it
+    after the create would drop the new address.
+    """
+    stampable = [o for o in ops if not (o["record"].get("rrset_action") or "")]
+    keys = {k for o in stampable if (k := rrset_target(o["op"], o["record"])) is not None}
+    if not keys:
+        return
+    final = {key: list(members) for key, members in (await resolve_rrsets(db, zone, keys)).items()}
+    for o in stampable:
+        key = rrset_target(o["op"], o["record"])
+        if key is not None:
+            final[key] = _fold(o["op"], o["record"], final.get(key, []))
+    for o in stampable:
+        key = rrset_target(o["op"], o["record"])
+        if key is not None:
+            o["record"]["rrset"] = _rrset_payload(final[key], zone.ttl)

--- a/backend/tests/test_dhcp_scope_active_alias.py
+++ b/backend/tests/test_dhcp_scope_active_alias.py
@@ -1,0 +1,287 @@
+"""#774 — ``enabled`` must not silently shadow ``is_active`` on a scope write.
+
+``ScopeResponse`` emits only ``enabled``; ``ScopeCreate`` / ``ScopeUpdate``
+accept ``is_active`` as well, because that is the column name and therefore the
+one a script reaches for. The natural read-modify-write — GET, edit, PUT the
+whole representation back — therefore produces a body carrying BOTH, and the
+handler used to let the ``enabled`` the GET supplied overwrite the ``is_active``
+the caller deliberately set. 200 OK, scope unchanged, no warning: a
+"deactivate this scope" that left the scope handing out addresses.
+
+These tests pin the resolution: a disagreement is a 422, either name works on
+its own, and agreeing values still apply.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.models.dhcp import DHCPScope, DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+CIDR = "192.0.2.0/24"
+
+
+async def _make_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _subnet_and_group(db: AsyncSession) -> tuple[Subnet, DHCPServerGroup]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    return subnet, grp
+
+
+async def _setup(client: AsyncClient, db: AsyncSession, **extra: object) -> tuple[dict, dict]:
+    """Returns (auth headers, created-scope body)."""
+    token = await _make_token(db)
+    subnet, grp = await _subnet_and_group(db)
+    await db.commit()
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "s", **extra},
+    )
+    assert r.status_code in (200, 201), r.text
+    return h, r.json()
+
+
+@pytest.mark.asyncio
+async def test_read_modify_write_with_is_active_is_refused_not_ignored(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The exact repro from the issue: GET, flip is_active, PUT it back."""
+    h, scope = await _setup(client, db_session)
+    assert scope["enabled"] is True
+
+    current = (await client.get(f"/api/v1/dhcp/scopes/{scope['id']}", headers=h)).json()
+    assert "is_active" not in current  # the response only ever carries `enabled`
+    current["is_active"] = False  # ...so the GET's `enabled: true` is now residue
+
+    r = await client.put(f"/api/v1/dhcp/scopes/{scope['id']}", headers=h, json=current)
+    assert r.status_code == 422, r.text
+    assert "is_active" in r.text and "enabled" in r.text
+
+    # And the scope is genuinely untouched — the old behaviour answered 200
+    # while doing exactly this.
+    after = (await client.get(f"/api/v1/dhcp/scopes/{scope['id']}", headers=h)).json()
+    assert after["enabled"] is True
+
+
+@pytest.mark.asyncio
+async def test_is_active_alone_deactivates(client: AsyncClient, db_session: AsyncSession) -> None:
+    h, scope = await _setup(client, db_session)
+    r = await client.put(f"/api/v1/dhcp/scopes/{scope['id']}", headers=h, json={"is_active": False})
+    assert r.status_code == 200, r.text
+    assert r.json()["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_enabled_alone_deactivates(client: AsyncClient, db_session: AsyncSession) -> None:
+    """What the frontend sends — must keep working untouched."""
+    h, scope = await _setup(client, db_session)
+    r = await client.put(f"/api/v1/dhcp/scopes/{scope['id']}", headers=h, json={"enabled": False})
+    assert r.status_code == 200, r.text
+    assert r.json()["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_both_names_agreeing_is_applied(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Only a *disagreement* is refused — a client that edits both is fine."""
+    h, scope = await _setup(client, db_session)
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{scope['id']}",
+        headers=h,
+        json={"enabled": False, "is_active": False},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_null_alias_counts_as_omitted(client: AsyncClient, db_session: AsyncSession) -> None:
+    """``enabled: null`` means "not specified", not "disagrees with False"."""
+    h, scope = await _setup(client, db_session)
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{scope['id']}",
+        headers=h,
+        json={"is_active": False, "enabled": None},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_hostname_sync_mode_alias_conflict_is_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The same shape on the other dual-named field found by the sweep.
+
+    ``ScopeResponse`` emits ``hostname_sync_mode``; ``hostname_to_ipam_sync`` is
+    the column name. Editing the column name on a fetched body used to be
+    shadowed exactly the same way — silently, though not service-affecting.
+    """
+    h, scope = await _setup(client, db_session)
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{scope['id']}",
+        headers=h,
+        json={"hostname_sync_mode": "on_static_only", "hostname_to_ipam_sync": "on_lease"},
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_hostname_sync_mode_legacy_alias_value_agrees(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``learned`` is the legacy spelling of ``on_lease`` — same value, not a
+    conflict. The comparison normalises before deciding."""
+    h, scope = await _setup(client, db_session)
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{scope['id']}",
+        headers=h,
+        json={"hostname_sync_mode": "learned", "hostname_to_ipam_sync": "on_lease"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["hostname_sync_mode"] == "on_lease"
+
+
+@pytest.mark.asyncio
+async def test_empty_string_alias_defers_to_the_other_name(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An empty ``hostname_sync_mode`` is "not supplied", not a disagreement.
+
+    The create handler resolves these with ``a or b``, so an empty string has
+    always fallen through to the other name; the guard must not turn that into
+    a 422.
+    """
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=h,
+        json={
+            "group_id": str(grp.id),
+            "name": "s",
+            "hostname_sync_mode": "",
+            "hostname_to_ipam_sync": "on_lease",
+        },
+    )
+    assert r.status_code in (200, 201), r.text
+    assert r.json()["hostname_sync_mode"] == "on_lease"
+
+
+@pytest.mark.asyncio
+async def test_refused_update_writes_no_audit_row_and_no_push(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A 422 mutates nothing, so there is nothing to audit and nothing to push.
+
+    The guard lives on the request model, so it fires during body parsing —
+    the handler, its audit write and the agent write-through never run.
+    """
+    h, scope = await _setup(client, db_session)
+    before = (
+        await db_session.execute(
+            select(func.count()).select_from(AuditLog).where(AuditLog.resource_id == scope["id"])
+        )
+    ).scalar_one()
+
+    r = await client.put(
+        f"/api/v1/dhcp/scopes/{scope['id']}",
+        headers=h,
+        json={"enabled": True, "is_active": False},
+    )
+    assert r.status_code == 422, r.text
+
+    after = (
+        await db_session.execute(
+            select(func.count()).select_from(AuditLog).where(AuditLog.resource_id == scope["id"])
+        )
+    ).scalar_one()
+    assert after == before
+    row = await db_session.get(DHCPScope, uuid.UUID(scope["id"]))
+    assert row is not None
+    await db_session.refresh(row)
+    assert row.is_active is True
+    assert row.last_pushed_at is None
+
+
+@pytest.mark.asyncio
+async def test_is_active_alone_is_audited_as_the_column_it_writes(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The handler rewrites the alias before auditing, so the trail names the
+    column that actually changed — and now it is the value the caller meant."""
+    h, scope = await _setup(client, db_session)
+    r = await client.put(f"/api/v1/dhcp/scopes/{scope['id']}", headers=h, json={"is_active": False})
+    assert r.status_code == 200, r.text
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog)
+            .where(AuditLog.resource_id == scope["id"], AuditLog.action == "update")
+            .order_by(AuditLog.timestamp.desc())
+            .limit(1)
+        )
+    ).scalar_one()
+    assert "is_active" in (audit.changed_fields or [])
+    row = await db_session.get(DHCPScope, uuid.UUID(scope["id"]))
+    assert row is not None
+    await db_session.refresh(row)
+    assert row.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_create_refuses_conflicting_names(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    subnet, grp = await _subnet_and_group(db_session)
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "s", "enabled": True, "is_active": False},
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_create_with_is_active_alone_lands_inactive(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _h, scope = await _setup(client, db_session, is_active=False)
+    assert scope["enabled"] is False

--- a/backend/tests/test_dns_rrset_ops.py
+++ b/backend/tests/test_dns_rrset_ops.py
@@ -1,0 +1,659 @@
+"""#773 — an agent-bound record op must carry the COMPLETE desired RRset.
+
+A record op names one record. Every agent driver has to turn that into a
+whole-RRset write, because none of the three wire protocols can express "change
+this RR and leave its siblings alone": BIND9 used RFC 2136 ``replace``,
+Technitium used ``overwrite=true``, PowerDNS spliced but could never retract.
+So a name carrying more than one value at the same type served only whichever
+op landed last — round-robin A records, a backup MX, an SPF beside a
+verification TXT, multiple apex NS. The database held every value and the
+agent's rendered zone file held every value; only the incremental update path
+lost them, which is exactly the kind of divergence nobody notices until a
+failover.
+
+The fix stops asking the wire protocol a question it cannot answer: the control
+plane already knows the whole RRset, so it stamps it onto the op and the driver
+applies it as one atomic write. This file pins that stamp — the payload shape,
+what it must and must not contain, and the two places it must stay absent.
+
+What each test guards:
+
+* the #773 repro itself — a second value at an existing name keeps the first
+* delete leaves siblings alone, and an empty member list is how "drop the whole
+  RRset" is expressed
+* the set is scoped to (name, type), and matched case-insensitively as DNS is
+* one TTL per RRset (RFC 2181), resolved from the zone default rather than a
+  driver-side hardcoded 3600
+* structured fields (priority / weight / port) ride along, or a two-member MX
+  loses the distinction between primary and backup
+* every op in a batch carries the same set, which is what makes a batch
+  order-independent and an op replay-safe
+* DNSSEC ops carry no RRset (they have no record to reason about) and must not
+  blow up on the way past
+* agentless drivers are NOT stamped — they never read the field, so a row
+  claiming an RRset write nobody performed is a lie in the audit trail
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSServerGroup, DNSZone
+from app.services.dns.record_ops import (
+    enqueue_record_op,
+    enqueue_record_ops_batch,
+    enqueue_record_ops_bulk,
+)
+
+# ── fixtures / helpers ──────────────────────────────────────────────────────
+
+
+async def _admin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"rr-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="RRset Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _group_and_zone(
+    db: AsyncSession,
+    *,
+    driver: str = "bind9",
+    zone_ttl: int = 3600,
+) -> tuple[DNSServerGroup, DNSServer, DNSZone]:
+    """One group, one primary server on ``driver``, one zone."""
+    grp = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    server = DNSServer(
+        group_id=grp.id,
+        driver=driver,
+        host="10.0.0.1",
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        is_primary=True,
+        is_enabled=True,
+    )
+    db.add(server)
+    await db.flush()
+    zone = DNSZone(
+        group_id=grp.id,
+        name=f"z{uuid.uuid4().hex[:6]}.example.",
+        zone_type="primary",
+        kind="forward",
+        primary_ns="ns1.example.",
+        admin_email="admin.example.",
+        ttl=zone_ttl,
+    )
+    db.add(zone)
+    await db.flush()
+    return grp, server, zone
+
+
+async def _add_record(
+    db: AsyncSession,
+    zone: DNSZone,
+    *,
+    name: str,
+    value: str,
+    record_type: str = "A",
+    ttl: int | None = None,
+    **struct: int | None,
+) -> DNSRecord:
+    """Insert a record row directly, bypassing the API.
+
+    Some cases need a row the API would normalise (a name stored with its
+    original case) or need the zone pre-populated without the create ops that
+    populating it through the API would also queue.
+    """
+    rec = DNSRecord(
+        zone_id=zone.id,
+        name=name,
+        fqdn=f"{name}.{zone.name}",
+        record_type=record_type,
+        value=value,
+        ttl=ttl,
+        **struct,
+    )
+    db.add(rec)
+    await db.flush()
+    return rec
+
+
+async def _ops(db: AsyncSession, zone: DNSZone) -> list[DNSRecordOp]:
+    return list(
+        (await db.execute(select(DNSRecordOp).where(DNSRecordOp.zone_name == zone.name)))
+        .scalars()
+        .all()
+    )
+
+
+async def _op_for_value(db: AsyncSession, zone: DNSZone, value: str) -> DNSRecordOp:
+    """The single op whose payload names ``value`` — ops in one transaction all
+    share a ``now()`` created_at, so they cannot be told apart by order."""
+    matches = [o for o in await _ops(db, zone) if o.record.get("value") == value]
+    assert len(matches) == 1, f"expected exactly one op for {value}, got {len(matches)}"
+    return matches[0]
+
+
+def _values(op: DNSRecordOp) -> set[str]:
+    return {m["value"] for m in op.record["rrset"]["members"]}
+
+
+def _records_url(zone: DNSZone) -> str:
+    return f"/api/v1/dns/groups/{zone.group_id}/zones/{zone.id}/records"
+
+
+class _RecordingDriver:
+    """Stand-in for an agentless driver — swallows the push and records it, so
+    the agentless branch runs end to end without a live WinRM host."""
+
+    def __init__(self) -> None:
+        self.changes: list[tuple[str, str, str]] = []
+
+    async def apply_record_change(self, _server: Any, change: Any) -> None:
+        self.changes.append((change.op, change.record.name, change.record.record_type))
+
+
+# ── 1. the #773 regression ──────────────────────────────────────────────────
+
+
+async def test_second_value_at_a_name_keeps_the_first(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """THE #773 regression. Adding a second round-robin A record must not retire
+    the first one.
+
+    Pre-fix the second op carried only ``10.0.0.2``, and the agent's whole-RRset
+    ``replace`` swapped the name's entire RRset for it — so the operator added
+    an address and silently lost one. The op now describes the state the server
+    must be in afterwards, which is both values.
+    """
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await db_session.commit()
+
+    for value in ("10.0.0.1", "10.0.0.2"):
+        r = await client.post(
+            _records_url(zone),
+            headers=headers,
+            json={"name": "www", "record_type": "A", "value": value},
+        )
+        assert r.status_code == 201, r.text
+
+    second = await _op_for_value(db_session, zone, "10.0.0.2")
+    assert _values(second) == {"10.0.0.1", "10.0.0.2"}
+
+    # The first op is honest about the state at the time it was enqueued — the
+    # name held one value then, and replaying it after the second op landed
+    # would be the one known-lossy case (documented in rrset.py).
+    first = await _op_for_value(db_session, zone, "10.0.0.1")
+    assert _values(first) == {"10.0.0.1"}
+
+
+# ── 2-3. delete semantics ───────────────────────────────────────────────────
+
+
+async def test_delete_one_value_keeps_the_surviving_siblings(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Removing one address from a round-robin set must leave the other two
+    serving. The delete op is a whole-RRset write like any other, so if it
+    carried only the removed value the agent would install *that* as the RRset —
+    deleting an address by making it the only one left."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    victim: DNSRecord | None = None
+    for value in ("10.0.0.1", "10.0.0.2", "10.0.0.3"):
+        rec = await _add_record(db_session, zone, name="pool", value=value)
+        if value == "10.0.0.2":
+            victim = rec
+    assert victim is not None
+    await db_session.commit()
+
+    r = await client.delete(f"{_records_url(zone)}/{victim.id}", headers=headers)
+    assert r.status_code == 204, r.text
+
+    op = await _op_for_value(db_session, zone, "10.0.0.2")
+    assert op.op == "delete"
+    assert _values(op) == {"10.0.0.1", "10.0.0.3"}
+    assert "10.0.0.2" not in _values(op)
+
+
+async def test_delete_of_the_last_value_yields_an_empty_member_list(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An empty ``members`` is how the payload says "this RRset should not
+    exist". It has to be distinguishable from a one-member set, or deleting the
+    only A record at a name would either leave it serving or make the driver
+    guess."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    only = await _add_record(db_session, zone, name="solo", value="10.0.0.9")
+    await db_session.commit()
+
+    r = await client.delete(f"{_records_url(zone)}/{only.id}", headers=headers)
+    assert r.status_code == 204, r.text
+
+    op = await _op_for_value(db_session, zone, "10.0.0.9")
+    assert op.op == "delete"
+    assert op.record["rrset"]["members"] == []
+
+
+# ── 4-5. what belongs in the set ────────────────────────────────────────────
+
+
+async def test_rrset_is_scoped_to_one_name_and_type(db_session: AsyncSession) -> None:
+    """The set is keyed on (name, type). Pulling in a neighbouring name's values
+    would publish them under the wrong label; pulling in another type's would
+    hand the driver rdata it cannot encode for the type it is writing."""
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await _add_record(db_session, zone, name="www", value="10.0.0.1")
+    await _add_record(db_session, zone, name="www", value="2001:db8::1", record_type="AAAA")
+    await _add_record(db_session, zone, name="www", value='"v=spf1 -all"', record_type="TXT")
+    await _add_record(db_session, zone, name="other", value="10.0.0.9")
+    await db_session.commit()
+
+    op = await enqueue_record_op(
+        db_session, zone, "create", {"name": "www", "type": "A", "value": "10.0.0.2"}
+    )
+    assert op is not None
+    assert _values(op) == {"10.0.0.1", "10.0.0.2"}
+
+
+async def test_sibling_stored_in_a_different_case_is_still_in_the_rrset(
+    db_session: AsyncSession,
+) -> None:
+    """DNS names are case-insensitive and nothing normalises them on write, so
+    the same name can be stored as ``WWW`` and ``www`` in two rows. Matching by
+    exact string would treat those as different RRsets — and the op for ``www``
+    would then quietly retire the ``WWW`` row's value on the wire."""
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await _add_record(db_session, zone, name="WWW", value="10.0.0.1")
+    await db_session.commit()
+
+    op = await enqueue_record_op(
+        db_session, zone, "create", {"name": "www", "type": "A", "value": "10.0.0.2"}
+    )
+    assert op is not None
+    assert _values(op) == {"10.0.0.1", "10.0.0.2"}
+
+
+# ── 6. one TTL per RRset ────────────────────────────────────────────────────
+
+
+async def test_null_ttl_resolves_to_the_zone_default_not_a_hardcoded_3600(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A NULL record TTL means "inherit the zone default" — that is how the zone
+    file renders it. The agents' record-op branch falls back to a hardcoded 3600
+    instead, so leaving the null on the wire would write 3600 onto every
+    inheriting record of a zone whose default is anything else. Resolving it
+    centrally keeps the incremental path and the rendered file agreeing."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session, zone_ttl=7200)
+    await db_session.commit()
+
+    r = await client.post(
+        _records_url(zone),
+        headers=headers,
+        json={"name": "app", "record_type": "A", "value": "10.0.0.5"},
+    )
+    assert r.status_code == 201, r.text
+
+    op = await _op_for_value(db_session, zone, "10.0.0.5")
+    assert op.record["ttl"] is None, "the row keeps its NULL — inheritance is stored, not resolved"
+    assert op.record["rrset"]["ttl"] == 7200
+    assert op.record["rrset"]["ttl"] != 3600, "must not be the driver-side fallback"
+
+
+async def test_members_with_different_ttls_resolve_to_the_lowest(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """RFC 2181: an RRset has ONE TTL. Two rows at one name can disagree, and
+    something has to pick — the lowest, because the only cost is shorter
+    caching, where the highest would leave resolvers holding a stale answer
+    past the TTL the operator asked for on the other member."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session, zone_ttl=7200)
+    await db_session.commit()
+
+    for value, ttl in (("10.0.0.1", 300), ("10.0.0.2", 60)):
+        r = await client.post(
+            _records_url(zone),
+            headers=headers,
+            json={"name": "www", "record_type": "A", "value": value, "ttl": ttl},
+        )
+        assert r.status_code == 201, r.text
+
+    second = await _op_for_value(db_session, zone, "10.0.0.2")
+    assert _values(second) == {"10.0.0.1", "10.0.0.2"}, "both members, or there is no TTL to pick"
+    assert second.record["rrset"]["ttl"] == 60
+    # The first op saw only its own member, so it resolves to that member's TTL —
+    # the min is over whatever the set held when the op was enqueued.
+    first = await _op_for_value(db_session, zone, "10.0.0.1")
+    assert first.record["rrset"]["ttl"] == 300
+    # Members carry no per-member TTL — it is a property of the set, and
+    # emitting one per member would invite a driver to write them individually.
+    assert all("ttl" not in m for m in second.record["rrset"]["members"])
+
+
+# ── 7. structured fields ────────────────────────────────────────────────────
+
+
+async def test_mx_members_keep_their_priorities(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A backup MX is distinguished from the primary by nothing but its
+    priority. Ship the set without it and the driver has two indistinguishable
+    exchangers — mail delivery order becomes a coin flip."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await db_session.commit()
+
+    for value, priority in (("mail1.example.", 10), ("mail2.example.", 20)):
+        r = await client.post(
+            _records_url(zone),
+            headers=headers,
+            json={"name": "@", "record_type": "MX", "value": value, "priority": priority},
+        )
+        assert r.status_code == 201, r.text
+
+    op = await _op_for_value(db_session, zone, "mail2.example.")
+    members = {m["value"]: m for m in op.record["rrset"]["members"]}
+    assert set(members) == {"mail1.example.", "mail2.example."}
+    assert members["mail1.example."]["priority"] == 10
+    assert members["mail2.example."]["priority"] == 20
+
+
+async def test_srv_members_keep_priority_weight_and_port(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """SRV rdata is ``priority weight port target``. Drivers substitute 0 for a
+    missing field (#424), so a member shipped without them renders as a valid
+    but meaningless ``0 0 0 target`` — a live-looking record pointing at the
+    wrong port."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await db_session.commit()
+
+    for value, port in (("sip1.example.", 5060), ("sip2.example.", 5061)):
+        r = await client.post(
+            _records_url(zone),
+            headers=headers,
+            json={
+                "name": "_sip._tcp",
+                "record_type": "SRV",
+                "value": value,
+                "priority": 10,
+                "weight": 20,
+                "port": port,
+            },
+        )
+        assert r.status_code == 201, r.text
+
+    op = await _op_for_value(db_session, zone, "sip2.example.")
+    members = {m["value"]: m for m in op.record["rrset"]["members"]}
+    assert set(members) == {"sip1.example.", "sip2.example."}
+    for value, port in (("sip1.example.", 5060), ("sip2.example.", 5061)):
+        assert (members[value]["priority"], members[value]["weight"], members[value]["port"]) == (
+            10,
+            20,
+            port,
+        )
+
+
+# ── 8. batches carry one shared set ─────────────────────────────────────────
+
+
+async def test_every_op_in_a_batch_carries_the_same_complete_set(
+    db_session: AsyncSession,
+) -> None:
+    """This is what makes a batch order-independent and each op replay-safe.
+
+    Every op at a shared (name, type) describes the SAME end state, so no op
+    depends on another having been applied first: the agent can drain them in
+    any order, retry one, or apply the same one twice, and the name still ends
+    up serving all three values. Stamping per-op instead — resolving as each
+    row lands — would make the last-applied op the winner all over again.
+    """
+    _grp, _server, zone = await _group_and_zone(db_session)
+    values = ("10.0.0.1", "10.0.0.2", "10.0.0.3")
+    for value in values:
+        await _add_record(db_session, zone, name="pool", value=value, ttl=300)
+    await db_session.commit()
+
+    rows = await enqueue_record_ops_batch(
+        db_session,
+        zone,
+        # ``ttl`` is carried the way ``record_op_payload`` carries it. The op's
+        # own payload — not the row it came from — is what the fold splices in,
+        # so a payload that omitted it would be asserting "no explicit TTL" and
+        # the RRset would correctly resolve to the zone default instead.
+        [
+            {"op": "create", "record": {"name": "pool", "type": "A", "value": v, "ttl": 300}}
+            for v in values
+        ],
+    )
+    assert all(r is not None for r in rows)
+
+    ops = await _ops(db_session, zone)
+    assert len(ops) == 3
+    assert all(_values(o) == set(values) for o in ops)
+    assert {o.record["rrset"]["ttl"] for o in ops} == {300}
+
+
+async def test_bulk_create_endpoint_stamps_every_op(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The bulk-create fast-path exists so a seeder does not pay a commit per
+    record — but a fast path that skipped the stamp would seed a round-robin
+    name and leave it serving one address, which is the #773 bug wearing a
+    different hat."""
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await db_session.commit()
+
+    values = ("10.0.0.1", "10.0.0.2", "10.0.0.3")
+    r = await client.post(
+        f"{_records_url(zone)}/bulk-create",
+        headers=headers,
+        json={"records": [{"name": "pool", "record_type": "A", "value": v} for v in values]},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["created"] == 3
+
+    ops = await _ops(db_session, zone)
+    assert len(ops) == 3
+    assert all(_values(o) == set(values) for o in ops)
+
+
+async def test_bulk_helper_stamps_the_rrset(db_session: AsyncSession) -> None:
+    """``enqueue_record_ops_bulk`` is a separate implementation from the singular
+    and batch paths — it resolves the server set once and inserts every op row in
+    one add_all rather than looping the singular path. A stamp added to the other
+    two and forgotten here would leave the importers and the seeder emitting
+    pre-#773 ops."""
+    _grp, _server, zone = await _group_and_zone(db_session)
+    values = ("10.0.0.1", "10.0.0.2")
+    for value in values:
+        await _add_record(db_session, zone, name="pool", value=value)
+    await db_session.commit()
+
+    dispatched = await enqueue_record_ops_bulk(
+        db_session,
+        zone,
+        [{"op": "create", "record": {"name": "pool", "type": "A", "value": v}} for v in values],
+    )
+    assert dispatched == 2
+
+    ops = await _ops(db_session, zone)
+    assert len(ops) == 2
+    assert all(_values(o) == set(values) for o in ops)
+
+
+async def test_a_payload_that_already_carries_an_rrset_is_not_restamped(
+    db_session: AsyncSession,
+) -> None:
+    """The batch path folds and stamps its whole list in one query and then
+    delegates to the singular path, which must leave the result alone.
+    Re-resolving per op would undo the fold — the very thing that keeps a batch
+    of deletes from contradicting itself — and cost a query per op."""
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await _add_record(db_session, zone, name="www", value="10.0.0.1")
+    await db_session.commit()
+
+    preset = {"ttl": 42, "members": [{"value": "192.0.2.1"}]}
+    op = await enqueue_record_op(
+        db_session,
+        zone,
+        "create",
+        {"name": "www", "type": "A", "value": "10.0.0.2", "rrset": preset},
+    )
+    assert op is not None
+    assert op.record["rrset"] == preset
+
+
+async def test_a_batch_of_deletes_at_one_name_agrees_with_itself(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Deleting two of three values at one name must leave exactly the third.
+
+    This is the case that makes folding the batch mandatory rather than a
+    nicety. ``bulk_delete_records`` builds its ops from LIVE rows and only
+    removes them from the database once the wire result comes back, so at stamp
+    time all three are still there. Reconciling each op against that snapshot in
+    isolation gives one op ``[B, C]`` and the other ``[A, C]`` — two whole-RRset
+    writes that contradict each other, and whichever the agent applies last
+    reinstates a value the operator just deleted.
+    """
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    keep = await _add_record(db_session, zone, name="pool", value="10.0.0.3")
+    doomed = [
+        await _add_record(db_session, zone, name="pool", value="10.0.0.1"),
+        await _add_record(db_session, zone, name="pool", value="10.0.0.2"),
+    ]
+    await db_session.commit()
+
+    resp = await client.post(
+        f"{_records_url(zone)}/bulk-delete",
+        headers=headers,
+        json={"record_ids": [str(r.id) for r in doomed]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    ops = [o for o in await _ops(db_session, zone) if o.op == "delete"]
+    assert len(ops) == 2
+    # Both ops describe the same end state, and it is the survivor alone.
+    for op in ops:
+        assert _values(op) == {keep.value}
+
+
+async def test_update_ships_the_new_value_and_not_the_old(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Changing one value of a multi-value RRset replaces exactly that value.
+
+    The op payload carries only the NEW value, which is why every driver had to
+    guess: BIND9 and Technitium wiped the RRset, and PowerDNS's own comment
+    admitted it could not remove the old one and left it live beside the new.
+    With the desired set on the op there is nothing to guess.
+    """
+    headers = await _admin_headers(db_session)
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await _add_record(db_session, zone, name="www", value="10.0.0.1")
+    target = await _add_record(db_session, zone, name="www", value="10.0.0.2")
+    await db_session.commit()
+
+    resp = await client.put(
+        f"{_records_url(zone)}/{target.id}", headers=headers, json={"value": "10.0.0.9"}
+    )
+    assert resp.status_code == 200, resp.text
+
+    op = await _op_for_value(db_session, zone, "10.0.0.9")
+    assert op.op == "update"
+    assert _values(op) == {"10.0.0.1", "10.0.0.9"}
+
+
+async def test_an_op_carrying_rrset_action_opts_out_of_stamping(
+    db_session: AsyncSession,
+) -> None:
+    """DNS pools and the cutover TTL pre-flight express precise per-RR
+    semantics, and must keep them.
+
+    A pool re-points a member as a ``delete_value`` of the old address plus an
+    ``add`` of the new — two SEPARATE enqueue calls on one serial. Per-RR ops
+    are order-independent; whole-RRset writes are not, because the delete's set
+    is computed before the row is mutated, so applying it after the create
+    would drop the new address. Stamping these would trade a real bug for a
+    subtler one.
+    """
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await _add_record(db_session, zone, name="pool", value="10.0.0.1")
+    await db_session.commit()
+
+    op = await enqueue_record_op(
+        db_session,
+        zone,
+        "create",
+        {"name": "pool", "type": "A", "value": "10.0.0.2", "rrset_action": "add"},
+    )
+    assert op is not None
+    assert "rrset" not in op.record
+
+
+# ── 9-10. where the stamp must NOT appear ───────────────────────────────────
+
+
+async def test_dnssec_ops_carry_no_rrset(db_session: AsyncSession) -> None:
+    """A DNSSEC op is zone-level and carries a placeholder record with no value
+    to reason about. It has to pass through the stamp untouched — attaching an
+    RRset would be meaningless, and raising on the placeholder would take zone
+    signing down as collateral damage from a record-path change."""
+    _grp, _server, zone = await _group_and_zone(db_session)
+    await db_session.commit()
+
+    op = await enqueue_record_op(
+        db_session, zone, "dnssec_sign", {"name": "@", "type": "DNSSEC_OP"}
+    )
+    assert op is not None
+    assert "rrset" not in op.record
+    assert op.op == "dnssec_sign"
+
+
+async def test_agentless_ops_are_not_stamped(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Windows DNS and the cloud providers apply immediately from the control
+    plane and never read the field. Stamping their rows would put an RRset in
+    the audit trail that no driver ever wrote — a record-ops dashboard claiming
+    a convergence that did not happen. (Windows DNS has its own whole-RRset
+    collapse; that is a separate fix, and it must not be papered over here.)"""
+    _grp, _server, zone = await _group_and_zone(db_session, driver="windows_dns")
+    await _add_record(db_session, zone, name="www", value="10.0.0.1")
+    await db_session.commit()
+
+    recorder = _RecordingDriver()
+    monkeypatch.setattr("app.services.dns.record_ops.get_driver", lambda _name: recorder)
+
+    op = await enqueue_record_op(
+        db_session, zone, "create", {"name": "www", "type": "A", "value": "10.0.0.2"}
+    )
+    assert op is not None
+    assert op.state == "applied", "the agentless branch really ran"
+    assert recorder.changes == [("create", "www", "A")]
+    assert "rrset" not in op.record

--- a/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
+++ b/charts/spatiumddi-appliance/templates/supervisor-rbac.yaml
@@ -198,12 +198,17 @@ rules:
   - apiGroups: ["k3s.cattle.io"]
     resources: ["etcdsnapshotfiles"]
     verbs: ["get", "list", "watch"]
-    # #590 — ensure_coredns_ha: the seed's heartbeat keeps the k3s-bundled
-    # CoreDNS at >=2 replicas with fast-evict tolerations (k3s resets it to
-    # a single 300s-toleration replica on every restart; a single replica
-    # deterministically sits on the seed, so a hard seed kill silences all
-    # Service/pod-FQDN resolution — api readiness's Postgres + Redis
-    # lookups included — for 5 minutes). resourceNames-pinned to coredns.
+    # #590 / #750 — ensure_coredns_ha: the seed's heartbeat matches the
+    # k3s-bundled CoreDNS to the cluster's node count. Two or more nodes get
+    # 2 replicas + fast-evict tolerations + required anti-affinity (k3s resets
+    # it to a single 300s-toleration replica on every restart; a single
+    # replica deterministically sits on the seed, so a hard seed kill silences
+    # all Service/pod-FQDN resolution — api readiness's Postgres + Redis
+    # lookups included — for 5 minutes). A single-node box is held at the
+    # stock shape instead, because the HA pod template cannot schedule there
+    # and deadlocks the rollout. resourceNames-pinned to coredns; the node
+    # count reads through the ``nodes`` LIST verb granted earlier in this rule
+    # list.
   - apiGroups: ["apps"]
     resources: ["deployments"]
     resourceNames: ["coredns"]

--- a/docs/SHIPPED.md
+++ b/docs/SHIPPED.md
@@ -1791,7 +1791,13 @@ Mirrors CLAUDE.md's three mixed sections:
     delete every existing RR at the name+type before adding
     the new one, silently clobbering siblings — for an N-
     member pool, only the most-recently-applied member
-    would survive in BIND9's running zone.
+    would survive in BIND9's running zone. **Superseded but
+    kept** by [#773](https://github.com/spatiumddi/spatiumddi/issues/773):
+    every agent-bound op now carries the complete desired
+    `rrset`, which is what a current agent acts on. Pools
+    were the only caller that ever set `rrset_action`
+    correctly, and the field remains their fallback for an
+    agent running an image older than that change.
   - Rename / type-change branch in `apply_pool_state`:
     when `record_name` or `record_type` shifts on an
     existing pool, emit a `delete_value` op for the old

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -127,6 +127,65 @@ class DNSDriver(ABC):
 | Update RPZ (blocking) | `rndc reload <rpz-zone>` after writing RPZ zone file | Zone-level reload only |
 | **Full daemon restart** | ❌ NEVER for normal operations | Only for: initial install, major version upgrade |
 
+### Record ops carry the whole RRset ([#773](https://github.com/spatiumddi/spatiumddi/issues/773))
+
+A record op names one record, but none of the three agent wire protocols
+can express "change this RR and leave its siblings alone" from a payload
+that only carries the NEW value. Each driver therefore had to perform a
+whole-RRset write, and each lost the siblings doing it: BIND9 used
+`upd.replace(...)`, Technitium `overwrite=true`, and PowerDNS — which
+read-merged and so kept siblings — could not remove the *old* value on an
+edit. A name with several values at one type (round-robin A, a backup MX,
+SPF beside a verification TXT, multiple apex NS) ended up serving only
+whichever op landed last.
+
+The control plane is the only place that knows the complete set, so it
+ships it. Every agent-bound `create` / `update` / `delete` op payload
+carries:
+
+```json
+"rrset": {"ttl": 3600,
+          "members": [{"value": "10.20.7.21"},
+                      {"value": "10.20.7.22"}]}
+```
+
+`members` is the desired state **after** the op — an empty list means the
+RRset should not exist. Members carry `priority` / `weight` / `port` so
+each driver composes their wire form exactly as it composes the op's own.
+Per RFC 2181 an RRset has one TTL, resolved control-plane-side (lowest of
+the members, with a NULL falling back to the zone default rather than a
+hardcoded 3600).
+
+Each driver applies it atomically where it can: BIND9 as a single
+`upd.replace(name, ttl, rtype, *values)` — dnspython emits one
+delete-RRset plus N adds in ONE update message — and PowerDNS as one
+`REPLACE` PATCH with no preceding GET. Technitium's REST API is one
+record per call, so a create/update is N calls (member 0 with
+`overwrite=true`, the rest `false`) while a delete stays a single
+value-scoped call. Ops are therefore idempotent: replaying one converges
+the server to the database rather than depending on what ran before it.
+
+Ops enqueued together all carry the RRset as it should be once the WHOLE
+batch has landed, not a running prefix — so they are order-independent
+too. That matters because `bulk_delete_records` builds its ops from live
+rows and only removes them once the wire result comes back: reconciling
+each op against the raw snapshot in isolation would have two deletes at
+one name ship contradictory sets, and whichever landed last would
+reinstate a value the operator deleted.
+
+`rrset_action` (`add` / `delete_value`) is the older per-op override.
+Setting it **opts an op out** of the stamping above, and it remains the
+fallback for an op enqueued by a control plane that predates `rrset`. Two
+callers use it: DNS pools and the Windows-cutover TTL pre-flight. Pools
+opt out deliberately — a pool re-points a member as a `delete_value` plus
+an `add` across two separate enqueue calls on one serial, and whole-RRset
+writes would make that pair order-dependent, since the delete's set is
+computed before the row is mutated.
+
+Not covered: the **agentless** Windows DNS driver
+(`backend/app/drivers/dns/windows.py`) has the same collapse in its own
+PowerShell path and is not fixed by this — it never receives the field.
+
 ### TSIG Authentication
 
 All RFC 2136 updates are TSIG-signed:
@@ -639,7 +698,7 @@ Third authoritative driver, alongside BIND9 and PowerDNS. Same agent-colocated s
 Unlike PowerDNS's rrset-REPLACE PATCH semantics, Technitium's `/api/zones/records/add` **appends** at a given `(name, type)` by default (round-robin A records coexist without a GET-merge-PATCH dance) and only wipes the rrset when `overwrite=true` is passed explicitly. The agent driver exploits this:
 
 - **Bulk reconcile** (`swap_and_reload`, fired on structural config changes): fetch the zone's full record set via `GET /api/zones/records/get?listZone=true`, diff by `(domain, type, params)` fingerprint against the desired bundle state, then `POST` deletes for what's extra and adds for what's missing. No `update` endpoint call needed — a changed value is just delete-old + add-new, computed from the full diff.
-- **Incremental ops** (`apply_record_op`, fired per live edit): `create`/`update` → `add` with `overwrite=false`; `delete` → `delete` with the exact matching value. Same "update leaves a stale value until an explicit delete" caveat PowerDNS's driver documents for the identical reason (the op payload carries only the new value).
+- **Incremental ops** (`apply_record_op`, fired per live edit): the op carries the complete desired `rrset` (see §2, [#773](https://github.com/spatiumddi/spatiumddi/issues/773)), so `create`/`update` is member 0 with `overwrite=true` — which clears — followed by an `add` per remaining member with `overwrite=false`, and `delete` is a single value-scoped `delete` of the op's own value (the survivors are already on the server; wiping and rebuilding them would open a window where the name serves less than it should). Before #773 this path was one `add` with `overwrite=true`, which is what collapsed every multi-value RRset to its last value.
 - Zone apex `NS`/`SOA` are **daemon-managed** — Technitium auto-creates its own SOA + one NS pointing at its own hostname on `/api/zones/create`, so the bundle's apex NS/SOA are intentionally excluded from every reconcile pass (pushing them would create duplicate/foreign records). Off-apex `NS` (delegations) reconcile normally.
 
 ### 4B.2 Auth — agent-provisioned bearer token

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -957,6 +957,18 @@ rule here has been surfaced to an operator, not just silently logged.
   modes are not selectable from the API. `422`.
 - **DDNS hostname policy enum.** `ddns_hostname_policy` must match one
   of the documented values (see §13). Pydantic validator.
+- **A field must not be set twice, under both its names, to different
+  values.** Two scope fields are accepted under two names: `enabled`
+  (what the response emits) is the same column as `is_active` (what
+  the model, the services layer and this document call it), and
+  `hostname_sync_mode` is the same as `hostname_to_ipam_sync`. Sending
+  both names of a pair with values that disagree is a `422`; sending
+  either name alone works as it always has. This closes a silent
+  no-op: a read-modify-write — `GET`, edit `is_active`, `PUT` the whole
+  representation back — used to resolve in favour of the `enabled` the
+  `GET` supplied and answer `200` while the scope kept handing out
+  addresses. A `null` or empty string on either name counts as "not
+  supplied", not as a disagreement.  `422`, [#774](https://github.com/spatiumddi/spatiumddi/issues/774).
 
 ### Pools
 


### PR DESCRIPTION
Three independent field-found bugs. One commit each, no shared surface
except that #773 and #774 were both surfaced by field-testing #756.

Closes #773, Closes #750, Closes #774

---

## #773 — every agent driver collapsed multi-value RRsets

A record op carries one record, but no agent wire protocol can express
"change this RR and leave its siblings alone" from a payload that names only
the new value. Each driver performed a whole-RRset write and lost the
siblings doing it — BIND9 via `upd.replace`, Technitium via
`overwrite=true`, and PowerDNS (which read-merged, so it kept siblings)
could not remove the OLD value on an edit and said so in its own comment.

So a name with several values at one type served whichever op landed last:
round-robin A, a backup MX, SPF beside a verification TXT, multiple apex NS.
The database held every value and the rendered zone file held every value;
only the incremental path lost them.

The control plane already knows the complete desired set, so it ships it:

```json
"rrset": {"ttl": 3600, "members": [{"value": "10.20.7.21"}, {"value": "10.20.7.22"}]}
```

Empty members means the RRset should not exist. Ops become idempotent and
self-healing — replaying one converges the server to the database — instead
of order-dependent.

**Two rules the batch path needs**, both learned from real call sites and
both non-obvious:

* **Fold the whole batch and stamp every op with the FINAL set.** Reconciling
  each op against the raw snapshot is actively wrong: `bulk_delete_records`
  builds its ops from live rows and only deletes them once the wire result
  comes back, so deleting two of three values at one name gives one op
  `[B, C]` and the other `[A, C]` — and whichever lands last reinstates a
  value the operator deleted. Stamping the final set rather than a running
  prefix also keeps the ops order-independent and replay-safe.
* **Leave ops carrying an explicit `rrset_action` alone.** A DNS pool
  re-points a member as `delete_value` + `add` across two separate enqueue
  calls on one serial. Per-RR semantics are order-independent there;
  whole-RRset writes would not be, because the delete's set is computed
  before the row is mutated.

Agentless drivers are not stamped — `enqueue_record_op` stamps after it has
branched, so their op rows cannot claim a write nobody performed.

The name lookup is chunked: the seed / import fast path can touch far more
distinct names than asyncpg's 32,767-bind-parameter ceiling, and blowing it
would fail the whole commit rather than one record.

Per driver:

| Driver | Whole-RRset write |
|---|---|
| BIND9 | one `upd.replace(name, ttl, rtype, *values)` — dnspython emits a single delete-RRset plus N adds in **one** message. Members are parsed individually first: they are siblings the op did not ask about, and one legacy row dnspython cannot read would otherwise block every future write to the name. |
| PowerDNS | one `REPLACE` PATCH, no zone GET. Also closes its own documented gap where an `update` stranded the old value. |
| Technitium | create/update is member 0 with `overwrite=true` then appends; **delete stays a single value-scoped call**, because the survivors are already on the server and wiping to rebuild them would open a window where the name serves less than it should. |

## #750 — coredns rollout deadlocked on a single-node appliance

`ensure_coredns_ha` applied #590's HA shape regardless of how many nodes
existed. On one node that deadlocks permanently: the patch rewrites the pod
template, so a new ReplicaSet appears whose pods can never schedule (one
node, occupied), while the old ReplicaSet's pod can never drain
(`maxUnavailable: 1` at `replicas: 2` leaves minAvailable 1, and zero new
pods are Ready). Three coredns pods forever, and every later coredns change
queues behind a rollout that cannot finish. The converged check was a
ratchet (`>= replicas`), so nothing could undo it.

The target is now a function of the node count — 1 node → k3s stock, ≥2 →
`min(registered, max_replicas)` with the full #590 shape. A fresh install
becomes a **total no-op** (stock already *is* the target, so the deadlock
cannot be re-created) and an appliance already stuck in it heals in one
patch, usually with no DNS gap.

Counts registered Node objects rather than `control_plane_size`: that is the
*committed* member count and can lead reality, which is precisely this bug.
Node objects survive NotReady, so a node outage cannot scale cluster DNS
down at the moment #590 needs it up.

Convergence compares the template we would **send** against the live one
rather than a set of "close enough" predicates — the loose version let a
template satisfy the check while still differing from the canonical body,
and that difference is a new pod-template hash, i.e. a rollout that skipped
the feasibility gate it exists to be. Six parametrized fixed-point cases
guard against a patch storm, which on a 30 s heartbeat would be worse than
the deadlock this fixes.

## #774 — `PUT /dhcp/scopes/{id}` silently no-oped a read-modify-write

`ScopeResponse` emits the active flag only as `enabled`; `ScopeUpdate`
accepts `is_active` too — the column name, and the one a script reaches
for. So GET → edit → PUT produced a body carrying both, and the handler let
the `enabled` the GET supplied overwrite the `is_active` the caller set.
`200 OK`, scope unchanged, no warning: a "deactivate this scope" that left
the scope handing out addresses.

Both write models now `422` when a field is set under both its names with
disagreeing values. Either name alone still works exactly as before, which
is what every client in the repo already sends.

A precedence rule *could* have been built — the response never emits
`is_active`, so one in a body is always deliberate while an `enabled` may be
residue. Refusing anyway: silently picking between two contradictory
instructions is the wrong posture for the flag that decides whether a DHCP
server hands out addresses, and the entire cost of this bug was that it was
silent.

The sweep the issue asked for found **a second pair in the same handler** —
`hostname_sync_mode` / `hostname_to_ipam_sync` — same shape, same silent
resolution. Covered by the same guard, comparing normalised values so
`learned` and `on_lease` agree.

## Follow-ups filed

* **#783** — the agentless Windows DNS driver has the same RRset collapse in
  its own PowerShell path. Different driver family, never receives the new
  field; recorded as not-covered in `DNS_DRIVERS.md`.
* **#784** — `ScopeResponse.ddns_domain_override` is a phantom field:
  advertised, hardcoded `null`, no backing column, and the scope modal sends
  it on every save. Same class as #774 but needs a column + migration or
  removal from both sides.

## Verification

314 tests green — 136 backend DNS/DHCP suites, 30 new-feature backend, 177
DNS agent, 274 supervisor. `make ci` and `helm lint` clean.

The backend RRset tests were mutation-checked: neutering `resolve_rrsets` to
return empty member lists (the pre-fix behaviour) fails 9 of 15, including
every sibling-preservation case. The 6 that survive are the deliberate
negative guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
