### PR TITLE
docs: add a Third-Party Components catalogue, and fix what NOTICE got wrong

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | `docs/DEVELOPMENT.md` | Coding standards, test requirements, CI pipeline |
 | `docs/OBSERVABILITY.md` | Logging (centralized + UI viewer), metrics, health dashboard, alerting |
 | `docs/TROUBLESHOOTING.md` | Recovery recipes: accidentally deleted agent rows, password reset, subnet delete refused |
+| `docs/THIRD_PARTY.md` | Catalogue of every bundled/shipped third-party component — engine, library, OS package — with license, the artifact it ships in, and the rationale. Operator-facing companion to the root `NOTICE` (which stays authoritative for license text). **When you add a shipped component, update BOTH** |
 | `docs/features/IPAM.md` | IP Space/Block/Subnet/Address management, VLAN/VXLAN, custom fields, import/export, tree UI |
 | `docs/features/DHCP.md` | DHCP servers, scopes, pools, static assignments, DDNS, caching, Windows DHCP (Path A) |
 | `docs/features/DNS.md` | DNS servers, zones, records, views, server groups, blocking lists, DDNS, zone tree, Windows DNS (Path A + B), Technitium, encrypted transports (DoT / DoH / DoQ), DNS threat analytics, sync-with-servers reconciliation |
@@ -72,7 +73,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | Frontend | React 18 + TypeScript, Vite, shadcn/ui, Tailwind, React Query |
 | Database | PostgreSQL 16 (HA via Patroni or CloudNativePG) |
 | Cache / Sessions | Redis 7 |
-| Auth | python-jose + bcrypt (local), ldap3 (LDAP), authlib (OIDC), python3-saml (SAML), pyrad (RADIUS), tacacs_plus (TACACS+); Fernet for secrets at rest |
+| Auth | python-jose + bcrypt (local), ldap3 (LDAP), joserfc (OIDC ID-token / JWKS), python3-saml (SAML), pyrad (RADIUS), tacacs_plus (TACACS+); Fernet for secrets at rest |
 | Logging | structlog → JSON → centralized log store (Loki / Elasticsearch) |
 | Metrics | Prometheus + Grafana; InfluxDB v1/v2 push export |
 | Containerization | Docker (multi-stage, amd64+arm64), Docker Compose, Kubernetes + Helm |

--- a/NOTICE
+++ b/NOTICE
@@ -4,41 +4,91 @@ Copyright 2024 SpatiumDDI Contributors
 This product bundles, ships, or integrates with the following open source
 components. Grouped by role; license + project URL for each.
 
