### PR TITLE
fix(dns): apply agentless record ops as whole-RRset writes (#783)

### DIFF
--- a/backend/app/drivers/dns/azuredns.py
+++ b/backend/app/drivers/dns/azuredns.py
@@ -249,13 +249,28 @@ class AzureDNSDriver(CloudDNSDriverBase):
             await self._apply_create(client, rg, zone_label, relative, rtype, change.record)
             return
 
-        # update — keep the single-value replace-the-RRset behaviour. The
-        # update op carries only the NEW value (no old value to match
-        # against), so a correct multi-value merge is impossible at this
-        # layer. Replace is right for the common single-value RRset (CNAME,
-        # a host with one A/TXT). Multi-value value-edits are an inherent
-        # per-row→RRset limitation tracked in issue #29.
-        params = self._build_record_set_params(change.record)
+        # update — replace the RRset. #783: with a resolved RRset the
+        # replacement is the COMPLETE desired set, so editing one of two A
+        # records at a name no longer retires the other. That used to be
+        # described here as an inherent per-row→RRset limitation; it was
+        # only inherent while the op carried a single value.
+        #
+        # Without a resolved set (a caller that opted out via
+        # ``rrset_action``), or for a single-valued type with no typed list
+        # to fill, the previous single-value replace is kept — right for the
+        # common single-value RRset (CNAME, a host with one A/TXT).
+        attr = _RECORD_TYPE_TO_AZURE_ATTR.get(rtype)
+        if change.rrset is not None and change.rrset.members and attr is not None:
+            params = {
+                "ttl": (
+                    change.rrset.ttl
+                    if change.rrset.ttl is not None
+                    else (change.record.ttl if change.record.ttl is not None else 3600)
+                ),
+                attr: [self._build_record_entry(r) for r in change.rrset.as_records(change.record)],
+            }
+        else:
+            params = self._build_record_set_params(change.record)
 
         def _put() -> None:
             client.record_sets.create_or_update(rg, zone_label, relative, rtype, params)

--- a/backend/app/drivers/dns/base.py
+++ b/backend/app/drivers/dns/base.py
@@ -312,6 +312,76 @@ class ConfigBundle:
 
 
 @dataclass(frozen=True)
+class RRsetMember:
+    """One value within a desired RRset.
+
+    Carries the structured fields as well as the value so a driver composes
+    each member's wire form exactly as it composes the op's own record.
+    """
+
+    value: str
+    priority: int | None = None
+    weight: int | None = None
+    port: int | None = None
+
+
+@dataclass(frozen=True)
+class RRsetData:
+    """The COMPLETE desired set of values at one ``(name, type)`` (#783).
+
+    An empty ``members`` means the RRset should not exist at all.
+
+    This is the agentless twin of the ``record["rrset"]`` payload the agent
+    drivers consume (#773), and it exists for the same reason: none of the
+    backends can express "change this one value and leave its siblings
+    alone" from an op that names only the NEW value.
+
+    * **Windows** rendered `Get-DnsServerResourceRecord … | Remove-…`, which
+      removes every RR at the ``(name, type)``, then added back the single
+      value the op mentioned — so a name with two A records, a backup MX, or
+      SPF beside a verification TXT ended up serving one of them.
+    * **Route 53 / Azure DNS / Google Cloud DNS** are RRset-oriented APIs.
+      Their create/delete paths read-merge and are fine; their ``update``
+      paths replaced the whole RRset with the op's single value, and each
+      says so in a comment deferring the fix.
+
+    A driver that sees this applies it as ONE whole-RRset write, which also
+    makes ops idempotent and self-healing: replaying one converges the
+    server to the database instead of moving it to an earlier state.
+
+    ``None`` means the control plane did not resolve a set for this op —
+    either the caller opted out via ``rrset_action`` (DNS pools, the
+    Windows-cutover TTL pre-flight, both of which need precise per-RR
+    semantics) or the op predates the field. Drivers MUST fall back to
+    their previous per-value behaviour in that case.
+    """
+
+    ttl: int | None
+    members: tuple[RRsetMember, ...]
+
+    def as_records(self, base: RecordData) -> list[RecordData]:
+        """Each member wearing ``base``'s ``(name, type)`` and TTL.
+
+        Lets a driver reuse whatever it already has for composing one
+        ``RecordData`` — rdata formatters, per-type cmdlet dispatch, provider
+        entry builders — instead of growing a parallel set of member-shaped
+        builders that could drift from them.
+        """
+        return [
+            RecordData(
+                name=base.name,
+                record_type=base.record_type,
+                value=m.value,
+                ttl=self.ttl if self.ttl is not None else base.ttl,
+                priority=m.priority,
+                weight=m.weight,
+                port=m.port,
+            )
+            for m in self.members
+        ]
+
+
+@dataclass(frozen=True)
 class RecordChange:
     """A single record mutation to be applied incrementally.
 
@@ -324,6 +394,9 @@ class RecordChange:
     target_serial: int
     tsig_key_name: str | None = None
     op_id: str = ""  # caller-supplied UUID for ACK tracking
+    # #783 — the complete desired RRset this op resolves to. Set on the
+    # agentless path by ``record_ops``; ``None`` when the caller opted out.
+    rrset: RRsetData | None = None
 
 
 @dataclass(frozen=True)

--- a/backend/app/drivers/dns/googledns.py
+++ b/backend/app/drivers/dns/googledns.py
@@ -278,17 +278,26 @@ class GoogleCloudDNSDriver(CloudDNSDriverBase):
                 changes.create()
                 return changes
 
-            # ``update`` carries only the NEW value (no old value), so a
-            # correct multi-value merge is impossible at this layer —
-            # replace the whole rrset with the single new value. Correct
-            # for the common single-value rrset (CNAME, SOA, a host with
-            # one A/TXT); multi-value value-edits are an inherent
-            # per-row→RRset limitation tracked in #29.
-            ttl = int(rr.ttl) if rr.ttl else 300
+            # ``update`` replaces the whole rrset — Cloud DNS has no in-place
+            # edit. #783: with a resolved RRset the replacement is the
+            # COMPLETE desired set, so editing one of two A records at a name
+            # no longer retires the other. This was described as an inherent
+            # per-row→RRset limitation; it was only inherent while the op
+            # carried a single value.
+            #
+            # Without a resolved set (a caller that opted out via
+            # ``rrset_action``) the single-value replace is kept — right for
+            # the common single-value rrset (CNAME, a host with one A/TXT).
+            if change.rrset is not None and change.rrset.members:
+                values = [m.value for m in change.rrset.members]
+                ttl = int(change.rrset.ttl or (rr.ttl if rr.ttl else 0) or 300)
+            else:
+                values = [rr.value]
+                ttl = int(rr.ttl) if rr.ttl else 300
             existing = self._find_rrset(zone, absolute, rtype)
             if existing is not None:
                 changes.delete_record_set(existing)
-            changes.add_record_set(zone.resource_record_set(absolute, rtype, ttl, [rr.value]))
+            changes.add_record_set(zone.resource_record_set(absolute, rtype, ttl, values))
             changes.create()
             return changes
 

--- a/backend/app/drivers/dns/route53.py
+++ b/backend/app/drivers/dns/route53.py
@@ -228,19 +228,33 @@ class Route53DNSDriver(CloudDNSDriverBase):
         # merge so siblings survive; update keeps the single-value replace
         # (see below).
         if change.op == "update":
-            # Replace the rrset with this single value. The update op carries
-            # only the NEW value (no old value), so a correct multi-value
-            # merge is impossible at this per-row→RRset layer — replace is
-            # correct for the common single-value rrset (CNAME, SOA, a host
-            # with one A/TXT). Multi-value value-edits are an inherent
-            # per-row→RRset limitation tracked in #29.
+            # #783 — UPSERT the COMPLETE desired rrset when the control plane
+            # resolved one. This used to write only the op's own value, which
+            # is a whole-rrset replace against an API that has no other kind
+            # of write: editing one of two A records at a name retired the
+            # other. The comment here used to call that an inherent
+            # per-row→RRset limitation; it was only inherent while the op
+            # carried a single value.
+            #
+            # Without a resolved set (a caller that opted out via
+            # ``rrset_action``) the single-value replace is kept — correct for
+            # the common single-value rrset (CNAME, a host with one A/TXT),
+            # and unchanged from before.
+            values = (
+                [{"Value": m.value} for m in change.rrset.members]
+                if change.rrset is not None and change.rrset.members
+                # MX / SRV: ``value`` already carries the priority/target, so
+                # a single ResourceRecords entry is correct.
+                else [{"Value": rr.value}]
+            )
+            ttl = int(
+                (change.rrset.ttl if change.rrset else None) or (rr.ttl if rr.ttl else 0) or 300
+            )
             rrset: dict[str, Any] = {
                 "Name": absolute,
                 "Type": rtype,
-                "TTL": default_ttl,
-                # MX / SRV: ``value`` already carries the priority/target, so
-                # a single ResourceRecords entry is correct.
-                "ResourceRecords": [{"Value": rr.value}],
+                "TTL": ttl,
+                "ResourceRecords": values,
             }
             await self._submit_change(server, client, zone_id, "UPSERT", rrset, change)
             return

--- a/backend/app/drivers/dns/windows.py
+++ b/backend/app/drivers/dns/windows.py
@@ -145,6 +145,17 @@ def _format_rdata(r: RecordData) -> str:
     return r.value
 
 
+def _rrset_members_or_self(change: RecordChange) -> list[RecordData] | None:
+    """The records this change should leave at its ``(name, type)`` (#783).
+
+    ``None`` means "no RRset was resolved" — the caller keeps its previous
+    per-value behaviour. An empty list means the RRset should not exist.
+    """
+    if change.rrset is None:
+        return None
+    return change.rrset.as_records(change.record)
+
+
 def _pack_record_chunks(
     eligible: list[tuple[int, RecordChange]],
 ) -> list[list[tuple[int, RecordChange]]]:
@@ -271,7 +282,25 @@ class WindowsDNSDriver(DNSDriver):
         rel_name = "@" if rr.name in ("", "@") else rr.name
         rdtype = dns.rdatatype.from_text(rtype)
 
-        if change.op == "delete":
+        if change.rrset is not None:
+            # #783 — one whole-RRset write of the complete desired set.
+            # ``replace`` is RFC 2136's "delete the RRset, then add these",
+            # which is exactly the semantics, and an empty member list
+            # degenerates to a bare delete. Without this, every op below
+            # named a single value while the wire operation addressed the
+            # whole RRset, so the siblings the op never mentioned were lost.
+            members = change.rrset.members
+            ttl = change.rrset.ttl or rr.ttl or 3600
+            if not members:
+                update.delete(rel_name, rdtype)
+            else:
+                update.replace(
+                    rel_name,
+                    ttl,
+                    rtype,
+                    *[_format_rdata(r) for r in change.rrset.as_records(rr)],
+                )
+        elif change.op == "delete":
             update.delete(rel_name, rdtype)
         else:  # create | update
             if change.op == "update":
@@ -889,32 +918,25 @@ if (Get-DnsServerZone -Name '{name}' -ErrorAction SilentlyContinue) {{
     raise ValueError(f"windows_dns._ps_apply_zone: bad op {op!r}")
 
 
-def _ps_apply_record(change: RecordChange) -> str:
-    """PowerShell script for ``apply_record_change`` create/update/delete.
+def _ps_add_record(zone: str, name: str, record: RecordData, ttl: int) -> str:
+    """The ``Add-DnsServerResourceRecord*`` call for ONE value.
 
-    Zone + record names, rdata, and TTL all flow through
-    ``_ps_escape_single_quoted`` so any PS metacharacter is neutered.
-    Update maps to delete+create on the target ``{name, type}`` since
-    Windows' PS cmdlets don't offer an atomic ``Set-…`` for all types.
-    That matches the ``_apply_record_change_rfc2136`` logic too.
+    ``zone`` and ``name`` arrive already escaped; the value + structured
+    fields are escaped here. Split out of ``_ps_apply_record`` so a
+    whole-RRset write can emit one of these per member without a second
+    copy of the per-type dispatch drifting from this one (#783).
     """
-    zone = _ps_escape_single_quoted((change.zone_name or "").rstrip("."))
-    rtype = change.record.record_type.upper()
-    rel_name = change.record.name if change.record.name not in ("", "@") else "@"
-    name = _ps_escape_single_quoted(rel_name)
-    ttl = int(change.record.ttl or 3600)
-    value = _ps_escape_single_quoted(change.record.value)
+    rtype = record.record_type.upper()
+    value = _ps_escape_single_quoted(record.value)
     # TXT: strip zone-file-style surrounding quotes so the WinRM path
     # publishes the same literal text as the RFC-2136 path (#426).
-    txt_value = _ps_escape_single_quoted(_strip_txt_quotes(change.record.value))
+    txt_value = _ps_escape_single_quoted(_strip_txt_quotes(record.value))
+    priority = int(record.priority or 0)
+    weight = int(record.weight or 0)
+    port = int(record.port or 0)
 
-    # Per-type create script. ``-AllowUpdateAny`` isn't a real switch — we
-    # use ``-ErrorAction Stop`` so any duplicate surfaces a clean failure
-    # rather than silently lying. The update op strips the old RR first.
-    priority = int(change.record.priority or 0)
-    weight = int(change.record.weight or 0)
-    port = int(change.record.port or 0)
-
+    # ``-AllowUpdateAny`` isn't a real switch — we use ``-ErrorAction Stop``
+    # so any duplicate surfaces a clean failure rather than silently lying.
     if rtype == "A":
         create = (
             f"Add-DnsServerResourceRecordA -ZoneName '{zone}' -Name '{name}' "
@@ -968,6 +990,43 @@ def _ps_apply_record(change: RecordChange) -> str:
         # ``apply_record_change`` before reaching this method; anything
         # that still lands here is a bug in dispatch.
         raise ValueError(f"windows_dns._ps_apply_record: unsupported type {rtype!r}")
+    return create
+
+
+def _ps_apply_record(change: RecordChange) -> str:
+    """PowerShell script for ``apply_record_change`` create/update/delete.
+
+    Zone + record names, rdata, and TTL all flow through
+    ``_ps_escape_single_quoted`` so any PS metacharacter is neutered.
+
+    #783 — when the change carries a resolved RRset, this renders ONE
+    whole-RRset write: remove every RR at the ``(name, type)``, then add
+    back each desired member. That is what the cmdlets can actually
+    express. The previous shape asked them for something narrower than
+    they do — ``Get-DnsServerResourceRecord … | Remove-…`` takes out the
+    whole RRset no matter which value the op named, and only the op's own
+    value was added back — so a second A record, a backup MX or an SPF
+    beside a verification TXT was silently retired by any write to the
+    name. Every op becomes idempotent as a side effect: replaying one
+    converges the server to the database.
+
+    Without an RRset (a caller that opted out via ``rrset_action``) the
+    previous per-value behaviour is kept: update maps to delete+create on
+    the target ``{name, type}``, since Windows' PS cmdlets don't offer an
+    atomic ``Set-…`` for all types, and that matches
+    ``_apply_record_change_rfc2136``.
+    """
+    zone = _ps_escape_single_quoted((change.zone_name or "").rstrip("."))
+    rtype = change.record.record_type.upper()
+    rel_name = change.record.name if change.record.name not in ("", "@") else "@"
+    name = _ps_escape_single_quoted(rel_name)
+    members = _rrset_members_or_self(change)
+    ttl = int((change.rrset.ttl if change.rrset else None) or change.record.ttl or 3600)
+    create = (
+        "\n".join(_ps_add_record(zone, name, m, ttl) for m in members)
+        if members
+        else _ps_add_record(zone, name, change.record, ttl)
+    )
 
     # Delete is idempotent: no-op if the zone or the record is already
     # absent. Without these guards, Get-DnsServerResourceRecord's
@@ -1004,16 +1063,27 @@ if (-not (Get-DnsServerZone -Name '{zone}' -ErrorAction SilentlyContinue)) {{
 {create}
 """.strip()
 
+    if change.op not in ("create", "update", "delete"):
+        raise ValueError(f"windows_dns._ps_apply_record: bad op {change.op!r}")
+
+    if members is not None:
+        # #783 — whole-RRset write. The op verb stops mattering: what the
+        # server should end up with is the resolved set, and every verb
+        # reaches it the same way. An empty set is a plain delete, which is
+        # what a delete op that removed the last value resolves to.
+        if not members:
+            return delete
+        return f"{delete}\n{create_with_zone_guard}"
+
+    # No resolved set — previous per-value behaviour.
     if change.op == "create":
         return create_with_zone_guard
     if change.op == "delete":
         return delete
-    if change.op == "update":
-        # Replace: wipe the existing RR(s) at (name, type) — idempotent —
-        # then add the new rdata guarded on zone existence. Matches what
-        # the RFC 2136 path does with update.delete(...) + update.add(...).
-        return f"{delete}\n{create_with_zone_guard}"
-    raise ValueError(f"windows_dns._ps_apply_record: bad op {change.op!r}")
+    # Replace: wipe the existing RR(s) at (name, type) — idempotent — then
+    # add the new rdata guarded on zone existence. Matches what the RFC 2136
+    # path does with update.delete(...) + update.add(...).
+    return f"{delete}\n{create_with_zone_guard}"
 
 
 def _ps_apply_record_batch(changes: Sequence[RecordChange]) -> str:
@@ -1043,11 +1113,41 @@ def _ps_apply_record_batch(changes: Sequence[RecordChange]) -> str:
     for i, change in enumerate(changes):
         rtype = change.record.record_type.upper()
         name = change.record.name if change.record.name not in ("", "@") else "@"
-        value = change.record.value or ""
-        # TXT: strip zone-file-style surrounding quotes for parity with the
-        # singular WinRM path + the RFC-2136 path (#426).
-        if rtype == "TXT":
-            value = _strip_txt_quotes(value)
+
+        def _member(rec: RecordData, rt: str = rtype) -> dict[str, Any]:
+            v = rec.value or ""
+            # TXT: strip zone-file-style surrounding quotes for parity with
+            # the singular WinRM path + the RFC-2136 path (#426).
+            if rt == "TXT":
+                v = _strip_txt_quotes(v)
+            return {
+                "v": v,
+                "pr": int(rec.priority or 0),
+                "w": int(rec.weight or 0),
+                "p": int(rec.port or 0),
+            }
+
+        # #783 — the wrapper is now one uniform "maybe clear the RRset, then
+        # add these values" body, and the two flags below say what each op
+        # means in those terms. That keeps a single copy of the per-type
+        # cmdlet dispatch while still expressing both semantics:
+        #
+        # * With a resolved RRset, ``m`` is the COMPLETE desired set, so the
+        #   clear-then-add IS the whole-RRset write. An empty ``m`` means the
+        #   RRset should not exist — which is what a delete of the last value
+        #   resolves to.
+        # * Without one (a caller that opted out via ``rrset_action``), the
+        #   previous per-value semantics are preserved exactly: create ADDS to
+        #   whatever is there (``rm=0``), update replaces, delete clears and
+        #   adds nothing. Getting this wrong turns a legacy delete into a
+        #   remove-then-re-add, i.e. a silent no-op.
+        members = _rrset_members_or_self(change)
+        if members is not None:
+            to_add, remove_first = members, True
+        elif change.op == "delete":
+            to_add, remove_first = [], True
+        else:
+            to_add, remove_first = [change.record], change.op == "update"
         ops.append(
             {
                 "i": i,
@@ -1055,11 +1155,11 @@ def _ps_apply_record_batch(changes: Sequence[RecordChange]) -> str:
                 "z": (change.zone_name or "").rstrip("."),
                 "n": name,
                 "t": rtype,
-                "v": value,
-                "ttl": int(change.record.ttl or 3600),
-                "pr": int(change.record.priority or 0),
-                "w": int(change.record.weight or 0),
-                "p": int(change.record.port or 0),
+                "m": [_member(r) for r in to_add],
+                "rm": 1 if remove_first else 0,
+                "ttl": int(
+                    (change.rrset.ttl if change.rrset else None) or change.record.ttl or 3600
+                ),
             }
         )
     blob = json.dumps(ops, separators=(",", ":")).encode("utf-8")
@@ -1086,18 +1186,25 @@ def _ps_apply_record_batch(changes: Sequence[RecordChange]) -> str:
         ' $e=[ordered]@{change_index=[int]$_.i;name="$($_.n)";'
         'type="$($_.t)";op="$($_.op)";ok=$false;error=$null}\n'
         " try{\n"
-        "  $z=$_.z;$n=$_.n;$t=$_.t;$v=$_.v;"
+        "  $z=$_.z;$n=$_.n;$t=$_.t;$m=$_.m;"
         "$tl=[TimeSpan]::FromSeconds([int]$_.ttl)\n"
         "  $ze=[bool](Get-DnsServerZone -Name $z -EA SilentlyContinue)\n"
-        "  if($_.op -eq 'delete'){\n"
-        "   if($ze){$x=Get-DnsServerResourceRecord -ZoneName $z -Name $n"
+        '  if($_.op -notin @("create","update","delete")){throw "Unsupported op"}\n'
+        # #783 — one body for every op: clear the RRset if asked, then add
+        # each value in ``m``. The caller encodes the op's meaning into those
+        # two fields (see _ps_apply_record_batch), so this holds exactly one
+        # copy of the per-type cmdlet dispatch.
+        #
+        # The zone guard stays keyed to "is there anything to add": a delete
+        # against a zone the server doesn't have is a no-op (reverse-zone
+        # drift is the common trigger), while a create/update there is a real
+        # error the operator fixes with Sync with Servers.
+        '  if($m.Count -gt 0 -and !$ze){throw "Zone $z not found"}\n'
+        "  if($ze -and [int]$_.rm -eq 1){$x=Get-DnsServerResourceRecord -ZoneName $z -Name $n"
         " -RRType $t -EA SilentlyContinue;"
         "if($x){$x|Remove-DnsServerResourceRecord -ZoneName $z -Force -EA Stop}}\n"
-        "  }elseif($_.op -eq 'create' -or $_.op -eq 'update'){\n"
-        '   if(!$ze){throw "Zone $z not found"}\n'
-        "   if($_.op -eq 'update'){$x=Get-DnsServerResourceRecord -ZoneName $z"
-        " -Name $n -RRType $t -EA SilentlyContinue;"
-        "if($x){$x|Remove-DnsServerResourceRecord -ZoneName $z -Force -EA Stop}}\n"
+        "  foreach($mm in $m){\n"
+        "   $v=$mm.v\n"
         "   switch($t){\n"
         "    'A'{Add-DnsServerResourceRecordA -ZoneName $z -Name $n"
         " -IPv4Address $v -TimeToLive $tl -EA Stop}\n"
@@ -1108,17 +1215,17 @@ def _ps_apply_record_batch(changes: Sequence[RecordChange]) -> str:
         "    'PTR'{Add-DnsServerResourceRecordPtr -ZoneName $z -Name $n"
         " -PtrDomainName $v -TimeToLive $tl -EA Stop}\n"
         "    'MX'{Add-DnsServerResourceRecordMX -ZoneName $z -Name $n"
-        " -MailExchange $v -Preference([int]$_.pr) -TimeToLive $tl -EA Stop}\n"
+        " -MailExchange $v -Preference([int]$mm.pr) -TimeToLive $tl -EA Stop}\n"
         "    'SRV'{Add-DnsServerResourceRecord -ZoneName $z -Name $n -Srv"
-        " -DomainName $v -Priority([int]$_.pr) -Weight([int]$_.w)"
-        " -Port([int]$_.p) -TimeToLive $tl -EA Stop}\n"
+        " -DomainName $v -Priority([int]$mm.pr) -Weight([int]$mm.w)"
+        " -Port([int]$mm.p) -TimeToLive $tl -EA Stop}\n"
         "    'NS'{Add-DnsServerResourceRecord -ZoneName $z -Name $n -NS"
         " -NameServer $v -TimeToLive $tl -EA Stop}\n"
         "    'TXT'{Add-DnsServerResourceRecord -ZoneName $z -Name $n -Txt"
         " -DescriptiveText $v -TimeToLive $tl -EA Stop}\n"
         '    default{throw "Unsupported type $t"}\n'
         "   }\n"
-        '  }else{throw "Unsupported op"}\n'
+        "  }\n"
         "  $e.ok=$true\n"
         ' }catch{$e.error="$($_.Exception.Message)"}\n'
         " $r+=(New-Object PSObject -Property $e)\n"

--- a/backend/app/services/dns/record_ops.py
+++ b/backend/app/services/dns/record_ops.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.agent_wake import collect_wake, dns_group_channel
 from app.drivers.dns import get_driver, is_agentless
-from app.drivers.dns.base import RecordChange, RecordData
+from app.drivers.dns.base import RecordChange, RecordData, RRsetData, RRsetMember
 from app.models.dns import DNSRecord, DNSRecordOp, DNSServer, DNSZone
 from app.services.dns.rrset import stamp_rrsets_for_ops
 from app.services.dns.serial import bump_zone_serial
@@ -38,6 +38,36 @@ async def resolve_primary_server(db: AsyncSession, zone: DNSZone) -> DNSServer |
     return res.scalar_one_or_none()
 
 
+def _rrset_from_payload(record: dict[str, Any]) -> RRsetData | None:
+    """Lift the stamped ``record["rrset"]`` payload into the neutral type.
+
+    #783 — the agentless drivers consume dataclasses, not the wire dict the
+    agent bundle ships, so the two representations meet here. Returns
+    ``None`` when the op carries no set (an ``rrset_action`` caller opted
+    out), which every driver reads as "keep your previous per-value
+    behaviour".
+    """
+    raw = record.get("rrset")
+    if not isinstance(raw, dict):
+        return None
+    members = raw.get("members")
+    if not isinstance(members, list):
+        return None
+    return RRsetData(
+        ttl=raw.get("ttl"),
+        members=tuple(
+            RRsetMember(
+                value=m.get("value", ""),
+                priority=m.get("priority"),
+                weight=m.get("weight"),
+                port=m.get("port"),
+            )
+            for m in members
+            if isinstance(m, dict)
+        ),
+    )
+
+
 async def _apply_agentless(
     db: AsyncSession,
     server: DNSServer,
@@ -51,7 +81,19 @@ async def _apply_agentless(
     Writes a DNSRecordOp row marked ``applied`` on success or ``failed`` on
     error. The request path continues either way — a failure is visible in
     the record-ops dashboard and via the existing IPAM↔DNS sync-check.
+
+    #783 — the op is stamped with its complete desired RRset first, the same
+    way the agent path is (#773). This used to be deliberately skipped here,
+    on the reasoning that an agentless op row must not claim an RRset write
+    nobody performed; that reasoning was sound and the conclusion was the
+    bug, because the agentless drivers were performing whole-RRset writes
+    anyway — just with one value in them, which is what silently retired the
+    siblings. Now they perform the write the row describes.
     """
+    if "rrset" not in record:
+        record = dict(record)
+        await stamp_rrsets_for_ops(db, zone, [{"op": op, "record": record}])
+
     op_row = DNSRecordOp(
         server_id=server.id,
         zone_name=zone.name,
@@ -76,6 +118,7 @@ async def _apply_agentless(
             port=record.get("port"),
         ),
         target_serial=target_serial or 0,
+        rrset=_rrset_from_payload(record),
     )
 
     try:
@@ -457,8 +500,17 @@ async def _apply_agentless_batch(
     (WinRM auth failure, PS parse error in the generated script) marks
     every row failed with the same error — per-op failures (a bad
     record type for example) only mark their own row.
+
+    #783 — the whole batch is folded and stamped with its desired RRsets in
+    ONE query before any row is written, exactly as the agent batch path
+    does. Folding matters here for the same reason it does there: a bulk
+    delete of two of three values at one name resolves both ops against the
+    same pre-delete snapshot, so reconciling each in isolation would ship
+    two contradictory sets and whichever landed last would reinstate a value
+    the operator deleted.
     """
-    from app.drivers.dns.base import RecordChange, RecordData  # noqa: PLC0415
+    ops = [{**o, "record": dict(o["record"])} for o in ops]
+    await stamp_rrsets_for_ops(db, zone, ops)
 
     op_rows: list[DNSRecordOp] = []
     for o in ops:
@@ -488,6 +540,7 @@ async def _apply_agentless_batch(
                 port=o["record"].get("port"),
             ),
             target_serial=o.get("target_serial") or 0,
+            rrset=_rrset_from_payload(o["record"]),
         )
         for o in ops
     ]

--- a/backend/tests/test_dns_agentless_rrset.py
+++ b/backend/tests/test_dns_agentless_rrset.py
@@ -1,0 +1,224 @@
+"""#783 — agentless drivers must apply a change as a whole-RRset write.
+
+#773 fixed this class for the three agent drivers by shipping the complete
+desired RRset on the op. The agentless drivers were left out on the
+reasoning that they never read the field — but they were performing
+whole-RRset writes the entire time:
+
+* **Windows** rendered ``Get-DnsServerResourceRecord … | Remove-…``, which
+  removes EVERY RR at the ``(name, type)``, and then added back only the one
+  value the op named. So a name with two A records, a backup MX, or SPF
+  beside a verification TXT served one of them after any write to the name.
+* **Route 53 / Azure DNS / Google Cloud DNS** replaced the whole RRset with
+  the op's single value on ``update``. Each carried a comment calling that
+  an inherent per-row→RRset limitation; it was only inherent while the op
+  carried one value.
+
+These tests pin the rendered wire form rather than mocking it out, because
+the bug lived entirely in what got rendered. They also pin the fallback:
+a change with ``rrset=None`` (a caller that opted out via ``rrset_action``)
+must behave exactly as it did before — in particular a legacy delete must
+not become a remove-then-re-add.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from app.drivers.dns.base import RecordChange, RecordData, RRsetData, RRsetMember
+from app.drivers.dns.windows import _ps_apply_record, _ps_apply_record_batch
+
+
+def _change(
+    op: str,
+    *,
+    value: str,
+    rtype: str = "A",
+    members: list[str] | None = None,
+    name: str = "www",
+    ttl: int | None = 3600,
+) -> RecordChange:
+    return RecordChange(
+        op=op,  # type: ignore[arg-type]
+        zone_name="example.com.",
+        record=RecordData(name=name, record_type=rtype, value=value, ttl=ttl),
+        target_serial=1,
+        rrset=(
+            None
+            if members is None
+            else RRsetData(ttl=ttl, members=tuple(RRsetMember(value=v) for v in members))
+        ),
+    )
+
+
+def _batch_payload(script: str) -> list[dict]:
+    """Pull the JSON op payload back out of the rendered batch script."""
+    marker = "FromBase64String('"
+    start = script.index(marker) + len(marker)
+    end = script.index("'", start)
+    return json.loads(base64.b64decode(script[start:end]).decode("utf-8"))
+
+
+# ── Windows: the singular PowerShell path ────────────────────────────
+
+
+def test_adding_a_second_a_record_re_adds_both() -> None:
+    """THE #783 regression.
+
+    The remove takes out the whole RRset, so the adds after it are the
+    complete desired state or the sibling is gone.
+    """
+    script = _ps_apply_record(_change("create", value="10.0.0.2", members=["10.0.0.1", "10.0.0.2"]))
+
+    assert script.count("Add-DnsServerResourceRecordA") == 2
+    assert "-IPv4Address '10.0.0.1'" in script
+    assert "-IPv4Address '10.0.0.2'" in script
+    assert "Remove-DnsServerResourceRecord" in script
+
+
+def test_deleting_one_of_two_values_re_adds_the_survivor() -> None:
+    script = _ps_apply_record(_change("delete", value="10.0.0.2", members=["10.0.0.1"]))
+
+    assert "-IPv4Address '10.0.0.1'" in script
+    assert "10.0.0.2" not in script
+
+
+def test_deleting_the_last_value_adds_nothing_back() -> None:
+    script = _ps_apply_record(_change("delete", value="10.0.0.1", members=[]))
+
+    assert "Remove-DnsServerResourceRecord" in script
+    assert "Add-DnsServerResourceRecord" not in script
+
+
+def test_mx_members_keep_their_own_preferences() -> None:
+    change = RecordChange(
+        op="update",
+        zone_name="example.com.",
+        record=RecordData(name="@", record_type="MX", value="mail1", ttl=3600, priority=10),
+        target_serial=1,
+        rrset=RRsetData(
+            ttl=3600,
+            members=(
+                RRsetMember(value="mail1", priority=10),
+                RRsetMember(value="mail2", priority=20),
+            ),
+        ),
+    )
+
+    script = _ps_apply_record(change)
+
+    # A shared priority would collapse primary and backup into one policy.
+    assert "-MailExchange 'mail1' -Preference 10" in script
+    assert "-MailExchange 'mail2' -Preference 20" in script
+
+
+def test_without_a_resolved_rrset_a_create_still_adds_only_its_own_value() -> None:
+    # ``rrset_action`` callers (DNS pools, the Windows-cutover TTL pre-flight)
+    # need precise per-RR semantics and must not be turned into whole-RRset
+    # writes behind their back.
+    script = _ps_apply_record(_change("create", value="10.0.0.9"))
+
+    assert script.count("Add-DnsServerResourceRecordA") == 1
+    assert "-IPv4Address '10.0.0.9'" in script
+
+
+def test_without_a_resolved_rrset_a_delete_adds_nothing_back() -> None:
+    # The regression this guards: routing every op through one
+    # remove-then-add body without distinguishing the legacy case turns a
+    # delete into a remove-then-re-add, i.e. a silent no-op.
+    script = _ps_apply_record(_change("delete", value="10.0.0.9"))
+
+    assert "Add-DnsServerResourceRecord" not in script
+
+
+# ── Windows: the batched PowerShell path ─────────────────────────────
+
+
+def test_batch_payload_carries_every_member() -> None:
+    script = _ps_apply_record_batch(
+        [_change("create", value="10.0.0.2", members=["10.0.0.1", "10.0.0.2"])]
+    )
+
+    ops = _batch_payload(script)
+
+    assert [m["v"] for m in ops[0]["m"]] == ["10.0.0.1", "10.0.0.2"]
+    assert ops[0]["rm"] == 1
+
+
+def test_batch_delete_of_the_last_value_carries_no_members() -> None:
+    script = _ps_apply_record_batch([_change("delete", value="10.0.0.1", members=[])])
+
+    ops = _batch_payload(script)
+
+    assert ops[0]["m"] == []
+    assert ops[0]["rm"] == 1
+
+
+def test_batch_legacy_delete_carries_no_members_and_still_clears() -> None:
+    script = _ps_apply_record_batch([_change("delete", value="10.0.0.9")])
+
+    ops = _batch_payload(script)
+
+    assert ops[0]["m"] == [], "a legacy delete must not re-add its own value"
+    assert ops[0]["rm"] == 1
+
+
+def test_batch_legacy_create_adds_without_clearing_first() -> None:
+    # Pre-#783 semantics for an op that opted out: create ADDS to whatever is
+    # already at the name. Clearing first would make it a replace.
+    script = _ps_apply_record_batch([_change("create", value="10.0.0.9")])
+
+    ops = _batch_payload(script)
+
+    assert [m["v"] for m in ops[0]["m"]] == ["10.0.0.9"]
+    assert ops[0]["rm"] == 0
+
+
+def test_batch_legacy_update_clears_then_adds_its_own_value() -> None:
+    script = _ps_apply_record_batch([_change("update", value="10.0.0.9")])
+
+    ops = _batch_payload(script)
+
+    assert [m["v"] for m in ops[0]["m"]] == ["10.0.0.9"]
+    assert ops[0]["rm"] == 1
+
+
+def test_batch_txt_members_are_unquoted_like_the_singular_path() -> None:
+    change = _change(
+        "update",
+        rtype="TXT",
+        value='"v=spf1 -all"',
+        members=['"v=spf1 -all"', '"google-site-verification=abc"'],
+    )
+
+    ops = _batch_payload(_ps_apply_record_batch([change]))
+
+    assert [m["v"] for m in ops[0]["m"]] == [
+        "v=spf1 -all",
+        "google-site-verification=abc",
+    ]
+
+
+# ── The neutral type ─────────────────────────────────────────────────
+
+
+def test_as_records_wears_the_ops_name_and_type() -> None:
+    base = RecordData(name="www", record_type="A", value="10.0.0.1", ttl=60)
+    rrset = RRsetData(ttl=300, members=(RRsetMember(value="10.0.0.7"),))
+
+    (record,) = rrset.as_records(base)
+
+    assert (record.name, record.record_type, record.value) == ("www", "A", "10.0.0.7")
+    # The RRset's TTL wins — per RFC 2181 an RRset has one TTL, and the
+    # resolver already reconciled disagreeing members down to the lowest.
+    assert record.ttl == 300
+
+
+def test_as_records_falls_back_to_the_base_ttl() -> None:
+    base = RecordData(name="www", record_type="A", value="10.0.0.1", ttl=60)
+    rrset = RRsetData(ttl=None, members=(RRsetMember(value="10.0.0.7"),))
+
+    (record,) = rrset.as_records(base)
+
+    assert record.ttl == 60

--- a/backend/tests/test_dns_rrset_ops.py
+++ b/backend/tests/test_dns_rrset_ops.py
@@ -30,8 +30,8 @@ What each test guards:
   order-independent and an op replay-safe
 * DNSSEC ops carry no RRset (they have no record to reason about) and must not
   blow up on the way past
-* agentless drivers are NOT stamped — they never read the field, so a row
-  claiming an RRset write nobody performed is a lie in the audit trail
+* agentless drivers ARE stamped too (#783), and the change handed to the
+  driver carries the set as a neutral ``RRsetData``
 """
 
 from __future__ import annotations
@@ -163,9 +163,22 @@ class _RecordingDriver:
 
     def __init__(self) -> None:
         self.changes: list[tuple[str, str, str]] = []
+        self.full_changes: list[Any] = []
 
     async def apply_record_change(self, _server: Any, change: Any) -> None:
         self.changes.append((change.op, change.record.name, change.record.record_type))
+        self.full_changes.append(change)
+
+    async def apply_record_changes(self, server: Any, changes: Any) -> list[Any]:
+        from app.drivers.dns.base import RecordChangeResult  # noqa: PLC0415
+
+        for change in changes:
+            await self.apply_record_change(server, change)
+        return [RecordChangeResult(ok=True, change=c) for c in changes]
+
+    @property
+    def last_change(self) -> Any:
+        return self.full_changes[-1] if self.full_changes else None
 
 
 # ── 1. the #773 regression ──────────────────────────────────────────────────
@@ -635,14 +648,21 @@ async def test_dnssec_ops_carry_no_rrset(db_session: AsyncSession) -> None:
     assert op.op == "dnssec_sign"
 
 
-async def test_agentless_ops_are_not_stamped(
+async def test_agentless_ops_are_stamped_and_reach_the_driver(
     db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Windows DNS and the cloud providers apply immediately from the control
-    plane and never read the field. Stamping their rows would put an RRset in
-    the audit trail that no driver ever wrote — a record-ops dashboard claiming
-    a convergence that did not happen. (Windows DNS has its own whole-RRset
-    collapse; that is a separate fix, and it must not be papered over here.)"""
+    """#783 — the agentless path gets the same set, as a neutral ``RRsetData``.
+
+    This test used to assert the opposite. The reasoning behind that was that
+    an agentless row must not claim an RRset write nobody performed — sound in
+    itself, and the wrong conclusion, because the agentless drivers were
+    performing whole-RRset writes the whole time. Windows' PowerShell
+    ``Get-DnsServerResourceRecord … | Remove-…`` takes out every RR at the
+    ``(name, type)`` no matter which value the op named, and only the op's own
+    value went back; Route 53 / Azure / Google replace the RRset on update.
+    So the write was always whole-RRset — it just had one value in it, which
+    is what silently retired the siblings. Now the row and the write agree.
+    """
     _grp, _server, zone = await _group_and_zone(db_session, driver="windows_dns")
     await _add_record(db_session, zone, name="www", value="10.0.0.1")
     await db_session.commit()
@@ -656,4 +676,42 @@ async def test_agentless_ops_are_not_stamped(
     assert op is not None
     assert op.state == "applied", "the agentless branch really ran"
     assert recorder.changes == [("create", "www", "A")]
-    assert "rrset" not in op.record
+    # The row records the desired end state...
+    assert {m["value"] for m in op.record["rrset"]["members"]} == {"10.0.0.1", "10.0.0.2"}
+    # ...and the driver was handed it, not just the one new value.
+    assert recorder.last_change is not None
+    assert recorder.last_change.rrset is not None
+    assert {m.value for m in recorder.last_change.rrset.members} == {"10.0.0.1", "10.0.0.2"}
+
+
+async def test_agentless_batch_folds_before_stamping(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A bulk delete of two of three values must not have the ops contradict.
+
+    Both ops resolve against the same pre-delete snapshot, so reconciling each
+    in isolation would ship ``[B, C]`` for one and ``[A, C]`` for the other and
+    whichever landed last would reinstate a value the operator deleted. The
+    whole batch is folded first, so both carry the survivor.
+    """
+    _grp, _server, zone = await _group_and_zone(db_session, driver="windows_dns")
+    for value in ("10.0.0.1", "10.0.0.2", "10.0.0.3"):
+        await _add_record(db_session, zone, name="www", value=value)
+    await db_session.commit()
+
+    recorder = _RecordingDriver()
+    monkeypatch.setattr("app.services.dns.record_ops.get_driver", lambda _name: recorder)
+
+    await enqueue_record_ops_batch(
+        db_session,
+        zone,
+        [
+            {"op": "delete", "record": {"name": "www", "type": "A", "value": "10.0.0.1"}},
+            {"op": "delete", "record": {"name": "www", "type": "A", "value": "10.0.0.2"}},
+        ],
+    )
+
+    sets = [
+        {m.value for m in c.rrset.members} for c in recorder.full_changes if c.rrset is not None
+    ]
+    assert sets == [{"10.0.0.3"}, {"10.0.0.3"}]

--- a/backend/tests/test_windows_winrm_hardening.py
+++ b/backend/tests/test_windows_winrm_hardening.py
@@ -200,7 +200,9 @@ def test_dns_batch_txt_value_quote_stripped() -> None:
     m = _re.search(r"FromBase64String\('([^']+)'\)", script)
     assert m, "payload not found in batch script"
     ops = _json.loads(_b64.b64decode(m.group(1)).decode("utf-8"))
-    assert ops[0]["v"] == "hello world"
+    # #783 moved each op's value into a members list (``m``) so one op can
+    # carry a whole RRset; the quote-stripping this test guards is unchanged.
+    assert [member["v"] for member in ops[0]["m"]] == ["hello world"]
 
 
 # ── credential schema validators (#11) ─────────────────────────────────

--- a/docs/drivers/DNS_DRIVERS.md
+++ b/docs/drivers/DNS_DRIVERS.md
@@ -182,9 +182,16 @@ an `add` across two separate enqueue calls on one serial, and whole-RRset
 writes would make that pair order-dependent, since the delete's set is
 computed before the row is mutated.
 
-Not covered: the **agentless** Windows DNS driver
-(`backend/app/drivers/dns/windows.py`) has the same collapse in its own
-PowerShell path and is not fixed by this — it never receives the field.
+The **agentless** drivers get the same set (#783), through
+`RecordChange.rrset` rather than the wire payload — `record_ops` stamps the
+op, then lifts it into the neutral `RRsetData` the drivers consume. Windows
+DNS applies it as one remove-all-then-add-each-member write on both its
+PowerShell paths and as an RFC 2136 `replace` on its Path A path; Route 53,
+Azure DNS and Google Cloud DNS apply it on their `update` path, which
+previously replaced the whole RRset with the op's single value (their
+create/delete paths already read-merged and were never affected).
+Cloudflare addresses individual records by provider id and never collapsed.
+A driver that sees `rrset=None` keeps its previous per-value behaviour.
 
 ### TSIG Authentication
 


### PR DESCRIPTION
The agentless half of the multi-value RRset collapse #773 fixed for the agent drivers.

## What was wrong

A name with two A records, a backup MX, SPF beside a verification TXT, or several apex NS ended up serving **one** of them after any write to that name. The database and the drift report showed every value throughout — only the incremental update path lost them, which is the kind of divergence nobody notices until a failover.

#773 fixed this class for the three *agent* drivers by shipping the complete desired RRset on the op. The agentless drivers were deliberately left out, on the reasoning that they never read the field and stamping their rows would put an RRset in the audit trail no driver ever wrote. That reasoning was sound; the conclusion was the bug. **They were performing whole-RRset writes the entire time** — just with one value in them.

- **Windows** renders `Get-DnsServerResourceRecord … | Remove-…`, which removes *every* RR at the `(name, type)` no matter which value the op named, then added back only that one value. Both the singular and the batched PowerShell paths had this shape, as did Path A's RFC 2136 delete+add.
- **Route 53 / Azure DNS / Google Cloud DNS** replaced the whole RRset with the op's single value on `update`. All three carried a comment calling that an inherent per-row→RRset limitation deferred to #29 — it was only inherent while the op carried a single value.
- **Cloudflare** addresses records by provider id and never collapsed. Unchanged.

## The fix

`RecordChange` gains `rrset: RRsetData | None` — the agentless twin of the wire payload the agent drivers consume. `record_ops` stamps both agentless paths and lifts the payload into the neutral type.

The batch path folds its whole list in one query *before* writing any row, for the same reason the agent batch does: a bulk delete of two of three values at one name resolves both ops against the same pre-delete snapshot, so reconciling each in isolation would ship `[B, C]` for one and `[A, C]` for the other, and whichever landed last would reinstate a value the operator deleted.

Windows applies the set as remove-all-then-add-each-member on both PowerShell paths and as an RFC 2136 `replace` on Path A. The three cloud drivers apply it on `update`; their create/delete paths already read-merged and were never affected. Ops become idempotent as a side effect — replaying one converges the server to the database instead of moving it to an earlier state.

### The fallback is load-bearing

`rrset=None` keeps the previous per-value behaviour for the two callers that opt out via `rrset_action` (DNS pools, the Windows-cutover TTL pre-flight), which need precise per-RR semantics — a pool re-points a member as a `delete_value` plus an `add` across two enqueue calls on one serial, and whole-RRset writes would make that pair order-dependent.

The batch payload carries that distinction **explicitly**, as a members list plus a remove-first flag, rather than inferring it from the op verb. Inferring it turns a legacy delete into a remove-then-re-add — a silent no-op. There is a regression test for exactly that.

## Testing

`make ci` green. 130 DNS driver + record-op tests pass (`test_dns_azure_dns`, `test_dns_google_dns`, `test_dns_route53`, `test_dns_cloudflare`, `test_windows_winrm_hardening`, `test_record_ops_disabled_primary`, `test_dns_record_struct_fields`), plus 19 in `test_dns_rrset_ops`.

14 new tests in `test_dns_agentless_rrset.py` assert against the **rendered wire form** rather than mocking the driver out — the bug lived entirely in what got rendered, so a mock would not have caught it. They cover the regression itself, delete-one-of-two, delete-the-last, per-member MX preferences, TXT unquoting, and both fallback semantics.

Two existing tests changed shape rather than behaviour: `test_dns_rrset_ops.py`'s "agentless ops are not stamped" is inverted to the new contract (with the old reasoning written up in its docstring, since it was reasonable and someone will wonder), and `test_windows_winrm_hardening.py`'s TXT-quote-stripping assertion follows the value into the new members list.

The full backend suite was **not** run locally (`-n auto` OOMs an 8-core/7 GB box, per CLAUDE.md) — this PR is how it gets exercised.

## Not covered

No live Windows DC or cloud account was available, so the rendered PowerShell and the three cloud `update` paths are verified by unit tests against the generated payloads, not end to end.

Closes #783

🤖 Generated with [Claude Code](https://claude.com/claude-code)