### PR TITLE
fix(appliance): slot-upgrade field bugs — clear-upgrade, rolling-path integrity hints, status version, asset URLs (#786, #787, #788, #789)

### DIFF
--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -845,16 +845,31 @@ def apply_clear_upgrade_command() -> bool:
             # box stays wedged — exactly the failure this exists to fix.
             log.warning("supervisor.clear_upgrade.unlink_failed", path=str(path), error=str(exc))
 
+    # Only rewrite a state that is actually stuck. Two reasons: a healthy
+    # box would otherwise report "cleared" on every heartbeat inside the
+    # flag's lifetime, and clobbering a live ``in-flight`` stamp would blind
+    # BOTH crash detectors that key on that literal — the runner's exit trap
+    # and the supervisor's stale-in-flight reaper — so a mid-apply Cancel
+    # could leave a truncated image with nothing recording the failure.
     try:
         if _HOST_SLOT_STATE.exists():
-            _HOST_SLOT_STATE.write_text(f"ready {datetime.now(UTC).isoformat()}\n", encoding="utf-8")
-            reset = True
+            current = _HOST_SLOT_STATE.read_text(encoding="utf-8").split(maxsplit=1)
+            if current and current[0] == "failed":
+                _HOST_SLOT_STATE.write_text(
+                    f"ready {datetime.now(UTC).isoformat()}\n", encoding="utf-8"
+                )
+                reset = True
     except OSError as exc:
         log.warning("supervisor.clear_upgrade.state_reset_failed", error=str(exc))
 
+    # OVERWRITE rather than unlink. release-state is mode 1777 (sticky) and
+    # this file is root-owned (the host runner writes it); a non-owner can
+    # never unlink it, but the runner now publishes it 0666 so an in-place
+    # write succeeds. An empty object reads as "no progress" to every
+    # consumer, which is what a cleared upgrade should show.
     try:
         if _SLOT_UPGRADE_PROGRESS.exists():
-            _SLOT_UPGRADE_PROGRESS.unlink(missing_ok=True)
+            _SLOT_UPGRADE_PROGRESS.write_text("{}\n", encoding="utf-8")
             reset = True
     except OSError as exc:
         log.warning("supervisor.clear_upgrade.progress_reset_failed", error=str(exc))

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -808,6 +808,61 @@ def clear_fleet_upgrade_marker() -> None:
         pass
 
 
+def apply_clear_upgrade_command() -> bool:
+    """#786 — the operator pressed "Clear failed upgrade"; make the host forget.
+
+    ``clear_fleet_upgrade_marker`` above is the *passive* heal, and it
+    deliberately returns early when a trigger file is still on disk so it
+    can't disturb an apply that is genuinely running. That guard is also
+    what made a wedged appliance unrecoverable: any failure that strands an
+    unconsumed ``slot-upgrade-pending`` — the path/service unit failing to
+    exec, the runner dying before its EXIT trap is armed, a missed rename
+    by the stale-in-flight reaper — blocks both the heal AND
+    ``maybe_fire_fleet_upgrade``, so the box could neither clear nor
+    re-apply, and no operator action could break the deadlock.
+
+    This is the explicit counterpart: the operator has *asked* for the
+    stranded state to go, so the trigger is removed rather than deferred
+    to. Returns True when anything was actually reset (for the log line).
+
+    Deliberately does NOT stop a running apply: it only removes the
+    trigger + resets the sidecars. A live ``spatiumddi-slot-upgrade``
+    process re-stamps its own progress as it goes, so a clear raced
+    against a real apply loses to the apply rather than corrupting it.
+    """
+    if detect_deployment_kind() != "appliance":
+        return False
+
+    reset = False
+    for path in (_TRIGGER_FILE, _FIRED_URL_MARKER):
+        try:
+            if path.exists():
+                path.unlink(missing_ok=True)
+                reset = True
+        except OSError as exc:
+            # Surfaced rather than swallowed: if the stranded trigger
+            # survives, the operator's clear silently didn't take and the
+            # box stays wedged — exactly the failure this exists to fix.
+            log.warning("supervisor.clear_upgrade.unlink_failed", path=str(path), error=str(exc))
+
+    try:
+        if _HOST_SLOT_STATE.exists():
+            _HOST_SLOT_STATE.write_text(f"ready {datetime.now(UTC).isoformat()}\n", encoding="utf-8")
+            reset = True
+    except OSError as exc:
+        log.warning("supervisor.clear_upgrade.state_reset_failed", error=str(exc))
+
+    try:
+        if _SLOT_UPGRADE_PROGRESS.exists():
+            _SLOT_UPGRADE_PROGRESS.unlink(missing_ok=True)
+            reset = True
+    except OSError as exc:
+        log.warning("supervisor.clear_upgrade.progress_reset_failed", error=str(exc))
+
+    _prune_failed_sidecars(keep=0)
+    return reset
+
+
 def _prune_host_config_sidecars(trigger_file: Path, keep: int = 5) -> None:
     """(#387) Keep only the newest ``.failed.<ts>`` / ``.done.<ts>`` /
     ``.invalid.<ts>`` sidecars for ONE trigger family, so a (pre-fix)
@@ -819,7 +874,10 @@ def _prune_host_config_sidecars(trigger_file: Path, keep: int = 5) -> None:
         parent = trigger_file.parent
         for suffix in ("failed", "done", "invalid"):
             stale = sorted(parent.glob(f"{trigger_file.name}.{suffix}.*"))
-            for path in stale[:-keep]:
+            # ``stale[:-0]`` is the EMPTY slice, not the whole list, so a
+            # plain slice would make keep=0 ("remove them all", used by the
+            # #786 explicit clear) silently prune nothing.
+            for path in stale if keep <= 0 else stale[:-keep]:
                 path.unlink(missing_ok=True)
     except OSError:
         # Best-effort housekeeping — leftover sidecars are cosmetic; a

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -875,6 +875,21 @@ def apply_clear_upgrade_command() -> bool:
         log.warning("supervisor.clear_upgrade.progress_reset_failed", error=str(exc))
 
     _prune_failed_sidecars(keep=0)
+
+    # A trigger we could not remove leaves the box exactly as wedged as it
+    # was — it still blocks both the passive heal and maybe_fire_fleet_
+    # upgrade. Field-observed: a root-owned trigger (this directory is
+    # sticky, so a non-owner can never unlink one) failed here while the
+    # state/progress resets succeeded, and the command still reported
+    # success. Say so instead, or the operator is told a clear worked when
+    # the appliance is still stuck.
+    if _TRIGGER_FILE.exists():
+        log.error(
+            "supervisor.clear_upgrade.trigger_survived",
+            path=str(_TRIGGER_FILE),
+            hint="not owned by the supervisor; remove it from the host to unwedge",
+        )
+        return False
     return reset
 
 

--- a/agent/supervisor/spatium_supervisor/heartbeat.py
+++ b/agent/supervisor/spatium_supervisor/heartbeat.py
@@ -794,6 +794,16 @@ def heartbeat_once(
     desired_next_boot_slot = body_out.get("desired_next_boot_slot")
     desired_default_slot = body_out.get("desired_default_slot")
     reboot_requested = bool(body_out.get("reboot_requested"))
+    clear_upgrade_requested = bool(body_out.get("clear_upgrade_requested"))
+
+    # #786 — an explicit "Clear failed upgrade" outranks everything below.
+    # Handled BEFORE the desired-upgrade branch so a clear issued while a
+    # failed desired-state is still on the row resets the host in the same
+    # heartbeat, and before the passive heal because only this path is
+    # allowed to remove a stranded trigger file.
+    if clear_upgrade_requested:
+        if appliance_state.apply_clear_upgrade_command():
+            log.info("supervisor.heartbeat.clear_upgrade_applied")
 
     if desired_version and desired_url:
         if appliance_state.maybe_fire_fleet_upgrade(

--- a/agent/supervisor/tests/test_clear_upgrade_command.py
+++ b/agent/supervisor/tests/test_clear_upgrade_command.py
@@ -1,0 +1,103 @@
+"""#786 — the operator-driven "make the host forget a failed upgrade" command.
+
+The visible failure state is re-published from these host sidecars on
+every heartbeat, so clearing the DB alone never worked: the next
+heartbeat restored it, and rebooting didn't help because release-state
+lives on the persistent /var a slot write never touches.
+
+The passive heal (``clear_fleet_upgrade_marker``) can't cover the wedged
+case either — it returns early whenever a trigger file is present, which
+is exactly the state a stranded apply leaves behind, and that same guard
+also blocks ``maybe_fire_fleet_upgrade``. So a box could neither clear
+nor re-apply.
+
+``apply_clear_upgrade_command`` is the explicit counterpart: the operator
+asked, so the stranded trigger goes.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from spatium_supervisor import appliance_state
+
+
+@pytest.fixture
+def paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> dict[str, Path]:
+    state = tmp_path / "slot-upgrade-pending.state"
+    trigger = tmp_path / "slot-upgrade-pending"
+    progress = tmp_path / "slot-upgrade.progress"
+    marker = tmp_path / "slot-upgrade-fired-url"
+    monkeypatch.setattr(appliance_state, "_HOST_SLOT_STATE", state)
+    monkeypatch.setattr(appliance_state, "_TRIGGER_FILE", trigger)
+    monkeypatch.setattr(appliance_state, "_SLOT_UPGRADE_PROGRESS", progress)
+    monkeypatch.setattr(appliance_state, "_FIRED_URL_MARKER", marker)
+    # The command is appliance-only; every other deployment kind no-ops.
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "appliance")
+    return {"state": state, "trigger": trigger, "progress": progress, "marker": marker}
+
+
+def _wedged(paths: dict[str, Path]) -> None:
+    """The shape a stranded failure leaves on disk."""
+    paths["state"].write_text("failed 2026-08-01T00:00:00+00:00\n", encoding="utf-8")
+    paths["progress"].write_text(json.dumps({"step": "failed", "pct": 40}), encoding="utf-8")
+    paths["trigger"].write_text("https://cp.local/x.raw.xz\n", encoding="utf-8")
+    paths["marker"].write_text("https://cp.local/x.raw.xz\n", encoding="utf-8")
+
+
+def test_clear_resets_every_sidecar_and_removes_the_trigger(paths: dict[str, Path]) -> None:
+    _wedged(paths)
+
+    assert appliance_state.apply_clear_upgrade_command() is True
+
+    assert not paths["trigger"].exists(), "a stranded trigger must be removed, not deferred to"
+    assert not paths["marker"].exists()
+    assert not paths["progress"].exists()
+    assert paths["state"].read_text(encoding="utf-8").startswith("ready ")
+
+
+def test_clear_removes_the_trigger_the_passive_heal_refuses_to_touch(
+    paths: dict[str, Path],
+) -> None:
+    """The regression this exists for: with a trigger on disk the passive
+    heal returns early and the box stays wedged forever."""
+    _wedged(paths)
+
+    appliance_state.clear_fleet_upgrade_marker()
+    assert paths["state"].read_text(encoding="utf-8").startswith("failed"), (
+        "passive heal is expected to bail while a trigger exists"
+    )
+
+    appliance_state.apply_clear_upgrade_command()
+    assert paths["state"].read_text(encoding="utf-8").startswith("ready ")
+
+
+def test_clear_prunes_every_failed_sidecar(paths: dict[str, Path]) -> None:
+    """#386's runaway re-fire left piles of these; an explicit clear takes
+    them all, not all-but-five."""
+    for ts in range(9):
+        (paths["trigger"].parent / f"slot-upgrade-pending.failed.{ts}").write_text("x")
+
+    appliance_state.apply_clear_upgrade_command()
+
+    assert list(paths["trigger"].parent.glob("slot-upgrade-pending.failed.*")) == []
+
+
+def test_clear_is_idempotent_on_an_already_clean_host(paths: dict[str, Path]) -> None:
+    """Nothing to reset → False, so the heartbeat doesn't log a reset that
+    didn't happen. Must not raise on the missing files."""
+    assert appliance_state.apply_clear_upgrade_command() is False
+
+
+def test_clear_is_a_noop_off_appliance(
+    paths: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(appliance_state, "detect_deployment_kind", lambda: "docker")
+    _wedged(paths)
+
+    assert appliance_state.apply_clear_upgrade_command() is False
+    assert paths["trigger"].exists()
+    assert paths["state"].read_text(encoding="utf-8").startswith("failed")

--- a/agent/supervisor/tests/test_clear_upgrade_command.py
+++ b/agent/supervisor/tests/test_clear_upgrade_command.py
@@ -55,8 +55,22 @@ def test_clear_resets_every_sidecar_and_removes_the_trigger(paths: dict[str, Pat
 
     assert not paths["trigger"].exists(), "a stranded trigger must be removed, not deferred to"
     assert not paths["marker"].exists()
-    assert not paths["progress"].exists()
+    # Overwritten, not unlinked: release-state is sticky and this file is
+    # root-owned, so a non-owner can never unlink it.
+    assert paths["progress"].read_text(encoding="utf-8").strip() == "{}"
     assert paths["state"].read_text(encoding="utf-8").startswith("ready ")
+
+
+def test_clear_leaves_a_live_in_flight_apply_alone(paths: dict[str, Path]) -> None:
+    """Cancelling mid-apply must not stamp `ready` over `in-flight`: both
+    crash detectors — the runner's exit trap and the stale-in-flight reaper
+    — key on that literal, so clobbering it would let a killed `dd` leave a
+    truncated image with nothing recording the failure."""
+    paths["state"].write_text("in-flight 2026-08-01T00:00:00+00:00\n", encoding="utf-8")
+
+    appliance_state.apply_clear_upgrade_command()
+
+    assert paths["state"].read_text(encoding="utf-8").startswith("in-flight")
 
 
 def test_clear_removes_the_trigger_the_passive_heal_refuses_to_touch(
@@ -88,7 +102,10 @@ def test_clear_prunes_every_failed_sidecar(paths: dict[str, Path]) -> None:
 
 def test_clear_is_idempotent_on_an_already_clean_host(paths: dict[str, Path]) -> None:
     """Nothing to reset → False, so the heartbeat doesn't log a reset that
-    didn't happen. Must not raise on the missing files."""
+    didn't happen. A `ready` state file is the norm on any appliance that
+    has ever applied an upgrade, so it must not by itself count as a reset."""
+    paths["state"].write_text("ready 2026-08-01T00:00:00+00:00\n", encoding="utf-8")
+
     assert appliance_state.apply_clear_upgrade_command() is False
 
 

--- a/agent/supervisor/tests/test_clear_upgrade_command.py
+++ b/agent/supervisor/tests/test_clear_upgrade_command.py
@@ -118,3 +118,25 @@ def test_clear_is_a_noop_off_appliance(
     assert appliance_state.apply_clear_upgrade_command() is False
     assert paths["trigger"].exists()
     assert paths["state"].read_text(encoding="utf-8").startswith("failed")
+
+
+def test_clear_reports_failure_when_the_trigger_survives(
+    paths: dict[str, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Field-observed on ddi1: the sticky directory means a trigger the
+    supervisor does not own can never be unlinked. The state/progress
+    resets still succeed, so the command used to report success while the
+    box stayed exactly as wedged — the trigger keeps blocking both the
+    passive heal and `maybe_fire_fleet_upgrade`."""
+    _wedged(paths)
+    real_unlink = Path.unlink
+
+    def _refuse_trigger(self, *a, **kw):
+        if self.name == "slot-upgrade-pending":
+            raise PermissionError(1, "Operation not permitted")
+        return real_unlink(self, *a, **kw)
+
+    monkeypatch.setattr(Path, "unlink", _refuse_trigger)
+
+    assert appliance_state.apply_clear_upgrade_command() is False
+    assert paths["trigger"].exists()

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -159,16 +159,23 @@ def cmd_status(_args) -> int:
               file=sys.stderr)
         return 2
     active, inactive = pair
-    # Both versions come from sync_slot_versions(), never from calling
-    # slot_version_label() on the active slot: that device is already
-    # mounted rw at /, so a second read-only mount of it is refused and
-    # the active slot would always render "unreadable" (#788). Syncing
-    # here also refreshes the sidecar the api + console read.
-    versions = sync_slot_versions()
+    # The ACTIVE slot's version is read from the booted
+    # /etc/spatiumddi/appliance-release directly. Never probe it with
+    # slot_version_label(): that device is already mounted rw at /, so a
+    # second read-only mount of it is refused and the slot would always
+    # render "unreadable" (#788).
+    #
+    # Deliberately does NOT call sync_slot_versions(): ``status`` is the
+    # command operators run to check on an upgrade, and it must stay
+    # read-only. Persisting a probe taken while an apply is mid-dd would
+    # overwrite the good slot-versions.json with "unreadable" — the very
+    # string this fix exists to stop showing — and that sidecar feeds the
+    # Fleet card, the console and the GRUB menu titles. Use
+    # ``sync-versions`` to refresh it.
     print(f"Active slot:    {active['partlabel']:8}  {active['device']:14}  "
-          f"version={versions.get(slot_versions_key(active), 'unknown')}")
+          f"version={_read_active_appliance_version()}")
     print(f"Inactive slot:  {inactive['partlabel']:8}  {inactive['device']:14}  "
-          f"version={versions.get(slot_versions_key(inactive), 'unknown')}")
+          f"version={slot_version_label(inactive)}")
     return 0
 
 

--- a/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-upgrade-slot
@@ -142,9 +142,14 @@ def slot_version_label(slot: dict[str, str]) -> str:
         try:
             mountpoint.rmdir()
         except OSError:
-            # Same: cleanup-only. Leaving the empty tmpdir behind is
-            # cosmetic — it's under /tmp and tmpfs reclaims on reboot.
+            # Same: cleanup-only. Leaving the empty probe dir behind is
+            # cosmetic — it's under /run, a tmpfs reclaimed on reboot.
             pass
+
+
+def slot_versions_key(slot: dict[str, str]) -> str:
+    """Map a slot dict to its key in ``slot-versions.json``."""
+    return "slot_a" if slot["partlabel"].lower() == "root_a" else "slot_b"
 
 
 def cmd_status(_args) -> int:
@@ -154,8 +159,16 @@ def cmd_status(_args) -> int:
               file=sys.stderr)
         return 2
     active, inactive = pair
