### PR TITLE
fix(dhcp): remove the phantom scope ddns_domain_override (#784)

### DIFF
--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -451,7 +451,14 @@ class ScopeResponse(BaseModel):
     options: list[dict[str, Any]]
     ddns_enabled: bool
     ddns_hostname_policy: str | None
-    ddns_domain_override: str | None = None
+    # #784 — there is deliberately NO ``ddns_domain_override`` here. The
+    # field used to be declared and hardcoded to ``None``: no column backed
+    # it, neither ScopeCreate nor ScopeUpdate accepted it, and the scope form
+    # sent it on every save, so an operator typed a domain, got a 200, and
+    # read back null. The DDNS domain lives on the IPAM chain
+    # (space → block → subnet, resolved by ``services/dns/ddns.py``), which
+    # is where it actually works; a scope maps 1:1 to a subnet, so putting a
+    # second copy here would be a second source of truth for one setting.
     hostname_sync_mode: str
     dns_track_dynamic_leases: bool = True
     address_family: str = "ipv4"
@@ -501,7 +508,6 @@ def _scope_to_response(scope: DHCPScope) -> ScopeResponse:
         options=opts,
         ddns_enabled=scope.ddns_enabled,
         ddns_hostname_policy=scope.ddns_hostname_policy,
-        ddns_domain_override=None,
         hostname_sync_mode=scope.hostname_to_ipam_sync,
         dns_track_dynamic_leases=getattr(scope, "dns_track_dynamic_leases", True),
         address_family=getattr(scope, "address_family", "ipv4") or "ipv4",

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -455,10 +455,11 @@ class ScopeResponse(BaseModel):
     # field used to be declared and hardcoded to ``None``: no column backed
     # it, neither ScopeCreate nor ScopeUpdate accepted it, and the scope form
     # sent it on every save, so an operator typed a domain, got a 200, and
-    # read back null. The DDNS domain lives on the IPAM chain
-    # (space → block → subnet, resolved by ``services/dns/ddns.py``), which
-    # is where it actually works; a scope maps 1:1 to a subnet, so putting a
-    # second copy here would be a second source of truth for one setting.
+    # read back null. The DDNS domain lives on the IPAM chain, where it
+    # actually works: ``services/dns/ddns.resolve_effective_ddns`` resolves
+    # it most-specific-first — the subnet, then up through its blocks, then
+    # the IP space. A scope maps 1:1 to a subnet, so putting a second copy
+    # here would be a second source of truth for one setting.
     hostname_sync_mode: str
     dns_track_dynamic_leases: bool = True
     address_family: str = "ipv4"

--- a/backend/tests/test_dhcp_scope_no_phantom_ddns_domain.py
+++ b/backend/tests/test_dhcp_scope_no_phantom_ddns_domain.py
@@ -1,0 +1,119 @@
+"""#784 — the scope surface must not advertise a DDNS domain it cannot keep.
+
+``ScopeResponse`` declared ``ddns_domain_override`` and ``_scope_to_response``
+hardcoded it to ``None``. No column backed it, neither ``ScopeCreate`` nor
+``ScopeUpdate`` declared it (so ``extra="ignore"`` dropped it from the body
+without a word), and the scope form sent it on every save. An operator typed a
+domain, got a 200, re-opened the scope, and found the field empty — with no
+error anywhere in between.
+
+It was removed rather than implemented. The DDNS domain is real one level up:
+``services/dns/ddns.resolve_effective_ddns`` walks subnet → block → space and
+reads ``ddns_domain_override`` there. A DHCP scope maps 1:1 to a subnet, so a
+scope-level copy would be a second source of truth for one setting rather than
+new capability.
+
+These tests pin both halves of "removed": the response does not offer the
+field, and a client still sending it (the old form, a saved script) is not
+broken by it — the write succeeds and the value is simply not persisted
+anywhere, which is what it always did.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+pytestmark = pytest.mark.asyncio
+
+CIDR = "198.51.100.0/24"
+
+
+async def _setup(client: AsyncClient, db: AsyncSession) -> tuple[dict[str, str], dict]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, grp])
+    await db.flush()
+    await db.commit()
+
+    headers = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    resp = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet.id}/dhcp-scopes",
+        headers=headers,
+        json={"group_id": str(grp.id), "name": "s", "ddns_enabled": True},
+    )
+    assert resp.status_code in (200, 201), resp.text
+    return headers, resp.json()
+
+
+async def test_scope_response_does_not_advertise_a_ddns_domain(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers, scope = await _setup(client, db_session)
+
+    assert "ddns_domain_override" not in scope
+
+    fetched = (await client.get(f"/api/v1/dhcp/scopes/{scope['id']}", headers=headers)).json()
+    assert "ddns_domain_override" not in fetched
+
+
+async def test_a_client_still_sending_the_old_field_is_not_broken(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The old scope form, or any saved script, keeps working.
+
+    The field was never accepted on write, so ignoring it is not a behaviour
+    change — this only pins that removing it from the RESPONSE did not turn a
+    previously-tolerated body into a 422.
+    """
+    headers, scope = await _setup(client, db_session)
+
+    resp = await client.put(
+        f"/api/v1/dhcp/scopes/{scope['id']}",
+        headers=headers,
+        json={"name": "renamed", "ddns_domain_override": "example.com"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "renamed"
+    assert "ddns_domain_override" not in resp.json()
+
+
+async def test_read_modify_write_of_a_fetched_scope_still_round_trips(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    # GET → edit → PUT is the shape that exposed the original bug, and it is
+    # also the shape most likely to break when a response field is removed.
+    headers, scope = await _setup(client, db_session)
+
+    current = (await client.get(f"/api/v1/dhcp/scopes/{scope['id']}", headers=headers)).json()
+    current["name"] = "round-tripped"
+    current.pop("is_active", None)
+
+    resp = await client.put(f"/api/v1/dhcp/scopes/{scope['id']}", headers=headers, json=current)
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["name"] == "round-tripped"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7496,7 +7496,8 @@ export interface DHCPScope {
   lease_cache_max_age: number | null;
   ddns_enabled: boolean;
   ddns_hostname_policy: string | null;
-  ddns_domain_override: string | null;
+  // #784 — no ddns_domain_override. It never existed as a column; the DDNS
+  // domain is resolved from the IPAM chain (space -> block -> subnet).
   hostname_sync_mode: string;
   // When false, this scope's dynamic-pool lease mirrors are excluded from the
   // IPAM↔DNS drift check, so ephemeral pulled leases don't read as "out of sync".

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7497,7 +7497,8 @@ export interface DHCPScope {
   ddns_enabled: boolean;
   ddns_hostname_policy: string | null;
   // #784 — no ddns_domain_override. It never existed as a column; the DDNS
-  // domain is resolved from the IPAM chain (space -> block -> subnet).
+  // domain is resolved from the IPAM chain, most-specific-first: the
+  // subnet, then up through its blocks, then the IP space.
   hostname_sync_mode: string;
   // When false, this scope's dynamic-pool lease mirrors are excluded from the
   // IPAM↔DNS drift check, so ephemeral pulled leases don't read as "out of sync".

--- a/frontend/src/pages/dhcp/CreateScopeModal.tsx
+++ b/frontend/src/pages/dhcp/CreateScopeModal.tsx
@@ -85,9 +85,6 @@ export function CreateScopeModal({
   const [ddnsPolicy, setDdnsPolicy] = useState(
     scope?.ddns_hostname_policy ?? "client",
   );
-  const [ddnsDomain, setDdnsDomain] = useState(
-    scope?.ddns_domain_override ?? "",
-  );
   // When off, this scope's dynamic-pool lease mirrors are excluded from the
   // IPAM↔DNS drift check (ephemeral pulled leases don't read as "out of sync").
   const [dnsTrackDynamicLeases, setDnsTrackDynamicLeases] = useState(
@@ -304,7 +301,6 @@ export function CreateScopeModal({
         lease_cache_max_age: parsedCacheMaxAge,
         ddns_enabled: ddnsEnabled,
         ddns_hostname_policy: ddnsEnabled ? ddnsPolicy : null,
-        ddns_domain_override: ddnsDomain || null,
         hostname_sync_mode: hostnameSync,
         dns_track_dynamic_leases: dnsTrackDynamicLeases,
         options,
@@ -778,7 +774,7 @@ export function CreateScopeModal({
             <span>DDNS — push lease updates to DNS</span>
           </label>
           {ddnsEnabled && (
-            <div className="grid grid-cols-2 gap-3 pl-6">
+            <div className="space-y-2 pl-6">
               <Field label="Hostname Policy">
                 <select
                   className={inputCls}
@@ -790,16 +786,16 @@ export function CreateScopeModal({
                   <option value="generate">Generate</option>
                 </select>
               </Field>
-              <Field
-                label="Domain Override"
-                hint="Blank = use subnet DNS zone."
-              >
-                <input
-                  className={inputCls}
-                  value={ddnsDomain}
-                  onChange={(e) => setDdnsDomain(e.target.value)}
-                />
-              </Field>
+              {/* #784 — a "Domain Override" input used to sit here. Nothing
+                  stored it: no column, no field on the create/update models,
+                  and the response hardcoded null, so a typed value was
+                  silently discarded. The setting is real one level up, on the
+                  subnet, which is where the DDNS resolution chain reads it. */}
+              <p className="text-xs text-muted-foreground">
+                The DDNS domain comes from the subnet (inherited from its block
+                or IP space unless overridden). Set it in IPAM → the subnet's
+                DDNS settings.
+              </p>
             </div>
           )}
         </div>


### PR DESCRIPTION
A field the API advertised, hardcoded to `null`, never stored, and the UI sent on every save.

## What was wrong

`ScopeResponse` declared `ddns_domain_override`; `_scope_to_response` hardcoded it to `None`. No column backed it, neither `ScopeCreate` nor `ScopeUpdate` declared it — so `extra="ignore"` dropped it from the request body without a word — and `CreateScopeModal` sent it on every save.

An operator typed a domain, got a `200`, re-opened the scope, and found the field empty. No error at any point. Both the response field and the input have shipped for a while, so anyone who used it believes they configured something.

## The decision

The issue deliberately left this open — make it real, or remove it — because the design question is where the field belongs, not how to write it.

**Removed**, because the setting already exists one level up and works there. `services/dns/ddns.resolve_effective_ddns` walks subnet → block → space and reads `ddns_domain_override` off that chain. A DHCP scope maps 1:1 to a subnet, so a scope-level copy would be a second source of truth for one setting rather than new capability.

The "complete the trio" argument doesn't hold on inspection: the scope's other DDNS fields aren't in that chain at all. `ddns_enabled` and `ddns_hostname_policy` feed the **Kea config bundle** (`services/dhcp/config_bundle.py` → `ScopeDef` → the Kea renderer), a different consumer from the IPAM DDNS resolution. Adding a domain here would have given one field name two different meanings depending on which path read it.

## What changed

- `ScopeResponse` loses the field, and carries a comment saying why it is deliberately absent — this is exactly the kind of thing that gets "helpfully" re-added.
- `DHCPScope` in `lib/api.ts` loses it too.
- The scope form keeps its DDNS block and loses only the dead input, replaced by a line saying where the domain actually comes from. That is *more* than the control offered before: its own hint already read "Blank = use subnet DNS zone", describing the fallback that was in fact the only behaviour.

## Testing

`make ci` green, 24 scope tests pass (`test_dhcp_scope_no_phantom_ddns_domain`, `test_dhcp_scope_active_alias`, `test_dhcp_scope_options_roundtrip`, `test_dhcp_scope_sync_mode`).

Three new tests: the response does not advertise the field; a client still sending it is not broken (it was never accepted on write, so this pins only that removing it from the *response* didn't turn a tolerated body into a 422); and GET → edit → PUT still round-trips, which is the shape most likely to break when a response field is removed — and the same shape that exposed the neighbouring #774 bug.

The full backend suite was **not** run locally (`-n auto` OOMs an 8-core/7 GB box, per CLAUDE.md) — this PR is how it gets exercised.

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)