### PR TITLE
docs(appliance): warn that image upload 413s when upgrading from <=2026.07.21-1 (#787)

### DIFF
--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1248,6 +1248,28 @@ control-plane cluster itself, not the registered agent fleet.
    > set `slotImageMirror.enabled=true` itself; nothing there tracks the
    > replica count. Upgrading from an external image URL needs no mirror
    > either way.
+   >
+   > ⚠️ **Upgrading *to* `2026.07.30-1` from `2026.07.21-1` or earlier: do
+   > not use upload.** The nginx `location /api/v1/appliance/upgrade-images`
+   > block that raises `client_max_body_size` to 4 GiB — matching the
+   > backend's own `MAX_UPLOAD_BYTES` — first shipped **in** `2026.07.30-1`.
+   > On any earlier release the request falls through to the generic
+   > `/api/` location and nginx's ~1 MB default returns **413** before
+   > FastAPI ever sees it, so a ~1.8–2 GB `.raw.xz` cannot be staged at all.
+   >
+   > This is a chicken-and-egg: the fix only exists once you are already on
+   > the release you are trying to install. Use the **URL** source (mode 2
+   > below) or the host CLI over SSH instead — neither goes through that
+   > nginx location:
+   >
+   > ```bash
+   > sudo spatium-upgrade-slot apply \
+   >   https://github.com/spatiumddi/spatiumddi/releases/download/2026.07.30-1/spatiumddi-appliance-slot-2026.07.30-1-amd64.raw.xz \
+   >   --checksum https://github.com/spatiumddi/spatiumddi/releases/download/2026.07.30-1/spatiumddi-appliance-slot-2026.07.30-1-amd64.sha256
+   > ```
+   >
+   > Upload works normally once the appliance is on `2026.07.30-1` or
+   > later. See [#787](https://github.com/spatiumddi/spatiumddi/issues/787).
 2. **URL** (connected install). Operator pastes the GitHub release
    asset URL — same `https://github.com/.../spatiumddi-appliance-
    slot-amd64.raw.xz` shape the per-box flow uses. Each node fetches

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -1249,8 +1249,8 @@ control-plane cluster itself, not the registered agent fleet.
    > replica count. Upgrading from an external image URL needs no mirror
    > either way.
    >
-   > ⚠️ **Upgrading *to* `2026.07.30-1` from `2026.07.21-1` or earlier: do
-   > not use upload.** The nginx `location /api/v1/appliance/upgrade-images`
+  > ⚠️ **Upgrading from `2026.07.21-1` or earlier: do not use upload to reach
+  > `2026.07.30-1` or later.** The nginx `location /api/v1/appliance/upgrade-images`
    > block that raises `client_max_body_size` to 4 GiB — matching the
    > backend's own `MAX_UPLOAD_BYTES` — first shipped **in** `2026.07.30-1`.
    > On any earlier release the request falls through to the generic


### PR DESCRIPTION
Closes the last unfinished item on #787. Causes 1 and 2 were fixed in
`785d9975` and `b12f1959`; the external-URL checksum is deferred with
reasoning recorded on the issue. This is Cause 3 — the one that needs a doc
note rather than code, because no code change can reach installs already in
the field.

## The problem

The nginx `location /api/v1/appliance/upgrade-images` block that raises
`client_max_body_size` to 4 GiB — matching the backend's own
`MAX_UPLOAD_BYTES` — first shipped **in** `2026.07.30-1`. Verified against
the tags:

| Tag | `upgrade-images` location |
|---|---|
| `2026.07.11-1` | no size override → falls through to `/api/` → **413** |
| `2026.07.21-1` | no size override → falls through to `/api/` → **413** |
| `2026.07.30-1` | `client_max_body_size 4g` |

So a ~1.8–2 GB `.raw.xz` cannot be staged at all on an older appliance:
nginx rejects it at its ~1 MB default before FastAPI's own (more
informative) size check ever runs.

The trap is that the fix only exists **once you are already on the release
you are trying to install**. That is precisely why the original field report
worked around it over SSH — the manual `spatium-upgrade-slot apply` command
never crosses that nginx location.

## The change

One callout inside the "Uploaded / imported image" source mode in
`APPLIANCE.md` — the only affected path — naming both recovery routes (the
URL source, or the host CLI) and giving the literal command including its
`--checksum` sidecar.

## Verification

Rendered through the repo's pinned Jekyll image on `:4000`: page returns
200, and the nested blockquote plus its fenced code block both survive
kramdown inside the list item (that nesting is fragile, so it was worth
checking rather than assuming).

Closes #787

🤖 Generated with [Claude Code](https://claude.com/claude-code)