-    print(f"Active slot:    {active['partlabel']:8}  {active['device']:14}  version={slot_version_label(active)}")
-    print(f"Inactive slot:  {inactive['partlabel']:8}  {inactive['device']:14}  version={slot_version_label(inactive)}")
+    # Both versions come from sync_slot_versions(), never from calling
+    # slot_version_label() on the active slot: that device is already
+    # mounted rw at /, so a second read-only mount of it is refused and
+    # the active slot would always render "unreadable" (#788). Syncing
+    # here also refreshes the sidecar the api + console read.
+    versions = sync_slot_versions()
+    print(f"Active slot:    {active['partlabel']:8}  {active['device']:14}  "
+          f"version={versions.get(slot_versions_key(active), 'unknown')}")
+    print(f"Inactive slot:  {inactive['partlabel']:8}  {inactive['device']:14}  "
+          f"version={versions.get(slot_versions_key(inactive), 'unknown')}")
     return 0
 
 
@@ -667,10 +680,8 @@ def sync_slot_versions() -> dict[str, str]:
     active, inactive = pair
 
     versions: dict[str, str] = {}
-    active_slot = "slot_a" if active["partlabel"].lower() == "root_a" else "slot_b"
-    inactive_slot = "slot_a" if active_slot == "slot_b" else "slot_b"
-    versions[active_slot] = _read_active_appliance_version()
-    versions[inactive_slot] = slot_version_label(inactive)
+    versions[slot_versions_key(active)] = _read_active_appliance_version()
+    versions[slot_versions_key(inactive)] = slot_version_label(inactive)
 
     try:
         _SLOT_VERSIONS_FILE.parent.mkdir(parents=True, exist_ok=True)

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -116,6 +116,16 @@ fi
 # its in-pod uid.
 mkdir -p /var/lib/spatiumddi/release-state /var/log/spatiumddi
 chmod 1777 /var/lib/spatiumddi/release-state
+# #786 — the slot-upgrade sidecars are written by the ROOT host runner but
+# must be resettable by the UNPRIVILEGED supervisor container. In a sticky
+# 1777 directory a non-owner can neither overwrite a root-owned 0644 file
+# nor unlink it, so every supervisor-side reset of a failed upgrade
+# silently no-op'd. The runner now publishes them 0666; backfill any that
+# predate that so an upgraded appliance is repaired on its first boot.
+for _sc in /var/lib/spatiumddi/release-state/slot-upgrade-pending.state \
+           /var/lib/spatiumddi/release-state/slot-upgrade.progress; do
+    [ -e "$_sc" ] && chmod 0666 "$_sc" 2>/dev/null || true
+done
 chmod 0755 /var/log/spatiumddi
 
 # /var/lib/spatiumddi/slot-images — OS A/B upgrade images uploaded /

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-upgrade
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-slot-upgrade
@@ -37,6 +37,17 @@ set -euo pipefail
 # as spatium-host-migrate's SPATIUM_HOST_* overrides.
 TRIGGER="${SPATIUM_SLOT_TRIGGER:-/var/lib/spatiumddi/release-state/slot-upgrade-pending}"
 PROGRESS="${SPATIUM_SLOT_PROGRESS:-/var/lib/spatiumddi/release-state/slot-upgrade.progress}"
+
+# The supervisor container runs unprivileged (``su-exec spatium``) while
+# these sidecars are written by THIS script as root, into a mode-1777
+# (sticky) directory. A non-owner therefore gets EACCES overwriting a
+# root-owned 0644 file and EPERM unlinking it — so every supervisor-side
+# reset of a failed upgrade silently no-op'd (#786). Publish them 0666 so
+# an in-place overwrite works. Content is non-secret state the api already
+# republishes to the operator; the sticky bit still stops unlink-by-others.
+publish_sidecar() {  # $1 = path
+    chmod 0666 "$1" 2>/dev/null || true
+}
 LOG_DIR="${SPATIUM_SLOT_LOG_DIR:-/var/log/spatiumddi}"
 LOG="$LOG_DIR/slot-upgrade.log"
 UPGRADE_SLOT_BIN="${SPATIUM_UPGRADE_SLOT_BIN:-/usr/local/bin/spatium-upgrade-slot}"
@@ -73,6 +84,7 @@ write_progress() {  # $1 = step, $2 = human detail
     printf '{"step":"%s","pct":null,"detail":"%s","at":"%s"}' \
         "$1" "$detail" "$(date -Iseconds)" > "${PROGRESS}.new" 2>/dev/null \
         && mv "${PROGRESS}.new" "$PROGRESS" 2>/dev/null || true
+    publish_sidecar "$PROGRESS"
 }
 
 # #421 — keep the coarse in-flight stamp fresh while we work. Best-effort:
@@ -80,6 +92,7 @@ write_progress() {  # $1 = step, $2 = human detail
 # (a dead ticker would let the supervisor falsely reap a live apply).
 mark_inflight() {
     echo "in-flight $(date -Iseconds)" > "${TRIGGER}.state" 2>/dev/null || true
+    publish_sidecar "${TRIGGER}.state"
 }
 
 # Background loop that re-stamps in-flight every $INFLIGHT_TICK_SECONDS
@@ -112,6 +125,7 @@ fail() {  # $1 = human reason
     echo
     echo "  ✗ $1"
     echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+    publish_sidecar "${TRIGGER}.state"
     write_progress "failed" "$1"
     mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" 2>/dev/null || true
     exit 1
@@ -134,6 +148,7 @@ on_exit() {
             echo
             echo "  ✗ runner exited (rc=$rc) without writing a terminal state"
             echo "failed $(date -Iseconds)" > "${TRIGGER}.state"
+    publish_sidecar "${TRIGGER}.state"
             write_progress "failed" "runner exited (rc=$rc) without completing"
             [ -f "$TRIGGER" ] && mv "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" 2>/dev/null || true
         fi
@@ -251,6 +266,7 @@ if [ "$apply_rc" -eq 0 ]; then
         echo "  ✓ next-boot armed. Operator needs to reboot to switch slots."
         stop_inflight_ticker  # before the terminal write so it can't be reverted
         echo "done $(date -Iseconds)" > "${TRIGGER}.state"
+        publish_sidecar "${TRIGGER}.state"
         write_progress "reboot-pending" "upgrade staged — reboot to boot the new slot"
         # Parity with every other terminal mv: never let a rename race
         # (e.g. supervisor already reaped the trigger) abort under set -e

--- a/appliance/tests/README.md
+++ b/appliance/tests/README.md
@@ -8,8 +8,18 @@ require a database, Docker, or an appliance ISO.
 
 | File | What it tests |
 |---|---|
+| `test_cluster_join_failure_reason.py` | `spatium-cluster-join`'s failure-reason classifier (#590) |
+| `test_cluster_join_identity.py` | `spatium-cluster-join`'s cluster-identity wipe (#590) |
+| `test_firewall_webui_sentinel.py` | Web UI reachability before the supervisor exists (#769) |
+| `test_firstboot_member_guard.py` | `spatiumddi-firstboot` not re-seeding manifests on a joined member (#590) |
+| `test_frontend_boot_gate.py` | SPA fallback landing on the initialising page (#767) |
 | `test_grub_render.py` | `spatium-grub-render` renderer via `--print` (DRY-RUN) |
 | `test_host_migrate.py` | `spatium-host-migrate` orchestrator via a patched subprocess |
+| `test_install_done_gate.py` | The headless-install Done-screen gate |
+| `test_preseed_lint.py` | `spatium-install --check-preseed` linter |
+| `test_preseed_security.py` | The #549 preseed installer's security guards (#581) |
+| `test_slot_status_active_version.py` | `spatium-upgrade-slot status` reading the active slot's version without a mount (#788) |
+| `test_slot_upgrade_runner.py` | `spatiumddi-slot-upgrade` dead/stalled-apply guards (#421) |
 
 ## How to run
 

--- a/appliance/tests/test_slot_status_active_version.py
+++ b/appliance/tests/test_slot_status_active_version.py
@@ -75,8 +75,6 @@ def stubbed(slot_cli, monkeypatch, tmp_path):
 
 
 def test_status_reports_the_active_slot_version(slot_cli, stubbed, capsys):
-    _active, _inactive, _probed = stubbed
-
     assert slot_cli.cmd_status(None) == 0
 
     out = capsys.readouterr().out

--- a/appliance/tests/test_slot_status_active_version.py
+++ b/appliance/tests/test_slot_status_active_version.py
@@ -8,10 +8,11 @@ second read-only mount of it and the helper returned the literal string
 unreadable, on every appliance and every release. Operators read that as
 a failed upgrade right after a successful one.
 
-The fix routes both versions through ``sync_slot_versions()``, which
-reads the active slot from the booted ``/etc/spatiumddi/appliance-release``
-directly (no mount) and mounts only the inactive slot — the behaviour
-APPLIANCE.md already documented.
+The fix reads the active slot from the booted
+``/etc/spatiumddi/appliance-release`` directly (no mount) and mounts only
+the inactive slot — the split APPLIANCE.md already documented. `status`
+also stays READ-ONLY: persisting the probe would let a run issued during
+an apply clobber the `slot-versions.json` the UI reads.
 
 These tests import the CLI as a module and stub the two discovery
 helpers, so they need no root, no partitions and no appliance.
@@ -25,7 +26,6 @@ No database, no Docker, no appliance ISO required.
 from __future__ import annotations
 
 import importlib.util
-import json
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 
@@ -99,14 +99,16 @@ def test_status_never_mounts_the_active_slot(slot_cli, stubbed, capsys):
     assert probed == [inactive["device"]]
 
 
-def test_status_refreshes_the_sidecar_the_ui_reads(slot_cli, stubbed, capsys):
-    _active, _inactive, _probed = stubbed
-
+def test_status_never_writes_the_sidecar_the_ui_reads(slot_cli, stubbed, capsys):
+    """`status` is what operators run to check on an in-flight upgrade. If
+    it persisted its probe, a mount of a half-written slot would overwrite
+    the good `slot-versions.json` with "unreadable" — the string this whole
+    fix exists to stop showing — and that file feeds the Fleet card, the
+    console and the GRUB menu titles. `sync-versions` is the writer."""
     slot_cli.cmd_status(None)
     capsys.readouterr()
 
-    written = json.loads(slot_cli._SLOT_VERSIONS_FILE.read_text())
-    assert written == {"slot_a": INACTIVE_VERSION, "slot_b": ACTIVE_VERSION}
+    assert not slot_cli._SLOT_VERSIONS_FILE.exists()
 
 
 def test_status_exits_2_when_slots_are_undetectable(slot_cli, monkeypatch, capsys):

--- a/appliance/tests/test_slot_status_active_version.py
+++ b/appliance/tests/test_slot_status_active_version.py
@@ -1,0 +1,116 @@
+"""Host-portable pytest for `spatium-upgrade-slot status` (#788).
+
+`status` used to probe BOTH slots with ``slot_version_label()``, which
+mounts the slot read-only to read its ``appliance-release``. The active
+slot's device is already mounted rw at ``/``, so the kernel refuses a
+second read-only mount of it and the helper returned the literal string
+``"unreadable"`` — meaning whichever slot was booted always displayed as
+unreadable, on every appliance and every release. Operators read that as
+a failed upgrade right after a successful one.
+
+The fix routes both versions through ``sync_slot_versions()``, which
+reads the active slot from the booted ``/etc/spatiumddi/appliance-release``
+directly (no mount) and mounts only the inactive slot — the behaviour
+APPLIANCE.md already documented.
+
+These tests import the CLI as a module and stub the two discovery
+helpers, so they need no root, no partitions and no appliance.
+
+HOW TO RUN (from the repo root or this directory):
+    python3 -m pytest appliance/tests/test_slot_status_active_version.py -v
+
+No database, no Docker, no appliance ISO required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+SCRIPT = (
+    Path(__file__).parent.parent / "mkosi.extra" / "usr" / "local" / "bin" /
+    "spatium-upgrade-slot"
+)
+
+ACTIVE_VERSION = "2026.07.30-1"
+INACTIVE_VERSION = "2026.07.21-1"
+
+
+@pytest.fixture(scope="module")
+def slot_cli():
+    """Import the extensionless CLI as a module (it has a __main__ guard)."""
+    loader = SourceFileLoader("spatium_upgrade_slot", str(SCRIPT))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def stubbed(slot_cli, monkeypatch, tmp_path):
+    """Active = root_b, inactive = root_a, with the mount probe recorded.
+
+    ``slot_version_label`` is the mount-based probe. Recording every call
+    is the whole point: calling it on the active slot is the bug.
+    """
+    active = {"partlabel": "root_b", "device": "/dev/nvme0n1p5", "fslabel": "root_b",
+              "uuid": "bbbb"}
+    inactive = {"partlabel": "root_a", "device": "/dev/nvme0n1p4", "fslabel": "root_a",
+                "uuid": "aaaa"}
+    probed: list[str] = []
+
+    def _fake_probe(slot):
+        probed.append(slot["device"])
+        return INACTIVE_VERSION
+
+    monkeypatch.setattr(slot_cli, "detect_active_inactive", lambda: (active, inactive))
+    monkeypatch.setattr(slot_cli, "slot_version_label", _fake_probe)
+    monkeypatch.setattr(slot_cli, "_read_active_appliance_version", lambda: ACTIVE_VERSION)
+    monkeypatch.setattr(slot_cli, "_SLOT_VERSIONS_FILE", tmp_path / "slot-versions.json")
+    return active, inactive, probed
+
+
+def test_status_reports_the_active_slot_version(slot_cli, stubbed, capsys):
+    _active, _inactive, _probed = stubbed
+
+    assert slot_cli.cmd_status(None) == 0
+
+    out = capsys.readouterr().out
+    active_line = next(ln for ln in out.splitlines() if ln.startswith("Active slot:"))
+    inactive_line = next(ln for ln in out.splitlines() if ln.startswith("Inactive slot:"))
+
+    assert f"version={ACTIVE_VERSION}" in active_line
+    assert f"version={INACTIVE_VERSION}" in inactive_line
+    assert "unreadable" not in out
+
+
+def test_status_never_mounts_the_active_slot(slot_cli, stubbed, capsys):
+    """The regression guard: the booted device must never be mount-probed."""
+    active, inactive, probed = stubbed
+
+    slot_cli.cmd_status(None)
+    capsys.readouterr()
+
+    assert active["device"] not in probed
+    assert probed == [inactive["device"]]
+
+
+def test_status_refreshes_the_sidecar_the_ui_reads(slot_cli, stubbed, capsys):
+    _active, _inactive, _probed = stubbed
+
+    slot_cli.cmd_status(None)
+    capsys.readouterr()
+
+    written = json.loads(slot_cli._SLOT_VERSIONS_FILE.read_text())
+    assert written == {"slot_a": INACTIVE_VERSION, "slot_b": ACTIVE_VERSION}
+
+
+def test_status_exits_2_when_slots_are_undetectable(slot_cli, monkeypatch, capsys):
+    monkeypatch.setattr(slot_cli, "detect_active_inactive", lambda: None)
+
+    assert slot_cli.cmd_status(None) == 2
+    assert "couldn't detect A/B slots" in capsys.readouterr().err

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -140,10 +140,10 @@ backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:83
 backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:84
 backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:85
 backend/alembic/versions/a4e91c7b3d82_dns_dga.py:drop_column:86
-backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:222
-backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:225
-backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:230
-backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:237
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:218
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:221
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:226
+backend/alembic/versions/a4f1c93d7e28_windows_cutover_plans.py:drop_table:233
 backend/alembic/versions/a4f81c26b9e3_self_service_requests.py:drop_column:88
 backend/alembic/versions/a4f81c26b9e3_self_service_requests.py:drop_column:89
 backend/alembic/versions/a4f9c2e8b316_appliance_supervisor_identity.py:drop_column:153
@@ -579,6 +579,8 @@ backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:66
 backend/alembic/versions/e2a6f3b8c1d4_add_auto_from_lease_to_ipaddress.py:drop_column:33
 backend/alembic/versions/e2b9c4f1a7d6_address_sets.py:drop_table:102
 backend/alembic/versions/e2c91d5f7a48_appliance_pairing_codes.py:drop_table:126
+backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py:drop_column:55
+backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py:drop_column:56
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:59
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:60
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:61

--- a/backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py
+++ b/backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py
@@ -16,8 +16,11 @@ carries it: the supervisor removes any stranded ``slot-upgrade-pending``
 trigger and resets its ``.state`` / ``.progress`` sidecars, then reports
 ``ready`` — at which point the cleared DB state stops being overwritten.
 
-Same fire-once shape as ``reboot_requested``, including the auto-clear on
-a later heartbeat, so nothing new is introduced to reason about.
+The flag is retired when the host ACKNOWLEDGES — the first heartbeat
+reporting a state other than ``failed``, which is what a successful reset
+produces. ``clear_upgrade_requested_at`` backs only a give-up timeout for
+a host that can never comply, so the flag cannot pin that appliance's
+heartbeat long-poll off forever.
 
 Revision ID: e3b7a1c25d94
 Revises: a4f1c93d7e28

--- a/backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py
+++ b/backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py
@@ -1,0 +1,56 @@
+"""Host-side clear-upgrade command (#786)
+
+Adds ``appliance.clear_upgrade_requested`` + ``…_at``.
+
+"Clear failed upgrade" could not clear a failed upgrade. The endpoint
+reset the four ``desired_slot_image_*`` columns, but the red failure card
+renders from ``last_upgrade_state`` / ``last_upgrade_progress`` — and
+those are re-published verbatim from host sidecar files under
+``/var/lib/spatiumddi/release-state/`` on every heartbeat. Clearing them
+in the DB would have been undone within 30 s, and rebooting never helped
+because that directory is on the persistent ``/var`` a slot write never
+touches.
+
+So the clear has to be a command to the host, not a DB write. This flag
+carries it: the supervisor removes any stranded ``slot-upgrade-pending``
+trigger and resets its ``.state`` / ``.progress`` sidecars, then reports
+``ready`` — at which point the cleared DB state stops being overwritten.
+
+Same fire-once shape as ``reboot_requested``, including the auto-clear on
+a later heartbeat, so nothing new is introduced to reason about.
+
+Revision ID: e3b7a1c25d94
+Revises: a4f1c93d7e28
+Create Date: 2026-08-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e3b7a1c25d94"
+down_revision = "a4f1c93d7e28"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "appliance",
+        sa.Column(
+            "clear_upgrade_requested",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "appliance",
+        sa.Column("clear_upgrade_requested_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("appliance", "clear_upgrade_requested_at")
+    op.drop_column("appliance", "clear_upgrade_requested")

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -42,6 +42,7 @@ import ipaddress
 import re
 import secrets
 import uuid
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Literal
@@ -105,6 +106,7 @@ from app.services.appliance.ntp import ntp_bundle
 from app.services.appliance.resolver import resolver_bundle
 from app.services.appliance.slot_image_target import (
     SlotImageResolutionError,
+    new_refire_nonce,
     resolve_slot_image_target,
     stamp_desired_slot_image,
 )
@@ -1991,11 +1993,18 @@ async def supervisor_heartbeat(
         row.reboot_requested = False
         row.reboot_requested_at = None
 
-    # Auto-clear clear_upgrade_requested on the same 15 s rule (#786). By
-    # then the supervisor has had the command and reset its sidecars, and
-    # the report it just sent — handled above — no longer carries the
-    # failure. Leaving the flag set would make every later heartbeat redo
-    # a no-op reset.
+    # Auto-clear clear_upgrade_requested on the same 15 s rule (#786).
+    #
+    # ``deliver_clear_upgrade`` is captured BEFORE this expiry because the
+    # response is built from the row ~300 lines below: expiring here and
+    # serialising the post-expiry value would let a single heartbeat both
+    # consume the flag AND report False, so the supervisor never resets
+    # and the failure card returns. The appliance this fires on always has
+    # ``desired_appliance_version`` still set, which suppresses the
+    # long-poll — so its heartbeats arrive a full interval apart and land
+    # past the 15 s window about half the time. The expiring heartbeat
+    # must therefore still carry the command.
+    deliver_clear_upgrade = row.clear_upgrade_requested
     if (
         row.clear_upgrade_requested
         and row.clear_upgrade_requested_at is not None
@@ -2281,7 +2290,7 @@ async def supervisor_heartbeat(
         desired_next_boot_slot=row.desired_next_boot_slot,  # type: ignore[arg-type]
         desired_default_slot=row.desired_default_slot,  # type: ignore[arg-type]
         reboot_requested=row.reboot_requested,
-        clear_upgrade_requested=row.clear_upgrade_requested,
+        clear_upgrade_requested=deliver_clear_upgrade,
         cert_pem=row.cert_pem,
         ca_chain_pem=ca_chain_pem,
         cert_expires_at=row.cert_expires_at,
@@ -4889,6 +4898,9 @@ async def schedule_appliance_upgrade(
             slot_image_id=body.slot_image_id,
             slot_image_url=body.desired_slot_image_url,
         )
+        # A fresh nonce per click: re-applying the SAME image from the Fleet
+        # button is an explicit retry and must re-fire the host trigger.
+        target = replace(target, nonce=new_refire_nonce())
     except SlotImageResolutionError as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
 
@@ -4934,15 +4946,26 @@ async def schedule_appliance_upgrade(
 async def clear_appliance_upgrade(
     appliance_id: uuid.UUID, current_user: CurrentUser, db: DB
 ) -> ApplianceRow:
-    """Drops ``desired_appliance_version`` + ``desired_slot_image_url``.
-    Once the supervisor has already fired the trigger file the host
-    runner won't notice this — the slot apply is in flight. The clear
-    is most useful when an upgrade was scheduled by mistake and the
-    supervisor hasn't heartbeat-polled yet."""
+    """Cancel a pending upgrade and dismiss a failed one.
+
+    Clears the desired slot-image state AND the ``last_upgrade_*`` columns
+    the Fleet failure card renders from, then raises a one-shot host
+    command (``clear_upgrade_requested``) that makes the supervisor reset
+    its own sidecars and drop a stranded ``slot-upgrade-pending`` trigger.
+
+    Clearing our copy alone is not enough: the host re-publishes those
+    columns verbatim on every heartbeat, so without the command the next
+    heartbeat restores the failure — and rebooting does not help, because
+    those sidecars live on the persistent /var (#786).
+    """
     _require_superadmin(current_user)
     row = await db.get(Appliance, appliance_id)
     if row is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND, "Appliance not found.")
+    # Raising a host command on a row that can never consume it would strand
+    # the flag set — which permanently suppresses that appliance's heartbeat
+    # long-poll. Same gate the other host-command mutators apply.
+    _check_appliance_slot_action_allowed(row)
     row.desired_appliance_version = None
     row.desired_slot_image_url = None
     row.desired_slot_image_sha256 = None

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -2040,7 +2040,13 @@ async def supervisor_heartbeat(
         has_pending_command = (
             row.desired_appliance_version is not None
             or row.reboot_requested
-            or row.clear_upgrade_requested
+            # ``deliver_clear_upgrade``, not the row: the auto-expiry above
+            # may have just cleared the flag while the response below still
+            # carries the command. Reading the row here would make this look
+            # idle — and a clear also nulls ``desired_appliance_version``, so
+            # nothing else keeps it pending — so we would hold the very
+            # response that delivers the clear for up to the hold cap.
+            or deliver_clear_upgrade
             or row.desired_next_boot_slot is not None
             or row.desired_default_slot is not None
         )

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1279,6 +1279,10 @@ class SupervisorHeartbeatResponse(BaseModel):
     desired_next_boot_slot: Literal["slot_a", "slot_b"] | None = None
     desired_default_slot: Literal["slot_a", "slot_b"] | None = None
     reboot_requested: bool = False
+    # #786 — one-shot: reset the host's slot-upgrade sidecars + drop any
+    # stranded trigger, so a cleared failure stays cleared instead of
+    # being re-published on the next heartbeat.
+    clear_upgrade_requested: bool = False
     # #170 Wave D follow-up — supervisor's signed cert + CA chain.
     # Populated when the appliance has been approved + the supervisor
     # hasn't picked them up yet. The supervisor saves them to
@@ -1636,17 +1640,24 @@ async def supervisor_heartbeat(
         row.slot_b_version = body.slot_b_version
     if body.is_trial_boot is not None:
         row.is_trial_boot = body.is_trial_boot
-    if body.last_upgrade_state is not None:
-        row.last_upgrade_state = body.last_upgrade_state
-    if body.last_upgrade_state_at is not None:
-        row.last_upgrade_state_at = body.last_upgrade_state_at
-    # #386 Part C — empty string is a meaningful value here ("no
-    # in-flight upgrade, clear any stale tail"), so persist on
-    # ``is not None`` rather than truthiness.
-    if body.last_upgrade_log_tail is not None:
-        row.last_upgrade_log_tail = body.last_upgrade_log_tail or None
-    if body.last_upgrade_progress is not None:
-        row.last_upgrade_progress = body.last_upgrade_progress or None
+    # #786 — while a clear is outstanding, ignore the upgrade state this
+    # heartbeat carries. The supervisor collected it BEFORE it saw the
+    # clear command, so it still describes the failure the operator just
+    # dismissed; ingesting it would re-stamp the row we cleared and the
+    # red card would never go away. The heartbeat after the host resets
+    # its sidecars reports ``ready`` and is ingested normally.
+    if not row.clear_upgrade_requested:
+        if body.last_upgrade_state is not None:
+            row.last_upgrade_state = body.last_upgrade_state
+        if body.last_upgrade_state_at is not None:
+            row.last_upgrade_state_at = body.last_upgrade_state_at
+        # #386 Part C — empty string is a meaningful value here ("no
+        # in-flight upgrade, clear any stale tail"), so persist on
+        # ``is not None`` rather than truthiness.
+        if body.last_upgrade_log_tail is not None:
+            row.last_upgrade_log_tail = body.last_upgrade_log_tail or None
+        if body.last_upgrade_progress is not None:
+            row.last_upgrade_progress = body.last_upgrade_progress or None
     if body.snmpd_running is not None:
         row.snmpd_running = body.snmpd_running
     if body.lldpd_running is not None:
@@ -1980,6 +1991,19 @@ async def supervisor_heartbeat(
         row.reboot_requested = False
         row.reboot_requested_at = None
 
+    # Auto-clear clear_upgrade_requested on the same 15 s rule (#786). By
+    # then the supervisor has had the command and reset its sidecars, and
+    # the report it just sent — handled above — no longer carries the
+    # failure. Leaving the flag set would make every later heartbeat redo
+    # a no-op reset.
+    if (
+        row.clear_upgrade_requested
+        and row.clear_upgrade_requested_at is not None
+        and (datetime.now(UTC) - row.clear_upgrade_requested_at).total_seconds() >= 15
+    ):
+        row.clear_upgrade_requested = False
+        row.clear_upgrade_requested_at = None
+
     await db.commit()
 
     # #358 Phase 1b — heartbeat long-poll. When the supervisor opts in
@@ -2007,6 +2031,7 @@ async def supervisor_heartbeat(
         has_pending_command = (
             row.desired_appliance_version is not None
             or row.reboot_requested
+            or row.clear_upgrade_requested
             or row.desired_next_boot_slot is not None
             or row.desired_default_slot is not None
         )
@@ -2256,6 +2281,7 @@ async def supervisor_heartbeat(
         desired_next_boot_slot=row.desired_next_boot_slot,  # type: ignore[arg-type]
         desired_default_slot=row.desired_default_slot,  # type: ignore[arg-type]
         reboot_requested=row.reboot_requested,
+        clear_upgrade_requested=row.clear_upgrade_requested,
         cert_pem=row.cert_pem,
         ca_chain_pem=ca_chain_pem,
         cert_expires_at=row.cert_expires_at,
@@ -4921,6 +4947,19 @@ async def clear_appliance_upgrade(
     row.desired_slot_image_url = None
     row.desired_slot_image_sha256 = None
     row.desired_slot_image_tls_insecure = False
+    # #786 — clearing the desired state alone left the appliance sitting in
+    # the red "Upgrade failed" card forever. That card renders from the
+    # ``last_upgrade_*`` columns, which the heartbeat re-publishes verbatim
+    # from host sidecars every ~30 s, so the host has to be told to forget
+    # too. Clear our copy for an immediate UI response AND raise the
+    # command that makes the host reset its own state; without the second
+    # half the next heartbeat simply restores what we just cleared.
+    row.last_upgrade_state = None
+    row.last_upgrade_state_at = None
+    row.last_upgrade_progress = None
+    row.last_upgrade_log_tail = None
+    row.clear_upgrade_requested = True
+    row.clear_upgrade_requested_at = datetime.now(UTC)
     db.add(
         AuditLog(
             user_id=current_user.id,

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -103,6 +103,11 @@ from app.services.appliance.firewall import firewall_bundle
 from app.services.appliance.lldp import lldp_bundle
 from app.services.appliance.ntp import ntp_bundle
 from app.services.appliance.resolver import resolver_bundle
+from app.services.appliance.slot_image_target import (
+    SlotImageResolutionError,
+    resolve_slot_image_target,
+    stamp_desired_slot_image,
+)
 from app.services.appliance.snmp import snmp_bundle
 from app.services.appliance.ssh import ssh_bundle
 from app.services.appliance.syslog import syslog_bundle
@@ -141,27 +146,6 @@ def _client_ip(request: Request) -> str | None:
 _HOST_ROLE_CONFIG = Path("/etc/spatiumddi-host/role-config")
 _SELF_BOOTSTRAP_VARIANTS = frozenset({"control-plane", "full-stack", "frontend-core"})
 _SELF_BOOTSTRAP_CODE_TTL = timedelta(minutes=10)
-
-# The slot-upgrade host runner only strips a URL ``#fragment`` before
-# fetching as of #386 (shipped 2026-06-12). An appliance on an older
-# supervisor hands the fragment straight to the downloader and the apply
-# wedges at "in-flight" forever (#419). Gate the re-fire nonce on the
-# target supervisor's reported version so older fleets get a clean URL.
-_URL_FRAGMENT_STRIP_MIN_VERSION = "2026.06.12"
-
-
-def _supervisor_strips_url_fragment(row: Appliance) -> bool:
-    """True if the appliance's supervisor / slot-upgrade runner strips a URL
-    ``#fragment`` before fetching (≥ 2026.06.12, i.e. has the #386 strip).
-
-    CalVer (``YYYY.MM.DD-N``) sorts lexicographically, so a string compare is
-    correct. A dev / unknown / pre-CalVer version stays on the safe clean-URL
-    path — losing only auto-re-fire of the *same* image (a new version already
-    changes the URL), never the ability to upgrade (#419)."""
-    ver = row.supervisor_version or row.installed_appliance_version or ""
-    return (
-        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= _URL_FRAGMENT_STRIP_MIN_VERSION
-    )
 
 
 def _read_host_role() -> str | None:
@@ -4861,80 +4845,29 @@ async def schedule_appliance_upgrade(
             ),
         )
 
-    # Resolve slot_image_id → internal URL. We compose the URL
-    # relative to the request's host so the supervisor can reach it
-    # from the same network it reaches the control plane on; the
-    # request's base_url is the operator-facing scheme + host the
-    # frontend is already using.
-    from app.models.appliance import ApplianceUpgradeImage  # noqa: PLC0415
-
-    resolved_url: str
-    # Issue #386 Part A — integrity + transport hints stamped alongside
-    # the URL. For an internal (self-served) image we know the sha256 and
-    # that the URL points at our own self-signed cert; for an external
-    # operator-pasted URL we trust public-CA TLS and have no hash.
-    image_sha256: str | None = None
-    tls_insecure = False
-    if body.slot_image_id is not None:
-        image = await db.get(ApplianceUpgradeImage, body.slot_image_id)
-        if image is None:
-            raise HTTPException(
-                status.HTTP_422_UNPROCESSABLE_ENTITY,
-                f"Upgrade image {body.slot_image_id} not found.",
-            )
-        # ``request.base_url`` ends with ``/`` and carries the scheme
-        # + host the frontend reached us on (X-Forwarded-Host /
-        # X-Forwarded-Proto, when nginx is in front). The supervisor
-        # is the only thing that resolves this URL, so as long as the
-        # frontend host is reachable from the appliance subnet (which
-        # it must be — that's where the supervisor already
-        # heartbeats), this lines up.
-        #
-        # ``?t=<hmac>`` token authorises the host-side
-        # ``spatium-upgrade-slot`` runner — it does an unauthenticated
-        # ``urllib.request.urlopen`` because it has no operator
-        # session and no mTLS material. The token is HMAC'd against
-        # the image_id + SECRET_KEY, so a leaked URL can't be replayed
-        # against a different image.
-        from app.api.v1.appliance.upgrade_images import (  # noqa: PLC0415
-            slot_image_download_token,
+    # Resolve slot_image_id → internal URL + integrity/transport hints,
+    # then stamp all four desired-state columns. Both live in
+    # ``services.appliance.slot_image_target`` so this surface and the
+    # multi-node rolling orchestrator cannot drift apart on what the host
+    # is told to fetch (#787) — the drift that re-introduced #386 there.
+    #
+    # The URL is composed against ``request.base_url``: the operator-facing
+    # scheme + host the frontend reached us on (X-Forwarded-Host / -Proto
+    # when nginx is in front), which is necessarily reachable from the
+    # appliance subnet because that is where the supervisor already
+    # heartbeats.
+    try:
+        target = await resolve_slot_image_target(
+            db,
+            base_url=str(request.base_url),
+            slot_image_id=body.slot_image_id,
+            slot_image_url=body.desired_slot_image_url,
         )
+    except SlotImageResolutionError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
 
-        token = slot_image_download_token(image.id)
-        resolved_url = (
-            f"{str(request.base_url).rstrip('/')}"
-            f"/api/v1/appliance/upgrade-images/{image.id}/raw.xz?t={token}"
-        )
-        # The image is served by our OWN control plane behind the
-        # self-signed web cert, so the host runner's bare urllib fetch
-        # would fail TLS verify (#386). Hand it the stored sha256 to
-        # verify bytes against + flag the self-served URL so it skips
-        # cert-verify for this fetch only.
-        image_sha256 = image.sha256
-        tls_insecure = True
-    else:
-        assert body.desired_slot_image_url is not None
-        resolved_url = body.desired_slot_image_url
-
-    # Issue #386 Part B — append a per-apply nonce as a URL *fragment* so
-    # each schedule yields a distinct ``desired_slot_image_url`` and the
-    # supervisor re-fires the trigger on a fresh apply of the same image
-    # (it fires once per distinct URL — no silent re-fire loop on failure).
-    # The host runner strips the fragment before fetching, but only since
-    # #386 (2026-06-12); an older appliance passes it straight to the
-    # downloader and the apply wedges at "in-flight" forever (#419). So only
-    # add the nonce when the target supervisor is known to strip it — older
-    # / unknown supervisors get a clean URL (a new version already changes
-    # the URL, so re-fire still works; only re-applying the *same* version
-    # loses auto-re-fire on those boxes).
-    if _supervisor_strips_url_fragment(row):
-        nonce = uuid.uuid4().hex[:12]
-        resolved_url = f"{resolved_url}#a={nonce}"
-
-    row.desired_appliance_version = body.desired_appliance_version
-    row.desired_slot_image_url = resolved_url
-    row.desired_slot_image_sha256 = image_sha256
-    row.desired_slot_image_tls_insecure = tls_insecure
+    stamp_desired_slot_image(row, target, desired_version=body.desired_appliance_version)
+    resolved_url = row.desired_slot_image_url or target.url
     db.add(
         AuditLog(
             user_id=current_user.id,

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -1491,6 +1491,15 @@ async def _ingest_lldp_neighbours(
 
 # #358 Phase 1b — server-side cap on how long the heartbeat long-poll holds
 # the connection. Must stay under the supervisor's client timeout
+# #786 — how long the control plane keeps re-sending a clear-upgrade
+# command before giving up on it. Not a delivery window: the command is
+# retired the moment the host acknowledges by reporting a non-``failed``
+# state. This is only the backstop for a host that can NEVER comply — a
+# trigger it does not own is unlinkable out of the sticky release-state
+# directory — so the flag can't pin the heartbeat long-poll off forever.
+_CLEAR_UPGRADE_GIVE_UP_SECONDS = 600.0
+
+
 # (heartbeat_interval + 10 s) so the hold returns before the client gives up.
 _HEARTBEAT_HOLD_CAP_S = 28.0
 
@@ -1642,13 +1651,18 @@ async def supervisor_heartbeat(
         row.slot_b_version = body.slot_b_version
     if body.is_trial_boot is not None:
         row.is_trial_boot = body.is_trial_boot
-    # #786 — while a clear is outstanding, ignore the upgrade state this
-    # heartbeat carries. The supervisor collected it BEFORE it saw the
-    # clear command, so it still describes the failure the operator just
-    # dismissed; ingesting it would re-stamp the row we cleared and the
-    # red card would never go away. The heartbeat after the host resets
-    # its sidecars reports ``ready`` and is ingested normally.
-    if not row.clear_upgrade_requested:
+    # #786 — while a clear is outstanding, drop ONLY a report that still
+    # carries the dismissed failure. The supervisor collected it before it
+    # saw the command, so ingesting it would re-stamp the row we cleared
+    # and the red card would never go away.
+    #
+    # Scoped to ``failed`` on purpose. Blanket-suppressing every
+    # ``last_upgrade_*`` for the whole window also threw away the host's
+    # post-reset ``ready`` — the very acknowledgement this waits for — and
+    # any progress from an upgrade the operator retried straight after
+    # clearing, which is the normal recovery gesture.
+    suppress_stale_failure = row.clear_upgrade_requested and body.last_upgrade_state == "failed"
+    if not suppress_stale_failure:
         if body.last_upgrade_state is not None:
             row.last_upgrade_state = body.last_upgrade_state
         if body.last_upgrade_state_at is not None:
@@ -1993,25 +2007,46 @@ async def supervisor_heartbeat(
         row.reboot_requested = False
         row.reboot_requested_at = None
 
-    # Auto-clear clear_upgrade_requested on the same 15 s rule (#786).
+    # Retire clear_upgrade_requested on ACKNOWLEDGEMENT, not on a clock
+    # (#786). The host's compliance is already observable: the clear's
+    # whole job is to turn a ``failed`` sidecar into ``ready``, so the
+    # first heartbeat reporting anything other than ``failed`` IS the ack.
+    # Until then the command keeps riding every response, so a supervisor
+    # that was offline, restarting, or simply slow still receives it.
     #
-    # ``deliver_clear_upgrade`` is captured BEFORE this expiry because the
-    # response is built from the row ~300 lines below: expiring here and
-    # serialising the post-expiry value would let a single heartbeat both
-    # consume the flag AND report False, so the supervisor never resets
-    # and the failure card returns. The appliance this fires on always has
-    # ``desired_appliance_version`` still set, which suppresses the
-    # long-poll — so its heartbeats arrive a full interval apart and land
-    # past the 15 s window about half the time. The expiring heartbeat
-    # must therefore still carry the command.
+    # This replaces a 15 s stopwatch that could expire before the command
+    # was ever delivered: a wedged appliance keeps ``desired_appliance_
+    # version`` set, which suppresses the long-poll, so its heartbeats
+    # arrive a full interval apart and landed past the window about half
+    # the time. No clock comparison between host and control plane is
+    # involved either, so appliance clock skew cannot strand the flag.
+    #
+    # ``deliver_clear_upgrade`` is still captured BEFORE the retire,
+    # because the response is built from the row ~300 lines below and the
+    # acknowledging heartbeat must carry the command one last time (it is
+    # idempotent host-side, and the alternative is dropping it).
     deliver_clear_upgrade = row.clear_upgrade_requested
-    if (
-        row.clear_upgrade_requested
-        and row.clear_upgrade_requested_at is not None
-        and (datetime.now(UTC) - row.clear_upgrade_requested_at).total_seconds() >= 15
-    ):
-        row.clear_upgrade_requested = False
-        row.clear_upgrade_requested_at = None
+    if row.clear_upgrade_requested:
+        acknowledged = body.last_upgrade_state is not None and body.last_upgrade_state != "failed"
+        # Backstop so a host that can never comply — e.g. a trigger it does
+        # not own, which it can never unlink out of the sticky release-state
+        # directory — cannot pin the flag on forever and permanently
+        # suppress this appliance's heartbeat long-poll.
+        stalled = (
+            row.clear_upgrade_requested_at is not None
+            and (datetime.now(UTC) - row.clear_upgrade_requested_at).total_seconds()
+            >= _CLEAR_UPGRADE_GIVE_UP_SECONDS
+        )
+        if acknowledged or stalled:
+            if stalled and not acknowledged:
+                logger.warning(
+                    "appliance_clear_upgrade_unacknowledged",
+                    appliance_id=str(row.id),
+                    hostname=row.hostname,
+                    last_upgrade_state=body.last_upgrade_state,
+                )
+            row.clear_upgrade_requested = False
+            row.clear_upgrade_requested_at = None
 
     await db.commit()
 

--- a/backend/app/api/v1/appliance/upgrade_images.py
+++ b/backend/app/api/v1/appliance/upgrade_images.py
@@ -58,6 +58,7 @@ import uuid
 from collections.abc import AsyncIterator
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 import structlog
@@ -107,10 +108,20 @@ MAX_UPLOAD_BYTES = 4 * 1024 * 1024 * 1024
 # coroutine yields between chunks) + large enough to avoid syscall
 # overhead.
 _CHUNK_BYTES = 4 * 1024 * 1024
-# Asset name convention the release workflow attaches to every cut
-# (see .github/workflows/release.yml). Both the stable + versioned
-# names point at the same bytes; either works for download.
+# Fallback display name for a GitHub-imported image, used only when the
+# asset URL doesn't end in a recognisable filename. Normally the row
+# records the asset actually downloaded — which is the VERSIONED name,
+# since that is what ``_pick_upgrade_assets`` resolves (the stable name is
+# pruned from every non-latest release, #392). Stamping the stable name
+# unconditionally used to leave the Fleet picker showing a filename that
+# matched no asset on the release it came from.
 _GITHUB_IMAGE_FILENAME = "spatiumddi-appliance-slot-amd64.raw.xz"
+
+
+def _github_asset_filename(asset_url: str) -> str:
+    """Last path segment of a release-asset URL, minus any query string."""
+    tail = urlparse(asset_url).path.rsplit("/", 1)[-1]
+    return tail if tail.endswith(".raw.xz") else _GITHUB_IMAGE_FILENAME
 
 
 def _require_superadmin(user: CurrentUser) -> None:
@@ -739,7 +750,7 @@ async def import_upgrade_image_from_github(
 
     row = ApplianceUpgradeImage(
         id=image_id,
-        filename=_GITHUB_IMAGE_FILENAME,
+        filename=_github_asset_filename(spec.image_asset_url),
         size_bytes=bytes_written,
         sha256=expected_sha,
         appliance_version=tag,

--- a/backend/app/api/v1/upgrades.py
+++ b/backend/app/api/v1/upgrades.py
@@ -30,6 +30,7 @@ All mutations are gated on ``admin appliance``; reads on
 from __future__ import annotations
 
 import uuid
+from dataclasses import replace
 from typing import Any
 
 import structlog
@@ -41,6 +42,7 @@ from app.core.permissions import require_permission
 from app.services.appliance.slot_image_target import (
     SlotImageResolutionError,
     SlotImageTarget,
+    new_refire_nonce,
     resolve_slot_image_target,
 )
 from app.services.upgrades import mutex, orchestrator, preflight
@@ -331,12 +333,15 @@ async def _resolve_slot_image_target(
     divergence that left this path re-creating #386 (see #787).
     """
     try:
-        return await resolve_slot_image_target(
+        target = await resolve_slot_image_target(
             db,
             base_url=str(request.base_url),
             slot_image_id=body.slot_image_id,
             slot_image_url=body.slot_image_url,
         )
+        # One nonce for the whole run, persisted in the plan, so a resume
+        # re-stamps the identical URL and the fire-once marker still holds.
+        return replace(target, nonce=new_refire_nonce())
     except SlotImageResolutionError as exc:
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
 

--- a/backend/app/api/v1/upgrades.py
+++ b/backend/app/api/v1/upgrades.py
@@ -38,6 +38,11 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import require_permission
+from app.services.appliance.slot_image_target import (
+    SlotImageResolutionError,
+    SlotImageTarget,
+    resolve_slot_image_target,
+)
 from app.services.upgrades import mutex, orchestrator, preflight
 
 logger = structlog.get_logger(__name__)
@@ -287,12 +292,12 @@ async def post_plan(
     → mirror path. Operators on connected installs keep using
     ``slot_image_url`` directly.
     """
-    resolved_url = await _resolve_slot_image_url(db, request, body)
+    target = await _resolve_slot_image_target(db, request, body)
     try:
         plan = await orchestrator.plan_upgrade(
             db,
             target_version=body.target_version,
-            slot_image_url=resolved_url,
+            slot_image=target,
             cnpg_cluster_name=body.cnpg_cluster_name,
             cnpg_namespace=body.cnpg_namespace,
             started_by_user_id=current_user.id,
@@ -313,45 +318,27 @@ async def post_plan(
     )
 
 
-async def _resolve_slot_image_url(
+async def _resolve_slot_image_target(
     db: DB,
     request: Request,
     body: PlanRequest,
-) -> str:
-    """Return the URL spatium-upgrade-slot apply will pull from.
+) -> SlotImageTarget:
+    """Resolve what every per-node runner in this run will fetch + verify.
 
-    Mirrors the resolution logic in supervisor.py's
-    ``schedule_appliance_upgrade`` — same HMAC token, same URL shape,
-    same operator-facing semantics. Centralised here so the rolling
-    upgrade flow + the per-box flow can't diverge on token shape
-    without both surfaces breaking together.
-
-    * ``slot_image_url`` → returned verbatim (operator-provided
-      external URL).
-    * ``slot_image_id`` → composed as
-      ``{request.base_url}/api/v1/appliance/upgrade-images/{id}/raw.xz
-      ?t={hmac}`` where the HMAC comes from
-      ``slot_image_download_token``.
+    Delegates to the same resolver the per-box ``schedule_appliance_
+    upgrade`` uses, so the two surfaces cannot diverge on URL shape, token
+    scheme, or the integrity/transport hints that ride alongside — the
+    divergence that left this path re-creating #386 (see #787).
     """
-    if body.slot_image_url is not None:
-        return body.slot_image_url
-    assert body.slot_image_id is not None  # ruled out by model_validator
-    from app.api.v1.appliance.upgrade_images import (  # noqa: PLC0415
-        slot_image_download_token,
-    )
-    from app.models.appliance import ApplianceUpgradeImage  # noqa: PLC0415
-
-    image = await db.get(ApplianceUpgradeImage, body.slot_image_id)
-    if image is None:
-        raise HTTPException(
-            status.HTTP_422_UNPROCESSABLE_ENTITY,
-            f"Upgrade image {body.slot_image_id} not found.",
+    try:
+        return await resolve_slot_image_target(
+            db,
+            base_url=str(request.base_url),
+            slot_image_id=body.slot_image_id,
+            slot_image_url=body.slot_image_url,
         )
-    token = slot_image_download_token(image.id)
-    return (
-        f"{str(request.base_url).rstrip('/')}"
-        f"/api/v1/appliance/upgrade-images/{image.id}/raw.xz?t={token}"
-    )
+    except SlotImageResolutionError as exc:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, str(exc)) from exc
 
 
 @router.post(

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -602,14 +602,18 @@ class Appliance(Base):
         DateTime(timezone=True), nullable=True
     )
     # #786 — operator asked to clear a failed upgrade. The visible failure
-    # state (``last_upgrade_*`` below) is re-published from host sidecar
-    # files on every heartbeat, so clearing the DB alone does nothing: the
-    # next heartbeat restores it, and rebooting doesn't help because those
-    # files live on the persistent /var. This flag is the command that
-    # makes the *host* forget — the supervisor deletes any stranded
-    # slot-upgrade trigger and resets its state/progress sidecars. Same
-    # fire-once shape as ``reboot_requested``: stamped by the endpoint,
-    # auto-cleared shortly after the supervisor has had it.
+    # state (the ``last_upgrade_*`` columns above) is re-published from
+    # host sidecar files on every heartbeat, so clearing the DB alone does
+    # nothing: the next heartbeat restores it, and rebooting doesn't help
+    # because those files live on the persistent /var. This flag is the
+    # command that makes the *host* forget — the supervisor deletes any
+    # stranded slot-upgrade trigger and resets its state/progress sidecars.
+    #
+    # Unlike ``reboot_requested`` this is retired by ACKNOWLEDGEMENT rather
+    # than a timer: the command rides every heartbeat response until the
+    # host reports a non-``failed`` state, which is exactly what a
+    # successful reset produces. ``_at`` exists only for the give-up
+    # backstop, not as a delivery window.
     clear_upgrade_requested: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa.text("false")
     )

--- a/backend/app/models/appliance.py
+++ b/backend/app/models/appliance.py
@@ -601,6 +601,21 @@ class Appliance(Base):
     reboot_requested_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # #786 — operator asked to clear a failed upgrade. The visible failure
+    # state (``last_upgrade_*`` below) is re-published from host sidecar
+    # files on every heartbeat, so clearing the DB alone does nothing: the
+    # next heartbeat restores it, and rebooting doesn't help because those
+    # files live on the persistent /var. This flag is the command that
+    # makes the *host* forget — the supervisor deletes any stranded
+    # slot-upgrade trigger and resets its state/progress sidecars. Same
+    # fire-once shape as ``reboot_requested``: stamped by the endpoint,
+    # auto-cleared shortly after the supervisor has had it.
+    clear_upgrade_requested: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
+    clear_upgrade_requested_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     # Per-slot boot control. Operator sets one of these via the Fleet
     # UI; supervisor reads from the heartbeat response + writes the
     # matching trigger file the host runners watch.

--- a/backend/app/services/appliance/releases.py
+++ b/backend/app/services/appliance/releases.py
@@ -48,7 +48,11 @@ _CACHE_TTL_SECONDS = 60
 #   spatiumddi-appliance-slot-amd64.raw.xz            (stable)
 #   spatiumddi-appliance-slot-<VERSION>-amd64.raw.xz  (versioned)
 # plus a matching ``.sha256`` sibling for each. Both names point at the
-# same bytes; either works for download.
+# same bytes — but only on the CURRENT latest release: the stable pair
+# exists solely to back ``releases/latest/download/<name>`` and #392's
+# retention prunes it from every release the moment a newer one is cut.
+# So a per-tag URL must use the versioned name, which is why the picker
+# below sorts longest-first.
 _UPGRADE_IMAGE_ASSET_RE = re.compile(r"^spatiumddi-appliance-slot.*-amd64\.raw\.xz$")
 
 
@@ -166,8 +170,15 @@ def _pick_upgrade_assets(assets: list[dict]) -> tuple[str, str, int | None] | No
     """Pick the ``.raw.xz`` upgrade-image asset + its ``.sha256`` sibling.
 
     Returns ``(image_url, checksum_url, size_bytes)`` or ``None`` when a
-    release doesn't carry a matched pair. Prefers the versioned asset
-    name (longer) but either points at the same bytes.
+    release doesn't carry a matched pair. Prefers the versioned asset name
+    (the longer one) — and that preference is load-bearing, not cosmetic:
+    the stable name is pruned from every non-latest release (#392), so a
+    URL built from it would 404 for anything but the newest cut.
+
+    Returning ``None`` on a half-pruned release is also deliberate. #392's
+    Tier 2 keeps the tiny ``.sha256`` provenance sidecar after dropping the
+    heavy ``.raw.xz``; requiring the matched PAIR is what makes such a
+    release disappear from the picker instead of offering a dead link.
     """
     by_name = {(a.get("name") or ""): a for a in assets}
     raws = [n for n in by_name if _UPGRADE_IMAGE_ASSET_RE.match(n)]

--- a/backend/app/services/appliance/slot_image_target.py
+++ b/backend/app/services/appliance/slot_image_target.py
@@ -1,0 +1,175 @@
+"""One resolver for the desired slot-image state an appliance is told to fetch.
+
+Two surfaces schedule OS slot upgrades — the per-box Fleet action
+(``schedule_appliance_upgrade``) and the multi-node rolling orchestrator
+(``/api/v1/upgrades/{run}/start`` → ``_step_trigger_slot_apply``). Both
+must stamp the SAME four ``Appliance.desired_slot_image_*`` columns,
+because the supervisor writes all four into the host trigger file and the
+host runner needs every one of them to fetch successfully.
+
+They diverged: the orchestrator stamped only version + URL, leaving
+``desired_slot_image_sha256`` and ``desired_slot_image_tls_insecure``
+unset. For an uploaded image that means the host fetches the appliance's
+own self-signed HTTPS URL with cert verification ON and no hash to verify
+against — exactly the #386 failure, re-introduced on the rolling path
+(#787). Worse, a stale sha256 left on the row from an earlier per-box
+schedule would be checked against the new image and fail as corruption.
+
+So resolution and stamping live here, and both callers go through them.
+Adding a fifth field means touching one function, not remembering two.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.appliance import Appliance, ApplianceUpgradeImage
+
+# The host runner only learned to strip a URL ``#fragment`` before
+# fetching in #386 (2026-06-12). An older runner passes the fragment
+# straight to the downloader and the apply wedges at "in-flight"
+# forever (#419), so the nonce is gated on the supervisor's version.
+URL_FRAGMENT_STRIP_MIN_VERSION = "2026.06.12"
+
+
+class SlotImageResolutionError(Exception):
+    """The requested upgrade image could not be resolved to a fetchable target."""
+
+
+@dataclass(frozen=True)
+class SlotImageTarget:
+    """Everything the host needs to fetch + verify one slot image.
+
+    ``sha256`` and ``tls_insecure`` are meaningful only for an image we
+    serve ourselves: we know its hash, and we know the URL points at our
+    own self-signed web cert. An operator-pasted external URL is fetched
+    over public-CA TLS with no hash (the ``.xz`` container's own integrity
+    check is what catches a truncated or corrupted download there).
+    """
+
+    url: str
+    sha256: str | None = None
+    tls_insecure: bool = False
+
+    def as_plan_fields(self) -> dict[str, object]:
+        """Serialise into an ``UpgradeRun.plan`` JSON blob."""
+        return {
+            "slot_image_url": self.url,
+            "slot_image_sha256": self.sha256,
+            "slot_image_tls_insecure": self.tls_insecure,
+        }
+
+    @classmethod
+    def from_plan_fields(cls, plan: dict) -> SlotImageTarget:
+        """Rebuild from an ``UpgradeRun.plan`` blob.
+
+        Tolerates a plan written before the two integrity fields existed —
+        those runs resolve to the same (url-only) target they had then.
+        """
+        return cls(
+            url=plan.get("slot_image_url") or "",
+            sha256=plan.get("slot_image_sha256"),
+            tls_insecure=bool(plan.get("slot_image_tls_insecure", False)),
+        )
+
+
+def supervisor_strips_url_fragment(row: Appliance) -> bool:
+    """True if this appliance's runner strips a URL ``#fragment`` (≥ #386).
+
+    CalVer (``YYYY.MM.DD-N``) sorts lexicographically, so a string compare
+    is correct. A dev / unknown / pre-CalVer version stays on the safe
+    clean-URL path — losing only auto-re-fire of the *same* image (a new
+    version already changes the URL), never the ability to upgrade (#419).
+    """
+    ver = row.supervisor_version or row.installed_appliance_version or ""
+    return (
+        re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= URL_FRAGMENT_STRIP_MIN_VERSION
+    )
+
+
+async def resolve_slot_image_target(
+    db: AsyncSession,
+    *,
+    base_url: str,
+    slot_image_id: uuid.UUID | None = None,
+    slot_image_url: str | None = None,
+) -> SlotImageTarget:
+    """Resolve an upload-or-URL choice into a fetchable target.
+
+    Exactly one of ``slot_image_id`` / ``slot_image_url`` must be given;
+    callers validate that at the request-model layer and this asserts it.
+
+    For an uploaded image the URL is composed against ``base_url`` — the
+    operator-facing scheme + host the frontend reached us on, which is
+    also the address the supervisor already heartbeats to. The ``?t=``
+    HMAC authorises the host runner's unauthenticated GET; it is bound to
+    the image id, so a leaked URL cannot be replayed for another image.
+
+    Raises ``SlotImageResolutionError`` when the image row is missing.
+    """
+    if (slot_image_id is None) == (slot_image_url is None):
+        raise SlotImageResolutionError("Pass exactly one of slot_image_id or slot_image_url.")
+
+    if slot_image_url is not None:
+        return SlotImageTarget(url=slot_image_url)
+
+    assert slot_image_id is not None  # narrowed by the check above
+    image = await db.get(ApplianceUpgradeImage, slot_image_id)
+    if image is None:
+        raise SlotImageResolutionError(f"Upgrade image {slot_image_id} not found.")
+
+    # Imported locally: the token mint lives on the API router that also
+    # serves the bytes, and importing it at module scope would cycle back
+    # through the router package.
+    from app.api.v1.appliance.upgrade_images import (  # noqa: PLC0415
+        slot_image_download_token,
+    )
+
+    token = slot_image_download_token(image.id)
+    return SlotImageTarget(
+        url=(
+            f"{base_url.rstrip('/')}"
+            f"/api/v1/appliance/upgrade-images/{image.id}/raw.xz?t={token}"
+        ),
+        sha256=image.sha256,
+        tls_insecure=True,
+    )
+
+
+def stamp_desired_slot_image(
+    row: Appliance,
+    target: SlotImageTarget,
+    *,
+    desired_version: str,
+    nonce: str | None = None,
+) -> None:
+    """Write all four desired-state columns onto ``row``.
+
+    ``nonce`` (#386 Part B) makes each schedule yield a distinct URL so the
+    supervisor's fire-once marker re-fires on a fresh apply of the same
+    image instead of treating it as already-fired. Pass ``None`` to let
+    this generate one; it is applied only when the appliance's runner is
+    known to strip the fragment.
+    """
+    url = target.url
+    if supervisor_strips_url_fragment(row):
+        url = f"{url}#a={nonce or uuid.uuid4().hex[:12]}"
+
+    row.desired_appliance_version = desired_version
+    row.desired_slot_image_url = url
+    row.desired_slot_image_sha256 = target.sha256
+    row.desired_slot_image_tls_insecure = target.tls_insecure
+
+
+__all__ = [
+    "URL_FRAGMENT_STRIP_MIN_VERSION",
+    "SlotImageResolutionError",
+    "SlotImageTarget",
+    "resolve_slot_image_target",
+    "stamp_desired_slot_image",
+    "supervisor_strips_url_fragment",
+]

--- a/backend/app/services/appliance/slot_image_target.py
+++ b/backend/app/services/appliance/slot_image_target.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
 from app.models.appliance import Appliance, ApplianceUpgradeImage
 
 # The host runner only learned to strip a URL ``#fragment`` before
@@ -91,6 +92,45 @@ def supervisor_strips_url_fragment(row: Appliance) -> bool:
     )
 
 
+def _assert_self_served_bytes_are_reachable() -> None:
+    """Refuse to point a host at an uploaded image it may not be able to fetch.
+
+    Uploaded bytes land on the api replica that served the upload, on a
+    node-local hostPath. The slot-image mirror is what makes them readable
+    from every replica — and it is off by default. So on a multi-node
+    control plane (api runs 2 replicas with hard anti-affinity), the host's
+    download round-robins through the Service and roughly half the time
+    reaches a replica without the bytes, which answers 404 "bytes missing
+    on disk — re-upload required". That message is actively misleading:
+    the bytes exist, just on a node the operator cannot see (#787).
+
+    Fail here instead, where we can say what to do about it. External URLs
+    are unaffected — nothing of ours serves those.
+
+    Silent no-op off Kubernetes (docker compose): one api process, so the
+    bytes are always local to whoever serves the download.
+    """
+    if settings.slot_image_mirror_url:
+        return  # bytes are reachable cluster-wide through the mirror
+
+    from app.services.appliance import k8s  # noqa: PLC0415
+
+    try:
+        status_code, nodes = k8s.list_nodes(label_selector="spatium.io/role=appliance")
+    except k8s.KubeapiUnavailableError:
+        return  # not on k8s — single api process
+    if status_code != 200 or len(nodes) <= 1:
+        return
+
+    raise SlotImageResolutionError(
+        f"This control plane spans {len(nodes)} nodes, and uploaded upgrade-image "
+        "bytes live on whichever node served the upload — the other api replicas "
+        "would answer the host's download with a 404. Either enable the slot-image "
+        "mirror (Helm value 'slotImageMirror.enabled=true', which gives the images a "
+        "shared PVC) or schedule this upgrade from an external image URL instead."
+    )
+
+
 async def resolve_slot_image_target(
     db: AsyncSession,
     *,
@@ -121,6 +161,8 @@ async def resolve_slot_image_target(
     image = await db.get(ApplianceUpgradeImage, slot_image_id)
     if image is None:
         raise SlotImageResolutionError(f"Upgrade image {slot_image_id} not found.")
+
+    _assert_self_served_bytes_are_reachable()
 
     # Imported locally: the token mint lives on the API router that also
     # serves the bytes, and importing it at module scope would cycle back

--- a/backend/app/services/appliance/slot_image_target.py
+++ b/backend/app/services/appliance/slot_image_target.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
 from app.models.appliance import Appliance, ApplianceUpgradeImage
 
 # The host runner only learned to strip a URL ``#fragment`` before
@@ -55,6 +54,15 @@ class SlotImageTarget:
     url: str
     sha256: str | None = None
     tls_insecure: bool = False
+    # #386 Part B re-fire nonce, appended to the URL as ``#a=<nonce>`` so a
+    # fresh apply of the same image is a distinct desired-state and the
+    # supervisor's fire-once marker doesn't suppress it. It lives on the
+    # TARGET, not minted per stamp, because the rolling orchestrator
+    # re-drives an incomplete node from step 1 on resume: a nonce minted
+    # per call would hand that node a URL it has never fired and trigger a
+    # second full slot apply of an image it already staged. Carried in the
+    # run plan so every node in a run, and every resume of it, agrees.
+    nonce: str | None = None
 
     def as_plan_fields(self) -> dict[str, object]:
         """Serialise into an ``UpgradeRun.plan`` JSON blob."""
@@ -62,6 +70,7 @@ class SlotImageTarget:
             "slot_image_url": self.url,
             "slot_image_sha256": self.sha256,
             "slot_image_tls_insecure": self.tls_insecure,
+            "slot_image_nonce": self.nonce,
         }
 
     @classmethod
@@ -75,6 +84,7 @@ class SlotImageTarget:
             url=plan.get("slot_image_url") or "",
             sha256=plan.get("slot_image_sha256"),
             tls_insecure=bool(plan.get("slot_image_tls_insecure", False)),
+            nonce=plan.get("slot_image_nonce"),
         )
 
 
@@ -89,45 +99,6 @@ def supervisor_strips_url_fragment(row: Appliance) -> bool:
     ver = row.supervisor_version or row.installed_appliance_version or ""
     return (
         re.match(r"\d{4}\.\d{2}\.\d{2}", ver) is not None and ver >= URL_FRAGMENT_STRIP_MIN_VERSION
-    )
-
-
-def _assert_self_served_bytes_are_reachable() -> None:
-    """Refuse to point a host at an uploaded image it may not be able to fetch.
-
-    Uploaded bytes land on the api replica that served the upload, on a
-    node-local hostPath. The slot-image mirror is what makes them readable
-    from every replica — and it is off by default. So on a multi-node
-    control plane (api runs 2 replicas with hard anti-affinity), the host's
-    download round-robins through the Service and roughly half the time
-    reaches a replica without the bytes, which answers 404 "bytes missing
-    on disk — re-upload required". That message is actively misleading:
-    the bytes exist, just on a node the operator cannot see (#787).
-
-    Fail here instead, where we can say what to do about it. External URLs
-    are unaffected — nothing of ours serves those.
-
-    Silent no-op off Kubernetes (docker compose): one api process, so the
-    bytes are always local to whoever serves the download.
-    """
-    if settings.slot_image_mirror_url:
-        return  # bytes are reachable cluster-wide through the mirror
-
-    from app.services.appliance import k8s  # noqa: PLC0415
-
-    try:
-        status_code, nodes = k8s.list_nodes(label_selector="spatium.io/role=appliance")
-    except k8s.KubeapiUnavailableError:
-        return  # not on k8s — single api process
-    if status_code != 200 or len(nodes) <= 1:
-        return
-
-    raise SlotImageResolutionError(
-        f"This control plane spans {len(nodes)} nodes, and uploaded upgrade-image "
-        "bytes live on whichever node served the upload — the other api replicas "
-        "would answer the host's download with a 404. Either enable the slot-image "
-        "mirror (Helm value 'slotImageMirror.enabled=true', which gives the images a "
-        "shared PVC) or schedule this upgrade from an external image URL instead."
     )
 
 
@@ -162,8 +133,6 @@ async def resolve_slot_image_target(
     if image is None:
         raise SlotImageResolutionError(f"Upgrade image {slot_image_id} not found.")
 
-    _assert_self_served_bytes_are_reachable()
-
     # Imported locally: the token mint lives on the API router that also
     # serves the bytes, and importing it at module scope would cycle back
     # through the router package.
@@ -182,24 +151,27 @@ async def resolve_slot_image_target(
     )
 
 
+def new_refire_nonce() -> str:
+    """Mint one ``#a=`` re-fire nonce. Call once per scheduling decision."""
+    return uuid.uuid4().hex[:12]
+
+
 def stamp_desired_slot_image(
     row: Appliance,
     target: SlotImageTarget,
     *,
     desired_version: str,
-    nonce: str | None = None,
 ) -> None:
     """Write all four desired-state columns onto ``row``.
 
-    ``nonce`` (#386 Part B) makes each schedule yield a distinct URL so the
-    supervisor's fire-once marker re-fires on a fresh apply of the same
-    image instead of treating it as already-fired. Pass ``None`` to let
-    this generate one; it is applied only when the appliance's runner is
-    known to strip the fragment.
+    The re-fire nonce comes from ``target``, so re-stamping the same target
+    (an orchestrator resume re-driving a node) reproduces the identical URL
+    and the supervisor's fire-once marker still suppresses it. Appended
+    only when the appliance's runner is known to strip the fragment (#419).
     """
     url = target.url
-    if supervisor_strips_url_fragment(row):
-        url = f"{url}#a={nonce or uuid.uuid4().hex[:12]}"
+    if target.nonce and supervisor_strips_url_fragment(row):
+        url = f"{url}#a={target.nonce}"
 
     row.desired_appliance_version = desired_version
     row.desired_slot_image_url = url
@@ -211,6 +183,7 @@ __all__ = [
     "URL_FRAGMENT_STRIP_MIN_VERSION",
     "SlotImageResolutionError",
     "SlotImageTarget",
+    "new_refire_nonce",
     "resolve_slot_image_target",
     "stamp_desired_slot_image",
     "supervisor_strips_url_fragment",

--- a/backend/app/services/upgrades/orchestrator.py
+++ b/backend/app/services/upgrades/orchestrator.py
@@ -51,6 +51,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.audit import AuditLog
 from app.models.system_upgrade import LIFECYCLE_STATES, SystemUpgradeRun
 from app.services.appliance import k8s
+from app.services.appliance.slot_image_target import SlotImageTarget
 from app.services.upgrades import (
     alerts as upgrade_alerts,
 )
@@ -127,7 +128,7 @@ async def plan_upgrade(
     db: AsyncSession,
     *,
     target_version: str,
-    slot_image_url: str,
+    slot_image: SlotImageTarget,
     cnpg_cluster_name: str = "",
     cnpg_namespace: str | None = None,
     started_by_user_id: uuid.UUID | None = None,
@@ -204,7 +205,10 @@ async def plan_upgrade(
         source_versions=source_versions,
         plan={
             "node_order": order,
-            "slot_image_url": slot_image_url,
+            # url + sha256 + tls_insecure together — a plan carrying only
+            # the URL is what left every per-node apply fetching our own
+            # self-signed cert with verification on (#787 / #386).
+            **slot_image.as_plan_fields(),
             "cnpg_cluster_name": cnpg_cluster_name,
             "cnpg_namespace": cnpg_namespace,
             "preflight_at_plan": [
@@ -518,7 +522,7 @@ async def _drive_loop(
     * On halt/abort signal: exits cleanly without further work.
     """
     plan_order: list[str] = run.plan.get("node_order") or []
-    slot_image_url: str = run.plan.get("slot_image_url") or ""
+    slot_image = SlotImageTarget.from_plan_fields(run.plan)
     cnpg_name: str = run.plan.get("cnpg_cluster_name") or ""
     cnpg_namespace: str | None = run.plan.get("cnpg_namespace")
 
@@ -698,7 +702,7 @@ async def _drive_loop(
             db,
             node_name=next_node,
             target_version=run.target_version,
-            slot_image_url=slot_image_url,
+            slot_image=slot_image,
             cnpg_cluster_name=cnpg_name,
             cnpg_namespace=cnpg_namespace,
         )

--- a/backend/app/services/upgrades/per_node.py
+++ b/backend/app/services/upgrades/per_node.py
@@ -40,7 +40,6 @@ from __future__ import annotations
 
 import asyncio
 import time
-import uuid
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -50,6 +49,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.appliance import Appliance
 from app.services.appliance import k8s
+from app.services.appliance.slot_image_target import (
+    SlotImageTarget,
+    stamp_desired_slot_image,
+)
 from app.services.upgrades import preflight
 
 logger = structlog.get_logger(__name__)
@@ -399,7 +402,7 @@ async def _step_trigger_slot_apply(
     db: AsyncSession,
     node_name: str,
     target_version: str,
-    slot_image_url: str,
+    slot_image: SlotImageTarget,
 ) -> StepResult:
     step = StepResult(
         name="trigger_slot_apply",
@@ -409,8 +412,12 @@ async def _step_trigger_slot_apply(
     appliance = await _resolve_appliance(db, node_name)
     if appliance is None:
         return step.finish(False, error=f"no Appliance row with hostname={node_name!r}")
-    appliance.desired_appliance_version = target_version
-    appliance.desired_slot_image_url = slot_image_url
+    # Stamps all four desired_* columns, not just version + URL. Setting
+    # only those two is what made every per-node apply of an uploaded
+    # image fetch our own self-signed cert with verification on, and left
+    # any stale sha256 from an earlier per-box schedule to fail the new
+    # image as corrupt (#787).
+    stamp_desired_slot_image(appliance, slot_image, desired_version=target_version)
     await db.flush()
     # NB: db.commit is the orchestrator's responsibility — Phase D will
     # commit at every step transition. For testing in Phase C the
@@ -606,7 +613,7 @@ async def single_node_upgrade(
     *,
     node_name: str,
     target_version: str,
-    slot_image_url: str,
+    slot_image: SlotImageTarget,
     cnpg_cluster_name: str = "",
     cnpg_namespace: str | None = None,
     start_step: StepName | None = None,
@@ -701,7 +708,7 @@ async def single_node_upgrade(
         return _failed(node_name, target_version, "drain", results)
     if not await _run(
         "trigger_slot_apply",
-        _step_trigger_slot_apply(db, node_name, target_version, slot_image_url),
+        _step_trigger_slot_apply(db, node_name, target_version, slot_image),
     ):
         return _failed(node_name, target_version, "trigger_slot_apply", results)
     if not await _run("health_gate", _step_health_gate(db, node_name, target_version)):
@@ -739,27 +746,12 @@ def _failed(
     )
 
 
-# Resolve the upstream slot-image URL for a given image_id. Phase B
-# wired ``SLOT_IMAGE_MIRROR_URL`` for in-cluster proxying, but the
-# host-side runner needs the operator-facing URL (the api endpoint
-# with the HMAC ?t= token). Re-use the existing
-# ``slot_image_download_token`` mint that ``apply_upgrade`` already
-# calls — exposed here as a helper so an orchestrator-driven start
-# doesn't have to import from the appliance router.
-def build_slot_image_url(*, request_base_url: str, image_id: uuid.UUID) -> str:
-    """Build the ``desired_slot_image_url`` value for an uploaded image.
-
-    Mirrors the path the existing ``apply_upgrade`` endpoint takes —
-    same HMAC ?t= scheme so the host runner's unauthenticated GET
-    works. The Phase D orchestrator will call this when scheduling
-    each node's apply.
-    """
-    from app.api.v1.appliance.upgrade_images import slot_image_download_token  # noqa: PLC0415
-
-    token = slot_image_download_token(image_id)
-    base = request_base_url.rstrip("/")
-    return f"{base}/api/v1/appliance/upgrade-images/{image_id}/raw.xz?t={token}"
-
+# ``build_slot_image_url`` used to live here so an orchestrator-driven
+# start didn't have to import from the appliance router. It composed only
+# the URL, which is precisely how this path lost the sha256 + tls_insecure
+# hints (#787). Both surfaces now go through
+# ``services.appliance.slot_image_target.resolve_slot_image_target``,
+# which returns all three together.
 
 __all__ = [
     "DEFAULT_CONVERGENCE_TIMEOUT_S",
@@ -768,6 +760,5 @@ __all__ = [
     "DEFAULT_SWITCHOVER_TIMEOUT_S",
     "SingleNodeResult",
     "StepResult",
-    "build_slot_image_url",
     "single_node_upgrade",
 ]

--- a/backend/tests/test_appliance_clear_upgrade.py
+++ b/backend/tests/test_appliance_clear_upgrade.py
@@ -8,9 +8,14 @@ reboot didn't help because those sidecars live on the persistent /var.
 
 So the endpoint now (a) clears our copy for an immediate UI response,
 (b) raises a one-shot command telling the supervisor to reset the host,
-and (c) ignores the upgrade state arriving on heartbeats until it has.
-Without (c) the very next heartbeat — collected before the supervisor
-ever saw the command — would re-stamp the failure we just cleared.
+and (c) drops a heartbeat report that still carries the dismissed
+failure. Without (c) the very next heartbeat — collected before the
+supervisor ever saw the command — would re-stamp what we just cleared.
+
+The flag is retired on ACKNOWLEDGEMENT: the first heartbeat reporting a
+state other than ``failed`` is exactly what a successful host reset
+produces, so the command rides every response until the host has actually
+complied. A wall-clock window could expire before it was ever delivered.
 """
 
 from __future__ import annotations
@@ -167,6 +172,38 @@ async def test_pending_clear_suppresses_the_stale_heartbeat_report(
 
 
 @pytest.mark.asyncio
+async def test_pending_clear_does_not_swallow_a_retrys_progress(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Clear-then-retry is the normal recovery gesture. Suppression is
+    scoped to the dismissed ``failed`` report, so an upgrade started right
+    after the clear still reports its progress."""
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.clear_upgrade_requested = True
+    appliance.clear_upgrade_requested_at = datetime.now(UTC)
+    appliance.last_upgrade_state = None
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            "last_upgrade_state": "in-flight",
+            "last_upgrade_progress": {"step": "downloading", "pct": 12},
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.last_upgrade_state == "in-flight"
+    assert refreshed.last_upgrade_progress == {"step": "downloading", "pct": 12}
+
+
+@pytest.mark.asyncio
 async def test_heartbeat_ingests_normally_once_no_clear_is_pending(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
@@ -225,19 +262,23 @@ async def test_expiring_clear_is_delivered_immediately_not_long_polled(
 
 
 @pytest.mark.asyncio
-async def test_clear_flag_auto_clears_after_the_grace_window(
+async def test_clear_is_retired_by_the_hosts_acknowledgement(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:
-    """Same fire-once shape as ``reboot_requested``: the flag must not stick
-    around re-running a no-op reset on every later heartbeat."""
+    """A non-``failed`` report is the ack — that is precisely what a
+    successful host reset produces — and it retires the command."""
     appliance, token = await _heartbeat_ready(db_session)
     appliance.clear_upgrade_requested = True
-    appliance.clear_upgrade_requested_at = datetime.now(UTC) - timedelta(seconds=16)
+    appliance.clear_upgrade_requested_at = datetime.now(UTC)
     await db_session.commit()
 
     resp = await client.post(
         "/api/v1/appliance/supervisor/heartbeat",
-        json={"appliance_id": str(appliance.id), "session_token": token},
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            "last_upgrade_state": "ready",
+        },
     )
     assert resp.status_code == 200, resp.text
 
@@ -247,3 +288,70 @@ async def test_clear_flag_auto_clears_after_the_grace_window(
     await db_session.refresh(refreshed)
     assert refreshed.clear_upgrade_requested is False
     assert refreshed.clear_upgrade_requested_at is None
+    # …and the ack itself is ingested, not swallowed: blanket suppression
+    # used to drop the host's post-reset ``ready`` and leave the chip blank.
+    assert refreshed.last_upgrade_state == "ready"
+
+
+@pytest.mark.asyncio
+async def test_clear_keeps_riding_until_the_host_complies(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The failure this replaces: a stopwatch could retire the command
+    before a slow, restarting or offline supervisor ever received it. An
+    unacknowledged clear must still be pending, and still be delivered."""
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.clear_upgrade_requested = True
+    appliance.clear_upgrade_requested_at = datetime.now(UTC) - timedelta(minutes=2)
+    # The endpoint nulls these; start from that state so the assertion
+    # below proves suppression rather than re-reading the seed.
+    appliance.last_upgrade_state = None
+    appliance.last_upgrade_progress = None
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            "last_upgrade_state": "failed",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["clear_upgrade_requested"] is True
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.clear_upgrade_requested is True, "still unacknowledged"
+    assert refreshed.last_upgrade_state is None, "the stale failure stays suppressed"
+
+
+@pytest.mark.asyncio
+async def test_clear_gives_up_on_a_host_that_can_never_comply(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Backstop: a host that cannot unlink a trigger it does not own would
+    otherwise pin the flag on forever, permanently suppressing this
+    appliance's heartbeat long-poll."""
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.clear_upgrade_requested = True
+    appliance.clear_upgrade_requested_at = datetime.now(UTC) - timedelta(minutes=11)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            "last_upgrade_state": "failed",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.clear_upgrade_requested is False

--- a/backend/tests/test_appliance_clear_upgrade.py
+++ b/backend/tests/test_appliance_clear_upgrade.py
@@ -195,6 +195,36 @@ async def test_heartbeat_ingests_normally_once_no_clear_is_pending(
 
 
 @pytest.mark.asyncio
+async def test_expiring_clear_is_delivered_immediately_not_long_polled(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The heartbeat that expires the flag still carries the command, so it
+    must not be treated as idle and held. A clear also nulls
+    ``desired_appliance_version``, so nothing else keeps the request pending
+    — reading the post-expiry row here would hold the very response that
+    delivers the clear for up to the hold cap."""
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.desired_appliance_version = None
+    appliance.desired_slot_image_url = None
+    appliance.clear_upgrade_requested = True
+    appliance.clear_upgrade_requested_at = datetime.now(UTC) - timedelta(seconds=16)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            "wait_seconds": 25,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["clear_upgrade_requested"] is True, "the expiring heartbeat still delivers it"
+    assert body["long_poll"] is False, "a pending command must not be held"
+
+
+@pytest.mark.asyncio
 async def test_clear_flag_auto_clears_after_the_grace_window(
     client: AsyncClient, db_session: AsyncSession
 ) -> None:

--- a/backend/tests/test_appliance_clear_upgrade.py
+++ b/backend/tests/test_appliance_clear_upgrade.py
@@ -1,0 +1,219 @@
+"""#786 — "Clear failed upgrade" has to make the HOST forget, not just the DB.
+
+The red "Upgrade failed" card renders from ``last_upgrade_state`` /
+``last_upgrade_progress``, and the heartbeat re-publishes both verbatim
+from host sidecar files every ~30 s. Clearing only the ``desired_*``
+columns — what the endpoint used to do — left the card up forever, and a
+reboot didn't help because those sidecars live on the persistent /var.
+
+So the endpoint now (a) clears our copy for an immediate UI response,
+(b) raises a one-shot command telling the supervisor to reset the host,
+and (c) ignores the upgrade state arriving on heartbeats until it has.
+Without (c) the very next heartbeat — collected before the supervisor
+ever saw the command — would re-stamp the failure we just cleared.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
+from app.models.auth import User
+from app.models.settings import PlatformSettings
+from app.services.appliance.ca import generate_session_token
+
+
+async def _make_superadmin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"admin-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test Admin",
+        hashed_password=hash_password("test-pw-786"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _seed_failed_appliance(db: AsyncSession) -> Appliance:
+    """An appliance sitting in the state the operator wants to dismiss."""
+    appliance = Appliance(
+        id=uuid.uuid4(),
+        hostname=f"ddi-{uuid.uuid4().hex[:8]}",
+        state=APPLIANCE_STATE_APPROVED,
+        public_key_der=b"fake-key",
+        public_key_fingerprint="ff" * 32,
+        cert_serial="0000",
+        deployment_kind="appliance",
+        supervisor_version="2026.07.30-1",
+        installed_appliance_version="2026.07.21-1",
+        desired_appliance_version="2026.07.30-1",
+        desired_slot_image_url="https://cp.local/x.raw.xz",
+        last_upgrade_state="failed",
+        last_upgrade_state_at=datetime.now(UTC),
+        last_upgrade_progress={"step": "failed", "pct": 40},
+        last_upgrade_log_tail="urllib.error.HTTPError: HTTP Error 404",
+    )
+    db.add(appliance)
+    await db.flush()
+    return appliance
+
+
+@pytest.mark.asyncio
+async def test_clear_upgrade_clears_the_visible_failure(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The four columns the failure card reads must go, not just desired_*."""
+    headers = await _make_superadmin(db_session)
+    appliance = await _seed_failed_appliance(db_session)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/appliance/appliances/{appliance.id}/clear-upgrade", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.last_upgrade_state is None
+    assert refreshed.last_upgrade_progress is None
+    assert refreshed.last_upgrade_log_tail is None
+    assert refreshed.desired_appliance_version is None
+
+
+@pytest.mark.asyncio
+async def test_clear_upgrade_raises_the_host_command(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Clearing our copy is not enough on its own — the host owns this state."""
+    headers = await _make_superadmin(db_session)
+    appliance = await _seed_failed_appliance(db_session)
+    await db_session.commit()
+
+    await client.post(f"/api/v1/appliance/appliances/{appliance.id}/clear-upgrade", headers=headers)
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.clear_upgrade_requested is True
+    assert refreshed.clear_upgrade_requested_at is not None
+
+
+async def _heartbeat_ready(db: AsyncSession) -> tuple[Appliance, str]:
+    """An approved supervisor that can post heartbeats."""
+    settings_row = await db.get(PlatformSettings, 1)
+    if settings_row is None:
+        settings_row = PlatformSettings(id=1)
+        db.add(settings_row)
+    settings_row.supervisor_registration_enabled = True
+
+    token, token_hash = generate_session_token()
+    appliance = await _seed_failed_appliance(db)
+    appliance.session_token_hash = token_hash
+    await db.flush()
+    return appliance, token
+
+
+@pytest.mark.asyncio
+async def test_pending_clear_suppresses_the_stale_heartbeat_report(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The heartbeat racing the clear carries state collected BEFORE the
+    supervisor saw the command. Ingesting it would undo the clear — which
+    is precisely why the failure used to survive a clear and a reboot.
+    """
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.clear_upgrade_requested = True
+    appliance.clear_upgrade_requested_at = datetime.now(UTC)
+    appliance.last_upgrade_state = None
+    appliance.last_upgrade_progress = None
+    appliance.last_upgrade_log_tail = None
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            # Exactly what a supervisor that hasn't seen the command yet sends.
+            "last_upgrade_state": "failed",
+            "last_upgrade_state_at": datetime.now(UTC).isoformat(),
+            "last_upgrade_progress": {"step": "failed", "pct": 40},
+            "last_upgrade_log_tail": "HTTP Error 404",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    # The command rides back so the supervisor can act on it.
+    assert resp.json()["clear_upgrade_requested"] is True
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.last_upgrade_state is None, "stale failure must not be re-stamped"
+    assert refreshed.last_upgrade_progress is None
+    assert refreshed.last_upgrade_log_tail is None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_ingests_normally_once_no_clear_is_pending(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The suppression is scoped to an outstanding clear — the host stays
+    the source of truth the rest of the time."""
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.clear_upgrade_requested = False
+    appliance.last_upgrade_state = None
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={
+            "appliance_id": str(appliance.id),
+            "session_token": token,
+            "last_upgrade_state": "failed",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.last_upgrade_state == "failed"
+
+
+@pytest.mark.asyncio
+async def test_clear_flag_auto_clears_after_the_grace_window(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Same fire-once shape as ``reboot_requested``: the flag must not stick
+    around re-running a no-op reset on every later heartbeat."""
+    appliance, token = await _heartbeat_ready(db_session)
+    appliance.clear_upgrade_requested = True
+    appliance.clear_upgrade_requested_at = datetime.now(UTC) - timedelta(seconds=16)
+    await db_session.commit()
+
+    resp = await client.post(
+        "/api/v1/appliance/supervisor/heartbeat",
+        json={"appliance_id": str(appliance.id), "session_token": token},
+    )
+    assert resp.status_code == 200, resp.text
+
+    refreshed = (
+        await db_session.execute(select(Appliance).where(Appliance.id == appliance.id))
+    ).scalar_one()
+    await db_session.refresh(refreshed)
+    assert refreshed.clear_upgrade_requested is False
+    assert refreshed.clear_upgrade_requested_at is None

--- a/backend/tests/test_appliance_upgrade_url_gate.py
+++ b/backend/tests/test_appliance_upgrade_url_gate.py
@@ -4,8 +4,10 @@ The control plane appends a per-apply nonce as a URL ``#fragment`` so a fresh
 apply of the same image re-fires the supervisor trigger. The host runner only
 strips that fragment before fetching as of #386 (2026-06-12); an older
 appliance hands it straight to the downloader and the apply wedges at
-"in-flight" forever. ``_supervisor_strips_url_fragment`` gates the nonce so
-only known-capable supervisors get it.
+"in-flight" forever. ``supervisor_strips_url_fragment`` gates the nonce so
+only known-capable supervisors get it. It lives in
+``services.appliance.slot_image_target`` alongside the resolver + stamper both
+scheduling surfaces share (#787).
 """
 
 from __future__ import annotations
@@ -14,7 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from app.api.v1.appliance import supervisor as sup
+from app.services.appliance.slot_image_target import supervisor_strips_url_fragment
 
 
 @pytest.mark.parametrize(
@@ -49,4 +51,4 @@ def test_supervisor_strips_url_fragment(
         supervisor_version=supervisor_version,
         installed_appliance_version=installed_version,
     )
-    assert sup._supervisor_strips_url_fragment(row) is expected  # type: ignore[arg-type]
+    assert supervisor_strips_url_fragment(row) is expected  # type: ignore[arg-type]

--- a/backend/tests/test_slot_image_target.py
+++ b/backend/tests/test_slot_image_target.py
@@ -106,6 +106,83 @@ async def test_exactly_one_source_required(kwargs) -> None:
         await resolve_slot_image_target(_FakeDB(), base_url="https://cp.local/", **kwargs)
 
 
+# ── multi-node reachability guard ────────────────────────────────────
+
+
+def _patch_nodes(monkeypatch: pytest.MonkeyPatch, count: int) -> None:
+    """Pretend the control plane spans ``count`` appliance nodes."""
+    from app.services.appliance import k8s
+
+    monkeypatch.setattr(k8s, "list_nodes", lambda **_kw: (200, [{}] * count))
+
+
+@pytest.mark.asyncio
+async def test_uploaded_image_refused_on_multi_node_without_a_mirror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#787: uploaded bytes are node-local, so on a multi-node control plane
+    the host's download 404s from every replica that didn't serve the
+    upload. Refuse at schedule time with something actionable instead."""
+    from app.services.appliance import slot_image_target as sit
+
+    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "")
+    _patch_nodes(monkeypatch, 3)
+    image = SimpleNamespace(id=uuid.uuid4(), sha256="ab" * 32)
+
+    with pytest.raises(SlotImageResolutionError, match="slotImageMirror"):
+        await resolve_slot_image_target(
+            _FakeDB(image), base_url="https://cp.local/", slot_image_id=image.id
+        )
+
+
+@pytest.mark.asyncio
+async def test_uploaded_image_allowed_when_the_mirror_is_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.appliance import slot_image_target as sit
+
+    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "http://mirror:8000")
+    _patch_nodes(monkeypatch, 3)
+    image = SimpleNamespace(id=uuid.uuid4(), sha256="ab" * 32)
+
+    target = await resolve_slot_image_target(
+        _FakeDB(image), base_url="https://cp.local/", slot_image_id=image.id
+    )
+    assert target.sha256 == "ab" * 32
+
+
+@pytest.mark.asyncio
+async def test_uploaded_image_allowed_on_a_single_node(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.services.appliance import slot_image_target as sit
+
+    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "")
+    _patch_nodes(monkeypatch, 1)
+    image = SimpleNamespace(id=uuid.uuid4(), sha256="ab" * 32)
+
+    target = await resolve_slot_image_target(
+        _FakeDB(image), base_url="https://cp.local/", slot_image_id=image.id
+    )
+    assert target.tls_insecure is True
+
+
+@pytest.mark.asyncio
+async def test_external_url_skips_the_reachability_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing of ours serves an external URL, so node count is irrelevant."""
+    from app.services.appliance import slot_image_target as sit
+
+    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "")
+    _patch_nodes(monkeypatch, 3)
+
+    target = await resolve_slot_image_target(
+        _FakeDB(), base_url="https://cp.local/", slot_image_url="https://github.com/x.raw.xz"
+    )
+    assert target.url == "https://github.com/x.raw.xz"
+
+
 # ── stamp_desired_slot_image ─────────────────────────────────────────
 
 

--- a/backend/tests/test_slot_image_target.py
+++ b/backend/tests/test_slot_image_target.py
@@ -106,83 +106,6 @@ async def test_exactly_one_source_required(kwargs) -> None:
         await resolve_slot_image_target(_FakeDB(), base_url="https://cp.local/", **kwargs)
 
 
-# ── multi-node reachability guard ────────────────────────────────────
-
-
-def _patch_nodes(monkeypatch: pytest.MonkeyPatch, count: int) -> None:
-    """Pretend the control plane spans ``count`` appliance nodes."""
-    from app.services.appliance import k8s
-
-    monkeypatch.setattr(k8s, "list_nodes", lambda **_kw: (200, [{}] * count))
-
-
-@pytest.mark.asyncio
-async def test_uploaded_image_refused_on_multi_node_without_a_mirror(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """#787: uploaded bytes are node-local, so on a multi-node control plane
-    the host's download 404s from every replica that didn't serve the
-    upload. Refuse at schedule time with something actionable instead."""
-    from app.services.appliance import slot_image_target as sit
-
-    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "")
-    _patch_nodes(monkeypatch, 3)
-    image = SimpleNamespace(id=uuid.uuid4(), sha256="ab" * 32)
-
-    with pytest.raises(SlotImageResolutionError, match="slotImageMirror"):
-        await resolve_slot_image_target(
-            _FakeDB(image), base_url="https://cp.local/", slot_image_id=image.id
-        )
-
-
-@pytest.mark.asyncio
-async def test_uploaded_image_allowed_when_the_mirror_is_on(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from app.services.appliance import slot_image_target as sit
-
-    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "http://mirror:8000")
-    _patch_nodes(monkeypatch, 3)
-    image = SimpleNamespace(id=uuid.uuid4(), sha256="ab" * 32)
-
-    target = await resolve_slot_image_target(
-        _FakeDB(image), base_url="https://cp.local/", slot_image_id=image.id
-    )
-    assert target.sha256 == "ab" * 32
-
-
-@pytest.mark.asyncio
-async def test_uploaded_image_allowed_on_a_single_node(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from app.services.appliance import slot_image_target as sit
-
-    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "")
-    _patch_nodes(monkeypatch, 1)
-    image = SimpleNamespace(id=uuid.uuid4(), sha256="ab" * 32)
-
-    target = await resolve_slot_image_target(
-        _FakeDB(image), base_url="https://cp.local/", slot_image_id=image.id
-    )
-    assert target.tls_insecure is True
-
-
-@pytest.mark.asyncio
-async def test_external_url_skips_the_reachability_guard(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Nothing of ours serves an external URL, so node count is irrelevant."""
-    from app.services.appliance import slot_image_target as sit
-
-    monkeypatch.setattr(sit.settings, "slot_image_mirror_url", "")
-    _patch_nodes(monkeypatch, 3)
-
-    target = await resolve_slot_image_target(
-        _FakeDB(), base_url="https://cp.local/", slot_image_url="https://github.com/x.raw.xz"
-    )
-    assert target.url == "https://github.com/x.raw.xz"
-
-
 # ── stamp_desired_slot_image ─────────────────────────────────────────
 
 
@@ -217,9 +140,32 @@ def test_stamp_clears_stale_integrity_hints() -> None:
 def test_stamp_adds_refire_nonce_for_a_capable_runner() -> None:
     row = _fake_appliance(supervisor_version="2026.07.30-1")
     stamp_desired_slot_image(
+        row,
+        SlotImageTarget(url="https://cp.local/x.raw.xz", nonce="abc123"),
+        desired_version="2026.07.30-1",
+    )
+    assert row.desired_slot_image_url == "https://cp.local/x.raw.xz#a=abc123"
+
+
+def test_restamping_the_same_target_reproduces_the_same_url() -> None:
+    """An orchestrator resume re-drives an incomplete node from step 1. If
+    the nonce were minted per stamp the node would get a URL it has never
+    fired and re-run a full slot apply of an image it already staged."""
+    target = SlotImageTarget(url="https://cp.local/x.raw.xz", nonce="stable99")
+    first, second = _fake_appliance(supervisor_version="2026.07.30-1"), _fake_appliance(
+        supervisor_version="2026.07.30-1"
+    )
+    stamp_desired_slot_image(first, target, desired_version="2026.07.30-1")
+    stamp_desired_slot_image(second, target, desired_version="2026.07.30-1")
+    assert first.desired_slot_image_url == second.desired_slot_image_url
+
+
+def test_stamp_omits_nonce_when_the_target_carries_none() -> None:
+    row = _fake_appliance(supervisor_version="2026.07.30-1")
+    stamp_desired_slot_image(
         row, SlotImageTarget(url="https://cp.local/x.raw.xz"), desired_version="2026.07.30-1"
     )
-    assert row.desired_slot_image_url.startswith("https://cp.local/x.raw.xz#a=")
+    assert row.desired_slot_image_url == "https://cp.local/x.raw.xz"
 
 
 def test_stamp_omits_nonce_for_a_pre_386_runner() -> None:
@@ -227,7 +173,9 @@ def test_stamp_omits_nonce_for_a_pre_386_runner() -> None:
     the apply wedges at in-flight forever (#419)."""
     row = _fake_appliance(supervisor_version="2026.06.11-1")
     stamp_desired_slot_image(
-        row, SlotImageTarget(url="https://cp.local/x.raw.xz"), desired_version="2026.07.30-1"
+        row,
+        SlotImageTarget(url="https://cp.local/x.raw.xz", nonce="abc123"),
+        desired_version="2026.07.30-1",
     )
     assert row.desired_slot_image_url == "https://cp.local/x.raw.xz"
 

--- a/backend/tests/test_slot_image_target.py
+++ b/backend/tests/test_slot_image_target.py
@@ -1,0 +1,172 @@
+"""The one resolver both slot-upgrade schedulers share (#787).
+
+The per-box Fleet action and the multi-node rolling orchestrator each
+used to compose the appliance's desired slot-image state themselves, and
+drifted: the orchestrator stamped only version + URL, so an uploaded
+image was fetched from our own self-signed HTTPS URL with verification
+on and no hash — the #386 failure, re-introduced on that path.
+
+These tests pin the contract that keeps them together.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.appliance.slot_image_target import (
+    SlotImageResolutionError,
+    SlotImageTarget,
+    resolve_slot_image_target,
+    stamp_desired_slot_image,
+)
+
+
+def _fake_appliance(**overrides) -> SimpleNamespace:
+    """An Appliance row carrying every column the stamper reads or writes."""
+    return SimpleNamespace(
+        **{
+            "supervisor_version": None,
+            "installed_appliance_version": None,
+            "desired_appliance_version": None,
+            "desired_slot_image_url": None,
+            "desired_slot_image_sha256": None,
+            "desired_slot_image_tls_insecure": False,
+            **overrides,
+        }
+    )
+
+
+class _FakeDB:
+    """Stands in for AsyncSession.get()."""
+
+    def __init__(self, image=None) -> None:
+        self._image = image
+
+    async def get(self, _model, _pk):
+        return self._image
+
+
+# ── resolve_slot_image_target ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_external_url_carries_no_hash_and_verifies_tls() -> None:
+    target = await resolve_slot_image_target(
+        _FakeDB(), base_url="https://cp.local/", slot_image_url="https://github.com/x.raw.xz"
+    )
+    assert target == SlotImageTarget(
+        url="https://github.com/x.raw.xz", sha256=None, tls_insecure=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_uploaded_image_carries_hash_and_relaxes_tls() -> None:
+    """Self-served bytes sit behind the appliance's own self-signed cert,
+    so the runner needs the hash to verify against AND permission to skip
+    cert-verify for that fetch (#386)."""
+    image_id = uuid.UUID("11111111-2222-3333-4444-555555555555")
+    image = SimpleNamespace(id=image_id, sha256="ab" * 32)
+
+    target = await resolve_slot_image_target(
+        _FakeDB(image), base_url="https://cp.local/", slot_image_id=image_id
+    )
+
+    assert target.sha256 == "ab" * 32
+    assert target.tls_insecure is True
+    assert target.url.startswith(
+        f"https://cp.local/api/v1/appliance/upgrade-images/{image_id}/raw.xz?t="
+    )
+    token = target.url.split("?t=")[1]
+    assert len(token) == 64
+    assert all(c in "0123456789abcdef" for c in token)
+
+
+@pytest.mark.asyncio
+async def test_missing_image_row_raises() -> None:
+    with pytest.raises(SlotImageResolutionError, match="not found"):
+        await resolve_slot_image_target(
+            _FakeDB(None), base_url="https://cp.local/", slot_image_id=uuid.uuid4()
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"slot_image_id": uuid.uuid4(), "slot_image_url": "https://x/y.raw.xz"},
+    ],
+    ids=["neither", "both"],
+)
+async def test_exactly_one_source_required(kwargs) -> None:
+    with pytest.raises(SlotImageResolutionError, match="exactly one"):
+        await resolve_slot_image_target(_FakeDB(), base_url="https://cp.local/", **kwargs)
+
+
+# ── stamp_desired_slot_image ─────────────────────────────────────────
+
+
+def test_stamp_writes_all_four_columns() -> None:
+    row = _fake_appliance()
+    target = SlotImageTarget(url="https://cp.local/x.raw.xz", sha256="cd" * 32, tls_insecure=True)
+
+    stamp_desired_slot_image(row, target, desired_version="2026.07.30-1")
+
+    assert row.desired_appliance_version == "2026.07.30-1"
+    assert row.desired_slot_image_url == "https://cp.local/x.raw.xz"
+    assert row.desired_slot_image_sha256 == "cd" * 32
+    assert row.desired_slot_image_tls_insecure is True
+
+
+def test_stamp_clears_stale_integrity_hints() -> None:
+    """Re-scheduling with an external URL must not leave the previous
+    upload's hash behind — the runner would check the new bytes against
+    the old digest and fail the apply as corruption."""
+    row = _fake_appliance()
+    row.desired_slot_image_sha256 = "ab" * 32
+    row.desired_slot_image_tls_insecure = True
+
+    stamp_desired_slot_image(
+        row, SlotImageTarget(url="https://github.com/y.raw.xz"), desired_version="2026.07.30-1"
+    )
+
+    assert row.desired_slot_image_sha256 is None
+    assert row.desired_slot_image_tls_insecure is False
+
+
+def test_stamp_adds_refire_nonce_for_a_capable_runner() -> None:
+    row = _fake_appliance(supervisor_version="2026.07.30-1")
+    stamp_desired_slot_image(
+        row, SlotImageTarget(url="https://cp.local/x.raw.xz"), desired_version="2026.07.30-1"
+    )
+    assert row.desired_slot_image_url.startswith("https://cp.local/x.raw.xz#a=")
+
+
+def test_stamp_omits_nonce_for_a_pre_386_runner() -> None:
+    """An older runner passes the fragment straight to the downloader and
+    the apply wedges at in-flight forever (#419)."""
+    row = _fake_appliance(supervisor_version="2026.06.11-1")
+    stamp_desired_slot_image(
+        row, SlotImageTarget(url="https://cp.local/x.raw.xz"), desired_version="2026.07.30-1"
+    )
+    assert row.desired_slot_image_url == "https://cp.local/x.raw.xz"
+
+
+# ── plan round-trip ──────────────────────────────────────────────────
+
+
+def test_plan_fields_round_trip() -> None:
+    target = SlotImageTarget(url="https://cp.local/x.raw.xz", sha256="ef" * 32, tls_insecure=True)
+    assert SlotImageTarget.from_plan_fields(target.as_plan_fields()) == target
+
+
+def test_plan_fields_tolerate_a_pre_787_plan() -> None:
+    """Runs planned before the integrity fields existed still resolve —
+    to exactly the url-only target they had at plan time."""
+    target = SlotImageTarget.from_plan_fields({"slot_image_url": "https://cp.local/x.raw.xz"})
+    assert target == SlotImageTarget(
+        url="https://cp.local/x.raw.xz", sha256=None, tls_insecure=False
+    )

--- a/backend/tests/test_upgrade_images.py
+++ b/backend/tests/test_upgrade_images.py
@@ -336,3 +336,32 @@ async def test_find_available_upgrade_images_tool(
     assert out["github_reachable"] is True
     assert out["count"] == 1
     assert out["available"][0]["tag"] == "2026.05.14-1"
+
+
+# ── imported-row filename (#789) ─────────────────────────────────────
+
+
+async def test_imported_row_records_the_asset_actually_downloaded() -> None:
+    """A GitHub-imported row used to be stamped with the STABLE asset name
+    no matter which asset was fetched. ``_pick_upgrade_assets`` resolves the
+    versioned one (the stable name is pruned from every non-latest release,
+    #392), so the Fleet picker showed a filename matching no asset on the
+    release it came from."""
+    from app.api.v1.appliance.upgrade_images import _github_asset_filename
+
+    assert (
+        _github_asset_filename(
+            "https://github.com/o/r/releases/download/2026.07.30-1/"
+            "spatiumddi-appliance-slot-2026.07.30-1-amd64.raw.xz"
+        )
+        == "spatiumddi-appliance-slot-2026.07.30-1-amd64.raw.xz"
+    )
+
+
+async def test_imported_row_filename_falls_back_on_an_unrecognisable_url() -> None:
+    from app.api.v1.appliance.upgrade_images import (
+        _GITHUB_IMAGE_FILENAME,
+        _github_asset_filename,
+    )
+
+    assert _github_asset_filename("https://example.test/download?id=7") == _GITHUB_IMAGE_FILENAME

--- a/backend/tests/test_upgrades_orchestrator.py
+++ b/backend/tests/test_upgrades_orchestrator.py
@@ -27,6 +27,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.services.appliance.slot_image_target import SlotImageTarget
 from app.services.upgrades import node_order, orchestrator, per_node
 
 # ── Node ordering ─────────────────────────────────────────────────────
@@ -129,7 +130,7 @@ async def test_plan_upgrade_refuses_on_preflight_fail() -> None:
             await orchestrator.plan_upgrade(
                 db,
                 target_version="2026.06.01-1",
-                slot_image_url="http://mirror/x.raw.xz",
+                slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
             )
 
 
@@ -142,7 +143,7 @@ async def test_plan_upgrade_refuses_on_existing_run() -> None:
             await orchestrator.plan_upgrade(
                 db,
                 target_version="2026.06.01-1",
-                slot_image_url="http://mirror/x.raw.xz",
+                slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
             )
 
 
@@ -157,7 +158,7 @@ async def test_plan_upgrade_refuses_on_zero_nodes() -> None:
             await orchestrator.plan_upgrade(
                 db,
                 target_version="2026.06.01-1",
-                slot_image_url="http://mirror/x.raw.xz",
+                slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
             )
 
 
@@ -177,7 +178,7 @@ async def test_plan_upgrade_persists_node_order_and_sources() -> None:
         plan = await orchestrator.plan_upgrade(
             db,
             target_version="2026.06.01-1",
-            slot_image_url="http://mirror/x.raw.xz",
+            slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
         )
     # Alphabetical.
     assert plan.node_order == ["node-a", "node-b"]

--- a/backend/tests/test_upgrades_per_node.py
+++ b/backend/tests/test_upgrades_per_node.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.services.appliance.slot_image_target import SlotImageTarget
 from app.services.upgrades import per_node, preflight
 
 # ── Step 1: preflight ────────────────────────────────────────────────
@@ -245,6 +246,20 @@ async def test_step_drain_timeout_reports_blocked(monkeypatch: pytest.MonkeyPatc
 # ── Step 7: trigger slot apply ───────────────────────────────────────
 
 
+class _FakeAppliance:
+    """Minimal stand-in carrying every column the stamper writes."""
+
+    def __init__(self, *, supervisor_version: str | None = None) -> None:
+        self.id = uuid.uuid4()
+        self.hostname = "node-1"
+        self.supervisor_version = supervisor_version
+        self.installed_appliance_version: str | None = None
+        self.desired_appliance_version: str | None = None
+        self.desired_slot_image_url: str | None = None
+        self.desired_slot_image_sha256: str | None = None
+        self.desired_slot_image_tls_insecure: bool = False
+
+
 @pytest.mark.asyncio
 async def test_step_trigger_slot_apply_missing_appliance() -> None:
     """No Appliance row for the node name → step fails with a clear
@@ -253,7 +268,7 @@ async def test_step_trigger_slot_apply_missing_appliance() -> None:
     # _resolve_appliance returns None → step fails.
     with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=None)):
         step = await per_node._step_trigger_slot_apply(
-            db, "ghost-node", "2026.06.01-1", "http://mirror/x.raw.xz"
+            db, "ghost-node", "2026.06.01-1", SlotImageTarget(url="http://mirror/x.raw.xz")
         )
     assert step.ok is False
     assert "ghost-node" in step.error
@@ -264,24 +279,76 @@ async def test_step_trigger_slot_apply_stamps_desired_fields() -> None:
     """Happy path: the Appliance row's ``desired_*`` fields get
     stamped + flush is called. The supervisor's heartbeat picks them
     up from there + writes the trigger file."""
-
-    class _FakeAppliance:
-        id = uuid.uuid4()
-        hostname = "node-1"
-        desired_appliance_version: str | None = None
-        desired_slot_image_url: str | None = None
-
     appliance = _FakeAppliance()
     db = MagicMock()
     db.flush = AsyncMock()
     with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=appliance)):
         step = await per_node._step_trigger_slot_apply(
-            db, "node-1", "2026.06.01-1", "http://mirror/x.raw.xz"
+            db, "node-1", "2026.06.01-1", SlotImageTarget(url="http://mirror/x.raw.xz")
         )
     assert step.ok is True
     assert appliance.desired_appliance_version == "2026.06.01-1"
     assert appliance.desired_slot_image_url == "http://mirror/x.raw.xz"
     db.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_step_trigger_slot_apply_carries_integrity_hints() -> None:
+    """#787 regression: an uploaded (self-served) image must arrive at the
+    host with BOTH its sha256 and the insecure-TLS flag.
+
+    Stamping only version + URL — what this step used to do — leaves the
+    runner fetching our own self-signed cert with verification on, which
+    is the #386 failure it was supposed to have fixed.
+    """
+    appliance = _FakeAppliance()
+    db = MagicMock()
+    db.flush = AsyncMock()
+    target = SlotImageTarget(
+        url="https://cp.local/raw.xz?t=abc", sha256="ab" * 32, tls_insecure=True
+    )
+    with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=appliance)):
+        step = await per_node._step_trigger_slot_apply(db, "node-1", "2026.06.01-1", target)
+    assert step.ok is True
+    assert appliance.desired_slot_image_sha256 == "ab" * 32
+    assert appliance.desired_slot_image_tls_insecure is True
+
+
+@pytest.mark.asyncio
+async def test_step_trigger_slot_apply_clears_a_stale_sha256() -> None:
+    """An external URL has no hash — any sha256 left on the row from an
+    earlier per-box schedule must be cleared, or the new image is verified
+    against the old one's digest and fails as corrupt."""
+    appliance = _FakeAppliance()
+    appliance.desired_slot_image_sha256 = "cd" * 32
+    appliance.desired_slot_image_tls_insecure = True
+    db = MagicMock()
+    db.flush = AsyncMock()
+    with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=appliance)):
+        await per_node._step_trigger_slot_apply(
+            db, "node-1", "2026.06.01-1", SlotImageTarget(url="https://github.com/x.raw.xz")
+        )
+    assert appliance.desired_slot_image_sha256 is None
+    assert appliance.desired_slot_image_tls_insecure is False
+
+
+@pytest.mark.asyncio
+async def test_step_trigger_slot_apply_adds_refire_nonce_only_when_supported() -> None:
+    """The ``#a=`` re-fire nonce is gated on the runner being able to strip
+    it; an older appliance must get a clean URL (#419)."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    target = SlotImageTarget(url="https://cp.local/raw.xz")
+
+    modern = _FakeAppliance(supervisor_version="2026.07.30-1")
+    with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=modern)):
+        await per_node._step_trigger_slot_apply(db, "node-1", "2026.07.30-1", target)
+    assert "#a=" in (modern.desired_slot_image_url or "")
+
+    legacy = _FakeAppliance(supervisor_version="2026.06.11-1")
+    with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=legacy)):
+        await per_node._step_trigger_slot_apply(db, "node-1", "2026.07.30-1", target)
+    assert legacy.desired_slot_image_url == "https://cp.local/raw.xz"
 
 
 # ── Step 8: health gate ──────────────────────────────────────────────
@@ -473,7 +540,7 @@ async def test_single_node_upgrade_happy_path(monkeypatch: pytest.MonkeyPatch) -
         MagicMock(),
         node_name="node-1",
         target_version="2026.06.01-1",
-        slot_image_url="http://mirror/x.raw.xz",
+        slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
         cnpg_cluster_name="pg-cluster",
         cnpg_namespace="spatium",
     )
@@ -528,7 +595,7 @@ async def test_single_node_upgrade_halts_on_cordon_failure(
         MagicMock(),
         node_name="node-1",
         target_version="2026.06.01-1",
-        slot_image_url="http://mirror/x.raw.xz",
+        slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
         cnpg_cluster_name="pg-cluster",
     )
     assert result.ok is False
@@ -562,29 +629,8 @@ async def test_single_node_upgrade_step_crash_caught(
         MagicMock(),
         node_name="node-1",
         target_version="2026.06.01-1",
-        slot_image_url="http://mirror/x.raw.xz",
+        slot_image=SlotImageTarget(url="http://mirror/x.raw.xz"),
     )
     assert result.ok is False
     assert result.failed_at == "preflight"
     assert "kubeapi unreachable" in result.error
-
-
-# ── build_slot_image_url helper ──────────────────────────────────────
-
-
-def test_build_slot_image_url_format(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The URL the orchestrator stamps into ``desired_slot_image_url``
-    follows the same ``?t=<hmac>`` shape the existing ``apply_upgrade``
-    endpoint uses, so the host-side runner's unauthenticated GET
-    works."""
-    image_id = uuid.UUID("11111111-2222-3333-4444-555555555555")
-    url = per_node.build_slot_image_url(
-        request_base_url="https://fleet.example.com/", image_id=image_id
-    )
-    assert url.startswith(
-        f"https://fleet.example.com/api/v1/appliance/upgrade-images/{image_id}/raw.xz?t="
-    )
-    # Token is 64-char hex.
-    token = url.split("?t=")[1]
-    assert len(token) == 64
-    assert all(c in "0123456789abcdef" for c in token)

--- a/backend/tests/test_upgrades_per_node.py
+++ b/backend/tests/test_upgrades_per_node.py
@@ -338,8 +338,7 @@ async def test_step_trigger_slot_apply_adds_refire_nonce_only_when_supported() -
     it; an older appliance must get a clean URL (#419)."""
     db = MagicMock()
     db.flush = AsyncMock()
-    target = SlotImageTarget(url="https://cp.local/raw.xz")
-
+    target = SlotImageTarget(url="https://cp.local/raw.xz", nonce="n1")
     modern = _FakeAppliance(supervisor_version="2026.07.30-1")
     with patch.object(per_node, "_resolve_appliance", AsyncMock(return_value=modern)):
         await per_node._step_trigger_slot_apply(db, "node-1", "2026.07.30-1", target)

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -156,6 +156,14 @@ api:
 # that also use the slot-image upload feature (= multi-node appliance
 # installs). Single-instance docker-compose / plain k8s installs that
 # just helm-upgrade through standard rolling updates don't need it.
+#
+# TURN THIS ON for a multi-node control plane that upgrades from UPLOADED
+# images. It stays off by default because the PVC is real storage the
+# single-node appliance (whose /var is the remainder of a 32 GiB minimum
+# disk) should not be asked to reserve. Leaving it off on multi-node used
+# to surface as a 404 mid-download on whichever replica hadn't served the
+# upload; scheduling now refuses up front with that instruction instead
+# (#787). Upgrading from an external image URL needs no mirror at all.
 slotImageMirror:
   enabled: false
   storage:

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -160,10 +160,10 @@ api:
 # TURN THIS ON for a multi-node control plane that upgrades from UPLOADED
 # images. It stays off by default because the PVC is real storage the
 # single-node appliance (whose /var is the remainder of a 32 GiB minimum
-# disk) should not be asked to reserve. Leaving it off on multi-node used
-# to surface as a 404 mid-download on whichever replica hadn't served the
-# upload; scheduling now refuses up front with that instruction instead
-# (#787). Upgrading from an external image URL needs no mirror at all.
+# disk) should not be asked to reserve. With it off on multi-node, uploaded
+# bytes live on whichever api replica served the upload, and the host's
+# download 404s from every other one (#787). Upgrading from an external
+# image URL needs no mirror at all.
 slotImageMirror:
   enabled: false
   storage:

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1208,14 +1208,23 @@ control-plane cluster itself, not the registered agent fleet.
    its sha256 sidecar out-of-band (air-gap), or — on a connected
    install — **import from GitHub** straight from the release-asset
    picker, where the control plane downloads + sha256-verifies the
-   image for you (no out-of-band round trip). Either way the bytes are
-   stored on the in-cluster mirror PVC (`slot-image-mirror` Deployment +
-   PVC, gated behind `slotImageMirror.enabled` — the mirror infra keeps
-   the historical name). On the Rolling Upgrade tab the operator picks
-   it from the dropdown — the control plane composes an authenticated
-   download URL with an HMAC token, every per-node host runner pulls
-   bytes through the same control-plane → mirror pipe. No node ever
+   image for you (no out-of-band round trip). On the Rolling Upgrade tab
+   the operator picks it from the dropdown — the control plane composes
+   an authenticated download URL with an HMAC token, and every per-node
+   host runner pulls bytes back through the control plane. No node ever
    talks to github.com.
+
+   > **Multi-node needs the mirror turned on.** Where those bytes live
+   > depends on `slotImageMirror.enabled` (`slot-image-mirror` Deployment
+   > + PVC — the mirror infra keeps the historical name). It is **off by
+   > default**, and with it off the bytes sit on a node-local hostPath —
+   > specifically, on whichever api replica served the upload. That is
+   > correct for a single-node appliance and wrong for every other shape:
+   > the host's download round-robins across api replicas and any replica
+   > without the bytes answers 404. Scheduling an uploaded-image upgrade
+   > on a multi-node control plane with the mirror off is refused up
+   > front, with the same instruction (#787). Upgrading from an external
+   > image URL needs no mirror.
 2. **URL** (connected install). Operator pastes the GitHub release
    asset URL — same `https://github.com/.../spatiumddi-appliance-
    slot-amd64.raw.xz` shape the per-box flow uses. Each node fetches

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1280,11 +1280,14 @@ so a first-time operator never gets stuck looking for the upload.
 **Air-gap operator workflow (TL;DR):**
 
 ```
-1. On a workstation with internet:
+1. On a workstation with internet — note the VERSIONED asset names.
+   The un-versioned `…-slot-amd64.raw.xz` name exists only to back the
+   `releases/latest/download/…` URLs and is pruned from every release
+   once a newer one is cut (#392), so pinning a tag to it 404s.
    wget https://github.com/spatiumddi/spatiumddi/releases/download/
-        2026.06.01-1/spatiumddi-appliance-slot-amd64.raw.xz
+        2026.06.01-1/spatiumddi-appliance-slot-2026.06.01-1-amd64.raw.xz
    wget https://github.com/spatiumddi/spatiumddi/releases/download/
-        2026.06.01-1/spatiumddi-appliance-slot-amd64.sha256
+        2026.06.01-1/spatiumddi-appliance-slot-2026.06.01-1-amd64.sha256
 
 2. Copy both files to the airgap LAN (USB stick, SCP through a jump
    host, whatever your security team approves).

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1221,10 +1221,11 @@ control-plane cluster itself, not the registered agent fleet.
    > specifically, on whichever api replica served the upload. That is
    > correct for a single-node appliance and wrong for every other shape:
    > the host's download round-robins across api replicas and any replica
-   > without the bytes answers 404. Scheduling an uploaded-image upgrade
-   > on a multi-node control plane with the mirror off is refused up
-   > front, with the same instruction (#787). Upgrading from an external
-   > image URL needs no mirror.
+   > without the bytes answers 404 ("bytes missing on disk — re-upload
+   > required", which is misleading: the bytes exist, on a node you cannot
+   > see). Turn the mirror on before upgrading a multi-node control plane
+   > from an uploaded image, or upgrade from an external image URL, which
+   > needs no mirror (#787).
 2. **URL** (connected install). Operator pastes the GitHub release
    asset URL — same `https://github.com/.../spatiumddi-appliance-
    slot-amd64.raw.xz` shape the per-box flow uses. Each node fetches
@@ -1291,6 +1292,9 @@ so a first-time operator never gets stuck looking for the upload.
 
 2. Copy both files to the airgap LAN (USB stick, SCP through a jump
    host, whatever your security team approves).
+   NOTE on a MULTI-NODE control plane: set `slotImageMirror.enabled=true`
+   first, or the uploaded bytes stay on one api replica and the other
+   nodes' downloads 404 (#787).
 
 3. In the SpatiumDDI UI (control-plane node, any operator browser
    that can reach the cluster):

--- a/frontend/src/pages/appliance/ClusterUpgradeTab.tsx
+++ b/frontend/src/pages/appliance/ClusterUpgradeTab.tsx
@@ -384,7 +384,7 @@ function PlanFormPanel() {
           ) : (
             <input
               type="text"
-              placeholder="https://github.com/.../spatiumddi-appliance-slot-amd64.raw.xz"
+              placeholder="https://github.com/.../spatiumddi-appliance-slot-<VERSION>-amd64.raw.xz"
               value={slotImageUrl}
               onChange={(e) => setSlotImageUrl(e.target.value)}
               className="rounded-md border bg-background px-2 py-1 text-sm"


### PR DESCRIPTION
Four appliance slot-upgrade issues from a Discord field report on `2026.07.30-1`, filed as #786–#789. Every fix is verified on real hardware (ddi1) — see the validation comments below.

## What was reported

> The clear failed upgrade button doesn't do much. It sends the POST to the clear-upgrade endpoint, but appliance remains in this error mode even after reboot.

> were you getting the 4XX error when trying to pull down the new image? […] now that I have the latest images, I see a discrepancy — `Active slot: root_b … version=unreadable`

## What shipped

**#786 — "Clear failed upgrade" could not clear a failed upgrade.** The endpoint reset the four `desired_slot_image_*` columns, but the red card renders from `last_upgrade_state` / `last_upgrade_progress`, which the heartbeat re-publishes verbatim from host sidecars every ~30 s. The host owns that state, so clearing the DB was undone on the next heartbeat — and rebooting never helped, because those sidecars live on the persistent `/var` a slot write never touches.

The clear is now a command to the host: a fire-once `clear_upgrade_requested` flag (migration `e3b7a1c25d94`) that makes the supervisor reset its sidecars and drop a stranded `slot-upgrade-pending` trigger. Unlike the passive heal it is *allowed* to remove that trigger, because the existing `if _TRIGGER_FILE.exists(): return` guard is exactly what deadlocked wedged boxes — it also blocks `maybe_fire_fleet_upgrade`, so an appliance could neither clear nor re-apply.

**A permission bug meant none of that would have worked, and probably explains the original report.** `release-state` is mode 1777 (sticky), the sidecars are written by the *root* host runner as 0644, and the supervisor container runs `su-exec spatium`. A non-owner gets `EACCES` overwriting and `EPERM` unlinking — verified empirically, not by inspection. So the supervisor-side reset was inert, and by the same mechanism so is the long-shipped `clear_fleet_upgrade_marker`. The runner now publishes both sidecars `0666`, the supervisor overwrites `.progress` rather than unlinking it (unlink can never work under the sticky bit), and firstboot backfills the mode so an upgraded appliance repairs itself.

**#787 — the rolling orchestrator re-created #386.** It stamped only version + URL, never `desired_slot_image_sha256` / `desired_slot_image_tls_insecure`, so an uploaded image was fetched from the appliance's own self-signed URL with verification on and no hash; a stale sha256 from an earlier per-box schedule would fail the new image as corrupt. Both scheduling surfaces now go through one resolver (`services/appliance/slot_image_target.py`) that returns and stamps all four together. The `#a=` re-fire nonce moved there too and is now **run-scoped**, so an orchestrator resume no longer re-drives a node with a URL it never fired.

**#788 — `spatium-upgrade-slot status` always showed the active slot as `unreadable`.** It probed both slots by mounting them read-only, but the active slot is already mounted rw at `/`, so the kernel refuses the differing-flags mount. Whichever slot was *booted* always displayed as unreadable, on every appliance and every release — so the reporter's upgrade had in fact succeeded. Now reads the active version from the live `appliance-release`. `status` stays read-only; an earlier revision of this branch routed it through `sync_slot_versions()`, which would have let a probe taken mid-`dd` persist `unreadable` over the sidecar that feeds the Fleet card, the console and the GRUB titles.

**#789 — docs advertised a URL shape that 404s.** The air-gap recipe pinned a tag *and* used the un-versioned asset name; that pair resolves only while the tag is newest, because #392's retention prunes the un-versioned assets from every non-latest release. Fixed there and in the Rolling Upgrade URL placeholder, plus two code comments that claimed the two names are interchangeable.

## Deliberately not fixed

**The multi-node slot-image gap (#787, stays open).** Uploaded bytes live on whichever api replica served the upload; the mirror that fixes it is off by default and the appliance chart never enables it, so on multi-node the host's download 404s from every other replica. An earlier commit on this branch added a schedule-time refusal — **reverted in `23e7d2c0`**, because it asked the wrong question (appliance-node count, when the invariant is api replica count), so it missed the stock multi-replica plain-k8s default while falsely refusing single-api-replica appliance fleets; it made a blocking kubeapi call from an async handler; and its only remedy names a Helm value an appliance operator has no supported way to set, which would have left air-gapped multi-node fleets with **no** upgrade path. The hazard is documented in `APPLIANCE.md` and `values.yaml` instead.

**External-URL checksums (#787, stays open).** Reasoning is on the issue: `.xz` verifies its own container during decompress, so corruption already fails the apply cleanly, and fetching `<url>.sha256` from the host that served the image buys little against tampering — while the two proper implementations cost an SSRF surface or a trigger-format change across mixed-version fleets.

## Testing

`make ci` green. 217 appliance host-script tests, 280 supervisor tests, 91 targeted backend tests. New suites: `appliance/tests/test_slot_status_active_version.py`, `agent/supervisor/tests/test_clear_upgrade_command.py`, `backend/tests/test_slot_image_target.py`, `backend/tests/test_appliance_clear_upgrade.py` — all wired into CI. For #788 I confirmed the tests catch the bug by stashing the fix and watching three of them fail.

The full backend suite was **not** run locally (`-n auto` OOMs an 8-core/7 GB box, per CLAUDE.md) — this PR is how it gets exercised.

## Both draft blockers are discharged

1. **Host changes field-validated on ddi1.** The permission bug was reproduced from first principles (supervisor runs uid=100; overwriting a root-owned `0644` sidecar in the sticky `release-state` gives EACCES, unlink gives EPERM), the fix verified, and the whole clear flow driven end to end against real images: stranded trigger removed, `.state` reset, DB settled to `ready`, failure did not return. #788 likewise reproduced (`version=unreadable`) and fixed. Details in the two validation comments.

2. **#786 now retires the command on acknowledgement, not a timer** (`121f670f`). The stopwatch could expire before the command was ever delivered and needed two follow-up fixes; the host's compliance was observable all along, since the clear's job is to turn `failed` into `ready`. Validated on ddi1 with a deliberately 5-minute-stale stamp — which the old timer would have discarded on arrival — and the command was still delivered and applied.

**Two bugs were found by field testing that no test had caught**: a failed trigger unlink still reported success (`b8dc805c`), and the ingest suppression swallowed the host's own acknowledgement. Both fixed with regression tests.

Closes #786
Closes #788
Closes #789
Refs #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)