+For an operator-facing catalogue of the same ground — which artifact each
+component ships in, the version pinned, and why it is there — see
+docs/THIRD_PARTY.md (published at https://www.spatiumddi.com/THIRD_PARTY.html).
+Where the two disagree about a license, THIS file is authoritative.
+
 ── Operating system & boot (OS appliance image) ──────────────────────────
 - Linux Kernel — GPL v2 — https://kernel.org
 - Debian — DFSG (mixed) — https://debian.org
 - Alpine Linux — MIT + GPL v2 (kernel) — https://alpinelinux.org
 - GRUB 2 — GPL v3 — https://www.gnu.org/software/grub
-- systemd — LGPL v2.1 — https://systemd.io
+- systemd (incl. udev, systemd-resolved) — LGPL v2.1 — https://systemd.io
 - NetworkManager — GPL v2+ — https://networkmanager.dev
 - chrony (NTP) — GPL v2 — https://chrony-project.org
 - Net-SNMP (snmpd) — BSD-style (multiple) — https://net-snmp.org
 - lldpd — ISC — https://lldpd.github.io
 - nftables — GPL v2 — https://netfilter.org
+- OpenSSH — BSD-style — https://www.openssh.com
+- rsyslog (+ rsyslog-gnutls) — GPL v3 / LGPL v3 (libs) — https://www.rsyslog.com
+- cloud-init — GPL v3 / Apache 2.0 (dual) — https://cloud-init.io
+- unattended-upgrades — GPL v2 — https://github.com/mvo5/unattended-upgrades
+- newt / whiptail (install wizard dialogs) — LGPL v2 — https://pagure.io/newt
+- gdisk / parted / dosfstools / e2fsprogs — GPL v2 / GPL v3 — (Debian)
+- rsync — GPL v3 — https://rsync.samba.org
+- qemu-guest-agent — GPL v2 — https://www.qemu.org
+- open-vm-tools — GPL v2 + BSD — https://github.com/vmware/open-vm-tools
+- zstd — BSD 3-Clause / GPL v2 (dual) — https://facebook.github.io/zstd
+- jq — MIT — https://jqlang.github.io/jq
+- curl — curl license (MIT-like) — https://curl.se
+- Rich / psutil (appliance console dashboard) — MIT / BSD 3-Clause —
+  https://github.com/Textualize/rich , https://github.com/giampaolo/psutil
 
 ── Kubernetes control plane / orchestration (multi-node HA appliance) ─────
 - k3s — Apache 2.0 — https://k3s.io
 - etcd — Apache 2.0 — https://etcd.io
 - containerd — Apache 2.0 — https://containerd.io
+- runc — Apache 2.0 — https://github.com/opencontainers/runc
+- CoreDNS — Apache 2.0 — https://coredns.io
 - Flannel (CNI) — Apache 2.0 — https://github.com/flannel-io/flannel
+- local-path-provisioner — Apache 2.0 — https://github.com/rancher/local-path-provisioner
+- Traefik (present in the k3s airgap bundle; disabled by config) — MIT —
+  https://traefik.io
+- metrics-server (present in the k3s airgap bundle; disabled by config) —
+  Apache 2.0 — https://github.com/kubernetes-sigs/metrics-server
 - Helm — Apache 2.0 — https://helm.sh
 - MetalLB (L2 load balancer / control-plane VIP) — Apache 2.0 — https://metallb.io
 - FRRouting (BGP daemon, via MetalLB's frr-k8s backend) — GPL v2 — https://frrouting.org
 - CloudNativePG (PostgreSQL operator) — Apache 2.0 — https://cloudnative-pg.io
+- Patroni (bare-metal HA Postgres overlay) — MIT — https://github.com/patroni/patroni
+- HAProxy (Patroni HA overlay) — GPL v2 (+ LGPL exception for libs) —
+  https://www.haproxy.org
 
 ── Data services ──────────────────────────────────────────────────────────
 - PostgreSQL — PostgreSQL License — https://postgresql.org
-- Redis — BSD 3-Clause (pre-7.4) / RSALv2+SSPL (7.4+) — https://redis.io
-- Prometheus (+ client libs) — Apache 2.0 — https://prometheus.io
-- node-exporter / kube-state-metrics — Apache 2.0 — https://prometheus.io
+- Redis — BSD 3-Clause (pre-7.4) / RSALv2 + SSPLv1 (7.4+) /
+  RSALv2 + SSPLv1 + AGPLv3 (8.0+; SpatiumDDI ships 8.x) — https://redis.io
+- Prometheus (+ client_python) — Apache 2.0 — https://prometheus.io
+- node-exporter / kube-state-metrics (default-off appliance workloads) —
+  Apache 2.0 — https://prometheus.io
 
 ── DNS / DHCP / routing service engines ────────────────────────────────────
 - ISC Kea DHCP — MPL 2.0 — https://kea.isc.org
 - radvd (IPv6 Router Advertisement Daemon) — BSD-style — https://radvd.litech.org
-- ISC BIND 9 — MPL 2.0 — https://isc.org/bind
+- ISC BIND 9 (+ bind-tools / dnsutils) — MPL 2.0 — https://isc.org/bind
 - PowerDNS Authoritative Server — GPL v2 — https://powerdns.com
 - PowerDNS dnsdist — GPL v2 — https://dnsdist.org
+- Technitium DNS Server — GPL v3 — https://technitium.com/dns
 - GoBGP (BGP Looking Glass collector, issue #566) — Apache 2.0 — https://github.com/osrg/gobgp
+
+── Container base images & init ────────────────────────────────────────────
+- python:3.12-slim — PSF + Debian — https://python.org
+- node (frontend build stage) — MIT — https://nodejs.org
+- ASP.NET Core runtime (Technitium agent image) — MIT — https://dotnet.microsoft.com
+- tini — MIT — https://github.com/krallin/tini
+- su-exec — MIT — https://github.com/ncopa/su-exec
+- gosu — Apache 2.0 — https://github.com/tianon/gosu
+
+── Operator tooling shipped in the API image ───────────────────────────────
+- nmap (network scanning) — NPSL (Nmap Public Source License) — https://nmap.org
+- tcpdump / libpcap (packet capture) — BSD 3-Clause — https://www.tcpdump.org
+- mtr — GPL v2 — https://www.bitwizard.nl/mtr
+- whois — GPL v2 — https://github.com/rfc1036/whois
+- iputils (ping) / traceroute — BSD / GPL v2 — (Debian)
+- PostgreSQL client tools (pg_dump / pg_restore) — PostgreSQL License —
+  https://postgresql.org
+- xmlsec1 (SAML signature verification) — MIT — https://www.aleksey.com/xmlsec
 
 ── Backend (Python) ───────────────────────────────────────────────────────
 - Python — PSF License — https://python.org
@@ -47,38 +97,78 @@ components. Grouped by role; license + project URL for each.
 - Uvicorn — BSD 3-Clause — https://www.uvicorn.org
 - SQLAlchemy — MIT — https://sqlalchemy.org
 - Alembic — MIT — https://alembic.sqlalchemy.org
-- Pydantic — MIT — https://pydantic.dev
+- asyncpg — Apache 2.0 — https://github.com/MagicStack/asyncpg
+- Pydantic (+ pydantic-settings) — MIT — https://pydantic.dev
 - Celery — BSD 3-Clause — https://celeryq.dev
+- redis-py (+ hiredis) — MIT — https://github.com/redis/redis-py
 - structlog — MIT / Apache 2.0 — https://www.structlog.org
 - cryptography — Apache 2.0 / BSD 3-Clause — https://cryptography.io
 - pyOpenSSL (TLS cert chain capture) — Apache 2.0 — https://www.pyopenssl.org
+- python-jose (JWT) — MIT — https://github.com/mpdavis/python-jose
+- joserfc (OIDC ID-token validation, JWKS) — BSD 3-Clause — https://jose.authlib.org
+- bcrypt — Apache 2.0 — https://github.com/pyca/bcrypt
+- pyotp (TOTP) — MIT — https://github.com/pyauth/pyotp
+- python-multipart — Apache 2.0 — https://github.com/Kludex/python-multipart
 - httpx — BSD 3-Clause — https://www.python-httpx.org
-- Authlib (OIDC/OAuth) — BSD 3-Clause — https://authlib.org
 - ldap3 (LDAP) — LGPL v3 — https://github.com/cannatag/ldap3
 - python3-saml (SAML) — MIT — https://github.com/SAML-Toolkits/python3-saml
+- pyrad (RADIUS) — BSD 3-Clause — https://github.com/pyradius/pyrad
+- tacacs_plus (TACACS+) — BSD — https://github.com/ansible/tacacs_plus
+- paramiko (SSH transport) — LGPL v2.1 — https://www.paramiko.org
+- smbprotocol (SMB backup targets) — MIT — https://github.com/jborean93/smbprotocol
+- dnspython — ISC — https://www.dnspython.org
+- Jinja2 — BSD 3-Clause — https://jinja.palletsprojects.com
+- pywinrm (Windows DNS / DHCP over WinRM) — MIT — https://github.com/diyan/pywinrm
+- pysnmp — BSD 2-Clause — https://github.com/lextudio/pysnmp
+- openpyxl (XLSX import/export) — MIT — https://openpyxl.readthedocs.io
 - reportlab (PDF export) — BSD 3-Clause — https://www.reportlab.com
+- croniter (schedule parsing) — MIT — https://github.com/kiorky/croniter
 - icalendar (Wake-on-LAN calendar gate — .ics parsing) — BSD 2-Clause — https://github.com/collective/icalendar
-- caldav (Wake-on-LAN calendar gate — CalDAV client) — Apache 2.0 — https://github.com/python-caldav/caldav
+- caldav (Wake-on-LAN calendar gate — CalDAV client) — Apache 2.0 / GPL v3 (dual) — https://github.com/python-caldav/caldav
 - python-dateutil (recurrence RRULE/RDATE expansion) — Apache 2.0 / BSD 3-Clause — https://github.com/dateutil/dateutil
 - idna (IDNA2008 host/record name normalization — issue #597) — BSD 3-Clause — https://github.com/kjd/idna
-- Scapy (passive DHCP fingerprinting) — GPL v2 — https://scapy.net
-- nmap (network scanning) — NPSL (Nmap Public Source License) — https://nmap.org
-- tcpdump / libpcap (packet capture) — BSD 3-Clause — https://www.tcpdump.org
-- boto3 / botocore (AWS — infra mirror + Route 53 DNS) — Apache 2.0 — https://github.com/boto/boto3
-- azure-identity / azure-mgmt-network / azure-mgmt-compute / azure-mgmt-dns / azure-mgmt-resource (Azure — infra mirror + Azure DNS) — MIT — https://github.com/Azure/azure-sdk-for-python
-- google-cloud-compute / google-cloud-dns / google-auth (GCP — infra mirror + Cloud DNS) — Apache 2.0 — https://github.com/googleapis/google-cloud-python
+- PyYAML — MIT — https://pyyaml.org
+- docker SDK for Python (appliance cert reload) — Apache 2.0 — https://github.com/docker/docker-py
+- boto3 / botocore (AWS — infra mirror + Route 53 DNS + S3 backups) — Apache 2.0 — https://github.com/boto/boto3
+- azure-identity / azure-mgmt-network / azure-mgmt-compute / azure-mgmt-dns / azure-mgmt-resource / azure-storage-blob (Azure — infra mirror + Azure DNS + Blob backups) — MIT — https://github.com/Azure/azure-sdk-for-python
+- google-cloud-compute / google-cloud-dns / google-cloud-storage / google-auth (GCP — infra mirror + Cloud DNS + GCS backups) — Apache 2.0 — https://github.com/googleapis/google-cloud-python
 - Cloudflare DNS API (Cloud DNS driver) — service API, no SDK (plain REST via httpx) — https://api.cloudflare.com
+- openai (Operator Copilot model client) — Apache 2.0 — https://github.com/openai/openai-python
+- anthropic (Operator Copilot model client) — MIT — https://github.com/anthropics/anthropic-sdk-python
+
+── Agent runtimes (Python, in the service container images) ────────────────
+- Scapy (passive DHCP fingerprinting — DHCP agent image) — GPL v2 — https://scapy.net
 
 ── Frontend (TypeScript / React) ──────────────────────────────────────────
 - React — MIT — https://react.dev
 - Vite — MIT — https://vitejs.dev
 - TypeScript — Apache 2.0 — https://www.typescriptlang.org
-- Tailwind CSS — MIT — https://tailwindcss.com
+- Tailwind CSS (+ tailwindcss-animate) — MIT — https://tailwindcss.com
 - TanStack Query (React Query) — MIT — https://tanstack.com/query
+- React Router — MIT — https://reactrouter.com
+- axios — MIT — https://axios-http.com
 - shadcn/ui (component patterns) — MIT — https://ui.shadcn.com
+- Radix UI primitives — MIT — https://www.radix-ui.com
 - Recharts — MIT — https://recharts.org
+- lucide-react (icons) — ISC — https://lucide.dev
+- react-markdown / remark-gfm — MIT — https://github.com/remarkjs/react-markdown
+- dnd-kit — MIT — https://dndkit.com
+- clsx / tailwind-merge — MIT — https://github.com/lukeed/clsx
 - nginx (frontend static serving + agent landing) — BSD 2-Clause — https://nginx.org
 
 This list covers the major bundled / shipped components; it is not an
-exhaustive enumeration of every transitive dependency. Full license texts
-for the primary components are available in the LICENSES/ directory.
+exhaustive enumeration of every transitive dependency. The complete
+transitive sets are backend/pyproject.toml (with the resolved versions
+visible via `pip list` inside the API image) and frontend/package-lock.json.
+
+Full license texts are not vendored into this repository. Each component's
+license ships with the component itself and can be read from a running
+system — for example:
+
+  /usr/share/doc/<package>/copyright        (Debian appliance packages)
+  /usr/share/licenses/<package>/            (Alpine agent images)
+  /usr/share/doc/k3s/LICENSE                (k3s, fetched at image build)
+  python3 -m pip show <name>                (Python packages)
+
+docs/THIRD_PARTY.md documents this in more detail, including the copyleft
+components and what their terms mean for redistribution.

--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,7 @@ Full docs at **[www.spatiumddi.com](https://www.spatiumddi.com)** — republishe
 | [Bare Metal](docs/deployment/BAREMETAL.md) | Bare-metal / VM paths — Docker Compose on a host, Patroni HA Postgres overlay, OS appliance |
 | [Appliance Deployment](docs/deployment/APPLIANCE.md) | OS appliance ISO — base OS selection, build pipeline, first-boot orchestration, `/appliance` management hub spec |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Recovery recipes — deleted agent rows, password reset, subnet-delete refused |
+| [Third-Party Components](docs/THIRD_PARTY.md) | Every bundled engine, library and OS package — license, artifact it ships in, and why it's there |
 
 ---
 
@@ -1389,7 +1390,7 @@ part of merging each contributor's first PR.
 
 Released under the [Apache 2.0 License](LICENSE).
 
-Bundled components (BIND9, ISC Kea) are distributed under their own licenses. See [NOTICE](NOTICE) for the full list.
+Bundled components (BIND9, PowerDNS, Technitium, ISC Kea, k3s, and the appliance's Debian userland) are distributed under their own licenses. See [NOTICE](NOTICE) for the attribution manifest, and [Third-Party Components](https://www.spatiumddi.com/THIRD_PARTY.html) for the full catalogue — what each component is, which artifact it ships in, and what its license means in practice.
 
 ---
 

--- a/docs/THIRD_PARTY.md
+++ b/docs/THIRD_PARTY.md
@@ -1,0 +1,397 @@
+---
+layout: default
+title: Third-Party Components
+description: Every third-party component SpatiumDDI bundles, ships or runs — grouped by artifact, with licenses and where each one comes from.
+---
+
+# Third-Party Components
+
+SpatiumDDI is an assembly job as much as it is a codebase. It does not
+reimplement DNS or DHCP — it runs BIND9, PowerDNS, Technitium and Kea, and it
+runs them on a Kubernetes distribution it did not write, on an operating system
+it did not write. This page is the catalogue of everything in that stack: what
+it is, which artifact it ships in, what license it carries, and why it is there.
+
+**Two files cover this ground, and they are not the same thing.**
+
+| File | Purpose | Authoritative for |
+|---|---|---|
+| [`NOTICE`](https://github.com/spatiumddi/spatiumddi/blob/main/NOTICE) | Legal attribution notice, shipped in the repo root and in every image | License obligations |
+| This page | Operator-facing catalogue — versions, artifact placement, rationale | Understanding what runs where |
+
+If the two ever disagree about a license, `NOTICE` wins and the discrepancy is
+a bug worth [filing](https://github.com/spatiumddi/spatiumddi/issues).
+
+Neither file enumerates every transitive dependency. They cover components that
+are **bundled, shipped, or directly depended on** — the things an operator can
+point at in a running system, and the things a license auditor asks about. The
+full transitive set for the Python and npm layers lives in
+`backend/pyproject.toml` + `frontend/package-lock.json`; for the OS layer, ask
+the package manager on a running appliance (see
+[Verifying a running system](#verifying-a-running-system)).
+
+## Artifacts
+
+The "Where" column throughout this page refers to these:
+
+| Artifact | What it is |
+|---|---|
+| **API image** | `ghcr.io/spatiumddi/spatiumddi-api` — FastAPI control plane, Celery worker, Celery beat, and the migrate job. One image, four roles |
+| **Frontend image** | `ghcr.io/spatiumddi/spatiumddi-frontend` — the built React SPA behind nginx |
+| **DNS agent images** | `dns-bind9`, `dns-powerdns`, `dns-technitium`, `dns-dnsdist` — each pairs a DNS engine with the Python sync agent |
+| **DHCP agent image** | `dhcp-kea` — Kea DHCPv4 + DHCPv6 + radvd + the Python sync agent |
+| **Looking Glass image** | `looking-glass` — GoBGP collector + agent |
+| **Supervisor image** | `spatium-supervisor` — host-side controller on the OS appliance |
+| **Appliance OS** | The bootable Debian image, including its baked k3s |
+| **Helm charts** | `charts/spatiumddi` (generic Kubernetes) and `charts/spatiumddi-appliance` (on-appliance k3s) |
+
+Versions below are the pins on `main` at the time of writing. They move; the
+**Pinned in** column names the file that is actually authoritative, and that is
+the one to check rather than trusting this table's numbers.
+
+## DNS, DHCP and routing engines
+
+The reason the project exists. Every one of these is a separate upstream daemon
+running as its own process — SpatiumDDI generates their configuration and talks
+to their control channels, it does not link against them.
+
+| Component | Version | License | Where | Pinned in |
+|---|---|---|---|---|
+| [ISC BIND 9](https://www.isc.org/bind/) | `>= 9.20.26` (Alpine) | MPL 2.0 | DNS agent image | `agent/dns/images/bind9/Dockerfile` |
+| [PowerDNS Authoritative Server](https://www.powerdns.com/) | Alpine `pdns` | GPL v2 | DNS agent image | `agent/dns/images/powerdns/Dockerfile` |
+| [Technitium DNS Server](https://technitium.com/dns/) | 15.4.0 (digest-pinned) | GPL v3 | DNS agent image | `agent/dns/images/technitium/Dockerfile` |
+| [PowerDNS dnsdist](https://dnsdist.org/) | Alpine `dnsdist` | GPL v2 | DNS agent image | `agent/dns/images/dnsdist/Dockerfile` |
+| [ISC Kea DHCP](https://www.isc.org/kea/) | Alpine `kea`, v4 + v6 | MPL 2.0 | DHCP agent image | `agent/dhcp/images/kea/Dockerfile` |
+| [radvd](https://radvd.litech.org/) | Alpine `radvd` | BSD-style | DHCP agent image | `agent/dhcp/images/kea/Dockerfile` |
+| [GoBGP](https://github.com/osrg/gobgp) | 4.7.0 (built from source) | Apache 2.0 | Looking Glass image | `agent/looking-glass/images/gobgp/Dockerfile` |
+| [BIND `dig` / `nsupdate`](https://www.isc.org/bind/) | `bind-tools` | MPL 2.0 | DNS + supervisor + API images | several Dockerfiles |
+
+Notes worth carrying:
+
+- **Technitium runs on .NET.** Its image is Ubuntu-based (upstream's own base),
+  not Alpine like the other agents, and it pulls in the ASP.NET Core runtime.
+  It is the one DNS engine whose base image SpatiumDDI does not choose.
+- **dnsdist is not a general DNS server here.** It exists to give PowerDNS
+  inbound DoT/DoH, which pdns-auth does not speak natively. See
+  [DNS](features/DNS.md).
+- **Kea 3.0 imposes path restrictions** on hook libraries and socket paths as a
+  result of CVE-2025-32801/2/3. The Dockerfile carries a prominent warning
+  about this; the paths in it are load-bearing, not stylistic.
+
+## Kubernetes and orchestration
+
+| Component | Version | License | Where | Pinned in |
+|---|---|---|---|---|
+| [k3s](https://k3s.io/) | v1.35.6+k3s1 | Apache 2.0 | Appliance OS | `appliance/scripts/fetch-k3s.sh` |
+| [containerd](https://containerd.io/) + [runc](https://github.com/opencontainers/runc) | embedded in k3s | Apache 2.0 | Appliance OS | (k3s bundle) |
+| [CoreDNS](https://coredns.io/) | k3s airgap bundle | Apache 2.0 | Appliance OS | (k3s bundle) |
+| [Flannel](https://github.com/flannel-io/flannel) | embedded in k3s, `host-gw` backend | Apache 2.0 | Appliance OS | `appliance/mkosi.extra/etc/rancher/k3s/config.yaml` |
+| [local-path-provisioner](https://github.com/rancher/local-path-provisioner) | k3s airgap bundle | Apache 2.0 | Appliance OS | (k3s bundle) |
+| [etcd](https://etcd.io/) | embedded in k3s | Apache 2.0 | Appliance OS | (k3s bundle) |
+| [Helm](https://helm.sh/) | k3s helm-controller | Apache 2.0 | Appliance OS | (k3s bundle) |
+| [Traefik](https://traefik.io/) | in k3s bundle, **disabled** | MIT | Appliance OS | `config.yaml` `disable:` list |
+| [metrics-server](https://github.com/kubernetes-sigs/metrics-server) | in k3s bundle, **disabled** | Apache 2.0 | Appliance OS | `config.yaml` `disable:` list |
+| [MetalLB](https://metallb.io/) | chart + images 0.15.3 | Apache 2.0 | Helm chart (opt-in) | `charts/spatiumddi-metallb/Chart.yaml` |
+| [FRRouting](https://frrouting.org/) | via MetalLB frr-k8s | GPL v2 | Helm chart (opt-in) | `charts/spatiumddi-metallb` values |
+| [CloudNativePG](https://cloudnative-pg.io/) | chart 0.28.2 | Apache 2.0 | Helm chart (opt-in) | `charts/spatiumddi-appliance/Chart.yaml` |
+| [Patroni](https://github.com/patroni/patroni) | `k8s/ha/` overlay | MIT | Bare-metal HA overlay | `k8s/ha/` |
+| [HAProxy](https://www.haproxy.org/) | 2.9-alpine | GPL v2 (+ LGPL libs) | Patroni HA overlay | `k8s/ha/` |
+
+Three of these deserve a sentence, because their state is not what you would
+assume from their presence:
+
+- **Traefik and metrics-server ship but are disabled.** They arrive inside the
+  k3s airgap image tarball, which is a single artifact — you cannot fetch a k3s
+  release without them. The appliance disables both in `config.yaml`: operator
+  TLS goes through the existing nginx reverse proxy, and metrics-server costs
+  ~80 MiB RSS for something not yet surfaced.
+- **MetalLB is pinned to 0.15.3 deliberately**, chart and images together. 0.16.0
+  regressed the speaker into an apiserver-flooding reconcile loop
+  ([metallb#3063](https://github.com/metallb/metallb/issues/3063)), and pinning
+  only the images while keeping the newer chart crashloops on a health probe the
+  older binary does not serve.
+- **FRRouting is GPL v2** and only enters the picture when an operator opts into
+  BGP-mode MetalLB. Both `bgp.enabled` and `frrk8s.enabled` default to false.
+
+## Data services
+
+| Component | Version | License | Where | Pinned in |
+|---|---|---|---|---|
+| [PostgreSQL](https://www.postgresql.org/) | 16-alpine | PostgreSQL License | Compose + Helm chart | `docker-compose.yml` |
+| [Redis](https://redis.io/) | 8.8-alpine | RSALv2 / SSPLv1 / AGPLv3 (Redis 8+) | Compose + Helm chart | `docker-compose.yml` |
+| [Prometheus node-exporter](https://github.com/prometheus/node_exporter) | v1.11.1, **default off** | Apache 2.0 | Appliance chart | `charts/spatiumddi-appliance/values.yaml` |
+| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) | v2.18.0, **default off** | Apache 2.0 | Appliance chart | `charts/spatiumddi-appliance/values.yaml` |
+| [prometheus-client](https://github.com/prometheus/client_python) | see manifest | Apache 2.0 AND BSD 2-Clause | API image | `backend/pyproject.toml` |
+
+**On Redis's license:** Redis relicensed away from BSD at 7.4 (RSALv2 + SSPLv1)
+and added an AGPLv3 option at 8.0. SpatiumDDI ships the stock upstream
+`redis:8.8-alpine` image unmodified and talks to it as a network service over
+its own protocol — no Redis code is linked into or vendored by SpatiumDDI.
+
+Operators who would rather not run that license family can point the deployment
+at any Redis-protocol-compatible server via the connection URL. The control
+plane uses only `GET` / `SET` / `DEL` / `INCR` / `EXPIRE` / `SCAN` and pub/sub —
+no modules, no Lua, no streams — and Celery's Redis broker is the other
+consumer. This is an untested configuration rather than a supported one; if you
+run SpatiumDDI on a Redis alternative,
+[tell us how it went](https://github.com/spatiumddi/spatiumddi/issues).
+
+The Helm chart used to bundle Bitnami's PostgreSQL and Redis subcharts. Bitnami
+pruned its Docker Hub namespace in late 2025 in favour of paid images, so the
+pinned tags stopped resolving; the chart now ships plain StatefulSets using the
+official upstream images instead.
+
+## Control-plane backend (Python)
+
+Runs in the **API image**. Authoritative list, with versions:
+`backend/pyproject.toml`.
+
+| Component | License | What it does here |
+|---|---|---|
+| [Python](https://www.python.org/) 3.12 | PSF | Runtime |
+| [FastAPI](https://fastapi.tiangolo.com/) / [Starlette](https://www.starlette.io/) | MIT / BSD 3-Clause | HTTP framework |
+| [Uvicorn](https://www.uvicorn.org/) | BSD 3-Clause | ASGI server |
+| [SQLAlchemy](https://www.sqlalchemy.org/) / [Alembic](https://alembic.sqlalchemy.org/) | MIT | ORM + migrations |
+| [asyncpg](https://github.com/MagicStack/asyncpg) | Apache 2.0 | Async PostgreSQL driver |
+| [Pydantic](https://pydantic.dev/) / pydantic-settings | MIT | Schema validation, settings |
+| [Celery](https://docs.celeryq.dev/) | BSD 3-Clause | Task queue |
+| [redis-py](https://github.com/redis/redis-py) + hiredis | MIT | Redis client |
+| [structlog](https://www.structlog.org/) | MIT OR Apache 2.0 | Structured JSON logging |
+| [cryptography](https://cryptography.io/) | Apache 2.0 OR BSD 3-Clause | Fernet secrets at rest, cert handling |
+| [pyOpenSSL](https://www.pyopenssl.org/) | Apache 2.0 | TLS chain capture (stdlib `ssl` cannot on 3.12) |
+| [python-jose](https://github.com/mpdavis/python-jose) / [joserfc](https://jose.authlib.org/) | MIT / BSD 3-Clause | JWT issue + verify |
+| [bcrypt](https://github.com/pyca/bcrypt) | Apache 2.0 | Local password hashing |
+| [pyotp](https://github.com/pyauth/pyotp) | MIT | TOTP second factor |
+| [ldap3](https://github.com/cannatag/ldap3) | **LGPL v3** | LDAP authentication |
+| [python3-saml](https://github.com/SAML-Toolkits/python3-saml) | MIT | SAML SP flow |
+| [pyrad](https://github.com/pyradius/pyrad) | BSD 3-Clause | RADIUS authentication |
+| [tacacs_plus](https://github.com/ansible/tacacs_plus) | BSD | TACACS+ authentication |
+| [httpx](https://www.python-httpx.org/) | BSD 3-Clause | HTTP client (all outbound integrations) |
+| [dnspython](https://www.dnspython.org/) | ISC | DDNS, AXFR, resolution |
+| [Jinja2](https://jinja.palletsprojects.com/) | BSD 3-Clause | Config rendering |
+| [pywinrm](https://github.com/diyan/pywinrm) | MIT | Windows DNS/DHCP over WinRM |
+| [pysnmp](https://github.com/lextudio/pysnmp) | BSD 2-Clause | SNMP polling |
+| [paramiko](https://www.paramiko.org/) | **LGPL 2.1** | SSH transport |
+| [smbprotocol](https://github.com/jborean93/smbprotocol) | MIT | SMB backup targets |
+| [openpyxl](https://openpyxl.readthedocs.io/) | MIT | XLSX import/export |
+| [reportlab](https://www.reportlab.com/) | BSD | PDF reports (audit, compliance, IPAM) |
+| [croniter](https://github.com/kiorky/croniter) | MIT | Schedule parsing |
+| [icalendar](https://github.com/collective/icalendar) / [caldav](https://github.com/python-caldav/caldav) / [python-dateutil](https://github.com/dateutil/dateutil) | BSD 2-Clause / Apache 2.0 (dual with GPL v3) / dual | Wake-on-LAN calendar gate |
+| [idna](https://github.com/kjd/idna) | BSD 3-Clause | IDNA2008 name normalization |
+| [boto3](https://github.com/boto/boto3) | Apache 2.0 | AWS mirror + Route 53 DNS + S3 backups |
+| [azure-identity / azure-mgmt-\*](https://github.com/Azure/azure-sdk-for-python) | MIT | Azure mirror + Azure DNS + Blob backups |
+| [google-cloud-\* / google-auth](https://github.com/googleapis/google-cloud-python) | Apache 2.0 | GCP mirror + Cloud DNS + GCS backups |
+| [docker](https://github.com/docker/docker-py) | Apache 2.0 | Cert-reload signal on non-k3s appliances |
+| [PyYAML](https://pyyaml.org/) | MIT | HelmChartConfig rewriting |
+| [openai](https://github.com/openai/openai-python) / [anthropic](https://github.com/anthropics/anthropic-sdk-python) | Apache 2.0 / MIT | Operator Copilot model clients |
+
+**Cloudflare has no SDK entry on purpose.** The Cloudflare DNS driver speaks
+plain REST over `httpx` rather than pulling in the official SDK, which ships a
+pydantic-v1 compatibility shim.
+
+**On the two copyleft Python libraries:** `ldap3` (LGPL v3) and `paramiko`
+(LGPL 2.1) are imported as libraries into an Apache-2.0 application. LGPL
+permits this; what it requires is that a recipient can replace the library. They
+are installed as ordinary, separately-replaceable site-packages in the image —
+nothing is statically linked or vendored.
+
+## Agent runtimes (Python)
+
+The DNS, DHCP, Looking Glass and supervisor agents each carry a much smaller
+dependency set than the control plane. Common to all: `httpx`, `structlog`,
+`pydantic`.
+
+| Agent | Additional | License | Why |
+|---|---|---|---|
+| DNS | dnspython, cryptography | ISC, Apache 2.0 OR BSD 3-Clause | DDNS + TSIG |
+| DHCP | [Scapy](https://scapy.net/) | GPL v2 | Passive DHCP fingerprinting — opt-in at runtime, installed unconditionally so the toggle needs no second image |
+| Supervisor | cryptography, PyYAML | Apache 2.0 OR BSD 3-Clause, MIT | Ed25519 identity, chart values |
+| Looking Glass | — | — | Talks to GoBGP over its API |
+
+## Frontend
+
+Runs in the **frontend image**. Authoritative list:
+`frontend/package.json`.
+
+| Component | License | What it does here |
+|---|---|---|
+| [React](https://react.dev/) + react-dom 18 | MIT | UI framework |
+| [TypeScript](https://www.typescriptlang.org/) | Apache 2.0 | Language |
+| [Vite](https://vite.dev/) | MIT | Build tool + dev server |
+| [Tailwind CSS](https://tailwindcss.com/) + tailwindcss-animate | MIT | Styling |
+| [shadcn/ui](https://ui.shadcn.com/) | MIT | Component patterns (vendored source, not a dependency) |
+| [Radix UI](https://www.radix-ui.com/) context-menu | MIT | Accessible primitive |
+| [TanStack Query](https://tanstack.com/query) | MIT | Server-state cache |
+| [React Router](https://reactrouter.com/) | MIT | Routing |
+| [axios](https://axios-http.com/) | MIT | HTTP client |
+| [Recharts](https://recharts.org/) | MIT | Charts |
+| [lucide-react](https://lucide.dev/) | ISC | Icons |
+| [react-markdown](https://github.com/remarkjs/react-markdown) + remark-gfm | MIT | Copilot message rendering |
+| [dnd-kit](https://dndkit.com/) | MIT | Drag-and-drop |
+| clsx, tailwind-merge | MIT | Class composition |
+| [nginx](https://nginx.org/) 1.31-alpine | BSD 2-Clause | Static serving + API reverse proxy |
+
+## Appliance operating system
+
+The bootable image is Debian 13 (trixie), built with
+[mkosi](https://github.com/systemd/mkosi). The full package list is
+`appliance/mkosi.conf` — this is the operator-meaningful subset.
+
+| Component | License | Why it is on the image |
+|---|---|---|
+| [Linux kernel](https://kernel.org/) | GPL v2 | `linux-image-amd64`, not the cloud variant — the cloud kernel strips KMS, leaving an 80x25 console instead of the dense one the dashboard needs |
+| [Debian](https://www.debian.org/) base | DFSG (mixed) | Base distribution |
+| [systemd](https://systemd.io/) + udev + systemd-resolved | LGPL 2.1+ | Init, device management, host resolver |
+| [GRUB 2](https://www.gnu.org/software/grub/) | GPL v3 | Hybrid BIOS + UEFI boot |
+| [NetworkManager](https://networkmanager.dev/) | GPL v2+ | Interface configuration |
+| [nftables](https://netfilter.org/) | GPL v2 | Default-deny inbound firewall, per-role drop-ins |
+| [chrony](https://chrony-project.org/) | GPL v2 | NTP |
+| [Net-SNMP](https://net-snmp.org/) | BSD-style | `snmpd` — needs unfiltered `/proc` and `/sys`, which is why it runs on the host and not in a container |
+| [lldpd](https://lldpd.github.io/) | ISC | Neighbour discovery |
+| [rsyslog](https://www.rsyslog.com/) + rsyslog-gnutls | GPL v3 / LGPL v3 | Syslog forwarding, TLS transport |
+| [OpenSSH](https://www.openssh.com/) | BSD-style | Operator access |
+| [cloud-init](https://cloud-init.io/) | GPL v3 / Apache 2.0 | First-boot provisioning |
+| [unattended-upgrades](https://github.com/mvo5/unattended-upgrades) | GPL v2 | Security patches (no kernel upgrades) |
+| [newt / whiptail](https://pagure.io/newt) | LGPL v2 | Install wizard dialogs |
+| [gdisk](https://www.rodsbooks.com/gdisk/), dosfstools, e2fsprogs, parted | GPL v2 / GPL v3 | Disk partitioning + filesystems |
+| [rsync](https://rsync.samba.org/) | GPL v3 | Rootfs mirror to target disk |
+| [qemu-guest-agent](https://www.qemu.org/) / [open-vm-tools](https://github.com/vmware/open-vm-tools) | GPL v2 / GPL v2 + BSD | Hypervisor integration; both no-op off their platform |
+| [zstd](https://facebook.github.io/zstd/) | BSD 3-Clause / GPL v2 | Image + airgap tarball compression |
+| [jq](https://jqlang.github.io/jq/), [curl](https://curl.se/), less, htop, tcpdump, dnsutils | MIT / curl / GPL / BSD / MPL 2.0 | Operator diagnostics |
+| [Rich](https://github.com/Textualize/rich) + [psutil](https://github.com/giampaolo/psutil) (python3-rich, python3-psutil) | MIT / BSD 3-Clause | The console dashboard on tty1 |
+
+**There is no Docker on the appliance.** It was removed in #183 Phase 7 — the
+image is k3s-only, and k3s's static binary carries its own containerd plus
+`kubectl` / `ctr` / `crictl` as argv symlinks.
+
+## Operator tooling inside the API image
+
+The Tools page (`/tools`) and PCAP capture shell out to real binaries, so they
+ship in the API image rather than being reimplemented. All are invoked through a
+sandboxed argv builder, never a shell string.
+
+| Component | License | Used by |
+|---|---|---|
+| [nmap](https://nmap.org/) | NPSL (Nmap Public Source License) | Port/service scan tools |
+| [tcpdump](https://www.tcpdump.org/) + libpcap | BSD 3-Clause | PCAP capture (#59), granted `cap_net_raw` |
+| [mtr](https://www.bitwizard.nl/mtr/) (mtr-tiny) | GPL v2 | Path analysis |
+| iputils-ping, traceroute | BSD / GPL v2 | Reachability |
+| [whois](https://github.com/rfc1036/whois) | GPL v2 | Registration lookup |
+| BIND `dig` (dnsutils) | MPL 2.0 | DNS query + propagation check |
+| [PostgreSQL client 16](https://www.postgresql.org/) | PostgreSQL License | `pg_dump` / `pg_restore` for backup + restore |
+| [xmlsec1](https://www.aleksey.com/xmlsec/) (libxmlsec1-openssl) | MIT | SAML assertion signature verification |
+
+**nmap's license is not OSI-approved.** The NPSL is a GPL v2 derivative with
+added restrictions on redistribution inside commercial products. SpatiumDDI is
+Apache 2.0 and ships nmap as an unmodified, separately-installed Debian package
+invoked as a subprocess — no linking, no derivative work. Anyone repackaging
+SpatiumDDI commercially should read the NPSL themselves rather than assume the
+Apache license covers it.
+
+## Container bases and init
+
+| Component | Version | License | Where |
+|---|---|---|---|
+| [Alpine Linux](https://alpinelinux.org/) | 3.23 | MIT (+ GPL v2 kernel) | All agent images, supervisor |
+| [Debian slim](https://www.debian.org/) | trixie / bookworm | DFSG (mixed) | Appliance builder, Technitium agent build stage |
+| [python:3.12-slim](https://www.python.org/) | 3.12 | PSF + Debian | API image |
+| [node](https://nodejs.org/) | 22-alpine | MIT | Frontend build stage |
+| [nginx](https://nginx.org/) | 1.31.3-alpine | BSD 2-Clause | Frontend runtime |
+| [ASP.NET Core runtime](https://dotnet.microsoft.com/) | 10.0 | MIT | Technitium agent image |
+| [tini](https://github.com/krallin/tini) | Alpine/Debian pkg | MIT | PID 1 in every agent image |
+| [su-exec](https://github.com/ncopa/su-exec) / [gosu](https://github.com/tianon/gosu) | Alpine / Debian pkg | MIT / Apache 2.0 | Privilege drop at entrypoint |
+
+Alpine is pinned at **3.23, not 3.24**, and that pin is load-bearing: 3.24 ships
+Python 3.13 while the agent Dockerfiles install into 3.12 paths, which produces a
+`ModuleNotFoundError` crashloop rather than a build failure. Dependabot is
+configured to hold the pin.
+
+## Build and test toolchain
+
+Not shipped to operators — listed because a contributor will meet all of it, and
+because CI gates depend on specific behaviour from several.
+
+| Component | License | Role |
+|---|---|---|
+| [mkosi](https://github.com/systemd/mkosi) | LGPL 2.1 | Builds the appliance disk image |
+| [Go](https://go.dev/) | BSD 3-Clause | Builds GoBGP from source in the Looking Glass image |
+| [Trivy](https://trivy.dev/) | Apache 2.0 | Image CVE gate (HIGH/CRITICAL, `--ignore-unfixed`) |
+| [pytest](https://pytest.org/) + pytest-asyncio / cov / xdist / split | MIT | Backend test suite |
+| [ruff](https://docs.astral.sh/ruff/) / [black](https://black.readthedocs.io/) / [mypy](https://mypy-lang.org/) | MIT | Backend lint + typecheck |
+| [ESLint](https://eslint.org/) / [Prettier](https://prettier.io/) / typescript-eslint | MIT | Frontend lint |
+| [Playwright](https://playwright.dev/) | Apache 2.0 | README/docs screenshot generation |
+| [Jekyll](https://jekyllrb.com/) + kramdown | MIT | This documentation site |
+| [Helm](https://helm.sh/) | Apache 2.0 | Chart packaging |
+
+## License obligations
+
+SpatiumDDI itself is [Apache 2.0](https://github.com/spatiumddi/spatiumddi/blob/main/LICENSE).
+Everything above keeps its own license. The combination is distributed as
+**separate, independently-installed programs** — container images built from
+upstream distribution packages, and a disk image built by a distribution's own
+package manager. Nothing copyleft is statically linked into, or vendored inside,
+the Apache-2.0 codebase.
+
+The practical consequences:
+
+- **GPL components ship unmodified.** BIND9, PowerDNS, dnsdist, Technitium,
+  Scapy, FRRouting, HAProxy and the Debian host userland are all upstream
+  binaries installed from their distributions' repositories. Source for each is
+  available from the distribution that packaged it, on the terms in that
+  package's license.
+- **The two LGPL Python libraries** (`ldap3`, `paramiko`) are imported, not
+  linked or vendored, and are replaceable in place inside the image.
+- **nmap's NPSL is the one license here that is not OSI-approved** and carries
+  redistribution conditions Apache 2.0 does not. See the note above.
+- **Technitium is GPL v3** and, unlike the other engines, runs from upstream's
+  own container image with a digest pin. SpatiumDDI adds the sync agent as a
+  separate process in that image; it does not patch the server.
+
+If you are performing a license review and need something this page does not
+answer, [open an issue](https://github.com/spatiumddi/spatiumddi/issues) — that
+is a documentation bug, not a support question.
+
+## Verifying a running system
+
+This page can drift. A running system cannot.
+
+Python packages in the API image, with versions and licenses:
+
+```bash
+docker compose exec api python3 -m pip list
+docker compose exec api python3 -m pip show ldap3 paramiko
+```
+
+OS packages on the appliance:
+
+```bash
+dpkg-query -W -f='${Package}\t${Version}\t${Homepage}\n' | sort
+```
+
+Packages inside an Alpine-based agent image:
+
+```bash
+docker compose exec dns-bind9 apk list --installed
+```
+
+What k3s actually bundles in the release you are running — the manifest is baked
+onto the appliance at build time, alongside k3s's own LICENSE:
+
+```bash
+cat /usr/share/doc/k3s/k3s-images.txt
+cat /usr/share/doc/k3s/LICENSE
+```
+
+Images running on the appliance's k3s cluster right now:
+
+```bash
+kubectl get pods -A -o jsonpath='{range .items[*].spec.containers[*]}{.image}{"\n"}{end}' | sort -u
+```
+
+## See also
+
+- [`NOTICE`](https://github.com/spatiumddi/spatiumddi/blob/main/NOTICE) — the shipped attribution notice
+- [Architecture](ARCHITECTURE.md) — how these components fit together
+- [DNS Drivers](drivers/DNS_DRIVERS.md) / [DHCP Drivers](drivers/DHCP_DRIVERS.md) — how SpatiumDDI drives the engines
+- [OS Appliance](deployment/APPLIANCE.md) — how the image is built
+- [Kubernetes](deployment/KUBERNETES.md) — the umbrella chart

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -46,5 +46,9 @@ Every specification, deployment guide and driver internal, grouped by what you'r
 
 ## Driver Internals
 
-- [DNS Drivers](drivers/DNS_DRIVERS.md) — BIND9 + Windows DNS driver internals
+- [DNS Drivers](drivers/DNS_DRIVERS.md) — BIND9 + PowerDNS + Technitium + Windows DNS driver internals
 - [DHCP Drivers](drivers/DHCP_DRIVERS.md) — Kea + Windows DHCP driver internals
+
+## Project
+
+- [Third-Party Components](THIRD_PARTY.md) — every bundled engine, library and OS package, with licenses and which artifact each ships in

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -16,6 +16,7 @@
   <url><loc>https://www.spatiumddi.com/deployment/BAREMETAL</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://www.spatiumddi.com/deployment/APPLIANCE</loc><changefreq>monthly</changefreq><priority>0.6</priority></url>
   <url><loc>https://www.spatiumddi.com/deployment/DNS_AGENT</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://www.spatiumddi.com/THIRD_PARTY</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.spatiumddi.com/drivers/DNS_DRIVERS</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
   <url><loc>https://www.spatiumddi.com/drivers/DHCP_DRIVERS</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 </urlset>


### PR DESCRIPTION
## Why

SpatiumDDI runs BIND9, PowerDNS, Technitium, Kea, k3s and a whole Debian
userland it did not write. The only place that was written down was the root
`NOTICE` — a flat attribution list with no versions, no indication of which
artifact anything ships in, and no rationale. "What third-party software does
this run, and where?" had no answer on the documentation site.

## What

**New [`docs/THIRD_PARTY.md`](https://github.com/spatiumddi/spatiumddi/blob/docs-third-party-components/docs/THIRD_PARTY.md)** — an operator-facing catalogue organised by
*artifact* rather than alphabetically, because "which image is this in?" is the
question an operator actually has. Eleven groups: DNS/DHCP engines, Kubernetes
and orchestration, data services, backend Python, agent runtimes, frontend,
appliance OS, API-image operator tooling, container bases, build toolchain, and
license obligations.

Two things make it more than a list:

- Every row carries a **Pinned in** column naming the file that is actually
  authoritative for that version, so the page can be *checked* rather than
  trusted — and it degrades honestly as versions move.
- It documents the things that are easy to get wrong. Traefik and
  metrics-server ship inside the k3s airgap bundle but are disabled by config.
  MetalLB is pinned to 0.15.3 chart-and-images-together because 0.16.0
  regressed the speaker into an apiserver-flooding loop. Alpine is held at 3.23
  because 3.24's Python 3.13 crashloops the agents.

It closes with commands to verify any of it against a running system, so the
page can be audited instead of believed.

## The audit found real problems in `NOTICE`

Reading every manifest to write the catalogue turned up five defects, all fixed
here:

| Problem | Detail |
|---|---|
| **Technitium was missing entirely** | A GPL v3 DNS server we ship, absent from the attribution notice. So were paramiko (LGPL 2.1), most of the appliance's Debian userland, CoreDNS / runc / local-path-provisioner, Patroni, HAProxy, the API image's operator tooling (mtr, whois, xmlsec1, `pg_dump`), and ~20 backend and frontend libraries |
| **Authlib listed but not a dependency** | Not in `pyproject.toml`, not installed — OIDC moved to `joserfc`. Corrected in `NOTICE` and in CLAUDE.md's stack table |
| **Scapy filed under Backend** | It ships in the DHCP agent image, not the API image |
| **Redis license stale** | Described as "RSALv2+SSPL (7.4+)" while we ship 8.8, which added the AGPLv3 option |
| **`LICENSES/` directory promised but never existed** | The closing line pointed readers at a directory that has never been in this repo. Replaced with paths that do work on a running system |

The Technitium omission is the one worth calling a compliance gap rather than
tidiness — shipping GPL v3 with no attribution.

## Provenance

Licenses and versions in both files were read out of the **installed packages** —
`pip` metadata inside the API image, `node_modules`, the Dockerfiles,
`mkosi.conf`, and chart values — not from memory. Two claims were checked
against the code rather than asserted: the Redis-alternative note lists only the
commands the control plane actually issues (`GET` / `SET` / `DEL` / `INCR` /
`EXPIRE` / `SCAN` + pub/sub, no modules, no Lua, no streams), and it is labelled
untested rather than supported.

## Also

- Linked from `docs/docs.md` (new **Project** group), the README's License
  section and Documentation table, CLAUDE.md's doc map, and `sitemap.xml`
- `docs/docs.md`'s DNS-driver line still said "BIND9 + Windows DNS" — a miss
  from the #800 Technitium sweep, corrected

## Verification

Rendered locally against the pinned Jekyll preview image (same plugin set as
GitHub Pages): 12 tables, 149 rows, 5 code blocks, 14 headings, no kramdown
breakage, escaped globs (`azure-mgmt-*`) render correctly. Every internal link
from the new page resolves 200. `sitemap.xml` parses.

Documentation only — no code, no tests, no migrations.
