### PR TITLE
fix(appliance): enable the slot-image mirror on multi-node control planes, and stop two writers fighting over one HelmChartConfig (#787, #792)

### DIFF
--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -32,6 +32,7 @@ from typing import Any
 from urllib.parse import quote
 
 import structlog
+import yaml
 
 log = structlog.get_logger(__name__)
 
@@ -147,8 +148,6 @@ def _parse_host_kubeconfig(path: Path) -> KubeConfig:
     pre-podification (legacy compose where someone still wants
     introspection).
     """
-    import yaml  # noqa: PLC0415 — lazy import; only on host-kubeconfig path.
-
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     contexts = {c["name"]: c["context"] for c in data.get("contexts") or []}
     current = data.get("current-context")
@@ -377,8 +376,6 @@ def apply_helmchart(
     same content is a no-op for k3s's helm-controller (Helm tracks
     revision diffs internally).
     """
-    import yaml  # noqa: PLC0415 — lazy; only on apply path.
-
     values_yaml = yaml.safe_dump(values, default_flow_style=False, sort_keys=False)
     body = {
         "apiVersion": "helm.cattle.io/v1",
@@ -634,8 +631,79 @@ def _helmchartconfig_upsert(
     )
 
 
-def _slot_image_mirror_values(cp_size: int) -> str:
-    """The ``slotImageMirror`` stanza for the spatium-control overrides.
+# Fast-evict tolerations for the CONTROL-PLANE workloads (api / frontend /
+# worker). Deliberately a separate constant from ``_FAST_EVICT_TOLERATIONS``,
+# which coredns uses: the two are the same 20 s today but answer different
+# questions (how fast must a control-plane replica leave a dead node, vs how
+# fast must cluster DNS), and collapsing them would make a future retune of
+# one silently retune the other.
+_CONTROL_PLANE_FAST_EVICT = [
+    {
+        "key": "node.kubernetes.io/unreachable",
+        "operator": "Exists",
+        "effect": "NoExecute",
+        "tolerationSeconds": 20,
+    },
+    {
+        "key": "node.kubernetes.io/not-ready",
+        "operator": "Exists",
+        "effect": "NoExecute",
+        "tolerationSeconds": 20,
+    },
+]
+
+
+def _deep_merge(base: dict, overlay: dict) -> dict:
+    """``overlay`` wins, recursing into dicts so sibling keys survive.
+
+    Lists and scalars are replaced wholesale — a partial merge of
+    ``tolerations`` or ``loadBalancerSourceRanges`` would be meaningless.
+    Neither input is mutated."""
+    out = dict(base)
+    for key, value in overlay.items():
+        existing = out.get(key)
+        if isinstance(value, dict) and isinstance(existing, dict):
+            out[key] = _deep_merge(existing, value)
+        else:
+            out[key] = value
+    return out
+
+
+def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict:
+    """Current ``spec.valuesContent`` of the HelmChartConfig, parsed.
+
+    Absent CR, unreadable kubeapi, unparseable JSON and unparseable YAML all
+    collapse to ``{}`` on purpose: every caller is asking "what is already
+    written here?", and for all four the honest answer is "nothing we can
+    rely on". Callers therefore fail OPEN — they recompute from cluster
+    state rather than inventing a state they cannot see. The one cost is
+    that a kubeapi blip can drop a foreign key (``image.tag``) on that
+    heartbeat; chart_bump re-stamps it, and the alternative — refusing to
+    write the control-plane overrides at all when the CR cannot be read —
+    would strand a promote."""
+    path = (
+        f"/apis/helm.cattle.io/v1/namespaces/{quote(namespace)}"
+        f"/helmchartconfigs/{quote(name)}"
+    )
+    try:
+        st, resp = _request("GET", path)
+    except (RuntimeError, OSError):
+        return {}
+    if st != 200:
+        return {}
+    try:
+        raw = (json.loads(resp).get("spec") or {}).get("valuesContent") or ""
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    try:
+        doc = yaml.safe_load(raw) if str(raw).strip() else None
+    except yaml.YAMLError:
+        return {}
+    return doc if isinstance(doc, dict) else {}
+
+
+def _slot_image_mirror_enabled(cp_size: int, current_doc: dict) -> bool:
+    """Whether ``slotImageMirror.enabled`` belongs in the overrides.
 
     #787 — an uploaded / GitHub-imported upgrade image lands on a
     node-local hostPath: on whichever api replica served the upload. The
@@ -660,23 +728,46 @@ def _slot_image_mirror_values(cp_size: int) -> str:
       for it. A schedule-time refusal keyed to appliance-node count, which
       an earlier revision of this branch tried, gets both directions
       wrong.
-    * A single-node appliance stays on the hostPath and never reserves the
-      PVC. That was the stated reason the chart default is off, and it
-      still holds — /var on a single box is the remainder of a 32 GiB
-      minimum disk.
-    * It is written on promote AND demote, so a cluster that shrinks back
-      to one node releases the PVC. The value is emitted in both states
-      rather than only when true, because omitting it would let the
-      enabled-once state persist through a demote (helm-controller merges,
-      it does not diff).
+    * A single-node appliance that has never been promoted stays on the
+      hostPath and never reserves the PVC. That was the stated reason the
+      chart default is off, and it still holds — /var on a single box is
+      the remainder of a 32 GiB minimum disk.
 
-    The transition still strands bytes uploaded BEFORE a promote: they sit
-    on the seed's hostPath and the mirror's PVC starts empty. The api's
-    download handler falls back to local FS on a mirror miss for exactly
-    that case (see ``download_upgrade_image``), which recovers it on the
-    seed; off the seed the operator re-uploads, and the mirror then holds
-    it for good."""
-    return f"slotImageMirror:\n  enabled: {'true' if cp_size >= 2 else 'false'}\n"
+    It LATCHES: once enabled, a later demote leaves it on. That is not
+    laziness, it is the only correct direction, for two independent
+    reasons:
+
+    * Turning it back off would not reclaim anything. The mirror's PVC and
+      auth Secret both carry ``helm.sh/resource-policy: keep``, so Helm
+      skips deleting them on the release update, and nothing else reaps
+      them — ``reclaim_stranded_redis_storage`` only matches ``-redis-``
+      claims. The disk stays committed either way.
+    * It would strand every image the mirror holds. With
+      ``SLOT_IMAGE_MIRROR_URL`` unset the api reads local FS only, so
+      images that were staged after the promote — the ones that exist
+      solely on the PVC — become unreachable, producing exactly the "bytes
+      missing on disk" 404 this whole change exists to remove.
+
+    So the answer is ``True`` if the cluster is multi-node OR the override
+    already says true. It is written as an explicit value in BOTH states
+    rather than omitted when false, because helm-controller MERGES a
+    HelmChartConfig instead of diffing it — an absent key keeps whatever
+    was written last, so a latch cannot be expressed by omission.
+
+    ``current_doc`` is the parsed live ``valuesContent``; passing it in
+    (rather than re-reading here) keeps this a pure function and the
+    kubeapi read in one place.
+
+    One transition remains, and it is handled outside this function: bytes
+    uploaded BEFORE a promote sit on the seed's hostPath while the mirror's
+    PVC starts empty. The api's download handler falls back to local FS
+    when the mirror cannot serve, which recovers it on the seed, and
+    re-uploading (or re-importing) now genuinely re-stores the bytes rather
+    than short-circuiting on the duplicate hash."""
+    if cp_size >= 2:
+        return True
+    block = current_doc.get("slotImageMirror")
+    return bool(isinstance(block, dict) and block.get("enabled") is True)
 
 
 def apply_control_plane_overrides(
@@ -696,17 +787,16 @@ def apply_control_plane_overrides(
 
     #787 — the slot-image mirror is enabled from the same number, because
     it is a function of exactly one thing: whether more than one api replica
-    can serve an upgrade-image download. See ``_slot_image_mirror_values``."""
+    can serve an upgrade-image download. It latches on rather than tracking
+    the size in both directions; see ``_slot_image_mirror_values``."""
     if cp_size < 1:
         return False, "cp_size < 1"
     vip = (control_plane_vip or "").strip()
-    # Flow-style JSON list is valid YAML; empty list = open (field omitted by
-    # the chart template). The supervisor already validates these CIDRs at the
-    # control plane, but they arrive here as plain strings — json.dumps keeps
-    # them quoted so a malformed entry can't break the YAML overlay.
-    src_json = json.dumps(
-        [c.strip() for c in (web_ui_allowed_cidrs or []) if c and c.strip()]
-    )
+    # Empty list = open (the field is omitted by the chart template). These
+    # arrive as plain strings the control plane has already validated; going
+    # through the YAML dumper below is what keeps a malformed entry from
+    # breaking the document, so no hand-quoting is needed here.
+    cidrs = [c.strip() for c in (web_ui_allowed_cidrs or []) if c and c.strip()]
     # #590 — pin api/frontend/worker to one replica per control-plane node,
     # and evict them from a dead node in seconds rather than the k8s default
     # 300 s. ``replicas`` here IS the node count, so hard
@@ -725,27 +815,43 @@ def apply_control_plane_overrides(
     # suppresses the DefaultTolerationSeconds admission plugin, which a
     # BYO-Kubernetes install still wants. They belong to the appliance,
     # where the control-plane node count is fixed.
-    fast_evict = (
-        "  tolerations:\n"
-        "    - key: node.kubernetes.io/unreachable\n"
-        "      operator: Exists\n"
-        "      effect: NoExecute\n"
-        "      tolerationSeconds: 20\n"
-        "    - key: node.kubernetes.io/not-ready\n"
-        "      operator: Exists\n"
-        "      effect: NoExecute\n"
-        "      tolerationSeconds: 20\n"
-    )
-    values = (
-        f"api:\n  replicas: {cp_size}\n  podAntiAffinity: hard\n{fast_evict}"
-        f"frontend:\n  replicas: {cp_size}\n  podAntiAffinity: hard\n{fast_evict}"
-        f'  controlPlaneVIP: "{vip}"\n'
-        f"  loadBalancerSourceRanges: {src_json}\n"
-        f"worker:\n  replicas: {cp_size}\n  podAntiAffinity: hard\n{fast_evict}"
-        f"{_slot_image_mirror_values(cp_size)}"
-        f"postgresql:\n  cnpg:\n    instances: {cp_size}\n"
-        f"redis:\n  sentinel:\n    replicas: {cp_size}\n"
-    )
+    scaled = {
+        "replicas": cp_size,
+        "podAntiAffinity": "hard",
+        "tolerations": _CONTROL_PLANE_FAST_EVICT,
+    }
+    current_doc = _helmchartconfig_doc("spatium-control")
+    owned: dict[str, Any] = {
+        "api": dict(scaled),
+        "frontend": dict(scaled)
+        | {
+            "controlPlaneVIP": vip,
+            "loadBalancerSourceRanges": cidrs,
+        },
+        "worker": dict(scaled),
+        "slotImageMirror": {"enabled": _slot_image_mirror_enabled(cp_size, current_doc)},
+        "postgresql": {"cnpg": {"instances": cp_size}},
+        "redis": {"sentinel": {"replicas": cp_size}},
+    }
+    # MERGE onto what is already there rather than replacing the document.
+    #
+    # This used to be a hand-concatenated string assigned wholesale to
+    # ``spec.valuesContent``, which silently deleted every key the
+    # supervisor does not own. One of those keys is load-bearing:
+    # ``chart_bump._patch_image_tag`` stamps ``image.tag`` onto this very
+    # CR to roll the control plane to a new version, and it re-dumps the
+    # document with ``yaml.safe_dump(sort_keys=True)``. That output could
+    # never equal the supervisor's hand-rolled rendering, so the next
+    # heartbeat — at most 30 s later, i.e. mid-upgrade — always saw a
+    # difference, PATCHed its own string back, and took ``image.tag`` with
+    # it. helm-controller then re-applied the chart at its default tag.
+    #
+    # Merging fixes the deletion; dumping through the SAME normalisation
+    # chart_bump uses fixes the churn, because two agents writing the same
+    # logical document now produce byte-identical strings and the upsert's
+    # idempotent compare finally holds.
+    merged = _deep_merge(current_doc, owned)
+    values = yaml.safe_dump(merged, sort_keys=True, default_flow_style=False)
     return _helmchartconfig_upsert("spatium-control", values)
 
 

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -672,41 +672,57 @@ def _deep_merge(base: dict, overlay: dict) -> dict:
 def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict | None:
     """Current ``spec.valuesContent`` of the HelmChartConfig, parsed.
 
-    Returns ``{}`` when the CR genuinely has no values yet — it does not
-    exist (404), or it exists carrying an empty / unparseable document. That
-    is a real answer: there is nothing there to preserve.
+    Returns ``{}`` only when there is genuinely nothing to preserve: the CR
+    does not exist (404), or it exists with an empty ``valuesContent``.
 
-    Returns ``None`` when the answer is UNKNOWN — the kubeapi could not be
-    reached or gave a status we cannot interpret. The distinction is
-    load-bearing, and conflating the two is how #792 comes back. A caller
-    that merges onto ``{}`` writes a document containing only the keys it
-    owns; if the read failed but the write then succeeds (a blip between two
-    calls a few milliseconds apart), that write DELETES ``image.tag`` — the
-    exact key a cluster rolling upgrade is depending on mid-flight. So an
-    unknown current state must abort the write, not proceed on a guess. The
-    supervisor retries every heartbeat; a promote is delayed by ~30 s rather
-    than a control-plane version being silently rolled back."""
+    Returns ``None`` for every other non-answer — kubeapi unreachable, an
+    unexpected status, a body we cannot parse, or a document that is not a
+    mapping. "There is a document and I cannot read it" is NOT the same
+    claim as "there is no document", and conflating them is how #792 comes
+    back: a caller that merges onto ``{}`` writes a document containing only
+    the keys it owns, so if the read failed but the write then succeeds (a
+    blip between two calls milliseconds apart, or a CR whose YAML we choked
+    on), that write DELETES ``image.tag`` — the exact key a cluster rolling
+    upgrade is depending on mid-flight.
+
+    So an unknown current state aborts the write. The supervisor retries
+    every heartbeat, which costs ~30 s on a transient failure; a CR that
+    stays unparseable needs an operator to fix or delete it, and the
+    warning below is how they find out, rather than discovering it as a
+    silently rolled-back control-plane version."""
     path = (
         f"/apis/helm.cattle.io/v1/namespaces/{quote(namespace)}"
         f"/helmchartconfigs/{quote(name)}"
     )
     try:
         st, resp = _request("GET", path)
-    except (RuntimeError, OSError):
+    except (RuntimeError, OSError) as exc:
+        log.warning("supervisor.helmchartconfig.read_failed", chart=name, error=str(exc))
         return None
     if st == 404:
         return {}
     if st != 200:
+        log.warning("supervisor.helmchartconfig.read_failed", chart=name, status=st)
         return None
     try:
         raw = (json.loads(resp).get("spec") or {}).get("valuesContent") or ""
     except (json.JSONDecodeError, ValueError):
+        log.warning("supervisor.helmchartconfig.unparseable_body", chart=name)
+        return None
+    if not str(raw).strip():
         return {}
     try:
-        doc = yaml.safe_load(raw) if str(raw).strip() else None
-    except yaml.YAMLError:
-        return {}
-    return doc if isinstance(doc, dict) else {}
+        doc = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        log.warning("supervisor.helmchartconfig.unparseable_values", chart=name, error=str(exc))
+        return None
+    if not isinstance(doc, dict):
+        # A list or scalar at the top level is not something we can merge
+        # into. Refusing beats replacing it with our own keys and calling
+        # the operator's document a typo.
+        log.warning("supervisor.helmchartconfig.values_not_a_mapping", chart=name)
+        return None
+    return doc
 
 
 def _slot_image_mirror_enabled(cp_size: int, current_doc: dict) -> bool:

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -634,6 +634,51 @@ def _helmchartconfig_upsert(
     )
 
 
+def _slot_image_mirror_values(cp_size: int) -> str:
+    """The ``slotImageMirror`` stanza for the spatium-control overrides.
+
+    #787 — an uploaded / GitHub-imported upgrade image lands on a
+    node-local hostPath: on whichever api replica served the upload. The
+    host runner's download then round-robins through the api Service, so
+    on any control plane with more than one replica roughly half the
+    downloads hit a replica without the bytes and get a 404 that reads
+    "bytes missing on disk — re-upload required". Re-uploading cannot fix
+    it; the bytes exist, on a node the operator cannot see.
+
+    The mirror (a single-replica Deployment on its own node-pinned PVC,
+    which every api replica proxies byte ops to) is the fix, and it
+    shipped in #296 Phase B — but it defaults off and nothing on the
+    appliance ever turned it on, so the feature was unreachable from the
+    only deployment shape that needs it.
+
+    Deriving it from ``cp_size`` here rather than defaulting it on in the
+    chart is what makes that safe:
+
+    * ``cp_size`` IS the api replica count (set from the same number a few
+      lines below), so this tracks the actual invariant — "can a download
+      land on a replica that did not serve the upload?" — and not a proxy
+      for it. A schedule-time refusal keyed to appliance-node count, which
+      an earlier revision of this branch tried, gets both directions
+      wrong.
+    * A single-node appliance stays on the hostPath and never reserves the
+      PVC. That was the stated reason the chart default is off, and it
+      still holds — /var on a single box is the remainder of a 32 GiB
+      minimum disk.
+    * It is written on promote AND demote, so a cluster that shrinks back
+      to one node releases the PVC. The value is emitted in both states
+      rather than only when true, because omitting it would let the
+      enabled-once state persist through a demote (helm-controller merges,
+      it does not diff).
+
+    The transition still strands bytes uploaded BEFORE a promote: they sit
+    on the seed's hostPath and the mirror's PVC starts empty. The api's
+    download handler falls back to local FS on a mirror miss for exactly
+    that case (see ``download_upgrade_image``), which recovers it on the
+    seed; off the seed the operator re-uploads, and the mirror then holds
+    it for good."""
+    return f"slotImageMirror:\n  enabled: {'true' if cp_size >= 2 else 'false'}\n"
+
+
 def apply_control_plane_overrides(
     cp_size: int,
     control_plane_vip: str,
@@ -647,7 +692,11 @@ def apply_control_plane_overrides(
     #285 Phase 6 — ``web_ui_allowed_cidrs`` (empty = open) also lands on the
     frontend as ``loadBalancerSourceRanges``, so the MetalLB VIP path is
     source-scoped by the same setting that scopes the per-node hostPort door
-    via nftables. Belt (VIP) + braces (hostPort) from one operator control."""
+    via nftables. Belt (VIP) + braces (hostPort) from one operator control.
+
+    #787 — the slot-image mirror is enabled from the same number, because
+    it is a function of exactly one thing: whether more than one api replica
+    can serve an upgrade-image download. See ``_slot_image_mirror_values``."""
     if cp_size < 1:
         return False, "cp_size < 1"
     vip = (control_plane_vip or "").strip()
@@ -693,6 +742,7 @@ def apply_control_plane_overrides(
         f'  controlPlaneVIP: "{vip}"\n'
         f"  loadBalancerSourceRanges: {src_json}\n"
         f"worker:\n  replicas: {cp_size}\n  podAntiAffinity: hard\n{fast_evict}"
+        f"{_slot_image_mirror_values(cp_size)}"
         f"postgresql:\n  cnpg:\n    instances: {cp_size}\n"
         f"redis:\n  sentinel:\n    replicas: {cp_size}\n"
     )

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -788,7 +788,7 @@ def apply_control_plane_overrides(
     #787 — the slot-image mirror is enabled from the same number, because
     it is a function of exactly one thing: whether more than one api replica
     can serve an upgrade-image download. It latches on rather than tracking
-    the size in both directions; see ``_slot_image_mirror_values``."""
+    the size in both directions; see ``_slot_image_mirror_enabled``."""
     if cp_size < 1:
         return False, "cp_size < 1"
     vip = (control_plane_vip or "").strip()

--- a/agent/supervisor/spatium_supervisor/k8s_api.py
+++ b/agent/supervisor/spatium_supervisor/k8s_api.py
@@ -669,18 +669,23 @@ def _deep_merge(base: dict, overlay: dict) -> dict:
     return out
 
 
-def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict:
+def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict | None:
     """Current ``spec.valuesContent`` of the HelmChartConfig, parsed.
 
-    Absent CR, unreadable kubeapi, unparseable JSON and unparseable YAML all
-    collapse to ``{}`` on purpose: every caller is asking "what is already
-    written here?", and for all four the honest answer is "nothing we can
-    rely on". Callers therefore fail OPEN — they recompute from cluster
-    state rather than inventing a state they cannot see. The one cost is
-    that a kubeapi blip can drop a foreign key (``image.tag``) on that
-    heartbeat; chart_bump re-stamps it, and the alternative — refusing to
-    write the control-plane overrides at all when the CR cannot be read —
-    would strand a promote."""
+    Returns ``{}`` when the CR genuinely has no values yet — it does not
+    exist (404), or it exists carrying an empty / unparseable document. That
+    is a real answer: there is nothing there to preserve.
+
+    Returns ``None`` when the answer is UNKNOWN — the kubeapi could not be
+    reached or gave a status we cannot interpret. The distinction is
+    load-bearing, and conflating the two is how #792 comes back. A caller
+    that merges onto ``{}`` writes a document containing only the keys it
+    owns; if the read failed but the write then succeeds (a blip between two
+    calls a few milliseconds apart), that write DELETES ``image.tag`` — the
+    exact key a cluster rolling upgrade is depending on mid-flight. So an
+    unknown current state must abort the write, not proceed on a guess. The
+    supervisor retries every heartbeat; a promote is delayed by ~30 s rather
+    than a control-plane version being silently rolled back."""
     path = (
         f"/apis/helm.cattle.io/v1/namespaces/{quote(namespace)}"
         f"/helmchartconfigs/{quote(name)}"
@@ -688,9 +693,11 @@ def _helmchartconfig_doc(name: str, *, namespace: str = "kube-system") -> dict:
     try:
         st, resp = _request("GET", path)
     except (RuntimeError, OSError):
+        return None
+    if st == 404:
         return {}
     if st != 200:
-        return {}
+        return None
     try:
         raw = (json.loads(resp).get("spec") or {}).get("valuesContent") or ""
     except (json.JSONDecodeError, ValueError):
@@ -821,6 +828,10 @@ def apply_control_plane_overrides(
         "tolerations": _CONTROL_PLANE_FAST_EVICT,
     }
     current_doc = _helmchartconfig_doc("spatium-control")
+    if current_doc is None:
+        # Unknown current state — see _helmchartconfig_doc. Writing here
+        # would merge onto {} and delete every key we do not own.
+        return False, "could not read the current spatium-control values"
     owned: dict[str, Any] = {
         "api": dict(scaled),
         "frontend": dict(scaled)

--- a/agent/supervisor/tests/test_slot_image_mirror_overrides.py
+++ b/agent/supervisor/tests/test_slot_image_mirror_overrides.py
@@ -231,3 +231,66 @@ def test_owned_scaling_still_lands_on_every_workload(monkeypatch) -> None:
     assert doc["redis"]["sentinel"]["replicas"] == 3
     assert doc["frontend"]["controlPlaneVIP"] == "10.0.0.9"
     assert doc["frontend"]["loadBalancerSourceRanges"] == ["10.0.0.0/8"]
+
+
+# ── unknown current state vs genuinely-empty current state ───────────
+#
+# The whole #792 fix rests on this distinction, so each branch is pinned
+# individually rather than through one happy-path call.
+
+
+def _reader(monkeypatch, status: int, body: str):
+    def _fake(method, path, body_=None, content_type=None):
+        return (status, body)
+
+    monkeypatch.setattr(k8s_api, "_request", _fake)
+
+
+def test_absent_cr_reads_as_empty(monkeypatch) -> None:
+    _reader(monkeypatch, 404, "")
+    assert k8s_api._helmchartconfig_doc("spatium-control") == {}
+
+
+def test_empty_values_read_as_empty(monkeypatch) -> None:
+    _reader(monkeypatch, 200, json.dumps({"spec": {"valuesContent": "   "}}))
+    assert k8s_api._helmchartconfig_doc("spatium-control") == {}
+
+
+def test_unexpected_status_reads_as_unknown(monkeypatch) -> None:
+    _reader(monkeypatch, 500, "boom")
+    assert k8s_api._helmchartconfig_doc("spatium-control") is None
+
+
+def test_unparseable_body_reads_as_unknown(monkeypatch) -> None:
+    _reader(monkeypatch, 200, "{not json")
+    assert k8s_api._helmchartconfig_doc("spatium-control") is None
+
+
+def test_unparseable_values_read_as_unknown(monkeypatch) -> None:
+    # "there is a document and I cannot read it" is not "there is no
+    # document" — merging onto {} here would delete the operator's keys.
+    _reader(monkeypatch, 200, json.dumps({"spec": {"valuesContent": "a: [unclosed"}}))
+    assert k8s_api._helmchartconfig_doc("spatium-control") is None
+
+
+def test_non_mapping_values_read_as_unknown(monkeypatch) -> None:
+    _reader(monkeypatch, 200, json.dumps({"spec": {"valuesContent": "- a\n- b\n"}}))
+    assert k8s_api._helmchartconfig_doc("spatium-control") is None
+
+
+def test_unparseable_values_abort_the_write(monkeypatch) -> None:
+    writes: list[str] = []
+
+    def _fake(method, path, body=None, content_type=None):
+        if method == "GET":
+            return (200, json.dumps({"spec": {"valuesContent": "a: [unclosed"}}))
+        writes.append(method)
+        return (200, "{}")
+
+    monkeypatch.setattr(k8s_api, "_request", _fake)
+
+    ok, err = k8s_api.apply_control_plane_overrides(2, "")
+
+    assert ok is False
+    assert err is not None
+    assert writes == [], "a document we cannot read must not be overwritten"

--- a/agent/supervisor/tests/test_slot_image_mirror_overrides.py
+++ b/agent/supervisor/tests/test_slot_image_mirror_overrides.py
@@ -1,0 +1,104 @@
+"""#787 — the slot-image mirror is enabled from the control-plane size.
+
+An uploaded upgrade image lands on the api replica that served the upload;
+the host runner's download round-robins through the Service, so on a
+multi-replica control plane roughly half the downloads 404. The mirror
+(#296 Phase B) is the fix but defaulted off and nothing on the appliance
+ever turned it on.
+
+These tests pin the derivation — enabled at >= 2, disabled at 1, and
+emitted in BOTH states so a demote actually releases the PVC (a
+HelmChartConfig is merged, not diffed, so an omitted key keeps its last
+value) — and that it rides the same HelmChartConfig write as cp-size
+rather than a second one that could disagree with it.
+"""
+
+from __future__ import annotations
+
+import json
+
+from spatium_supervisor import k8s_api
+
+
+class _Recorder:
+    """Stand-in for k8s_api._request: 404 on the GET (no HelmChartConfig
+    yet) so the upsert takes its create path, then records the POST."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, bytes | None]] = []
+
+    def __call__(self, method, path, body=None, content_type=None):
+        self.calls.append((method, path, body))
+        if method == "GET":
+            return (404, "")
+        return (201, "{}")
+
+    @property
+    def values(self) -> str:
+        for method, _, body in self.calls:
+            if method == "POST" and body is not None:
+                return json.loads(body)["spec"]["valuesContent"]
+        raise AssertionError("no HelmChartConfig POST recorded")
+
+
+def test_single_node_leaves_the_mirror_off(monkeypatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    ok, err = k8s_api.apply_control_plane_overrides(1, "")
+
+    assert (ok, err) == (True, None)
+    assert "slotImageMirror:\n  enabled: false\n" in rec.values
+
+
+def test_multi_node_turns_the_mirror_on(monkeypatch) -> None:
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    ok, err = k8s_api.apply_control_plane_overrides(3, "10.0.0.9")
+
+    assert (ok, err) == (True, None)
+    assert "slotImageMirror:\n  enabled: true\n" in rec.values
+
+
+def test_demote_writes_the_off_state_rather_than_omitting_it(monkeypatch) -> None:
+    # The regression this guards: emitting the key only when true. A
+    # HelmChartConfig's valuesContent is merged over the HelmChart's, so a
+    # dropped key is not "back to the chart default" — the previously
+    # written ``true`` is what helm-controller keeps applying, and a
+    # 3-node cluster demoted to 1 would hold the PVC forever.
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    k8s_api.apply_control_plane_overrides(1, "")
+
+    assert "slotImageMirror:" in rec.values
+
+
+def test_mirror_state_rides_the_cp_size_write(monkeypatch) -> None:
+    # One HelmChartConfig, one write: the mirror cannot end up describing a
+    # different cluster size than the replica counts it was derived from.
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    k8s_api.apply_control_plane_overrides(2, "")
+
+    writes = [m for m, _, _ in rec.calls if m in ("POST", "PATCH")]
+    assert writes == ["POST"]
+    values = rec.values
+    assert "api:\n  replicas: 2\n" in values
+    assert "slotImageMirror:\n  enabled: true\n" in values
+
+
+def test_values_stay_parseable_yaml(monkeypatch) -> None:
+    # The stanza is string-concatenated into a YAML document; a missing
+    # newline would silently glue it onto the worker block above.
+    yaml = __import__("yaml")
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    k8s_api.apply_control_plane_overrides(2, "10.0.0.9")
+
+    parsed = yaml.safe_load(rec.values)
+    assert parsed["slotImageMirror"] == {"enabled": True}
+    assert parsed["worker"]["replicas"] == 2

--- a/agent/supervisor/tests/test_slot_image_mirror_overrides.py
+++ b/agent/supervisor/tests/test_slot_image_mirror_overrides.py
@@ -6,39 +6,65 @@ multi-replica control plane roughly half the downloads 404. The mirror
 (#296 Phase B) is the fix but defaulted off and nothing on the appliance
 ever turned it on.
 
-These tests pin the derivation — enabled at >= 2, disabled at 1, and
-emitted in BOTH states so a demote actually releases the PVC (a
-HelmChartConfig is merged, not diffed, so an omitted key keeps its last
-value) — and that it rides the same HelmChartConfig write as cp-size
-rather than a second one that could disagree with it.
+These tests pin:
+
+* the derivation — on at >= 2 nodes, off on a box that has never grown;
+* the LATCH — a demote leaves it on, because turning it off reclaims
+  nothing (PVC + Secret carry ``helm.sh/resource-policy: keep``) and would
+  strand every image that exists only on the mirror;
+* that the override write MERGES onto the live document instead of
+  replacing it, so ``chart_bump``'s ``image.tag`` survives a heartbeat
+  landing mid-upgrade.
 """
 
 from __future__ import annotations
 
 import json
 
+import yaml
+
 from spatium_supervisor import k8s_api
 
 
 class _Recorder:
-    """Stand-in for k8s_api._request: 404 on the GET (no HelmChartConfig
-    yet) so the upsert takes its create path, then records the POST."""
+    """Stand-in for k8s_api._request.
 
-    def __init__(self) -> None:
+    ``current`` is the HelmChartConfig's live ``valuesContent``; ``None``
+    means the CR does not exist yet (GET 404 → the upsert creates it).
+    Both the pre-render read and the upsert's own read are served from it.
+    """
+
+    def __init__(self, current: str | None = None):
+        self._current = current
         self.calls: list[tuple[str, str, bytes | None]] = []
 
     def __call__(self, method, path, body=None, content_type=None):
         self.calls.append((method, path, body))
         if method == "GET":
-            return (404, "")
-        return (201, "{}")
+            if self._current is None:
+                return (404, "")
+            return (200, json.dumps({"spec": {"valuesContent": self._current}}))
+        return (200 if method == "PATCH" else 201, "{}")
 
     @property
-    def values(self) -> str:
+    def written(self) -> str:
         for method, _, body in self.calls:
-            if method == "POST" and body is not None:
-                return json.loads(body)["spec"]["valuesContent"]
-        raise AssertionError("no HelmChartConfig POST recorded")
+            if method in ("POST", "PATCH") and body is not None:
+                payload = json.loads(body)
+                return payload["spec"]["valuesContent"]
+        raise AssertionError("no HelmChartConfig write recorded")
+
+    @property
+    def doc(self) -> dict:
+        return yaml.safe_load(self.written)
+
+    @property
+    def wrote_anything(self) -> bool:
+        return any(m in ("POST", "PATCH") for m, _, _ in self.calls)
+
+
+def _values(**overrides) -> str:
+    return yaml.safe_dump(overrides, sort_keys=True, default_flow_style=False)
 
 
 def test_single_node_leaves_the_mirror_off(monkeypatch) -> None:
@@ -48,7 +74,7 @@ def test_single_node_leaves_the_mirror_off(monkeypatch) -> None:
     ok, err = k8s_api.apply_control_plane_overrides(1, "")
 
     assert (ok, err) == (True, None)
-    assert "slotImageMirror:\n  enabled: false\n" in rec.values
+    assert rec.doc["slotImageMirror"] == {"enabled": False}
 
 
 def test_multi_node_turns_the_mirror_on(monkeypatch) -> None:
@@ -58,47 +84,124 @@ def test_multi_node_turns_the_mirror_on(monkeypatch) -> None:
     ok, err = k8s_api.apply_control_plane_overrides(3, "10.0.0.9")
 
     assert (ok, err) == (True, None)
-    assert "slotImageMirror:\n  enabled: true\n" in rec.values
+    assert rec.doc["slotImageMirror"] == {"enabled": True}
+    assert rec.doc["api"]["replicas"] == 3
 
 
-def test_demote_writes_the_off_state_rather_than_omitting_it(monkeypatch) -> None:
-    # The regression this guards: emitting the key only when true. A
-    # HelmChartConfig's valuesContent is merged over the HelmChart's, so a
-    # dropped key is not "back to the chart default" — the previously
-    # written ``true`` is what helm-controller keeps applying, and a
-    # 3-node cluster demoted to 1 would hold the PVC forever.
+def test_demote_latches_the_mirror_on(monkeypatch) -> None:
+    # Turning it off would reclaim nothing (keep-annotated PVC + Secret) and
+    # would strand every image that lives only on the mirror's PVC, which is
+    # the same 404 this change exists to remove.
+    rec = _Recorder(_values(slotImageMirror={"enabled": True}))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    k8s_api.apply_control_plane_overrides(1, "")
+
+    assert rec.doc["slotImageMirror"] == {"enabled": True}
+
+
+def test_latch_is_explicit_not_an_omission(monkeypatch) -> None:
+    # helm-controller MERGES valuesContent rather than diffing it, so the
+    # state has to be written as a value. An absent key would silently keep
+    # whatever was there before, which is not a latch — it is a coin flip.
     rec = _Recorder()
     monkeypatch.setattr(k8s_api, "_request", rec)
 
     k8s_api.apply_control_plane_overrides(1, "")
 
-    assert "slotImageMirror:" in rec.values
+    assert "slotImageMirror" in rec.doc
 
 
-def test_mirror_state_rides_the_cp_size_write(monkeypatch) -> None:
-    # One HelmChartConfig, one write: the mirror cannot end up describing a
-    # different cluster size than the replica counts it was derived from.
-    rec = _Recorder()
+def test_unreadable_current_state_falls_back_to_the_node_count(monkeypatch) -> None:
+    # A kubeapi blip must not turn the latch into a guess. Reading the live
+    # document fails closed to "{}", so the decision falls back to cp_size
+    # rather than to an invented previous state. (The WRITE still fails on
+    # an unreachable kubeapi — that is the upsert's own pre-existing
+    # behaviour, and it retries on the next heartbeat.)
+    def _boom(method, path, body=None, content_type=None):
+        raise RuntimeError("kubeapi down")
+
+    monkeypatch.setattr(k8s_api, "_request", _boom)
+
+    assert k8s_api._helmchartconfig_doc("spatium-control") == {}
+    assert k8s_api._slot_image_mirror_enabled(2, {}) is True
+    assert k8s_api._slot_image_mirror_enabled(1, {}) is False
+
+
+def test_malformed_current_values_do_not_crash_the_latch() -> None:
+    # An operator hand-edit (or a half-written CR) must not take the
+    # control-plane override write down with it.
+    for junk in ({"slotImageMirror": "yes"}, {"slotImageMirror": None}, {}):
+        assert k8s_api._slot_image_mirror_enabled(1, junk) is False
+        assert k8s_api._slot_image_mirror_enabled(2, junk) is True
+
+
+# ── The override write must not clobber keys it does not own ─────────
+
+
+def test_image_tag_survives_the_override_write(monkeypatch) -> None:
+    """The regression this exists for.
+
+    ``chart_bump._patch_image_tag`` stamps ``image.tag`` on this same CR to
+    roll the control plane to a new version. The override write used to
+    replace ``spec.valuesContent`` wholesale, so the next heartbeat — at
+    most 30 s later, i.e. mid-upgrade — deleted the tag and helm-controller
+    re-applied the chart at its default.
+    """
+    rec = _Recorder(_values(image={"tag": "2026.08.01-1"}, api={"replicas": 3}))
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
+    k8s_api.apply_control_plane_overrides(3, "")
+
+    assert rec.doc["image"] == {"tag": "2026.08.01-1"}
+    assert rec.doc["api"]["replicas"] == 3
+
+
+def test_foreign_nested_keys_are_preserved_not_replaced(monkeypatch) -> None:
+    # The merge recurses: owning ``api.replicas`` must not take an operator's
+    # ``api.resources`` with it.
+    rec = _Recorder(_values(api={"replicas": 1, "resources": {"limits": {"cpu": "2"}}}))
     monkeypatch.setattr(k8s_api, "_request", rec)
 
     k8s_api.apply_control_plane_overrides(2, "")
 
-    writes = [m for m, _, _ in rec.calls if m in ("POST", "PATCH")]
-    assert writes == ["POST"]
-    values = rec.values
-    assert "api:\n  replicas: 2\n" in values
-    assert "slotImageMirror:\n  enabled: true\n" in values
+    assert rec.doc["api"]["resources"] == {"limits": {"cpu": "2"}}
+    assert rec.doc["api"]["replicas"] == 2
 
 
-def test_values_stay_parseable_yaml(monkeypatch) -> None:
-    # The stanza is string-concatenated into a YAML document; a missing
-    # newline would silently glue it onto the worker block above.
-    yaml = __import__("yaml")
+def test_rewrite_is_byte_stable_so_the_upsert_stays_idempotent(monkeypatch) -> None:
+    # Two agents write this CR. They now share one normalisation, so a
+    # settled document produces an identical string and the upsert skips the
+    # PATCH — no helm re-apply, no Deployment roll, no fight.
+    first = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", first)
+    k8s_api.apply_control_plane_overrides(2, "10.0.0.9")
+
+    second = _Recorder(first.written)
+    monkeypatch.setattr(k8s_api, "_request", second)
+    changed, err = k8s_api.apply_control_plane_overrides(2, "10.0.0.9")
+
+    assert (changed, err) == (False, None)
+    assert not second.wrote_anything
+
+
+def test_owned_scaling_still_lands_on_every_workload(monkeypatch) -> None:
     rec = _Recorder()
     monkeypatch.setattr(k8s_api, "_request", rec)
 
-    k8s_api.apply_control_plane_overrides(2, "10.0.0.9")
+    k8s_api.apply_control_plane_overrides(
+        3, "10.0.0.9", web_ui_allowed_cidrs=["10.0.0.0/8"]
+    )
 
-    parsed = yaml.safe_load(rec.values)
-    assert parsed["slotImageMirror"] == {"enabled": True}
-    assert parsed["worker"]["replicas"] == 2
+    doc = rec.doc
+    for component in ("api", "frontend", "worker"):
+        assert doc[component]["replicas"] == 3
+        assert doc[component]["podAntiAffinity"] == "hard"
+        assert [t["tolerationSeconds"] for t in doc[component]["tolerations"]] == [
+            20,
+            20,
+        ]
+    assert doc["postgresql"]["cnpg"]["instances"] == 3
+    assert doc["redis"]["sentinel"]["replicas"] == 3
+    assert doc["frontend"]["controlPlaneVIP"] == "10.0.0.9"
+    assert doc["frontend"]["loadBalancerSourceRanges"] == ["10.0.0.0/8"]

--- a/agent/supervisor/tests/test_slot_image_mirror_overrides.py
+++ b/agent/supervisor/tests/test_slot_image_mirror_overrides.py
@@ -112,18 +112,44 @@ def test_latch_is_explicit_not_an_omission(monkeypatch) -> None:
     assert "slotImageMirror" in rec.doc
 
 
-def test_unreadable_current_state_falls_back_to_the_node_count(monkeypatch) -> None:
-    # A kubeapi blip must not turn the latch into a guess. Reading the live
-    # document fails closed to "{}", so the decision falls back to cp_size
-    # rather than to an invented previous state. (The WRITE still fails on
-    # an unreachable kubeapi — that is the upsert's own pre-existing
-    # behaviour, and it retries on the next heartbeat.)
+def test_an_unreadable_current_state_aborts_the_write(monkeypatch) -> None:
+    """Unknown != empty, and conflating them is how #792 comes back.
+
+    Merging onto ``{}`` produces a document holding only supervisor-owned
+    keys. If the READ failed but the WRITE then succeeds — a blip between
+    two calls milliseconds apart — that write deletes ``image.tag``, the one
+    key a cluster rolling upgrade is depending on mid-flight. So the write
+    is abandoned and retried on the next heartbeat.
+    """
+
     def _boom(method, path, body=None, content_type=None):
-        raise RuntimeError("kubeapi down")
+        if method == "GET":
+            raise RuntimeError("kubeapi down")
+        raise AssertionError("must not write when the current state is unknown")
 
     monkeypatch.setattr(k8s_api, "_request", _boom)
 
+    ok, err = k8s_api.apply_control_plane_overrides(2, "")
+
+    assert ok is False
+    assert err is not None
+
+
+def test_an_absent_cr_is_empty_not_unknown(monkeypatch) -> None:
+    # A 404 is a real answer — there is no document to preserve — so the
+    # first write on a fresh install must still go through.
+    rec = _Recorder()
+    monkeypatch.setattr(k8s_api, "_request", rec)
+
     assert k8s_api._helmchartconfig_doc("spatium-control") == {}
+
+    ok, err = k8s_api.apply_control_plane_overrides(2, "")
+    assert (ok, err) == (True, None)
+
+
+def test_the_latch_still_derives_from_the_node_count_when_nothing_is_written(
+    monkeypatch,
+) -> None:
     assert k8s_api._slot_image_mirror_enabled(2, {}) is True
     assert k8s_api._slot_image_mirror_enabled(1, {}) is False
 

--- a/backend/app/api/v1/appliance/upgrade_images.py
+++ b/backend/app/api/v1/appliance/upgrade_images.py
@@ -888,9 +888,34 @@ async def download_upgrade_image(
 
     if settings.slot_image_mirror_url:
         # #296 Phase B — bytes live on the mirror Deployment. Stream
-        # through. The mirror's 404 surfaces as 404 here; transport
-        # errors as 502.
-        return await _stream_download_from_mirror(row.id, filename=row.filename)
+        # through. Transport errors surface as 502.
+        try:
+            return await _stream_download_from_mirror(row.id, filename=row.filename)
+        except HTTPException as exc:
+            # #787 — a mirror MISS (404) is not necessarily "these bytes are
+            # gone". The appliance turns the mirror on at promote, so an image
+            # uploaded while the control plane was single-node sits on this
+            # node's hostPath while the mirror's PVC starts empty. Fall back to
+            # local FS for that window; on any other node the file is absent
+            # and the operator gets the same 404 they would have anyway.
+            #
+            # Only 404 falls through — a 502 means the mirror is unreachable or
+            # erroring, and serving a local copy there would silently mask a
+            # broken mirror on whichever replica happens to hold a stale file.
+            if exc.status_code != status.HTTP_404_NOT_FOUND:
+                raise
+            local = _image_path(row.id)
+            if not local.exists():
+                raise
+            logger.info(
+                "appliance.upgrade_image.served_from_local_after_mirror_miss",
+                image_id=str(row.id),
+            )
+            return FileResponse(
+                local,
+                media_type="application/octet-stream",
+                filename=row.filename,
+            )
 
     path = _image_path(row.id)
     if not path.exists():

--- a/backend/app/api/v1/appliance/upgrade_images.py
+++ b/backend/app/api/v1/appliance/upgrade_images.py
@@ -216,6 +216,25 @@ async def _stream_upload_through_mirror(
         )
 
 
+class MirrorUnavailable(Exception):
+    """The mirror could not be reached at all — connect / read failure.
+
+    Deliberately distinct from an HTTP error the mirror itself returned
+    (#787). Those two say very different things about the fleet:
+
+    * unreachable — the mirror pod is gone. Its PVC is RWO local-path, so
+      the single replica is pinned to one node, and losing that node leaves
+      it Pending indefinitely. Nothing about the stored image is wrong.
+    * answered with an error — the mirror is alive and refusing or failing.
+      A mismatched ``X-Mirror-Auth`` secret is the likely cause, and it is a
+      configuration fault that will never self-heal.
+
+    The download handler serves a local copy for the first and surfaces the
+    second, which is only expressible if the two do not collapse into one
+    status code.
+    """
+
+
 async def _stream_download_from_mirror(
     image_id: uuid.UUID,
     *,
@@ -226,6 +245,11 @@ async def _stream_download_from_mirror(
     The mirror serves a FileResponse; we open a streaming GET against
     it and pass the chunks through. The mirror's content-length passes
     through too, so the host runner's progress bar still works.
+
+    Raises :class:`MirrorUnavailable` when the mirror cannot be reached,
+    a 404 ``HTTPException`` when it reports the bytes absent, and a 502
+    ``HTTPException`` when it answers with anything else — three outcomes
+    the caller has to tell apart (#787).
 
     ``filename`` controls the ``Content-Disposition`` header so the
     browser / host runner sees the same filename as the local-FS path
@@ -246,10 +270,7 @@ async def _stream_download_from_mirror(
         upstream = await client.send(request, stream=True)
     except httpx.HTTPError as exc:
         await client.aclose()
-        raise HTTPException(
-            status.HTTP_502_BAD_GATEWAY,
-            f"Mirror download failed: {exc}",
-        ) from exc
+        raise MirrorUnavailable(str(exc)) from exc
     if upstream.status_code == 404:
         await upstream.aclose()
         await client.aclose()
@@ -977,49 +998,61 @@ async def download_upgrade_image(
 
     if settings.slot_image_mirror_url:
         # #296 Phase B — bytes live on the mirror Deployment. Stream through.
+        #
+        # #787 — two of the three ways that can fail mean "the mirror cannot
+        # answer right now", not "this image is wrong", and this replica may
+        # be holding the exact bytes. Both are real now that the mirror is on
+        # the mandatory upgrade path of every multi-node appliance:
+        #
+        # * 404 — the image predates the promote that enabled the mirror, so
+        #   it is on this node's hostPath while the mirror's PVC is empty.
+        # * unreachable — the mirror's PVC is RWO local-path, so the single
+        #   pod is pinned to one node; losing that node leaves it Pending
+        #   indefinitely. Refusing to serve a local copy would make an
+        #   unrelated node loss block every upgrade in the fleet, including
+        #   the one that repairs it.
+        #
+        # A mirror that ANSWERS with an error is the third case and is NOT
+        # covered. It is alive and refusing or failing — a mismatched
+        # X-Mirror-Auth secret being the likely cause — which is a
+        # configuration fault that never self-heals. Falling back there would
+        # let nodes holding a stale local copy quietly succeed while the rest
+        # of the fleet 502s, so the fault would be discovered as an
+        # inexplicably half-working upgrade instead of an error. It surfaces.
+        #
+        # Serving local bytes in the two covered cases is not a correctness
+        # risk: the host runner verifies them against the sha256 stamped
+        # alongside the URL, and delete_upgrade_image now clears local copies
+        # too, so a deleted image cannot resurface here.
         try:
             return await _stream_download_from_mirror(row.id, filename=row.filename)
+        except MirrorUnavailable as exc:
+            local = _image_path(row.id)
+            if not local.exists():
+                raise HTTPException(
+                    status.HTTP_502_BAD_GATEWAY,
+                    f"Mirror download failed: {exc}",
+                ) from exc
+            logger.warning(
+                "appliance_upgrade_image_served_from_local_mirror_unreachable",
+                image_id=str(row.id),
+                error=str(exc)[:200],
+            )
         except HTTPException as exc:
-            # #787 — the mirror failing is not the same as the image being
-            # gone, and this replica may be holding the exact bytes. Two
-            # distinct cases land here, both real now that the mirror is on
-            # the mandatory upgrade path of every multi-node appliance:
-            #
-            # * 404 — the image predates the promote that enabled the mirror,
-            #   so it is on this node's hostPath while the mirror's PVC is
-            #   empty.
-            # * 502 — the mirror is unreachable. Its PVC is RWO local-path,
-            #   so the single mirror pod is pinned to one node; losing that
-            #   node leaves it Pending indefinitely. Refusing to serve a
-            #   local copy would make an unrelated node loss block every
-            #   upgrade in the fleet, including the one that repairs it.
-            #
-            # Serving local bytes is not a correctness risk: the host runner
-            # verifies them against the sha256 stamped alongside the URL, and
-            # delete_upgrade_image now clears local copies too, so a deleted
-            # image cannot resurface here. The one thing worth protecting is
-            # visibility — a degraded mirror must not look healthy, hence the
-            # warning log on the non-404 path.
+            if exc.status_code != status.HTTP_404_NOT_FOUND:
+                raise
             local = _image_path(row.id)
             if not local.exists():
                 raise
-            if exc.status_code == status.HTTP_404_NOT_FOUND:
-                logger.info(
-                    "appliance_upgrade_image_served_from_local_after_mirror_miss",
-                    image_id=str(row.id),
-                )
-            else:
-                logger.warning(
-                    "appliance_upgrade_image_served_from_local_mirror_degraded",
-                    image_id=str(row.id),
-                    mirror_status=exc.status_code,
-                    detail=str(exc.detail)[:200],
-                )
-            return FileResponse(
-                local,
-                media_type="application/octet-stream",
-                filename=row.filename,
+            logger.info(
+                "appliance_upgrade_image_served_from_local_after_mirror_miss",
+                image_id=str(row.id),
             )
+        return FileResponse(
+            local,
+            media_type="application/octet-stream",
+            filename=row.filename,
+        )
 
     path = _image_path(row.id)
     if not path.exists():

--- a/backend/app/api/v1/appliance/upgrade_images.py
+++ b/backend/app/api/v1/appliance/upgrade_images.py
@@ -294,6 +294,49 @@ async def _stream_download_from_mirror(
     )
 
 
+async def _bytes_present_in_active_store(image_id: uuid.UUID) -> bool:
+    """Does the store a download would actually read from hold these bytes?
+
+    #787 — this is what makes "re-upload the image" a real remedy instead
+    of a no-op. Both ingest paths short-circuit on a duplicate SHA-256, so
+    an operator whose bytes are missing from the active store could
+    re-upload forever and change nothing.
+
+    When the mirror is configured the answer is about the MIRROR only,
+    deliberately, even though the api may also hold a local copy: a local
+    copy is readable on exactly one node, which is the condition being
+    repaired. Saying "present" because this replica happens to have the
+    file would leave the fleet in the state the re-upload was meant to fix.
+
+    A mirror that cannot be reached raises rather than guessing. Guessing
+    "absent" would re-download gigabytes from GitHub into a PUT that is
+    about to fail anyway; guessing "present" would silently skip a repair
+    the operator asked for.
+    """
+    if not settings.slot_image_mirror_url:
+        return _image_path(image_id).exists()
+
+    headers = {"X-Mirror-Auth": mirror_auth_token("get", image_id)}
+    async with httpx.AsyncClient(timeout=_MIRROR_HTTP_TIMEOUT) as client:
+        try:
+            # Starlette routes a GET as HEAD too, so this costs headers
+            # rather than the 1-4 GiB body.
+            resp = await client.head(_mirror_url(image_id), headers=headers)
+        except httpx.HTTPError as exc:
+            raise HTTPException(
+                status.HTTP_502_BAD_GATEWAY,
+                f"Could not reach the upgrade-image mirror: {exc}",
+            ) from exc
+    if resp.status_code == 404:
+        return False
+    if resp.status_code != 200:
+        raise HTTPException(
+            status.HTTP_502_BAD_GATEWAY,
+            f"Upgrade-image mirror returned {resp.status_code} on a presence check.",
+        )
+    return True
+
+
 async def _delete_from_mirror(image_id: uuid.UUID) -> None:
     """Issue DELETE against the mirror; tolerate 404 (already gone)."""
     headers = {"X-Mirror-Auth": mirror_auth_token("delete", image_id)}
@@ -547,7 +590,46 @@ async def upload_upgrade_image(
             select(ApplianceUpgradeImage).where(ApplianceUpgradeImage.sha256 == expected_sha)
         )
     ).scalar_one_or_none()
+
+    async def _file_iter() -> AsyncIterator[bytes]:
+        while True:
+            chunk = await file.read(_CHUNK_BYTES)
+            if not chunk:
+                return
+            yield chunk
+
     if existing is not None:
+        # ...unless the bytes are GONE from the active store, in which
+        # case the short-circuit is the bug (#787). Re-uploading is the
+        # documented remedy after a promote flips the mirror on and its
+        # PVC starts empty, and it has to actually store something.
+        if not await _bytes_present_in_active_store(existing.id):
+            # Re-store under the EXISTING id, not a new one: appliance
+            # rows may already carry a ``desired_slot_image_url`` built
+            # from it, and a fresh id would leave those pointing at
+            # nothing while the operator watches a "successful" upload.
+            repaired = await _store_verified_image(existing.id, _file_iter(), expected_sha)
+            db.add(
+                AuditLog(
+                    user_id=current_user.id,
+                    user_display_name=current_user.display_name,
+                    auth_source=current_user.auth_source,
+                    action="appliance.upgrade_image_bytes_restored",
+                    resource_type="appliance_upgrade_image",
+                    resource_id=str(existing.id),
+                    resource_display=f"{existing.filename} ({existing.appliance_version})",
+                    result="success",
+                    new_value={"size_bytes": repaired, "sha256": expected_sha},
+                )
+            )
+            await db.commit()
+            logger.info(
+                "appliance_upgrade_image_bytes_restored",
+                image_id=str(existing.id),
+                size_bytes=repaired,
+                user=current_user.username,
+            )
+            return _row_to_schema(existing)
         # Drain + discard the upload body so the client doesn't see a
         # half-read socket (httpx waits for the server's read before
         # closing the request — stalling here on a stale connection
@@ -557,13 +639,6 @@ async def upload_upgrade_image(
         return _row_to_schema(existing)
 
     image_id = uuid.uuid4()
-
-    async def _file_iter() -> AsyncIterator[bytes]:
-        while True:
-            chunk = await file.read(_CHUNK_BYTES)
-            if not chunk:
-                return
-            yield chunk
 
     bytes_written = await _store_verified_image(image_id, _file_iter(), expected_sha)
 
@@ -717,17 +792,23 @@ async def import_upgrade_image_from_github(
             f"The .sha256 sidecar for {tag} did not contain a 64-char hex digest.",
         )
 
-    # 2. Idempotent short-circuit — already imported/uploaded this hash.
+    # 2. Idempotent short-circuit — already imported/uploaded this hash
+    #    AND the bytes are still in the active store. #787: re-importing
+    #    is the connected-install equivalent of re-uploading, so when the
+    #    store has lost them (a promote moved it to a fresh mirror PVC)
+    #    the import has to re-fetch rather than report success and do
+    #    nothing. Re-stores under the existing id so any already-stamped
+    #    ``desired_slot_image_url`` keeps resolving.
     existing = (
         await db.execute(
             select(ApplianceUpgradeImage).where(ApplianceUpgradeImage.sha256 == expected_sha)
         )
     ).scalar_one_or_none()
-    if existing is not None:
+    if existing is not None and await _bytes_present_in_active_store(existing.id):
         return _row_to_schema(existing)
 
     # 3. Stream-download the .raw.xz + store with verification.
-    image_id = uuid.uuid4()
+    image_id = existing.id if existing is not None else uuid.uuid4()
     try:
         async with httpx.AsyncClient(timeout=_MIRROR_HTTP_TIMEOUT, follow_redirects=True) as client:
             async with client.stream("GET", spec.image_asset_url) as resp:
@@ -748,22 +829,30 @@ async def import_upgrade_image_from_github(
             f"Failed to download the {tag} upgrade image from GitHub: {exc}",
         ) from exc
 
-    row = ApplianceUpgradeImage(
-        id=image_id,
-        filename=_github_asset_filename(spec.image_asset_url),
-        size_bytes=bytes_written,
-        sha256=expected_sha,
-        appliance_version=tag,
-        uploaded_by_user_id=current_user.id,
-        notes=f"Imported from GitHub release {tag}",
-    )
-    db.add(row)
+    if existing is not None:
+        # Bytes-only repair of a row we already had — keep its metadata
+        # (filename / notes / who staged it) rather than rewriting the
+        # provenance of an image the operator staged some other way.
+        row = existing
+        action = "appliance.upgrade_image_bytes_restored"
+    else:
+        row = ApplianceUpgradeImage(
+            id=image_id,
+            filename=_github_asset_filename(spec.image_asset_url),
+            size_bytes=bytes_written,
+            sha256=expected_sha,
+            appliance_version=tag,
+            uploaded_by_user_id=current_user.id,
+            notes=f"Imported from GitHub release {tag}",
+        )
+        db.add(row)
+        action = "appliance.upgrade_image_imported"
     db.add(
         AuditLog(
             user_id=current_user.id,
             user_display_name=current_user.display_name,
             auth_source=current_user.auth_source,
-            action="appliance.upgrade_image_imported",
+            action=action,
             resource_type="appliance_upgrade_image",
             resource_id=str(row.id),
             resource_display=f"{row.filename} ({tag})",
@@ -887,30 +976,45 @@ async def download_upgrade_image(
         )
 
     if settings.slot_image_mirror_url:
-        # #296 Phase B — bytes live on the mirror Deployment. Stream
-        # through. Transport errors surface as 502.
+        # #296 Phase B — bytes live on the mirror Deployment. Stream through.
         try:
             return await _stream_download_from_mirror(row.id, filename=row.filename)
         except HTTPException as exc:
-            # #787 — a mirror MISS (404) is not necessarily "these bytes are
-            # gone". The appliance turns the mirror on at promote, so an image
-            # uploaded while the control plane was single-node sits on this
-            # node's hostPath while the mirror's PVC starts empty. Fall back to
-            # local FS for that window; on any other node the file is absent
-            # and the operator gets the same 404 they would have anyway.
+            # #787 — the mirror failing is not the same as the image being
+            # gone, and this replica may be holding the exact bytes. Two
+            # distinct cases land here, both real now that the mirror is on
+            # the mandatory upgrade path of every multi-node appliance:
             #
-            # Only 404 falls through — a 502 means the mirror is unreachable or
-            # erroring, and serving a local copy there would silently mask a
-            # broken mirror on whichever replica happens to hold a stale file.
-            if exc.status_code != status.HTTP_404_NOT_FOUND:
-                raise
+            # * 404 — the image predates the promote that enabled the mirror,
+            #   so it is on this node's hostPath while the mirror's PVC is
+            #   empty.
+            # * 502 — the mirror is unreachable. Its PVC is RWO local-path,
+            #   so the single mirror pod is pinned to one node; losing that
+            #   node leaves it Pending indefinitely. Refusing to serve a
+            #   local copy would make an unrelated node loss block every
+            #   upgrade in the fleet, including the one that repairs it.
+            #
+            # Serving local bytes is not a correctness risk: the host runner
+            # verifies them against the sha256 stamped alongside the URL, and
+            # delete_upgrade_image now clears local copies too, so a deleted
+            # image cannot resurface here. The one thing worth protecting is
+            # visibility — a degraded mirror must not look healthy, hence the
+            # warning log on the non-404 path.
             local = _image_path(row.id)
             if not local.exists():
                 raise
-            logger.info(
-                "appliance.upgrade_image.served_from_local_after_mirror_miss",
-                image_id=str(row.id),
-            )
+            if exc.status_code == status.HTTP_404_NOT_FOUND:
+                logger.info(
+                    "appliance_upgrade_image_served_from_local_after_mirror_miss",
+                    image_id=str(row.id),
+                )
+            else:
+                logger.warning(
+                    "appliance_upgrade_image_served_from_local_mirror_degraded",
+                    image_id=str(row.id),
+                    mirror_status=exc.status_code,
+                    detail=str(exc.detail)[:200],
+                )
             return FileResponse(
                 local,
                 media_type="application/octet-stream",
@@ -949,14 +1053,27 @@ async def delete_upgrade_image(image_id: uuid.UUID, current_user: CurrentUser, d
         # the DB row delete below is the authoritative signal; stale
         # bytes on the mirror get reaped by the future prune task.
         await _delete_from_mirror(row.id)
-    else:
-        path = _image_path(row.id)
-        try:
-            path.unlink(missing_ok=True)
-        except OSError:
-            # Disk-side cleanup is best-effort — the row delete below
-            # is the authoritative "this image is gone" signal.
-            pass
+    # #787 — always sweep local FS too, not just on the no-mirror branch.
+    # The appliance keeps the slot-images hostPath mounted even with the
+    # mirror on (so a pre-promote image is still readable), which means a
+    # local copy can exist in mirror mode. Skipping it here would strand
+    # 1-4 GiB per deleted image on the seed's /var forever — the "future
+    # prune task" the mirror branch defers to does not exist, and would
+    # not cover local FS anyway. It also removes the stale-bytes hazard
+    # the download fallback would otherwise inherit: without this, a
+    # deleted image could still be served from a node's local copy.
+    try:
+        _image_path(row.id).unlink(missing_ok=True)
+    except OSError as exc:
+        # Disk-side cleanup is best-effort — the row delete below is the
+        # authoritative "this image is gone" signal. Logged rather than
+        # swallowed so a permission / read-only-mount problem is visible
+        # instead of quietly accumulating gigabytes.
+        logger.warning(
+            "upgrade_image_local_unlink_failed",
+            image_id=str(row.id),
+            error=str(exc),
+        )
     filename = row.filename
     version = row.appliance_version
     await db.delete(row)

--- a/backend/tests/test_upgrade_image_mirror_fallback.py
+++ b/backend/tests/test_upgrade_image_mirror_fallback.py
@@ -1,0 +1,165 @@
+"""#787 — the download handler falls back to local FS when the mirror misses.
+
+The appliance turns the slot-image mirror on at PROMOTE (the supervisor
+derives ``slotImageMirror.enabled`` from the control-plane size), so an
+image staged while the box was still single-node sits on the seed's
+hostPath while the mirror's PVC comes up empty. Without a fallback the
+first multi-node upgrade after a promote fails on a download the operator
+cannot diagnose — the bytes are right there on the node.
+
+The fallback is deliberately narrow, and these tests pin both halves:
+
+* a mirror **404** falls through to local disk when the file is there;
+* a mirror **502** does not, because serving a local copy would mask an
+  unreachable or erroring mirror on whichever replica happens to hold a
+  stale file.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException, status
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.appliance import upgrade_images
+from app.models.appliance import ApplianceUpgradeImage
+
+pytestmark = pytest.mark.asyncio
+
+_BASE = "/api/v1/appliance/upgrade-images"
+_BYTES = b"\xfd7zXZ\x00fake-slot-image-payload"
+
+
+async def _seed_image(db: AsyncSession) -> ApplianceUpgradeImage:
+    image = ApplianceUpgradeImage(
+        id=uuid.uuid4(),
+        filename="spatiumddi-appliance-slot-2026.08.01-1-amd64.raw.xz",
+        size_bytes=len(_BYTES),
+        sha256="b" * 64,
+        appliance_version="2026.08.01-1",
+    )
+    db.add(image)
+    await db.flush()
+    return image
+
+
+def _stage_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, image_id: uuid.UUID) -> Path:
+    """Put real bytes where the pre-promote hostPath would have them."""
+    path = tmp_path / f"{image_id}.raw.xz"
+    path.write_bytes(_BYTES)
+    monkeypatch.setattr(upgrade_images, "_image_path", lambda _id: tmp_path / f"{_id}.raw.xz")
+    return path
+
+
+def _mirror_raises(monkeypatch: pytest.MonkeyPatch, exc: HTTPException) -> None:
+    monkeypatch.setattr(upgrade_images.settings, "slot_image_mirror_url", "http://mirror")
+
+    async def _boom(*_args, **_kwargs):
+        raise exc
+
+    monkeypatch.setattr(upgrade_images, "_stream_download_from_mirror", _boom)
+
+
+def _url(image: ApplianceUpgradeImage) -> str:
+    token = upgrade_images.slot_image_download_token(image.id)
+    return f"{_BASE}/{image.id}/raw.xz?t={token}"
+
+
+async def test_mirror_miss_serves_the_pre_promote_local_copy(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    image = await _seed_image(db_session)
+    _stage_local(monkeypatch, tmp_path, image.id)
+    _mirror_raises(
+        monkeypatch,
+        HTTPException(status.HTTP_404_NOT_FOUND, "Upgrade image bytes missing on mirror"),
+    )
+
+    resp = await client.get(_url(image))
+
+    assert resp.status_code == 200
+    assert resp.content == _BYTES
+
+
+async def test_mirror_miss_with_no_local_copy_still_404s(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Every node that did NOT serve the original upload lands here — the
+    # fallback must not invent a different outcome for them.
+    image = await _seed_image(db_session)
+    monkeypatch.setattr(upgrade_images, "_image_path", lambda _id: tmp_path / f"{_id}.raw.xz")
+    _mirror_raises(
+        monkeypatch,
+        HTTPException(status.HTTP_404_NOT_FOUND, "Upgrade image bytes missing on mirror"),
+    )
+
+    resp = await client.get(_url(image))
+
+    assert resp.status_code == 404
+
+
+async def test_mirror_transport_error_is_not_masked_by_a_local_copy(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # A 502 means the mirror is broken, not that the image is absent from
+    # it. Falling back here would let a whole fleet upgrade off stale local
+    # copies while the real store is down and nobody is told.
+    image = await _seed_image(db_session)
+    _stage_local(monkeypatch, tmp_path, image.id)
+    _mirror_raises(
+        monkeypatch,
+        HTTPException(status.HTTP_502_BAD_GATEWAY, "Mirror download failed: boom"),
+    )
+
+    resp = await client.get(_url(image))
+
+    assert resp.status_code == 502
+
+
+async def test_no_mirror_configured_still_serves_local_directly(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # The single-node path is untouched by the fallback branch.
+    image = await _seed_image(db_session)
+    _stage_local(monkeypatch, tmp_path, image.id)
+    monkeypatch.setattr(upgrade_images.settings, "slot_image_mirror_url", "")
+
+    resp = await client.get(_url(image))
+
+    assert resp.status_code == 200
+    assert resp.content == _BYTES
+
+
+async def test_fallback_does_not_bypass_the_download_token(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Auth is checked before either storage path is consulted; the new
+    # branch must not become a way in without a valid ``?t=``.
+    image = await _seed_image(db_session)
+    _stage_local(monkeypatch, tmp_path, image.id)
+    _mirror_raises(
+        monkeypatch,
+        HTTPException(status.HTTP_404_NOT_FOUND, "Upgrade image bytes missing on mirror"),
+    )
+
+    assert (await client.get(f"{_BASE}/{image.id}/raw.xz")).status_code == 401
+    assert (await client.get(f"{_BASE}/{image.id}/raw.xz?t=nope")).status_code == 403

--- a/backend/tests/test_upgrade_image_mirror_fallback.py
+++ b/backend/tests/test_upgrade_image_mirror_fallback.py
@@ -7,19 +7,24 @@ hostPath while the mirror's PVC comes up empty. Without a fallback the
 first multi-node upgrade after a promote fails on a download the operator
 cannot diagnose — the bytes are right there on the node.
 
-Both mirror failure modes fall back when this replica holds the bytes:
+Two of the three ways the mirror can fail mean "it cannot answer right
+now", and both fall back when this replica holds the bytes:
 
 * **404** — the image predates the promote that enabled the mirror.
-* **502** — the mirror is unreachable. Its PVC is RWO local-path, so the
-  single mirror pod is pinned to one node; losing that node would
-  otherwise block every upgrade in the fleet, including the one that
-  repairs it.
+* **unreachable** — the mirror's PVC is RWO local-path, so the single pod
+  is pinned to one node; losing that node would otherwise block every
+  upgrade in the fleet, including the one that repairs it.
 
-Serving local bytes is safe because the host runner verifies them against
-the stamped sha256 and ``delete_upgrade_image`` now clears local copies
-too, so a deleted image cannot resurface. What must not happen is a
-degraded mirror looking healthy — hence the warning-level log, asserted
-here.
+The third — a mirror that ANSWERS with an error — does **not** fall back.
+It is alive and refusing or failing, most likely a mismatched
+``X-Mirror-Auth`` secret, which never self-heals. Falling back there would
+let nodes holding a stale local copy quietly succeed while the rest of the
+fleet 502s, so the fault would surface as an inexplicably half-working
+upgrade rather than an error.
+
+Serving local bytes in the two covered cases is safe because the host
+runner verifies them against the stamped sha256 and ``delete_upgrade_image``
+now clears local copies too, so a deleted image cannot resurface.
 
 Also covers the two halves that make "re-upload it" a real remedy rather
 than a no-op: both ingest paths re-store when the active store has lost
@@ -68,7 +73,7 @@ def _stage_local(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, image_id: uuid
     return path
 
 
-def _mirror_raises(monkeypatch: pytest.MonkeyPatch, exc: HTTPException) -> None:
+def _mirror_raises(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
     monkeypatch.setattr(upgrade_images.settings, "slot_image_mirror_url", "http://mirror")
 
     async def _boom(*_args, **_kwargs):
@@ -132,10 +137,7 @@ async def test_unreachable_mirror_falls_back_and_warns(
     # the degradation has to be visible, not silent.
     image = await _seed_image(db_session)
     _stage_local(monkeypatch, tmp_path, image.id)
-    _mirror_raises(
-        monkeypatch,
-        HTTPException(status.HTTP_502_BAD_GATEWAY, "Mirror download failed: boom"),
-    )
+    _mirror_raises(monkeypatch, upgrade_images.MirrorUnavailable("connect timeout"))
     warnings: list[tuple[str, dict]] = []
     monkeypatch.setattr(
         upgrade_images.logger,
@@ -147,7 +149,9 @@ async def test_unreachable_mirror_falls_back_and_warns(
 
     assert resp.status_code == 200
     assert resp.content == _BYTES
-    assert [e for e, _ in warnings] == ["appliance_upgrade_image_served_from_local_mirror_degraded"]
+    assert [e for e, _ in warnings] == [
+        "appliance_upgrade_image_served_from_local_mirror_unreachable"
+    ]
 
 
 async def test_unreachable_mirror_with_no_local_copy_still_502s(
@@ -161,14 +165,38 @@ async def test_unreachable_mirror_with_no_local_copy_still_502s(
     # send the operator down the wrong path.
     image = await _seed_image(db_session)
     monkeypatch.setattr(upgrade_images, "_image_path", lambda _id: tmp_path / f"{_id}.raw.xz")
+    _mirror_raises(monkeypatch, upgrade_images.MirrorUnavailable("connect timeout"))
+
+    resp = await client.get(_url(image))
+
+    assert resp.status_code == 502
+
+
+async def test_a_mirror_that_answers_with_an_error_is_not_masked(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The case that made the fallback too broad.
+
+    A mismatched ``X-Mirror-Auth`` secret makes the mirror answer 401, which
+    the proxy wraps as a 502. Serving the local copy there would let every
+    node holding one succeed while the rest of the fleet 502s — so the
+    operator meets a half-working upgrade instead of a configuration error,
+    and the mirror stays misconfigured because nothing ever complained.
+    """
+    image = await _seed_image(db_session)
+    _stage_local(monkeypatch, tmp_path, image.id)
     _mirror_raises(
         monkeypatch,
-        HTTPException(status.HTTP_502_BAD_GATEWAY, "Mirror download failed: boom"),
+        HTTPException(status.HTTP_502_BAD_GATEWAY, "Mirror returned 401: b'forbidden'"),
     )
 
     resp = await client.get(_url(image))
 
     assert resp.status_code == 502
+    assert "401" in resp.text
 
 
 async def test_no_mirror_configured_still_serves_local_directly(

--- a/backend/tests/test_upgrade_image_mirror_fallback.py
+++ b/backend/tests/test_upgrade_image_mirror_fallback.py
@@ -7,12 +7,23 @@ hostPath while the mirror's PVC comes up empty. Without a fallback the
 first multi-node upgrade after a promote fails on a download the operator
 cannot diagnose — the bytes are right there on the node.
 
-The fallback is deliberately narrow, and these tests pin both halves:
+Both mirror failure modes fall back when this replica holds the bytes:
 
-* a mirror **404** falls through to local disk when the file is there;
-* a mirror **502** does not, because serving a local copy would mask an
-  unreachable or erroring mirror on whichever replica happens to hold a
-  stale file.
+* **404** — the image predates the promote that enabled the mirror.
+* **502** — the mirror is unreachable. Its PVC is RWO local-path, so the
+  single mirror pod is pinned to one node; losing that node would
+  otherwise block every upgrade in the fleet, including the one that
+  repairs it.
+
+Serving local bytes is safe because the host runner verifies them against
+the stamped sha256 and ``delete_upgrade_image`` now clears local copies
+too, so a deleted image cannot resurface. What must not happen is a
+degraded mirror looking healthy — hence the warning-level log, asserted
+here.
+
+Also covers the two halves that make "re-upload it" a real remedy rather
+than a no-op: both ingest paths re-store when the active store has lost
+the bytes, and delete cleans local FS even in mirror mode.
 """
 
 from __future__ import annotations
@@ -26,7 +37,9 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.v1.appliance import upgrade_images
+from app.core.security import create_access_token, hash_password
 from app.models.appliance import ApplianceUpgradeImage
+from app.models.auth import User
 
 pytestmark = pytest.mark.asyncio
 
@@ -108,17 +121,46 @@ async def test_mirror_miss_with_no_local_copy_still_404s(
     assert resp.status_code == 404
 
 
-async def test_mirror_transport_error_is_not_masked_by_a_local_copy(
+async def test_unreachable_mirror_falls_back_and_warns(
     client: AsyncClient,
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    # A 502 means the mirror is broken, not that the image is absent from
-    # it. Falling back here would let a whole fleet upgrade off stale local
-    # copies while the real store is down and nobody is told.
+    # The mirror pod is pinned to one node by its RWO PVC. Losing that node
+    # must not block an upgrade on a replica that has the exact bytes — but
+    # the degradation has to be visible, not silent.
     image = await _seed_image(db_session)
     _stage_local(monkeypatch, tmp_path, image.id)
+    _mirror_raises(
+        monkeypatch,
+        HTTPException(status.HTTP_502_BAD_GATEWAY, "Mirror download failed: boom"),
+    )
+    warnings: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        upgrade_images.logger,
+        "warning",
+        lambda event, **kw: warnings.append((event, kw)),
+    )
+
+    resp = await client.get(_url(image))
+
+    assert resp.status_code == 200
+    assert resp.content == _BYTES
+    assert [e for e, _ in warnings] == ["appliance_upgrade_image_served_from_local_mirror_degraded"]
+
+
+async def test_unreachable_mirror_with_no_local_copy_still_502s(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Nothing to serve — the mirror's own error is the honest answer, and
+    # must not be flattened into a 404 ("re-upload required") that would
+    # send the operator down the wrong path.
+    image = await _seed_image(db_session)
+    monkeypatch.setattr(upgrade_images, "_image_path", lambda _id: tmp_path / f"{_id}.raw.xz")
     _mirror_raises(
         monkeypatch,
         HTTPException(status.HTTP_502_BAD_GATEWAY, "Mirror download failed: boom"),
@@ -163,3 +205,125 @@ async def test_fallback_does_not_bypass_the_download_token(
 
     assert (await client.get(f"{_BASE}/{image.id}/raw.xz")).status_code == 401
     assert (await client.get(f"{_BASE}/{image.id}/raw.xz?t=nope")).status_code == 403
+
+
+# ── "Re-upload it" has to actually re-store ──────────────────────────
+
+
+async def _superadmin_headers(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"admin-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test Admin",
+        hashed_password=hash_password("test-pw-787"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+def _upload_files() -> dict:
+    return {"file": ("image.raw.xz", _BYTES, "application/octet-stream")}
+
+
+def _upload_form(image: ApplianceUpgradeImage) -> dict[str, str]:
+    return {
+        "sha256": image.sha256,
+        "appliance_version": image.appliance_version,
+    }
+
+
+async def test_duplicate_upload_restores_bytes_missing_from_the_store(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The documented post-promote remedy, which used to be a no-op.
+
+    The row exists (same sha256) but the mirror's PVC came up empty, so the
+    duplicate short-circuit returned success while storing nothing — the
+    operator could re-upload forever and change nothing.
+    """
+    image = await _seed_image(db_session)
+    headers = await _superadmin_headers(db_session)
+    monkeypatch.setattr(upgrade_images.settings, "slot_image_mirror_url", "http://mirror")
+
+    async def _absent(_id):
+        return False
+
+    stored: dict[str, uuid.UUID] = {}
+
+    async def _store(image_id, source, expected_sha):
+        written = 0
+        async for chunk in source:
+            written += len(chunk)
+        stored["id"] = image_id
+        return written
+
+    monkeypatch.setattr(upgrade_images, "_bytes_present_in_active_store", _absent)
+    monkeypatch.setattr(upgrade_images, "_store_verified_image", _store)
+
+    resp = await client.post(
+        _BASE, headers=headers, files=_upload_files(), data=_upload_form(image)
+    )
+
+    assert resp.status_code == 200
+    # Re-stored under the EXISTING id — a fresh one would leave any
+    # already-stamped desired_slot_image_url pointing at nothing.
+    assert stored["id"] == image.id
+    assert resp.json()["id"] == str(image.id)
+
+
+async def test_duplicate_upload_still_short_circuits_when_bytes_are_present(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The idempotent path is the common one and must stay cheap: no re-store
+    # of a 1-4 GiB body just because the operator clicked upload twice.
+    image = await _seed_image(db_session)
+    headers = await _superadmin_headers(db_session)
+    monkeypatch.setattr(upgrade_images.settings, "slot_image_mirror_url", "http://mirror")
+
+    async def _present(_id):
+        return True
+
+    async def _never(*_args, **_kwargs):
+        raise AssertionError("must not re-store when the bytes are already there")
+
+    monkeypatch.setattr(upgrade_images, "_bytes_present_in_active_store", _present)
+    monkeypatch.setattr(upgrade_images, "_store_verified_image", _never)
+
+    resp = await client.post(
+        _BASE, headers=headers, files=_upload_files(), data=_upload_form(image)
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["id"] == str(image.id)
+
+
+async def test_delete_clears_the_local_copy_in_mirror_mode(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # The hostPath stays mounted with the mirror on, so a local copy can
+    # exist. Leaving it behind would strand gigabytes per deleted image AND
+    # let the download fallback serve something the operator deleted.
+    image = await _seed_image(db_session)
+    headers = await _superadmin_headers(db_session)
+    local = _stage_local(monkeypatch, tmp_path, image.id)
+    monkeypatch.setattr(upgrade_images.settings, "slot_image_mirror_url", "http://mirror")
+
+    async def _noop_delete(_id):
+        return None
+
+    monkeypatch.setattr(upgrade_images, "_delete_from_mirror", _noop_delete)
+
+    resp = await client.delete(f"{_BASE}/{image.id}", headers=headers)
+
+    assert resp.status_code == 204
+    assert not local.exists()

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -122,18 +122,23 @@ spec:
             - name: spatiumddi-host-etc
               mountPath: /etc/spatiumddi-host
               readOnly: true
-            {{- if not .Values.slotImageMirror.enabled }}
             # #386 — uploaded / GitHub-imported upgrade-image bytes. Without
             # a persistent mount these live in the api's ephemeral container
             # layer and vanish on every api restart: the DB row survives but
             # the bytes 404 ("Upgrade image bytes missing on disk — re-upload
             # required"), so a scheduled upgrade fails on download. The
             # multi-node slot-image mirror (#296) holds these on its own PVC
-            # and the api proxies byte ops there, so this single-node hostPath
-            # only applies when the mirror is off. api WRITES here.
+            # and the api proxies byte ops there. api WRITES here.
+            #
+            # #787 — mounted even when the mirror is ON, which reads as
+            # redundant and is not. The appliance flips the mirror on at
+            # PROMOTE (the supervisor derives it from the control-plane size),
+            # so an image uploaded while the box was single-node is already on
+            # this hostPath when the mirror's PVC comes up empty. The download
+            # handler falls back to local FS on a mirror miss and finds it
+            # here. A DirectoryOrCreate hostPath costs nothing when unused.
             - name: slot-images
               mountPath: /var/lib/spatiumddi/slot-images
-            {{- end }}
             # #59 — packet-capture .pcap store. api READS here on download;
             # the worker writes. Single-node shared hostPath (firstboot
             # chowns it 1000:1000). Always mounted (not mirror-gated).
@@ -154,14 +159,14 @@ spec:
           hostPath:
             path: {{ .Values.api.applianceHostMounts.hostEtcDir }}
             type: DirectoryOrCreate
-        {{- if not .Values.slotImageMirror.enabled }}
-        # #386 — persist upgrade-image bytes across api restarts (single
-        # node; the mirror's PVC handles the multi-node case).
+        # #386 — persist upgrade-image bytes across api restarts. The
+        # mirror's PVC is where they live once the mirror is on (#296);
+        # this stays mounted regardless so a pre-promote upload survives
+        # the switch-over (#787 — see the volumeMount comment).
         - name: slot-images
           hostPath:
             path: {{ .Values.api.applianceHostMounts.slotImagesDir }}
             type: DirectoryOrCreate
-        {{- end }}
         # #59 — packet-capture .pcap store (shared with the worker).
         - name: pcaps
           hostPath:

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -157,13 +157,21 @@ api:
 # installs). Single-instance docker-compose / plain k8s installs that
 # just helm-upgrade through standard rolling updates don't need it.
 #
-# TURN THIS ON for a multi-node control plane that upgrades from UPLOADED
-# images. It stays off by default because the PVC is real storage the
-# single-node appliance (whose /var is the remainder of a 32 GiB minimum
-# disk) should not be asked to reserve. With it off on multi-node, uploaded
-# bytes live on whichever api replica served the upload, and the host's
-# download 404s from every other one (#787). Upgrading from an external
-# image URL needs no mirror at all.
+# REQUIRED whenever api.replicas > 1 AND you upgrade from UPLOADED images.
+# With it off, uploaded bytes live on whichever api replica served the
+# upload and the host's download 404s from every other one (#787). It
+# stays off by DEFAULT because the PVC is real storage the single-node
+# appliance (whose /var is the remainder of a 32 GiB minimum disk) should
+# not be asked to reserve. Upgrading from an external image URL needs no
+# mirror at all.
+#
+# ON THE APPLIANCE THIS IS AUTOMATIC and you should not set it here: the
+# seed supervisor derives it from the control-plane size and writes it to
+# the spatium-control HelmChartConfig on every promote/demote, so a
+# multi-node appliance turns the mirror on by itself and a demote releases
+# the PVC (agent/supervisor/spatium_supervisor/k8s_api.py,
+# _slot_image_mirror_values). This knob is for BYO-Kubernetes installs,
+# where nothing tracks the replica count for you.
 slotImageMirror:
   enabled: false
   storage:

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -167,11 +167,13 @@ api:
 #
 # ON THE APPLIANCE THIS IS AUTOMATIC and you should not set it here: the
 # seed supervisor derives it from the control-plane size and writes it to
-# the spatium-control HelmChartConfig on every promote/demote, so a
-# multi-node appliance turns the mirror on by itself and a demote releases
-# the PVC (agent/supervisor/spatium_supervisor/k8s_api.py,
-# _slot_image_mirror_values). This knob is for BYO-Kubernetes installs,
-# where nothing tracks the replica count for you.
+# the spatium-control HelmChartConfig, so a multi-node appliance turns the
+# mirror on by itself (agent/supervisor/spatium_supervisor/k8s_api.py,
+# _slot_image_mirror_enabled). It LATCHES — a later demote leaves it on,
+# because switching back would reclaim nothing (the PVC + Secret below
+# carry helm.sh/resource-policy: keep, so Helm never deletes them) while
+# stranding every image that exists only on the mirror. This knob is for
+# BYO-Kubernetes installs, where nothing tracks the replica count for you.
 slotImageMirror:
   enabled: false
   storage:

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -135,7 +135,10 @@ api:
     # (SPATIUM_SLOT_IMAGE_DIR, default /var/lib/spatiumddi/slot-images).
     # Persists uploaded / GitHub-imported images across api restarts so
     # they don't 404 with "bytes missing on disk" on the next upgrade.
-    # Only mounted when the multi-node slot-image mirror is off.
+    # Mounted even when the mirror is on (#787): the mirror is enabled at
+    # promote, so an image staged while the box was single-node is still
+    # here when the mirror's PVC comes up empty, and the download handler
+    # falls back to it.
     slotImagesDir: /var/lib/spatiumddi/slot-images
     # #59 — host dir backing packet-capture .pcap artifacts
     # (SPATIUM_PCAP_DIR). Shared by api (reads on download) + worker

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1214,18 +1214,28 @@ control-plane cluster itself, not the registered agent fleet.
    host runner pulls bytes back through the control plane. No node ever
    talks to github.com.
 
-   > **Multi-node needs the mirror turned on.** Where those bytes live
-   > depends on `slotImageMirror.enabled` (`slot-image-mirror` Deployment
-   > + PVC — the mirror infra keeps the historical name). It is **off by
-   > default**, and with it off the bytes sit on a node-local hostPath —
-   > specifically, on whichever api replica served the upload. That is
-   > correct for a single-node appliance and wrong for every other shape:
-   > the host's download round-robins across api replicas and any replica
-   > without the bytes answers 404 ("bytes missing on disk — re-upload
-   > required", which is misleading: the bytes exist, on a node you cannot
-   > see). Turn the mirror on before upgrading a multi-node control plane
-   > from an uploaded image, or upgrade from an external image URL, which
-   > needs no mirror (#787).
+   > **Multi-node uses the mirror, and turns it on for you.** Where those
+   > bytes live depends on `slotImageMirror.enabled` (`slot-image-mirror`
+   > Deployment + PVC — the mirror infra keeps the historical name). With
+   > it off the bytes sit on a node-local hostPath — specifically, on
+   > whichever api replica served the upload. That is correct for a
+   > single-node appliance and wrong for every other shape: the host's
+   > download round-robins across api replicas and any replica without the
+   > bytes answers 404 ("bytes missing on disk — re-upload required", which
+   > is misleading: the bytes exist, on a node you cannot see).
+   >
+   > On the appliance you do not configure this (#787). The seed supervisor
+   > derives it from the control-plane size and writes it to the
+   > `spatium-control` HelmChartConfig on every promote/demote, so growing
+   > past one node enables the mirror and shrinking back releases the PVC.
+   > One caveat at the transition: an image uploaded **before** the promote
+   > is on the seed's hostPath, not on the mirror's fresh PVC. The api
+   > falls back to local disk when the mirror misses, which recovers it if
+   > the download lands on the seed — re-upload it after promoting to stop
+   > depending on that. A **BYO-Kubernetes** control plane with
+   > `api.replicas > 1` still has to set `slotImageMirror.enabled=true`
+   > itself; nothing there tracks the replica count. Upgrading from an
+   > external image URL needs no mirror either way.
 2. **URL** (connected install). Operator pastes the GitHub release
    asset URL — same `https://github.com/.../spatiumddi-appliance-
    slot-amd64.raw.xz` shape the per-box flow uses. Each node fetches
@@ -1292,9 +1302,10 @@ so a first-time operator never gets stuck looking for the upload.
 
 2. Copy both files to the airgap LAN (USB stick, SCP through a jump
    host, whatever your security team approves).
-   NOTE on a MULTI-NODE control plane: set `slotImageMirror.enabled=true`
-   first, or the uploaded bytes stay on one api replica and the other
-   nodes' downloads 404 (#787).
+   NOTE on a MULTI-NODE appliance the mirror is already on (the supervisor
+   enables it at promote), so uploaded bytes are reachable from every api
+   replica. Upload AFTER promoting — an image staged while the box was
+   still single-node sits on the seed's hostPath, not the mirror (#787).
 
 3. In the SpatiumDDI UI (control-plane node, any operator browser
    that can reach the cluster):

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1234,10 +1234,14 @@ control-plane cluster itself, not the registered agent fleet.
    >
    > One caveat at the transition: an image staged **before** the promote is
    > on the seed's hostPath, not on the mirror's fresh PVC. Two things cover
-   > it — the api falls back to local disk when the mirror cannot serve, and
-   > re-uploading (or re-importing) the same image now genuinely re-stores
-   > the bytes instead of short-circuiting on the duplicate checksum. Either
-   > recovers it; the re-upload is the one that fixes it for every node.
+   > it — the api falls back to local disk when the mirror reports the image
+   > missing or cannot be reached at all, and re-uploading (or re-importing)
+   > the same image now genuinely re-stores the bytes instead of
+   > short-circuiting on the duplicate checksum. Either recovers it; the
+   > re-upload is the one that fixes it for every node. A mirror that
+   > *answers* with an error is deliberately not covered — that is a fault
+   > (usually a mismatched `X-Mirror-Auth` secret) worth surfacing rather
+   > than papering over on whichever nodes happen to hold a local copy.
    >
    > A **BYO-Kubernetes** control plane with `api.replicas > 1` still has to
    > set `slotImageMirror.enabled=true` itself; nothing there tracks the

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1226,16 +1226,23 @@ control-plane cluster itself, not the registered agent fleet.
    >
    > On the appliance you do not configure this (#787). The seed supervisor
    > derives it from the control-plane size and writes it to the
-   > `spatium-control` HelmChartConfig on every promote/demote, so growing
-   > past one node enables the mirror and shrinking back releases the PVC.
-   > One caveat at the transition: an image uploaded **before** the promote
-   > is on the seed's hostPath, not on the mirror's fresh PVC. The api
-   > falls back to local disk when the mirror misses, which recovers it if
-   > the download lands on the seed — re-upload it after promoting to stop
-   > depending on that. A **BYO-Kubernetes** control plane with
-   > `api.replicas > 1` still has to set `slotImageMirror.enabled=true`
-   > itself; nothing there tracks the replica count. Upgrading from an
-   > external image URL needs no mirror either way.
+   > `spatium-control` HelmChartConfig, so growing past one node enables the
+   > mirror. It **latches**: a later demote leaves it on, because turning it
+   > off would reclaim nothing (the PVC and its Secret are
+   > `helm.sh/resource-policy: keep`, so Helm never deletes them) while
+   > making every mirror-only image unreachable.
+   >
+   > One caveat at the transition: an image staged **before** the promote is
+   > on the seed's hostPath, not on the mirror's fresh PVC. Two things cover
+   > it — the api falls back to local disk when the mirror cannot serve, and
+   > re-uploading (or re-importing) the same image now genuinely re-stores
+   > the bytes instead of short-circuiting on the duplicate checksum. Either
+   > recovers it; the re-upload is the one that fixes it for every node.
+   >
+   > A **BYO-Kubernetes** control plane with `api.replicas > 1` still has to
+   > set `slotImageMirror.enabled=true` itself; nothing there tracks the
+   > replica count. Upgrading from an external image URL needs no mirror
+   > either way.
 2. **URL** (connected install). Operator pastes the GitHub release
    asset URL — same `https://github.com/.../spatiumddi-appliance-
    slot-amd64.raw.xz` shape the per-box flow uses. Each node fetches


### PR DESCRIPTION
Fixes the field-reported **4XX when pulling the upgrade image** on a multi-node appliance, plus a pre-existing bug found reviewing it.

## #787 — the download 404

The Fleet UI defaults to the **uploaded** image source. Those bytes land on a node-local hostPath — on whichever api replica served the upload — and the host runner's download round-robins through the api Service. On a multi-node control plane roughly half the downloads hit a replica without the bytes and get `404 "bytes missing on disk — re-upload required"`. That message is actively misleading: the bytes exist, on a node the operator cannot see, and re-uploading could not fix it.

The mirror that solves this shipped in **#296 Phase B** and has been sitting there unused: it defaults off, and the appliance never turned it on. The feature was unreachable from the only deployment shape that needs it.

**The seed supervisor now derives `slotImageMirror.enabled` from the control-plane size** and writes it to the `spatium-control` HelmChartConfig alongside the replica counts. `cp_size` *is* the api replica count — set from the same number two lines below — so this tracks the real invariant ("can a download land on a replica that did not serve the upload?") rather than a proxy for it. An earlier revision of this work refused at schedule time on *appliance-node* count, which missed stock multi-replica plain-k8s while falsely refusing single-api-replica appliance fleets; that was reverted in `23e7d2c0` on the previous branch and is not what is here.

Single-node installs are untouched — hostPath, no PVC, which was the stated reason the chart default is off. BYO-Kubernetes still sets the value itself; `values.yaml` now says so instead of telling every operator to flip it.

**It latches.** A later demote leaves the mirror on, because turning it off would reclaim nothing — the PVC and its auth Secret carry `helm.sh/resource-policy: keep`, so Helm never deletes them and nothing else reaps them — while stranding every image that exists only on the PVC, producing the exact 404 this PR removes. The value is written explicitly in both states because helm-controller *merges* a HelmChartConfig rather than diffing it, so a latch cannot be expressed by omission.

### The promote transition

An image staged **before** the promote sits on the seed's hostPath while the mirror's PVC comes up empty. Three changes make that survivable:

- **The appliance keeps the slot-images hostPath mounted even with the mirror on**, so the file is still there to find.
- **The download handler falls back to local FS when the mirror cannot answer** — on a 404 (the image predates the promote) and when the mirror is *unreachable*. The second matters more than it first looks: the mirror is a single-replica Deployment on an RWO local-path PVC, so it is pinned to one node, and it is now on the mandatory upgrade path of every multi-node appliance. Refusing to serve a local copy there would let one unrelated node loss block every upgrade in the fleet, including the one that repairs it. Serving local bytes is safe — the host runner verifies them against the stamped sha256, and delete now clears local copies so a deleted image cannot resurface.

  A mirror that **answers** with an error is deliberately *not* covered. It is alive and refusing or failing — a mismatched `X-Mirror-Auth` secret being the likely cause — which never self-heals. Falling back there would let nodes holding a local copy quietly succeed while the rest of the fleet 502s, so the operator would meet an inexplicably half-working upgrade instead of a configuration error. The two cases are distinguishable because the mirror proxy raises `MirrorUnavailable` for a transport failure rather than folding it into the same 502 it uses for an unexpected upstream status.
- **"Re-upload it" now actually re-stores.** Both ingest paths short-circuited on a duplicate SHA-256 (upload drained the body and returned the existing row; import returned before fetching), so the documented remedy was a no-op the operator could repeat forever. Both now ask whether the *active* store holds the bytes and re-store when it does not, under the **existing** id so an already-stamped `desired_slot_image_url` keeps resolving. Presence is asked of the mirror only, deliberately: a local copy is readable on exactly one node, which is the condition being repaired.

**Delete now cleans both stores.** With the hostPath mounted in mirror mode, the mirror-only delete branch would strand 1–4 GiB per deleted image on the seed's `/var` forever — the "future prune task" its comment defers to does not exist. This also closes the one hazard the fallback would otherwise carry: a deleted image can no longer resurface from a node's local copy.

## #792 — two writers, one CR (pre-existing)

`apply_control_plane_overrides` assigned a hand-concatenated `valuesContent` **wholesale**, deleting every key it does not own. One of those keys is load-bearing: `chart_bump._patch_image_tag` stamps `image.tag` on the *same* `spatium-control` HelmChartConfig to roll the control plane to a new version. The supervisor runs on every heartbeat, so within ~30 s — mid-upgrade — it PATCHed its own string back and took the tag with it, and helm-controller re-applied the chart at its default.

There was a quieter half too: the two renderings could never produce the same string for the same logical document, so the upsert's idempotent compare never held and each side PATCHed the other back on every cycle, rolling Deployments for no reason.

The supervisor now builds a dict, deep-merges onto the parsed live document, and dumps through the **same** normalisation `chart_bump` uses. Merging stops the deletion; the shared normalisation makes the compare hold, so a settled document produces no write at all.

Worth knowing if you add supervisor-owned values later: the write is a merge now, so a key *removed* from the owned dict is no longer removed from the CR.

## Testing

`make ci` green. 291 supervisor tests, 63 related backend tests (`test_upgrade_images`, `test_slot_image_mirror`, `test_appliance_upgrade_download`, `test_slot_image_target`, `test_upgrades_chart_bump`), `helm lint` clean, and the chart rendered both ways.

21 new tests. Supervisor: latch in both directions, malformed/unreadable current state, `image.tag` survives an override write, foreign nested keys (`api.resources`) survive, a second call against the first call's output writes nothing. Backend: both fallback modes and their no-local-copy counterparts, the warning on the degraded path, re-store on a duplicate when bytes are missing, no re-store when present, delete clears the local copy in mirror mode. I confirmed the original fallback test fails without the fix.

The full backend suite was **not** run locally (`-n auto` OOMs an 8-core/7 GB box, per CLAUDE.md) — this PR is how it gets exercised.

## Not fixed here

**External-URL fleet upgrades still apply without a checksum** (#787's "found in passing"). Reasoning is on the issue and unchanged from #790: `.xz` verifies its own container during decompress, so corruption already fails the apply cleanly.

**Nothing here is field-validated.** The supervisor half is host behaviour no test in this PR exercises — same caveat #790 carried. Wedging a promote on a test VM and confirming the mirror comes up is the check that matters.

Refs #787
Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)
