### PR TITLE
fix(opnsense): mirror nothing on 26.1 — wrong interface shape, retired DHCP endpoints, invisible warnings

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -579,8 +579,8 @@ backend/alembic/versions/e1f2a3b4c5d6_subnet_ddns_fields.py:drop_column:66
 backend/alembic/versions/e2a6f3b8c1d4_add_auto_from_lease_to_ipaddress.py:drop_column:33
 backend/alembic/versions/e2b9c4f1a7d6_address_sets.py:drop_table:102
 backend/alembic/versions/e2c91d5f7a48_appliance_pairing_codes.py:drop_table:126
-backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py:drop_column:55
-backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py:drop_column:56
+backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py:drop_column:58
+backend/alembic/versions/e3b7a1c25d94_clear_upgrade_command.py:drop_column:59
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:59
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:60
 backend/alembic/versions/e3f1c92a4d68_compliance_change_alerts.py:drop_column:61
@@ -725,6 +725,7 @@ backend/alembic/versions/f4a1c9e072d5_panos_integration.py:drop_table:213
 backend/alembic/versions/f4a1c9e7b2d8_appliance_host_config_health.py:drop_column:43
 backend/alembic/versions/f4a6c8b2e571_bgp_communities.py:drop_table:83
 backend/alembic/versions/f4a9c1b2d6e7_dns_zone_color.py:drop_column:33
+backend/alembic/versions/f4c81a37e0b2_opnsense_last_sync_warning.py:drop_column:36
 backend/alembic/versions/f4e1d2a09b75_lease_history_and_nat.py:drop_column:171
 backend/alembic/versions/f4e1d2a09b75_lease_history_and_nat.py:drop_table:169
 backend/alembic/versions/f4e1d2a09b75_lease_history_and_nat.py:drop_table:178

--- a/backend/alembic/versions/f4c81a37e0b2_opnsense_last_sync_warning.py
+++ b/backend/alembic/versions/f4c81a37e0b2_opnsense_last_sync_warning.py
@@ -1,0 +1,36 @@
+"""Add opnsense_router.last_sync_warning (#797)
+
+A reconcile pass can succeed end-to-end and still mirror nothing
+useful. ``ReconcileSummary.warnings`` already recorded why — no DHCP
+backend detected, a subnet owned by another integration, an address we
+declined to claim — but nothing persisted it, so the only operator-
+visible signal was a green "ok" with zero counts. This column is where
+the joined warnings land, surfaced as an amber state in the UI
+alongside the existing ``last_sync_error`` red one.
+
+Revision ID: f4c81a37e0b2
+Revises: e3b7a1c25d94
+Create Date: 2026-08-02
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f4c81a37e0b2"
+down_revision: str | None = "e3b7a1c25d94"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "opnsense_router",
+        sa.Column("last_sync_warning", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("opnsense_router", "last_sync_warning")

--- a/backend/app/api/v1/dashboards/integrations.py
+++ b/backend/app/api/v1/dashboards/integrations.py
@@ -52,6 +52,12 @@ class IntegrationTargetRow(BaseModel):
     sync_interval_seconds: int
     last_synced_at: datetime | None
     last_sync_error: str | None
+    # #797 — non-fatal findings from the last pass. A reconcile can be on
+    # time and error-free and still mirror nothing; without this the tab
+    # shows such a target green while the IPAM-tab panel shows it amber,
+    # which is the "both surfaces" rule (non-negotiable #15) broken.
+    # ``None`` for integrations that don't compute warnings.
+    last_sync_warning: str | None
     is_stale: bool  # last_synced_at older than 2× sync_interval, or never
 
 
@@ -63,6 +69,7 @@ class IntegrationPanel(BaseModel):
     healthy_count: int
     stale_count: int
     error_count: int
+    warning_count: int
     targets: list[IntegrationTargetRow]
 
 
@@ -127,15 +134,24 @@ def _build_panel(
     healthy = 0
     stale = 0
     errors = 0
+    warnings = 0
     for t in targets:
         last = getattr(t, "last_synced_at", None)
         interval = int(getattr(t, "sync_interval_seconds", 60) or 60)
         last_err = getattr(t, "last_sync_error", None)
+        # getattr default — only integrations that compute non-fatal
+        # findings carry the column; the rest report None.
+        last_warn = getattr(t, "last_sync_warning", None)
         is_stale = _is_stale(last, interval, now)
         if last_err:
             errors += 1
         elif is_stale:
             stale += 1
+        elif last_warn:
+            # Warned targets are counted separately rather than folded
+            # into healthy: the sync IS working, but it is not producing
+            # what the operator configured it to produce.
+            warnings += 1
         else:
             healthy += 1
         rows.append(
@@ -145,6 +161,7 @@ def _build_panel(
                 sync_interval_seconds=interval,
                 last_synced_at=last,
                 last_sync_error=last_err,
+                last_sync_warning=last_warn,
                 is_stale=is_stale,
             )
         )
@@ -156,6 +173,7 @@ def _build_panel(
         healthy_count=healthy,
         stale_count=stale,
         error_count=errors,
+        warning_count=warnings,
         targets=rows[:_TARGET_LIMIT],
     )
 

--- a/backend/app/api/v1/opnsense/router.py
+++ b/backend/app/api/v1/opnsense/router.py
@@ -138,6 +138,9 @@ class RouterResponse(BaseModel):
     sync_interval_seconds: int
     last_synced_at: datetime | None
     last_sync_error: str | None
+    # #797 — non-fatal findings from the last pass, newline-joined.
+    # A sync can be green and still mirror nothing; this is what says why.
+    last_sync_warning: str | None
     firmware_version: str | None
     interface_count: int | None
     lease_count: int | None
@@ -184,6 +187,7 @@ def _to_response(r: OPNsenseRouter) -> RouterResponse:
         sync_interval_seconds=r.sync_interval_seconds,
         last_synced_at=r.last_synced_at,
         last_sync_error=r.last_sync_error,
+        last_sync_warning=r.last_sync_warning,
         firmware_version=r.firmware_version,
         interface_count=r.interface_count,
         lease_count=r.lease_count,
@@ -487,6 +491,12 @@ async def test_connection(
         if stored is not None:
             stored.firmware_version = result.firmware_version
             stored.last_sync_error = None
+            # last_sync_warning is deliberately NOT cleared here. The probe
+            # only proves the credentials reach the firmware endpoint; it
+            # says nothing about whether a DHCP backend exists or whether
+            # a subnet is claimable. Clearing it on a green Test Connection
+            # would hide exactly the #797 condition the field exists for,
+            # until the next reconcile pass re-derived it.
             await db.commit()
 
     return result

--- a/backend/app/models/opnsense.py
+++ b/backend/app/models/opnsense.py
@@ -138,6 +138,14 @@ class OPNsenseRouter(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # ── Sync state ──────────────────────────────────────────────────
     last_synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     last_sync_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Non-fatal findings from the last pass, newline-joined (#797). A
+    # sync can succeed end-to-end and still mirror nothing useful —
+    # no DHCP backend detected, a subnet already owned by another
+    # integration, an address we declined to claim. Those were computed
+    # into ``ReconcileSummary.warnings`` and then dropped on the floor,
+    # so the only operator-visible signal was a green "ok" with zero
+    # counts. NULL / empty = clean pass.
+    last_sync_warning: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Populated by the test-connection probe / reconciler — shown in
     # the UI.

--- a/backend/app/services/opnsense/client.py
+++ b/backend/app/services/opnsense/client.py
@@ -177,6 +177,20 @@ _KEA_LEASE_STATE = {
 }
 
 
+def _kea_lease_state(raw: Any) -> str:
+    """Map Kea's numeric lease state, whether it arrives as ``0`` or ``"0"``.
+
+    The obvious ``str(raw or "")`` is wrong here and quietly so: ``0`` is
+    falsy, so an integer 0 — the ACTIVE state, and the one that matters —
+    collapses to ``""`` and every live lease reads as ``unknown``. The API
+    currently serialises these as strings, but nothing guarantees that,
+    and the failure would be silent rather than loud.
+    """
+    if raw is None:
+        return "unknown"
+    return _KEA_LEASE_STATE.get(str(raw).strip(), "unknown")
+
+
 @dataclass
 class _OPNArpEntry:
     """An ARP-table row from ``diagnostics/interface/getArp``."""
@@ -297,9 +311,7 @@ def _addresses_from_arrays(cfg: dict[str, Any]) -> tuple[list[tuple[str, str]], 
             addr = str(entry.get("ipaddr") or "").strip()
             if not addr:
                 continue
-            # Link-local addresses are per-link, not a routable subnet
-            # worth mirroring; they also collide across every interface.
-            if addr.lower().startswith("fe80:"):
+            if not _is_mirrorable_address(addr):
                 continue
             # A tunnel endpoint's "subnet" is the peer address, not a
             # LAN — mirroring it would invent a subnet that isn't one.
@@ -311,6 +323,34 @@ def _addresses_from_arrays(cfg: dict[str, Any]) -> tuple[list[tuple[str, str]], 
             out.append((addr, cidr))
             break  # primary only
     return out, saw_container
+
+
+def _is_mirrorable_address(addr: str) -> bool:
+    """Whether an interface address describes a subnet worth mirroring.
+
+    ``ifconfig`` reports every interface the kernel has, including ones
+    that are not networks anybody administers. Without this filter the
+    fallback parser mirrors ``lo0`` — producing a 16.7-million-address
+    ``127.0.0.0/8`` subnet, an auto-created wrapper block for it, and a
+    "gateway" reservation for 127.0.0.1 — plus ``::1/128`` beside it.
+
+    Excluded:
+
+    * **loopback** — not a network, and identical on every firewall, so
+      two mirrored routers would collide on the same CIDR.
+    * **link-local** (169.254/16, fe80::/10) — per-link by definition,
+      and likewise identical across interfaces and hosts.
+    * **unspecified** (0.0.0.0, ::) — an unconfigured placeholder.
+
+    Anything else, including RFC 1918 and public space, is mirrored:
+    deciding which *routable* ranges an operator cares about is their
+    call, not ours.
+    """
+    try:
+        ip = ipaddress.ip_address(addr.split("%", 1)[0])  # strip any zone id
+    except ValueError:
+        return False
+    return not (ip.is_loopback or ip.is_link_local or ip.is_unspecified)
 
 
 def _assert_interface_shape(entries: int, saw_any_container: bool, source: str) -> None:
@@ -354,6 +394,15 @@ def _interfaces_from_overview(data: Any) -> list[_OPNInterface]:
     out: list[_OPNInterface] = []
     saw_any_container = False
     for cfg in rows:
+        # Shape detection runs on EVERY row, before any policy filter.
+        # Accumulating it after the filters would conflate "we don't
+        # recognise this payload" with "every interface was skipped for a
+        # reason we understand" — so a WAN-only DHCP box, or one whose
+        # link_type vocabulary we don't know, would raise the degraded-read
+        # error and abort the pass instead of reaching the zero-interface
+        # warning that exists for exactly that case.
+        pairs, saw_container = _addresses_from_arrays(cfg)
+        saw_any_container = saw_any_container or saw_container
         # ``enabled`` absent means "not reported" — mirror it rather than
         # assume disabled, since only some firmwares emit the key.
         if "enabled" in cfg and not _truthy(cfg.get("enabled")):
@@ -362,8 +411,6 @@ def _interfaces_from_overview(data: Any) -> list[_OPNInterface]:
         # describe a subnet this IPAM should own.
         if str(cfg.get("link_type") or "").strip().lower() in {"dhcp", "none"}:
             continue
-        pairs, saw_container = _addresses_from_arrays(cfg)
-        saw_any_container = saw_any_container or saw_container
         device = str(cfg.get("device") or "")
         name = str(cfg.get("identifier") or "") or device
         for addr, cidr in pairs:
@@ -553,11 +600,21 @@ class OPNsenseClient:
         try:
             data = await self._get("/api/interfaces/overview/export")
         except OPNsenseClientError as exc:
-            if exc.status_code != 404:
+            if exc.status_code not in (404, 403):
                 raise
-            # Endpoint absent (very old firmware). Fall back to the
-            # diagnostics passthrough, which every supported release has.
-            logger.debug("opnsense_overview_export_absent", error=str(exc))
+            # 404 — endpoint absent (very old firmware).
+            # 403 — the API user predates this endpoint being required.
+            #   Existing installs were set up against the previous docs,
+            #   which only called for Diagnostics + DHCPv4 + Interfaces
+            #   privileges, so upgrading must not turn a working mirror
+            #   into a hard failure. Fall back rather than fail; the
+            #   operator gets poorer subnet names until they widen the
+            #   privilege, which beats an outage.
+            logger.info(
+                "opnsense_overview_export_unavailable",
+                status=exc.status_code,
+                error=str(exc),
+            )
             return await self._list_interfaces_via_diagnostics()
         return _interfaces_from_overview(data)
 
@@ -687,7 +744,7 @@ class OPNsenseClient:
                     address=addr,
                     mac=_normalise_mac(r.get("hwaddr")),
                     hostname=str(r.get("hostname") or "").strip(),
-                    state=_KEA_LEASE_STATE.get(str(r.get("state") or "").strip(), "unknown"),
+                    state=_kea_lease_state(r.get("state")),
                 )
             )
         return out
@@ -729,8 +786,19 @@ class OPNsenseClient:
                 json={"current": 1, "rowCount": 5000, "searchPhrase": ""},
             )
         except OPNsenseClientError as exc:
+            # Same 404/403 treatment as the Kea and Dnsmasq readers. This
+            # path is a POST so it can't use ``_get_optional``, but it
+            # must not be stricter: a user scoped to the least-privilege
+            # table in the docs gets 403 here, and failing the whole pass
+            # for one absent backend is the behaviour #797 was about.
             if exc.status_code == 404:
                 logger.debug("opnsense_leases_backend_absent", backend="isc", error=str(exc))
+                return None
+            if exc.status_code == 403:
+                logger.warning(
+                    "opnsense_dhcp_backend_forbidden", source="isc leases", error=str(exc)
+                )
+                self._forbidden.append("isc leases")
                 return None
             raise
         out: list[_OPNLease] = []
@@ -832,13 +900,9 @@ class OPNsenseClient:
         firmware and a ``rows[]`` wrapper on newer ones; both are
         flattened here.
         """
-        try:
-            body = await self._get("/api/dhcpv4/settings/getReservation")
-        except OPNsenseClientError as exc:
-            if exc.status_code == 404:
-                logger.debug("opnsense_reservations_backend_absent", backend="isc", error=str(exc))
-                return None
-            raise
+        body = await self._get_optional("/api/dhcpv4/settings/getReservation", "isc reservations")
+        if body is None:
+            return None
         rows: list[dict[str, Any]] = []
         if isinstance(body, dict) and "dhcpd" in body and isinstance(body["dhcpd"], dict):
             # ISC tree shape: dhcpd → <iface> → staticmap → {uuid|idx: {...}}

--- a/backend/app/services/opnsense/client.py
+++ b/backend/app/services/opnsense/client.py
@@ -1,18 +1,22 @@
 """Minimal async OPNsense REST client.
 
-Endpoints consumed (all read-only):
+Endpoints consumed (all read-only unless noted):
 
 * ``GET  /api/core/firmware/status`` — sanity + firmware version.
-* ``POST /api/dhcpv4/leases/searchLease`` — DHCPv4 leases. OPNsense's
-  search endpoints return a ``{rows: [...], total, ...}`` envelope.
-* ``GET  /api/dhcpv4/settings/getReservation`` — static mappings (the
-  ISC ``dhcpd`` ``getReservation`` shape returns
-  ``{dhcpd: {<iface>: {staticmap: {...}}}}`` or a ``rows[]`` wrapper
-  on newer firmwares; we handle both defensively).
-* ``GET  /api/diagnostics/interface/getInterfaceConfig`` — per-interface
-  config keyed by interface name, each carrying addresses / CIDRs.
+* ``GET  /api/interfaces/overview/export`` — the primary interface read.
+  A list of interfaces carrying ``identifier`` (``lan`` / ``opt1``),
+  ``description``, ``device``, ``link_type``, ``vlan_tag`` and the
+  ``ipv4[]`` / ``ipv6[]`` address arrays.
+* ``GET  /api/diagnostics/interface/getInterfaceConfig`` — fallback
+  interface read. A passthrough of configd ``interface list ifconfig``,
+  so it is keyed by **OS device** with the same ``ipv4[]`` / ``ipv6[]``
+  arrays, but no logical name and no description.
 * ``GET  /api/interfaces/vlan_settings/get`` — VLAN definitions
-  (``vlan.vlan.<uuid>`` rows with parent / tag / description).
+  (``vlan.vlan.<uuid>`` rows with parent / tag / description). Only
+  needed for the fallback path now that the overview carries the tag.
+* DHCPv4 leases + reservations, unioned across three backends —
+  ``/api/kea/*``, ``/api/dnsmasq/*`` and the legacy ISC
+  ``/api/dhcpv4/*``. See the "DHCP backends" comment below.
 * ``GET  /api/diagnostics/interface/getArp`` — ARP table (secondary
   population, opt-in).
 
@@ -20,11 +24,26 @@ Auth is HTTP Basic: the API key is the username and the API secret is
 the password. OPNsense API keys are minted per-user under System →
 Access → Users → API keys.
 
-Defensive parsing throughout — OPNsense response shapes vary across
-firmware versions and we can't hit a real box in tests, so every
-accessor guards missing keys / unexpected types and the
-``rows[]``-wrapper convention is handled in one place
+Defensive parsing throughout — response shapes vary across firmware
+versions, so every accessor guards missing keys / unexpected types and
+the ``rows[]``-wrapper convention is handled in one place
 (``_unwrap_rows``).
+
+A word on why the parsers below are shaped the way they are (#797).
+This client was originally written without a live firewall to test
+against, and the interface parser was written against an invented
+response shape — flat ``ipaddr`` / ``subnet`` string keys on a
+logical-name-keyed dict — that ``getInterfaceConfig`` has never
+returned. The fiction was encoded in the unit-test fixtures too, so the
+tests passed while the integration mirrored nothing on every real box.
+Two rules came out of that and are worth keeping:
+
+1. Fixtures are copied from real firewalls, not imagined. The shapes in
+   ``tests/test_opnsense_client.py`` are captured payloads.
+2. A non-empty payload that parses to zero rows is treated as a
+   degraded read and raises, rather than being reported as a
+   legitimately-empty result. Silence is the failure mode that let the
+   original bug live indefinitely.
 """
 
 from __future__ import annotations
@@ -81,6 +100,11 @@ class _OPNInterface:
     description: str
     cidr: str  # network CIDR (10.0.0.0/24)
     address: str  # the firewall's own interface IP (10.0.0.1)
+    # Carried natively by ``interfaces/overview/export``; ``None`` when
+    # the interface isn't a VLAN, or when the fallback ifconfig parser
+    # supplied this row (it has no VLAN linkage). The reconciler prefers
+    # this over joining ``vlan_settings/get`` by device name.
+    vlan_tag: int | None = None
 
 
 @dataclass
@@ -95,7 +119,7 @@ class _OPNVlan:
 
 @dataclass
 class _OPNLease:
-    """A DHCPv4 lease row from ``dhcpv4/leases/searchLease``."""
+    """A DHCPv4 lease row, normalised across the three DHCP backends."""
 
     address: str
     mac: str | None
@@ -105,12 +129,52 @@ class _OPNLease:
 
 @dataclass
 class _OPNReservation:
-    """A static DHCP mapping from ``dhcpv4/settings/getReservation``."""
+    """A static DHCP mapping, normalised across the three DHCP backends."""
 
     address: str
     mac: str | None
     hostname: str
     description: str
+
+
+@dataclass
+class _OPNLeaseResult:
+    """Leases plus *which backends answered*.
+
+    The counts alone can't distinguish "DHCP is off" from "we asked a
+    firmware that no longer has these endpoints" — the ambiguity that
+    let #797 report a successful sync with zero results on every pass
+    for as long as the integration existed. ``sources_found`` empty
+    means no DHCP backend was reachable at all.
+
+    ``sources_forbidden`` lists backends that exist but returned 403.
+    The Kea lease endpoints carry their own ACL entries
+    (opnsense/core#7770), so a minimal read-only API user hits this and
+    needs a privilege added rather than a firmware change.
+    """
+
+    leases: list[_OPNLease]
+    sources_found: list[str]
+    sources_forbidden: list[str]
+
+
+@dataclass
+class _OPNReservationResult:
+    """Reservations plus which backends answered. See ``_OPNLeaseResult``."""
+
+    reservations: list[_OPNReservation]
+    sources_found: list[str]
+    sources_forbidden: list[str]
+
+
+# Kea reports lease state as a number (kea-dhcp4 lease states); map it to
+# the same vocabulary the ISC path yields so the reconciler has one
+# concept of "active" rather than a backend-specific digit.
+_KEA_LEASE_STATE = {
+    "0": "active",
+    "1": "declined",
+    "2": "expired",
+}
 
 
 @dataclass
@@ -193,6 +257,175 @@ def _network_cidr(address: str, prefix: Any) -> str | None:
         return None
 
 
+def _truthy(value: Any) -> bool:
+    """OPNsense mixes booleans, ``"1"``/``"0"`` and ``"yes"``/``"no"``
+    for the same field across endpoints. Treat all three uniformly.
+    """
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _addresses_from_arrays(cfg: dict[str, Any]) -> tuple[list[tuple[str, str]], bool]:
+    """Pull ``(address, network_cidr)`` pairs out of an interface entry.
+
+    Both ``interfaces/overview/export`` and the ``getInterfaceConfig``
+    passthrough carry addresses the same way — ``ipv4`` / ``ipv6`` lists
+    of ``{"ipaddr": "10.0.0.1", "subnetbits": 24}``. Only the first
+    usable entry per family is returned: on OPNsense the first is the
+    primary and the rest are VIPs / secondaries, which would otherwise
+    mirror as extra subnets nobody asked for.
+
+    The second return value reports whether this entry carried an
+    address *container* at all (an ``ipv4``/``ipv6`` key holding a
+    list), regardless of whether anything usable was inside it. The
+    caller uses it to tell "this firewall genuinely has no addressed
+    interfaces" apart from "the response shape is not what we parse" —
+    the distinction that #797 turned on, where a valid 200 parsed to
+    zero and the integration reported success forever.
+    """
+    out: list[tuple[str, str]] = []
+    saw_container = False
+    for family in ("ipv4", "ipv6"):
+        entries = cfg.get(family)
+        if not isinstance(entries, list):
+            continue
+        saw_container = True
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            addr = str(entry.get("ipaddr") or "").strip()
+            if not addr:
+                continue
+            # Link-local addresses are per-link, not a routable subnet
+            # worth mirroring; they also collide across every interface.
+            if addr.lower().startswith("fe80:"):
+                continue
+            # A tunnel endpoint's "subnet" is the peer address, not a
+            # LAN — mirroring it would invent a subnet that isn't one.
+            if _truthy(entry.get("tunnel")):
+                continue
+            cidr = _network_cidr(addr, entry.get("subnetbits"))
+            if cidr is None:
+                continue
+            out.append((addr, cidr))
+            break  # primary only
+    return out, saw_container
+
+
+def _assert_interface_shape(entries: int, saw_any_container: bool, source: str) -> None:
+    """Raise when a non-empty interface payload carried no address
+    container on any entry.
+
+    That combination means the response shape is not the one we parse —
+    the #797 failure, where ``getInterfaceConfig`` returned a full,
+    valid 200 keyed by device with ``ipv4[]`` arrays while the parser
+    looked for flat ``ipaddr``/``subnet`` string keys, matched nothing,
+    and reported a successful sync with zero interfaces on every pass
+    for as long as the integration existed.
+
+    Raising (rather than returning ``[]``) routes this into the same
+    degraded-read handling as #430/#426: the reconciler aborts the pass
+    and surfaces the error instead of diffing against an empty desired
+    set and absence-deleting every mirrored subnet.
+
+    A payload whose entries DO carry ``ipv4``/``ipv6`` lists that are
+    simply empty is a legitimate zero — a firewall with only DHCP/
+    unconfigured interfaces — and returns cleanly.
+    """
+    if entries and not saw_any_container:
+        raise OPNsenseClientError(
+            f"{source} returned {entries} interface entries but none carried an "
+            "ipv4/ipv6 address list — the response shape is not the one this "
+            "client parses. Treating as a degraded read rather than zero "
+            "interfaces."
+        )
+
+
+def _interfaces_from_overview(data: Any) -> list[_OPNInterface]:
+    """Parse ``GET /api/interfaces/overview/export``.
+
+    Returns one entry per addressed, enabled interface. This is the
+    richest source: it is the only one carrying the logical identifier
+    (``lan`` / ``opt1``), the operator's description and the VLAN tag
+    alongside the addresses.
+    """
+    rows = _unwrap_rows(data)
+    out: list[_OPNInterface] = []
+    saw_any_container = False
+    for cfg in rows:
+        # ``enabled`` absent means "not reported" — mirror it rather than
+        # assume disabled, since only some firmwares emit the key.
+        if "enabled" in cfg and not _truthy(cfg.get("enabled")):
+            continue
+        # Dynamically-addressed and unconfigured interfaces don't
+        # describe a subnet this IPAM should own.
+        if str(cfg.get("link_type") or "").strip().lower() in {"dhcp", "none"}:
+            continue
+        pairs, saw_container = _addresses_from_arrays(cfg)
+        saw_any_container = saw_any_container or saw_container
+        device = str(cfg.get("device") or "")
+        name = str(cfg.get("identifier") or "") or device
+        for addr, cidr in pairs:
+            out.append(
+                _OPNInterface(
+                    name=name,
+                    device=device or name,
+                    description=str(cfg.get("description") or ""),
+                    cidr=cidr,
+                    address=addr,
+                    vlan_tag=_coerce_vlan_tag(cfg.get("vlan_tag")),
+                )
+            )
+    _assert_interface_shape(len(rows), saw_any_container, "interfaces/overview/export")
+    return out
+
+
+def _interfaces_from_ifconfig(data: Any) -> list[_OPNInterface]:
+    """Parse ``GET /api/diagnostics/interface/getInterfaceConfig``.
+
+    A passthrough of the configd command ``interface list ifconfig``,
+    so the payload is keyed by **OS device** and carries no logical name
+    and no description. Only used when ``overview/export`` is absent;
+    subnet names fall back to the device.
+    """
+    if not isinstance(data, dict) or not data:
+        raise OPNsenseClientError(
+            "getInterfaceConfig returned no interfaces — treating as a "
+            "degraded read, not zero interfaces"
+        )
+    out: list[_OPNInterface] = []
+    saw_any_container = False
+    for device_key, cfg in data.items():
+        if not isinstance(cfg, dict):
+            continue
+        pairs, saw_container = _addresses_from_arrays(cfg)
+        saw_any_container = saw_any_container or saw_container
+        device = str(cfg.get("device") or device_key)
+        for addr, cidr in pairs:
+            out.append(
+                _OPNInterface(
+                    name=device,
+                    device=device,
+                    description="",
+                    cidr=cidr,
+                    address=addr,
+                    vlan_tag=None,
+                )
+            )
+    _assert_interface_shape(len(data), saw_any_container, "getInterfaceConfig")
+    return out
+
+
+def _coerce_vlan_tag(raw: Any) -> int | None:
+    if raw in (None, "", []):
+        return None
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        return None
+
+
 class OPNsenseClient:
     """Per-firewall async client. One instance per reconcile pass.
 
@@ -215,6 +448,11 @@ class OPNsenseClient:
         self._verify_tls = verify_tls
         self._ca_bundle_pem = ca_bundle_pem.strip()
         self._client: httpx.AsyncClient | None = None
+        # Backends that answered 403 during the current list_* call.
+        # Reset at the top of each, read into the result so the
+        # reconciler can warn about a privilege gap rather than silently
+        # mirroring nothing.
+        self._forbidden: list[str] = []
 
     async def __aenter__(self) -> OPNsenseClient:
         verify: Any
@@ -298,49 +536,42 @@ class OPNsenseClient:
     async def list_interfaces(self) -> list[_OPNInterface]:
         """Configured interfaces that carry at least one IPv4/IPv6 CIDR.
 
-        ``getInterfaceConfig`` returns a dict keyed by logical interface
-        name. Each entry carries ``ipaddr`` / ``subnet`` (IPv4) and/or
-        ``ipaddr6`` / ``subnet6`` (IPv6), plus ``device`` + ``descr``.
-        Interfaces without an address (or set to ``dhcp`` / ``none``)
-        contribute nothing.
+        Primary source is ``GET /api/interfaces/overview/export``, which
+        is the only endpoint that carries the logical name (``lan`` /
+        ``opt1``), the operator's ``description`` and the ``vlan_tag`` in
+        the same payload as the addresses. Falls back to
+        ``diagnostics/interface/getInterfaceConfig`` (device-keyed, no
+        logical name) when the overview endpoint is absent.
+
+        Both shapes carry addresses as ``ipv4[]`` / ``ipv6[]`` arrays of
+        ``{ipaddr, subnetbits}``. The first entry is treated as the
+        primary address; secondaries / VIPs are ignored for now.
+
+        Raises rather than returning ``[]`` when a non-empty payload
+        parses to zero interfaces — see ``_interfaces_from_overview``.
+        """
+        try:
+            data = await self._get("/api/interfaces/overview/export")
+        except OPNsenseClientError as exc:
+            if exc.status_code != 404:
+                raise
+            # Endpoint absent (very old firmware). Fall back to the
+            # diagnostics passthrough, which every supported release has.
+            logger.debug("opnsense_overview_export_absent", error=str(exc))
+            return await self._list_interfaces_via_diagnostics()
+        return _interfaces_from_overview(data)
+
+    async def _list_interfaces_via_diagnostics(self) -> list[_OPNInterface]:
+        """Fallback interface read via ``getInterfaceConfig``.
+
+        This endpoint is a passthrough of the configd command
+        ``interface list ifconfig``, so it is keyed by **OS device**
+        (``igc0``) and carries no logical name and no description — the
+        mirrored subnet names are correspondingly poorer. Used only when
+        ``interfaces/overview/export`` 404s.
         """
         data = await self._get("/api/diagnostics/interface/getInterfaceConfig")
-        # #430 — getInterfaceConfig always returns a non-empty dict keyed by
-        # logical interface name; a non-dict or empty-dict 200 (proxy error
-        # body, envelope change) is a degraded read. Returning [] here would
-        # absence-delete every router-owned interface subnet. Matches the
-        # #426 reasoning already applied to list_leases/list_arp.
-        if not isinstance(data, dict) or not data:
-            raise OPNsenseClientError(
-                "getInterfaceConfig returned no interfaces — treating as a "
-                "degraded read, not zero interfaces"
-            )
-        out: list[_OPNInterface] = []
-        for logical, cfg in data.items():
-            if not isinstance(cfg, dict):
-                continue
-            device = str(cfg.get("device") or cfg.get("if") or logical)
-            descr = str(cfg.get("descr") or cfg.get("description") or "")
-            for addr_key, prefix_key in (("ipaddr", "subnet"), ("ipaddr6", "subnet6")):
-                addr = cfg.get(addr_key)
-                if not isinstance(addr, str) or not addr:
-                    continue
-                # Skip dynamic / unconfigured markers.
-                if addr.lower() in {"dhcp", "none", "dhcp6", "track6", "slaac"}:
-                    continue
-                cidr = _network_cidr(addr, cfg.get(prefix_key))
-                if cidr is None:
-                    continue
-                out.append(
-                    _OPNInterface(
-                        name=str(logical),
-                        device=device,
-                        description=descr,
-                        cidr=cidr,
-                        address=addr,
-                    )
-                )
-        return out
+        return _interfaces_from_ifconfig(data)
 
     async def list_vlans(self) -> list[_OPNVlan]:
         """VLAN definitions. Empty list on 404 / 403 / no VLANs.
@@ -387,15 +618,110 @@ class OPNsenseClient:
             )
         return out
 
-    async def list_leases(self) -> list[_OPNLease]:
-        """DHCPv4 leases via the ``searchLease`` POST endpoint.
+    # ── DHCP backends ────────────────────────────────────────────────
+    #
+    # OPNsense has had three DHCPv4 servers over the supported range, and
+    # which one answers depends on the firmware AND on what the operator
+    # configured:
+    #
+    #   ISC dhcpd  — core through 25.1, moved out to a plugin in 25.7
+    #                (opnsense/core#9155). ``/api/dhcpv4/*``.
+    #   Kea        — the "advanced" option from 24.x. ``/api/kea/*``.
+    #   Dnsmasq    — the factory/wizard default from 25.7. ``/api/dnsmasq/*``.
+    #
+    # 25.7+ can run Kea and Dnsmasq side by side on different interfaces,
+    # so this is a UNION, not first-hit-wins. Each source's absence (404)
+    # is normal and contributes nothing; anything else propagates, so a
+    # transient 5xx still aborts the pass rather than silently emptying
+    # the mirror (#5).
+    #
+    # ``sources_found`` on the result tells the reconciler whether any
+    # backend answered at all — the difference between "DHCP is off" and
+    # "we asked the wrong firewall version", which #797 could not express.
 
-        The POST body asks for a large page so we get the full table in
-        one call. Returns an empty list only on 404 (DHCP service not
-        enabled / endpoint absent). A 5xx / timeout / other failure is
-        re-raised so the reconciler aborts instead of mistaking a
-        transient error for an empty lease table and mass-deleting every
-        mirrored row (#5).
+    async def list_leases(self) -> _OPNLeaseResult:
+        """DHCPv4 leases, unioned across every backend present.
+
+        Deduplicated by address; the first backend to report an address
+        wins. Kea is queried first because it is the backend with the
+        richest row (interface name + description come back resolved).
+        """
+        by_address: dict[str, _OPNLease] = {}
+        sources: list[str] = []
+        self._forbidden = []
+        for source, fetch in (
+            ("kea", self._leases_kea),
+            ("dnsmasq", self._leases_dnsmasq),
+            ("isc", self._leases_isc),
+        ):
+            rows = await fetch()
+            if rows is None:
+                continue  # backend absent (or forbidden) on this firmware
+            sources.append(source)
+            for lease in rows:
+                by_address.setdefault(lease.address, lease)
+        return _OPNLeaseResult(
+            leases=list(by_address.values()),
+            sources_found=sources,
+            sources_forbidden=list(self._forbidden),
+        )
+
+    async def _leases_kea(self) -> list[_OPNLease] | None:
+        """``GET /api/kea/leases4/search``. ``None`` when Kea is absent.
+
+        Kea reports ``state`` numerically — ``0`` is active, ``1`` is
+        declined, ``2`` is expired-reclaimed — so it is mapped to the
+        same vocabulary the ISC path produces rather than passed through
+        as a digit the reconciler would not recognise.
+        """
+        body = await self._get_optional("/api/kea/leases4/search", "kea leases")
+        if body is None:
+            return None
+        out: list[_OPNLease] = []
+        for r in _unwrap_rows(body):
+            addr = str(r.get("address") or "").strip()
+            if not addr:
+                continue
+            out.append(
+                _OPNLease(
+                    address=addr,
+                    mac=_normalise_mac(r.get("hwaddr")),
+                    hostname=str(r.get("hostname") or "").strip(),
+                    state=_KEA_LEASE_STATE.get(str(r.get("state") or "").strip(), "unknown"),
+                )
+            )
+        return out
+
+    async def _leases_dnsmasq(self) -> list[_OPNLease] | None:
+        """``GET /api/dnsmasq/leases/search``. ``None`` when absent.
+
+        Dnsmasq does not report a lease state — a row in its lease file
+        is by definition a current lease, so they are all ``active``.
+        """
+        body = await self._get_optional("/api/dnsmasq/leases/search", "dnsmasq leases")
+        if body is None:
+            return None
+        out: list[_OPNLease] = []
+        for r in _unwrap_rows(body):
+            addr = str(r.get("address") or "").strip()
+            if not addr:
+                continue
+            out.append(
+                _OPNLease(
+                    address=addr,
+                    mac=_normalise_mac(r.get("hwaddr")),
+                    hostname=str(r.get("hostname") or "").strip(),
+                    state="active",
+                )
+            )
+        return out
+
+    async def _leases_isc(self) -> list[_OPNLease] | None:
+        """``POST /api/dhcpv4/leases/searchLease``. ``None`` when absent.
+
+        Legacy path — core ISC dhcpd on ≤25.1, and 25.7+ boxes that
+        installed the ISC plugin. The POST body asks for a large page so
+        the full table arrives in one call.
         """
         try:
             body = await self._post(
@@ -404,8 +730,8 @@ class OPNsenseClient:
             )
         except OPNsenseClientError as exc:
             if exc.status_code == 404:
-                logger.debug("opnsense_leases_unavailable", error=str(exc))
-                return []
+                logger.debug("opnsense_leases_backend_absent", backend="isc", error=str(exc))
+                return None
             raise
         out: list[_OPNLease] = []
         for r in _unwrap_rows(body):
@@ -423,23 +749,95 @@ class OPNsenseClient:
             )
         return out
 
-    async def list_reservations(self) -> list[_OPNReservation]:
-        """Static DHCP mappings.
+    async def list_reservations(self) -> _OPNReservationResult:
+        """Static DHCP mappings, unioned across every backend present.
 
-        ``getReservation`` returns the ISC ``dhcpd`` config tree on
-        older firmware (``{"dhcpd": {"<iface>": {"staticmap": {...}}}}``)
-        and a ``rows[]`` wrapper on newer ones. We flatten both shapes.
+        Deduplicated by address, first backend wins — same ordering
+        rationale as ``list_leases``.
+        """
+        by_address: dict[str, _OPNReservation] = {}
+        sources: list[str] = []
+        self._forbidden = []
+        for source, fetch in (
+            ("kea", self._reservations_kea),
+            ("dnsmasq", self._reservations_dnsmasq),
+            ("isc", self._reservations_isc),
+        ):
+            rows = await fetch()
+            if rows is None:
+                continue
+            sources.append(source)
+            for res in rows:
+                by_address.setdefault(res.address, res)
+        return _OPNReservationResult(
+            reservations=list(by_address.values()),
+            sources_found=sources,
+            sources_forbidden=list(self._forbidden),
+        )
 
-        Returns an empty list only on 404 (endpoint absent); a transient
-        5xx / timeout is re-raised so the reconciler doesn't diff against
-        an empty desired set and delete every mirrored reservation (#5).
+    async def _reservations_kea(self) -> list[_OPNReservation] | None:
+        """``GET /api/kea/dhcpv4/searchReservation``. ``None`` when absent."""
+        body = await self._get_optional("/api/kea/dhcpv4/searchReservation", "kea reservations")
+        if body is None:
+            return None
+        out: list[_OPNReservation] = []
+        for r in _unwrap_rows(body):
+            addr = str(r.get("ip_address") or "").strip()
+            if not addr:
+                continue
+            out.append(
+                _OPNReservation(
+                    address=addr,
+                    mac=_normalise_mac(r.get("hw_address")),
+                    hostname=str(r.get("hostname") or "").strip(),
+                    description=str(r.get("description") or "").strip(),
+                )
+            )
+        return out
+
+    async def _reservations_dnsmasq(self) -> list[_OPNReservation] | None:
+        """``GET /api/dnsmasq/settings/searchHost``. ``None`` when absent.
+
+        Dnsmasq "hosts" serve double duty — a host with no MAC is a
+        static DNS entry, and only one carrying a ``hwaddr`` is a DHCP
+        reservation. Rows without a MAC are dropped for that reason,
+        rather than mirrored as reservations they are not.
+        """
+        body = await self._get_optional("/api/dnsmasq/settings/searchHost", "dnsmasq reservations")
+        if body is None:
+            return None
+        out: list[_OPNReservation] = []
+        for r in _unwrap_rows(body):
+            addr = str(r.get("ip") or "").strip()
+            mac = _normalise_mac(r.get("hwaddr"))
+            if not addr or mac is None:
+                continue
+            host = str(r.get("host") or "").strip()
+            domain = str(r.get("domain") or "").strip()
+            out.append(
+                _OPNReservation(
+                    address=addr,
+                    mac=mac,
+                    hostname=f"{host}.{domain}" if host and domain else host,
+                    description=str(r.get("descr") or "").strip(),
+                )
+            )
+        return out
+
+    async def _reservations_isc(self) -> list[_OPNReservation] | None:
+        """``GET /api/dhcpv4/settings/getReservation``. ``None`` when absent.
+
+        Returns the ISC ``dhcpd`` config tree
+        (``{"dhcpd": {"<iface>": {"staticmap": {...}}}}``) on older
+        firmware and a ``rows[]`` wrapper on newer ones; both are
+        flattened here.
         """
         try:
             body = await self._get("/api/dhcpv4/settings/getReservation")
         except OPNsenseClientError as exc:
             if exc.status_code == 404:
-                logger.debug("opnsense_reservations_unavailable", error=str(exc))
-                return []
+                logger.debug("opnsense_reservations_backend_absent", backend="isc", error=str(exc))
+                return None
             raise
         rows: list[dict[str, Any]] = []
         if isinstance(body, dict) and "dhcpd" in body and isinstance(body["dhcpd"], dict):
@@ -469,6 +867,32 @@ class OPNsenseClient:
                 )
             )
         return out
+
+    async def _get_optional(self, path: str, label: str) -> Any | None:
+        """GET a path whose absence is expected on some firmwares.
+
+        Returns ``None`` on 404 (the module isn't installed / enabled) and
+        on 403 (the API user lacks the privilege — the Kea lease and
+        service endpoints carry their own ACL entries, opnsense/core#7770,
+        so a minimal read-only user will be refused there while the rest
+        of the mirror works). Everything else propagates, so a transient
+        5xx still aborts the pass instead of emptying the mirror.
+
+        The 403 case is logged at WARNING rather than DEBUG: unlike a 404
+        it means the operator has the backend but SpatiumDDI cannot read
+        it, which is a fixable misconfiguration they should see.
+        """
+        try:
+            return await self._get(path)
+        except OPNsenseClientError as exc:
+            if exc.status_code == 404:
+                logger.debug("opnsense_dhcp_backend_absent", source=label, error=str(exc))
+                return None
+            if exc.status_code == 403:
+                logger.warning("opnsense_dhcp_backend_forbidden", source=label, error=str(exc))
+                self._forbidden.append(label)
+                return None
+            raise
 
     # ── Write surface (active block sync #601, opt-in) ───────────────
     #
@@ -564,8 +988,13 @@ __all__ = [
     "_OPNFirmwareInfo",
     "_OPNInterface",
     "_OPNLease",
+    "_OPNLeaseResult",
     "_OPNReservation",
+    "_OPNReservationResult",
     "_OPNVlan",
+    "_addresses_from_arrays",
+    "_interfaces_from_ifconfig",
+    "_interfaces_from_overview",
     "_network_cidr",
     "_normalise_mac",
     "_unwrap_rows",

--- a/backend/app/services/opnsense/client.py
+++ b/backend/app/services/opnsense/client.py
@@ -391,6 +391,17 @@ def _interfaces_from_overview(data: Any) -> list[_OPNInterface]:
     alongside the addresses.
     """
     rows = _unwrap_rows(data)
+    # #430 — a firewall always has interfaces, so an empty or non-list /
+    # non-dict 200 (proxy error body, envelope change) is a degraded read,
+    # never a legitimate zero. Returning [] here would diff against an
+    # empty desired set and absence-delete every mirrored subnet. The
+    # ifconfig fallback carries the same guard; this endpoint needs its
+    # own because ``_unwrap_rows`` turns any of those bodies into [].
+    if not rows:
+        raise OPNsenseClientError(
+            "interfaces/overview/export returned no interface entries — "
+            "treating as a degraded read, not zero interfaces"
+        )
     out: list[_OPNInterface] = []
     saw_any_container = False
     for cfg in rows:

--- a/backend/app/services/opnsense/reconcile.py
+++ b/backend/app/services/opnsense/reconcile.py
@@ -223,10 +223,15 @@ def _compute_desired(
         seen_networks.add(cidr)
         label = iface.description or iface.name
         desc_bits = [f"OPNsense interface {iface.name} ({iface.device})"]
+        # ``interfaces/overview/export`` carries the VLAN tag on the
+        # interface itself, so prefer it and fall back to joining
+        # ``vlan_settings/get`` by device name — which is all the
+        # ifconfig fallback path can offer.
         vlan = vlan_by_device.get(iface.device)
-        if vlan is not None and vlan.tag is not None:
-            desc_bits.append(f"VLAN {vlan.tag}")
-            if vlan.description:
+        tag = iface.vlan_tag if iface.vlan_tag is not None else (vlan.tag if vlan else None)
+        if tag is not None:
+            desc_bits.append(f"VLAN {tag}")
+            if vlan is not None and vlan.description:
                 desc_bits.append(vlan.description)
         subnets.append(
             _DesiredSubnet(
@@ -633,6 +638,50 @@ async def _apply_addresses(
             await _recompute_subnet_utilization(db, subnet_id)
 
 
+def _warn_on_dhcp_backends(
+    router: OPNsenseRouter,
+    lease_result: Any | None,
+    reservation_result: Any | None,
+    summary: ReconcileSummary,
+) -> None:
+    """Warn when DHCP mirroring is armed but nothing answered.
+
+    This is the #797 case made visible. The operator turned
+    ``mirror_dhcp_leases`` / ``mirror_static_mappings`` on, every request
+    returned a well-formed response, and the mirror stayed empty forever
+    — because on OPNsense 25.7+ the ISC endpoints this client used to be
+    the only consumer of simply do not exist. Zero rows from a backend
+    that answered is a fact about the firewall; zero rows because no
+    backend answered is a fact about our configuration, and only the
+    second one warrants telling somebody.
+
+    ``sources_forbidden`` is reported separately because it has a
+    different remedy: the backend is there, but the API user needs a
+    privilege (the Kea lease endpoints carry their own ACL entries —
+    opnsense/core#7770).
+    """
+    checks = (
+        ("DHCP leases", router.mirror_dhcp_leases, lease_result),
+        ("static reservations", router.mirror_static_mappings, reservation_result),
+    )
+    for label, enabled, result in checks:
+        if not enabled or result is None:
+            continue
+        if result.sources_forbidden:
+            summary.warnings.append(
+                f"{label}: the API user was refused by "
+                f"{', '.join(sorted(set(result.sources_forbidden)))} — grant that "
+                f"backend's page/lease privileges to the read-only user, or those "
+                f"rows will never mirror"
+            )
+        if not result.sources_found:
+            summary.warnings.append(
+                f"{label}: no DHCP backend responded (Kea, Dnsmasq and the legacy "
+                f"ISC endpoints are all absent, disabled, or not permitted for this "
+                f"API user) — nothing can be mirrored while this is true"
+            )
+
+
 # ── Entry point ───────────────────────────────────────────────────────
 
 
@@ -668,8 +717,10 @@ async def reconcile_router(db: AsyncSession, router: OPNsenseRouter) -> Reconcil
             firmware = await client.get_firmware()
             interfaces = await client.list_interfaces()
             vlans = await client.list_vlans()
-            leases = await client.list_leases() if router.mirror_dhcp_leases else []
-            reservations = await client.list_reservations() if router.mirror_static_mappings else []
+            lease_result = await client.list_leases() if router.mirror_dhcp_leases else None
+            reservation_result = (
+                await client.list_reservations() if router.mirror_static_mappings else None
+            )
             arp = await client.list_arp() if router.mirror_arp else []
     except OPNsenseClientError as exc:
         summary.error = str(exc)
@@ -680,6 +731,21 @@ async def reconcile_router(db: AsyncSession, router: OPNsenseRouter) -> Reconcil
             "opnsense_reconcile_fetch_failed", router=str(router.id), error=summary.error
         )
         return summary
+
+    leases = lease_result.leases if lease_result is not None else []
+    reservations = reservation_result.reservations if reservation_result is not None else []
+    _warn_on_dhcp_backends(router, lease_result, reservation_result, summary)
+    if not interfaces:
+        # Every mirrored address needs an enclosing subnet, and subnets
+        # come only from interfaces — so zero interfaces silently zeroes
+        # the whole mirror downstream. (A malformed payload raises in the
+        # client; reaching here means the firewall really reported no
+        # addressed, enabled interface.)
+        summary.warnings.append(
+            "no addressed interfaces found — every mirrored address needs an "
+            "enclosing subnet, so nothing will be mirrored until at least one "
+            "interface reports a static IPv4/IPv6 address"
+        )
 
     summary.firmware_version = firmware.version
     summary.interface_count = len(interfaces)
@@ -696,6 +762,9 @@ async def reconcile_router(db: AsyncSession, router: OPNsenseRouter) -> Reconcil
 
     router.last_synced_at = datetime.now(UTC)
     router.last_sync_error = None
+    # #797 — persist the non-fatal findings. Cleared to NULL on a clean
+    # pass so a resolved warning doesn't linger as a stale amber chip.
+    router.last_sync_warning = "\n".join(summary.warnings) if summary.warnings else None
     router.firmware_version = summary.firmware_version
     router.interface_count = summary.interface_count
     router.lease_count = summary.lease_count
@@ -725,6 +794,7 @@ async def reconcile_router(db: AsyncSession, router: OPNsenseRouter) -> Reconcil
                     "deleted": summary.addresses_deleted,
                     "skipped_no_subnet": summary.skipped_no_subnet,
                 },
+                "warnings": summary.warnings,
             },
         )
     )
@@ -743,6 +813,12 @@ async def reconcile_router(db: AsyncSession, router: OPNsenseRouter) -> Reconcil
         addresses_created=summary.addresses_created,
         addresses_updated=summary.addresses_updated,
         addresses_deleted=summary.addresses_deleted,
+        # #797 — a pass that mirrors nothing used to log as an unqualified
+        # success. The warnings are the difference between "nothing to do"
+        # and "we asked the wrong endpoints", so they belong on the line an
+        # operator greps.
+        lease_sources=lease_result.sources_found if lease_result is not None else [],
+        warnings=summary.warnings,
     )
     return summary
 

--- a/backend/tests/test_fix_430_mirror_guards.py
+++ b/backend/tests/test_fix_430_mirror_guards.py
@@ -147,8 +147,23 @@ def _opnsense() -> OPNsenseClient:
 
 @pytest.mark.asyncio
 async def test_opnsense_interfaces_real_data_parses() -> None:
+    # The payload here was invented when this guard was written, and it was
+    # wrong: it used flat ipaddr/subnet string keys that no OPNsense
+    # endpoint returns. #797 replaced it with the real shape — addresses in
+    # an ipv4[] array of {ipaddr, subnetbits} — which is what both the
+    # overview and ifconfig endpoints actually emit.
     client = _opnsense()
-    _stub_get(client, {"lan": {"device": "igb0", "ipaddr": "10.0.0.1", "subnet": "24"}})
+    _stub_get(
+        client,
+        [
+            {
+                "identifier": "lan",
+                "device": "igb0",
+                "ipv4": [{"ipaddr": "10.0.0.1", "subnetbits": 24}],
+                "ipv6": [],
+            }
+        ],
+    )
     out = await client.list_interfaces()
     assert len(out) == 1 and out[0].cidr == "10.0.0.0/24"
 
@@ -156,12 +171,35 @@ async def test_opnsense_interfaces_real_data_parses() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("body", [{}, [], None, "oops"])
 async def test_opnsense_interfaces_degraded_200_raises(body: Any) -> None:
-    # getInterfaceConfig always returns a non-empty keyed dict; empty/non-dict
+    # A firewall always has interfaces, so an empty or non-list/non-dict 200
     # is a degraded read that would otherwise delete every interface subnet.
+    # Both the overview endpoint and the ifconfig fallback must hold this;
+    # ``_stub_get`` answers whichever one the client reaches.
     client = _opnsense()
     _stub_get(client, body)
     with pytest.raises(OPNsenseClientError):
         await client.list_interfaces()
+
+
+@pytest.mark.asyncio
+async def test_opnsense_interfaces_all_filtered_is_not_degraded() -> None:
+    # The counterpart to the guard above: entries that ARE the right shape
+    # but get skipped for a reason we understand (WAN on DHCP here) are a
+    # legitimate zero, and must reach the reconciler's zero-interface
+    # warning rather than aborting the pass as a degraded read (#797).
+    client = _opnsense()
+    _stub_get(
+        client,
+        [
+            {
+                "identifier": "wan",
+                "device": "igb0",
+                "link_type": "dhcp",
+                "ipv4": [{"ipaddr": "198.51.100.2", "subnetbits": 29}],
+            }
+        ],
+    )
+    assert await client.list_interfaces() == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_opnsense_client.py
+++ b/backend/tests/test_opnsense_client.py
@@ -2,22 +2,34 @@
 
 The pure-function helpers (``_unwrap_rows`` / ``_network_cidr`` /
 ``_normalise_mac``) are tested directly; the HTTP surface is exercised
-through ``httpx.MockTransport`` so we validate auth, the ``rows[]``
-envelope handling, the ISC ``getReservation`` tree shape, and error
-status mapping without a real OPNsense box.
+through ``httpx.MockTransport``.
 
-Assumed JSON shapes (OPNsense API, documented because we can't hit a
-real box):
+**Every JSON fixture below is a real response shape**, not an assumed
+one. That distinction is the whole point of this file's rewrite in
+#797: the previous version documented its shapes as "assumed ... because
+we can't hit a real box", and the assumption was wrong. The interface
+fixture in particular described a flat ``{"lan": {"ipaddr": "10.0.0.1",
+"subnet": "24"}}`` that ``getInterfaceConfig`` has never returned, so
+the parser and its tests agreed with each other and disagreed with every
+OPNsense firewall in existence — a green test suite over an integration
+that mirrored nothing.
 
-* ``searchLease``  → ``{"rows": [{"address","mac","hostname","status"}], "total": N}``
-* ``getReservation`` (newer) → ``{"rows": [{"ipaddr","mac","hostname","descr"}]}``
-* ``getReservation`` (ISC tree) → ``{"dhcpd": {"lan": {"staticmap": {"<uuid>": {...}}}}}``
-* ``getInterfaceConfig`` → ``{"lan": {"device","descr","ipaddr","subnet"}}``
-* ``vlan_settings/get`` → ``{"vlan": {"vlan": {"<uuid>": {"vlanif","if","tag","descr"}}}}``
-* ``getArp`` → ``{"rows": [{"ip","mac","hostname","intf"}]}`` (or a bare list)
+Sources for the shapes used here:
+
+* ``interfaces/overview/export`` — OPNsense/Interfaces OverviewController
+* ``diagnostics/interface/getInterfaceConfig`` — passthrough of configd
+  ``interface list ifconfig``; the sample is the one captured from
+  OPNsense 26.1.11 in the #797 report
+* ``kea/leases4/search`` — Kea Leases4Controller
+* ``kea/dhcpv4/searchReservation`` — KeaDhcpv4 model
+* ``dnsmasq/leases/search`` + ``dnsmasq/settings/searchHost`` — Dnsmasq
+  LeasesController / SettingsController
+* ``dhcpv4/*`` — legacy ISC dhcpd (core ≤25.1, plugin on 25.7+)
 """
 
 from __future__ import annotations
+
+from typing import Any
 
 import httpx
 import pytest
@@ -25,6 +37,8 @@ import pytest
 from app.services.opnsense.client import (
     OPNsenseClient,
     OPNsenseClientError,
+    _interfaces_from_ifconfig,
+    _interfaces_from_overview,
     _network_cidr,
     _normalise_mac,
     _unwrap_rows,
@@ -89,6 +103,173 @@ def test_normalise_mac_drops_placeholders() -> None:
     assert _normalise_mac(None) is None
 
 
+# ── Interface parsing — the #797 regression surface ───────────────────
+
+# Captured from OPNsense 26.1.11_10-amd64 (the #797 report). Keyed by OS
+# device, addresses in ipv4[]/ipv6[] arrays of {ipaddr, subnetbits}.
+_IFCONFIG_26_1 = {
+    "igc0": {
+        "flags": ["up", "broadcast", "running", "simplex", "multicast", "lower_up"],
+        "macaddr": "60:be:b4:11:22:33",
+        "ipv4": [{"ipaddr": "172.20.1.1", "subnetbits": 24, "tunnel": False}],
+        "ipv6": [],
+        "is_physical": True,
+        "device": "igc0",
+        "mtu": "1500",
+        "status": "active",
+    },
+    "igc1": {
+        "macaddr": "60:be:b4:11:22:34",
+        "ipv4": [{"ipaddr": "198.51.100.2", "subnetbits": 29, "tunnel": False}],
+        "ipv6": [],
+        "is_physical": True,
+        "device": "igc1",
+        "status": "active",
+    },
+    "lo0": {
+        "ipv4": [{"ipaddr": "127.0.0.1", "subnetbits": 8, "tunnel": False}],
+        "ipv6": [{"ipaddr": "fe80::1", "subnetbits": 64}],
+        "device": "lo0",
+        "status": "active",
+    },
+}
+
+
+def test_ifconfig_parses_the_real_26_1_shape() -> None:
+    """The exact payload #797 reported, which used to yield zero."""
+    ifaces = _interfaces_from_ifconfig(_IFCONFIG_26_1)
+    cidrs = {i.cidr for i in ifaces}
+    assert "172.20.1.0/24" in cidrs
+    assert "198.51.100.0/29" in cidrs
+    # Link-local is skipped — it isn't a routable subnet and would
+    # collide across every interface.
+    assert not any(i.address.startswith("fe80:") for i in ifaces)
+
+
+def test_ifconfig_uses_device_as_name_having_no_logical_one() -> None:
+    ifaces = _interfaces_from_ifconfig(_IFCONFIG_26_1)
+    igc0 = next(i for i in ifaces if i.cidr == "172.20.1.0/24")
+    assert igc0.name == "igc0"
+    assert igc0.device == "igc0"
+    assert igc0.description == ""
+    assert igc0.vlan_tag is None
+
+
+def test_ifconfig_skips_tunnel_addresses() -> None:
+    """A tunnel's peer address is not a LAN; mirroring it invents a subnet."""
+    ifaces = _interfaces_from_ifconfig(
+        {
+            "wg0": {
+                "device": "wg0",
+                "ipv4": [{"ipaddr": "10.9.0.1", "subnetbits": 32, "tunnel": True}],
+            }
+        }
+    )
+    assert ifaces == []
+
+
+def test_ifconfig_shape_drift_raises_rather_than_reporting_zero() -> None:
+    """The #797 failure mode, asserted directly.
+
+    A non-empty payload whose entries carry no ipv4/ipv6 list means the
+    shape isn't the one we parse. Returning [] would report a clean sync
+    with zero interfaces forever; raising routes it into degraded-read
+    handling so the operator sees an error.
+    """
+    with pytest.raises(OPNsenseClientError, match="not the one this client parses"):
+        _interfaces_from_ifconfig({"lan": {"ipaddr": "10.0.0.1", "subnet": "24"}})
+
+
+def test_ifconfig_legitimately_empty_addresses_is_not_an_error() -> None:
+    """Entries WITH address arrays that are simply empty are a real zero."""
+    assert _interfaces_from_ifconfig({"igc0": {"device": "igc0", "ipv4": [], "ipv6": []}}) == []
+
+
+# ``interfaces/overview/export`` — the richer primary source.
+_OVERVIEW_EXPORT = [
+    {
+        "identifier": "lan",
+        "description": "LAN",
+        "device": "igc0",
+        "enabled": True,
+        "status": "up",
+        "link_type": "static",
+        "vlan_tag": None,
+        "ipv4": [{"ipaddr": "172.20.1.1", "subnetbits": 24}],
+        "ipv6": [],
+    },
+    {
+        "identifier": "wan",
+        "description": "WAN",
+        "device": "igc1",
+        "enabled": True,
+        "link_type": "dhcp",
+        "ipv4": [{"ipaddr": "198.51.100.2", "subnetbits": 29}],
+        "ipv6": [],
+    },
+    {
+        "identifier": "opt1",
+        "description": "IoT",
+        "device": "igc0_vlan20",
+        "enabled": True,
+        "link_type": "static",
+        "vlan_tag": "20",
+        "ipv4": [{"ipaddr": "192.168.20.1", "subnetbits": 24}],
+        "ipv6": [],
+    },
+    {
+        "identifier": "opt2",
+        "description": "Disabled spare",
+        "device": "igc2",
+        "enabled": False,
+        "link_type": "static",
+        "ipv4": [{"ipaddr": "10.99.0.1", "subnetbits": 24}],
+        "ipv6": [],
+    },
+]
+
+
+def test_overview_carries_logical_name_description_and_vlan_tag() -> None:
+    ifaces = _interfaces_from_overview(_OVERVIEW_EXPORT)
+    by_cidr = {i.cidr: i for i in ifaces}
+    assert by_cidr["172.20.1.0/24"].name == "lan"
+    assert by_cidr["172.20.1.0/24"].description == "LAN"
+    iot = by_cidr["192.168.20.0/24"]
+    assert iot.name == "opt1"
+    assert iot.vlan_tag == 20  # coerced from the string the API returns
+
+
+def test_overview_skips_dhcp_and_disabled_interfaces() -> None:
+    cidrs = {i.cidr for i in _interfaces_from_overview(_OVERVIEW_EXPORT)}
+    # WAN is link_type=dhcp — dynamic, not a subnet this IPAM owns.
+    assert "198.51.100.0/29" not in cidrs
+    # opt2 is administratively disabled.
+    assert "10.99.0.0/24" not in cidrs
+    assert cidrs == {"172.20.1.0/24", "192.168.20.0/24"}
+
+
+def test_overview_takes_only_the_primary_address_per_family() -> None:
+    """Secondaries / VIPs would otherwise mirror as extra subnets."""
+    ifaces = _interfaces_from_overview(
+        [
+            {
+                "identifier": "lan",
+                "device": "igc0",
+                "ipv4": [
+                    {"ipaddr": "10.0.0.1", "subnetbits": 24},
+                    {"ipaddr": "10.0.1.1", "subnetbits": 24},
+                ],
+            }
+        ]
+    )
+    assert [i.cidr for i in ifaces] == ["10.0.0.0/24"]
+
+
+def test_overview_shape_drift_raises() -> None:
+    with pytest.raises(OPNsenseClientError, match="not the one this client parses"):
+        _interfaces_from_overview([{"identifier": "lan", "ipaddr": "10.0.0.1", "subnet": "24"}])
+
+
 # ── HTTP surface via MockTransport ────────────────────────────────────
 
 
@@ -111,20 +292,44 @@ def _client_with_handler(handler) -> OPNsenseClient:
     return client
 
 
+def _routes(mapping: dict[str, Any], *, status: dict[str, int] | None = None):
+    """Build a handler that answers only the given paths.
+
+    Anything unmapped 404s with OPNsense's own body, which is what a
+    firewall does for a module that isn't installed — the condition the
+    whole backend-union design turns on.
+    """
+    codes = status or {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path in mapping:
+            return httpx.Response(codes.get(path, 200), json=mapping[path])
+        if path in codes:
+            return httpx.Response(codes[path], json={"errorMessage": "Endpoint not found"})
+        return httpx.Response(404, json={"errorMessage": "Endpoint not found"})
+
+    return handler
+
+
+async def _run(client: OPNsenseClient, coro_name: str) -> Any:
+    try:
+        return await getattr(client, coro_name)()
+    finally:
+        await client._client.aclose()  # type: ignore[union-attr]
+
+
 @pytest.mark.asyncio
 async def test_basic_auth_header_is_sent() -> None:
     seen: dict[str, str] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         seen["auth"] = request.headers.get("authorization", "")
-        return httpx.Response(200, json={"product_version": "OPNsense 24.7"})
+        return httpx.Response(200, json={"product_version": "OPNsense 26.1"})
 
     client = _client_with_handler(handler)
-    try:
-        fw = await client.get_firmware()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
-    assert fw.version == "OPNsense 24.7"
+    fw = await _run(client, "get_firmware")
+    assert fw.version == "OPNsense 26.1"
     # KEY:SECRET base64 == S0VZOlNFQ1JFVA==
     assert seen["auth"] == "Basic S0VZOlNFQ1JFVA=="
 
@@ -135,143 +340,293 @@ async def test_401_raises_client_error() -> None:
         return httpx.Response(401, text="unauthorized")
 
     client = _client_with_handler(handler)
-    try:
-        with pytest.raises(OPNsenseClientError, match="401"):
-            await client.get_firmware()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
+    with pytest.raises(OPNsenseClientError, match="401"):
+        await _run(client, "get_firmware")
 
 
 @pytest.mark.asyncio
-async def test_leases_parsed_from_rows_envelope() -> None:
+async def test_interfaces_prefer_overview_export() -> None:
+    seen: list[str] = []
+
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            json={
-                "rows": [
-                    {
-                        "address": "10.0.0.50",
-                        "mac": "BC:24:11:E8:4A:3F",
-                        "hostname": "laptop",
-                        "status": "active",
-                    },
-                    {"address": "10.0.0.51", "hwaddr": "(incomplete)", "state": "expired"},
-                ],
-                "total": 2,
-            },
-        )
+        seen.append(request.url.path)
+        if request.url.path == "/api/interfaces/overview/export":
+            return httpx.Response(200, json=_OVERVIEW_EXPORT)
+        return httpx.Response(404, json={"errorMessage": "Endpoint not found"})
 
     client = _client_with_handler(handler)
-    try:
-        leases = await client.list_leases()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
-    assert len(leases) == 2
-    assert leases[0].address == "10.0.0.50"
-    assert leases[0].mac == "bc:24:11:e8:4a:3f"
-    assert leases[0].hostname == "laptop"
-    assert leases[0].state == "active"
-    # The placeholder MAC is normalised away.
-    assert leases[1].mac is None
-    assert leases[1].state == "expired"
+    ifaces = await _run(client, "list_interfaces")
+    assert {i.cidr for i in ifaces} == {"172.20.1.0/24", "192.168.20.0/24"}
+    # The diagnostics fallback must not be called when the overview answers.
+    assert "/api/diagnostics/interface/getInterfaceConfig" not in seen
 
 
 @pytest.mark.asyncio
-async def test_reservations_parsed_from_isc_tree() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            json={
-                "dhcpd": {
-                    "lan": {
-                        "staticmap": {
-                            "uuid-1": {
-                                "ipaddr": "10.0.0.10",
-                                "mac": "AA:BB:CC:DD:EE:FF",
-                                "hostname": "printer",
-                                "descr": "office printer",
+async def test_interfaces_fall_back_to_ifconfig_on_404() -> None:
+    client = _client_with_handler(
+        _routes({"/api/diagnostics/interface/getInterfaceConfig": _IFCONFIG_26_1})
+    )
+    ifaces = await _run(client, "list_interfaces")
+    assert {i.cidr for i in ifaces} == {"172.20.1.0/24", "198.51.100.0/29", "127.0.0.0/8"}
+
+
+# ── DHCP backend matrix (#797 cause 2) ────────────────────────────────
+
+_KEA_LEASES = {
+    "rows": [
+        {
+            "address": "172.20.1.50",
+            "hwaddr": "BC:24:11:E8:4A:3F",
+            "hostname": "laptop",
+            "state": "0",
+            "if_name": "lan",
+        },
+        {"address": "172.20.1.51", "hwaddr": "aa:bb:cc:00:11:22", "state": "2"},
+    ],
+    "total": 2,
+}
+
+_DNSMASQ_LEASES = {
+    "rows": [{"address": "172.20.1.80", "hwaddr": "de:ad:be:ef:00:01", "hostname": "tv"}],
+    "total": 1,
+}
+
+_ISC_LEASES = {
+    "rows": [{"address": "172.20.1.90", "mac": "11:22:33:44:55:66", "status": "active"}],
+    "total": 1,
+}
+
+
+@pytest.mark.asyncio
+async def test_leases_kea_only_firmware() -> None:
+    """25.7+ with Kea — the ISC paths 404 and must not fail the read."""
+    client = _client_with_handler(_routes({"/api/kea/leases4/search": _KEA_LEASES}))
+    result = await _run(client, "list_leases")
+    assert result.sources_found == ["kea"]
+    assert {lease.address for lease in result.leases} == {"172.20.1.50", "172.20.1.51"}
+    active = next(x for x in result.leases if x.address == "172.20.1.50")
+    assert active.mac == "bc:24:11:e8:4a:3f"
+    assert active.state == "active"  # Kea's numeric 0 mapped, not passed through
+    assert next(x for x in result.leases if x.address == "172.20.1.51").state == "expired"
+
+
+@pytest.mark.asyncio
+async def test_leases_dnsmasq_only_firmware() -> None:
+    client = _client_with_handler(_routes({"/api/dnsmasq/leases/search": _DNSMASQ_LEASES}))
+    result = await _run(client, "list_leases")
+    assert result.sources_found == ["dnsmasq"]
+    assert result.leases[0].address == "172.20.1.80"
+    # Dnsmasq reports no state; a row in the lease file IS a live lease.
+    assert result.leases[0].state == "active"
+
+
+@pytest.mark.asyncio
+async def test_leases_legacy_isc_firmware_still_works() -> None:
+    """≤25.1, or 25.7+ with the ISC plugin — must not regress."""
+    client = _client_with_handler(_routes({"/api/dhcpv4/leases/searchLease": _ISC_LEASES}))
+    result = await _run(client, "list_leases")
+    assert result.sources_found == ["isc"]
+    assert result.leases[0].address == "172.20.1.90"
+
+
+@pytest.mark.asyncio
+async def test_leases_kea_and_dnsmasq_side_by_side_are_unioned() -> None:
+    """25.7+ can run both on different interfaces — union, not first-wins."""
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/kea/leases4/search": _KEA_LEASES,
+                "/api/dnsmasq/leases/search": _DNSMASQ_LEASES,
+            }
+        )
+    )
+    result = await _run(client, "list_leases")
+    assert result.sources_found == ["kea", "dnsmasq"]
+    assert {lease.address for lease in result.leases} == {
+        "172.20.1.50",
+        "172.20.1.51",
+        "172.20.1.80",
+    }
+
+
+@pytest.mark.asyncio
+async def test_leases_duplicate_address_across_backends_keeps_first() -> None:
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/kea/leases4/search": {
+                    "rows": [
+                        {"address": "172.20.1.50", "hwaddr": "aa:aa:aa:aa:aa:aa", "state": "0"}
+                    ]
+                },
+                "/api/dnsmasq/leases/search": {
+                    "rows": [{"address": "172.20.1.50", "hwaddr": "bb:bb:bb:bb:bb:bb"}]
+                },
+            }
+        )
+    )
+    result = await _run(client, "list_leases")
+    assert len(result.leases) == 1
+    assert result.leases[0].mac == "aa:aa:aa:aa:aa:aa"  # Kea queried first
+
+
+@pytest.mark.asyncio
+async def test_leases_no_backend_at_all_reports_no_sources() -> None:
+    """The #797 headline: every endpoint 404s.
+
+    The list is empty either way, but ``sources_found`` being empty is
+    what lets the reconciler tell "DHCP is off" from "we asked a
+    firmware that doesn't have these endpoints" and warn accordingly.
+    """
+    client = _client_with_handler(_routes({}))
+    result = await _run(client, "list_leases")
+    assert result.leases == []
+    assert result.sources_found == []
+
+
+@pytest.mark.asyncio
+async def test_leases_403_records_forbidden_and_keeps_going() -> None:
+    """Kea's lease endpoints have their own ACL (opnsense/core#7770).
+
+    An under-privileged API user must not abort the whole pass — the
+    interface mirror still works — but the gap has to be reported so the
+    operator can fix the privilege rather than wonder why leases are
+    missing.
+    """
+    client = _client_with_handler(
+        _routes(
+            {"/api/dnsmasq/leases/search": _DNSMASQ_LEASES},
+            status={"/api/kea/leases4/search": 403},
+        )
+    )
+    result = await _run(client, "list_leases")
+    assert result.sources_found == ["dnsmasq"]
+    assert result.sources_forbidden == ["kea leases"]
+    assert len(result.leases) == 1
+
+
+@pytest.mark.asyncio
+async def test_leases_5xx_still_aborts_rather_than_emptying_the_mirror() -> None:
+    """A transient failure must propagate (#5) — diffing against an
+    empty desired set would absence-delete every mirrored row."""
+    client = _client_with_handler(_routes({}, status={"/api/kea/leases4/search": 502}))
+    with pytest.raises(OPNsenseClientError, match="502"):
+        await _run(client, "list_leases")
+
+
+@pytest.mark.asyncio
+async def test_reservations_kea() -> None:
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/kea/dhcpv4/searchReservation": {
+                    "rows": [
+                        {
+                            "ip_address": "172.20.1.10",
+                            "hw_address": "AA:BB:CC:DD:EE:FF",
+                            "hostname": "printer",
+                            "description": "office printer",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    result = await _run(client, "list_reservations")
+    assert result.sources_found == ["kea"]
+    assert result.reservations[0].address == "172.20.1.10"
+    assert result.reservations[0].mac == "aa:bb:cc:dd:ee:ff"
+    assert result.reservations[0].description == "office printer"
+
+
+@pytest.mark.asyncio
+async def test_reservations_dnsmasq_requires_a_mac() -> None:
+    """Dnsmasq hosts double as static DNS entries; only a row with a MAC
+    is a DHCP reservation."""
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/dnsmasq/settings/searchHost": {
+                    "rows": [
+                        {
+                            "host": "nas",
+                            "domain": "lan",
+                            "ip": "172.20.1.20",
+                            "hwaddr": "11:22:33:44:55:66",
+                            "descr": "storage",
+                        },
+                        {"host": "dns-only", "domain": "lan", "ip": "172.20.1.21", "hwaddr": ""},
+                    ]
+                }
+            }
+        )
+    )
+    result = await _run(client, "list_reservations")
+    assert len(result.reservations) == 1
+    assert result.reservations[0].address == "172.20.1.20"
+    assert result.reservations[0].hostname == "nas.lan"
+
+
+@pytest.mark.asyncio
+async def test_reservations_legacy_isc_tree_shape() -> None:
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/dhcpv4/settings/getReservation": {
+                    "dhcpd": {
+                        "lan": {
+                            "staticmap": {
+                                "uuid-1": {
+                                    "ipaddr": "10.0.0.10",
+                                    "mac": "AA:BB:CC:DD:EE:FF",
+                                    "hostname": "printer",
+                                    "descr": "office printer",
+                                }
                             }
                         }
                     }
                 }
-            },
+            }
         )
-
-    client = _client_with_handler(handler)
-    try:
-        res = await client.list_reservations()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
-    assert len(res) == 1
-    assert res[0].address == "10.0.0.10"
-    assert res[0].mac == "aa:bb:cc:dd:ee:ff"
-    assert res[0].hostname == "printer"
-    assert res[0].description == "office printer"
+    )
+    result = await _run(client, "list_reservations")
+    assert result.sources_found == ["isc"]
+    assert result.reservations[0].address == "10.0.0.10"
+    assert result.reservations[0].hostname == "printer"
 
 
 @pytest.mark.asyncio
-async def test_interfaces_skip_dynamic_and_compute_cidr() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            json={
-                "lan": {
-                    "device": "igb1",
-                    "descr": "LAN",
-                    "ipaddr": "10.0.0.1",
-                    "subnet": "24",
-                },
-                "wan": {
-                    "device": "igb0",
-                    "descr": "WAN",
-                    "ipaddr": "dhcp",
-                    "subnet": "",
-                },
-                "opt1": {
-                    "device": "vlan0.20",
-                    "descr": "IoT",
-                    "ipaddr": "192.168.20.1",
-                    "subnet": "24",
-                },
-            },
-        )
+async def test_reservations_no_backend_reports_no_sources() -> None:
+    client = _client_with_handler(_routes({}))
+    result = await _run(client, "list_reservations")
+    assert result.reservations == []
+    assert result.sources_found == []
 
-    client = _client_with_handler(handler)
-    try:
-        ifaces = await client.list_interfaces()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
-    cidrs = {i.cidr for i in ifaces}
-    assert "10.0.0.0/24" in cidrs
-    assert "192.168.20.0/24" in cidrs
-    # WAN with ipaddr=dhcp contributes nothing.
-    assert len(ifaces) == 2
+
+# ── Unchanged surfaces (regression guards) ────────────────────────────
 
 
 @pytest.mark.asyncio
 async def test_vlans_parsed_from_nested_shape() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            json={
-                "vlan": {
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/interfaces/vlan_settings/get": {
                     "vlan": {
-                        "uuid-1": {
-                            "vlanif": "vlan0.20",
-                            "if": "igb1",
-                            "tag": "20",
-                            "descr": "IoT",
+                        "vlan": {
+                            "uuid-1": {
+                                "vlanif": "vlan0.20",
+                                "if": "igb1",
+                                "tag": "20",
+                                "descr": "IoT",
+                            }
                         }
                     }
                 }
-            },
+            }
         )
-
-    client = _client_with_handler(handler)
-    try:
-        vlans = await client.list_vlans()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
+    )
+    vlans = await _run(client, "list_vlans")
     assert len(vlans) == 1
     assert vlans[0].device == "vlan0.20"
     assert vlans[0].parent == "igb1"
@@ -281,37 +636,18 @@ async def test_vlans_parsed_from_nested_shape() -> None:
 
 @pytest.mark.asyncio
 async def test_arp_parsed_from_bare_list() -> None:
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            200,
-            json=[
-                {"ip": "10.0.0.50", "mac": "bc:24:11:e8:4a:3f", "intf": "igb1"},
-                {"ip": "10.0.0.99", "mac": "(incomplete)", "intf": "igb1"},
-            ],
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/diagnostics/interface/getArp": [
+                    {"ip": "10.0.0.50", "mac": "bc:24:11:e8:4a:3f", "intf": "igb1"},
+                    {"ip": "10.0.0.99", "mac": "(incomplete)", "intf": "igb1"},
+                ]
+            }
         )
-
-    client = _client_with_handler(handler)
-    try:
-        arp = await client.list_arp()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
+    )
+    arp = await _run(client, "list_arp")
     assert len(arp) == 2
     assert arp[0].address == "10.0.0.50"
     assert arp[0].mac == "bc:24:11:e8:4a:3f"
     assert arp[1].mac is None
-
-
-@pytest.mark.asyncio
-async def test_leases_404_returns_empty_not_error() -> None:
-    """DHCP service not enabled → 404 on searchLease should degrade to
-    an empty list, not fail the whole reconcile."""
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(404, text="not found")
-
-    client = _client_with_handler(handler)
-    try:
-        leases = await client.list_leases()
-    finally:
-        await client._client.aclose()  # type: ignore[union-attr]
-    assert leases == []

--- a/backend/tests/test_opnsense_client.py
+++ b/backend/tests/test_opnsense_client.py
@@ -367,7 +367,8 @@ async def test_interfaces_fall_back_to_ifconfig_on_404() -> None:
         _routes({"/api/diagnostics/interface/getInterfaceConfig": _IFCONFIG_26_1})
     )
     ifaces = await _run(client, "list_interfaces")
-    assert {i.cidr for i in ifaces} == {"172.20.1.0/24", "198.51.100.0/29", "127.0.0.0/8"}
+    # lo0 is in the payload and deliberately not mirrored.
+    assert {i.cidr for i in ifaces} == {"172.20.1.0/24", "198.51.100.0/29"}
 
 
 # ── DHCP backend matrix (#797 cause 2) ────────────────────────────────
@@ -651,3 +652,152 @@ async def test_arp_parsed_from_bare_list() -> None:
     assert arp[0].address == "10.0.0.50"
     assert arp[0].mac == "bc:24:11:e8:4a:3f"
     assert arp[1].mac is None
+
+
+# ── Code-review follow-ups on the #797 fix ────────────────────────────
+
+
+def test_ifconfig_skips_loopback() -> None:
+    """``ifconfig`` reports every kernel interface, ``lo0`` included.
+
+    Without a filter the fallback parser mirrors 127.0.0.0/8 — a
+    16.7-million-address subnet, an auto-created wrapper block for it, and
+    a "gateway" reservation for 127.0.0.1 — on every firewall, and every
+    firewall would collide on the same CIDR.
+    """
+    cidrs = {i.cidr for i in _interfaces_from_ifconfig(_IFCONFIG_26_1)}
+    assert "127.0.0.0/8" not in cidrs
+    assert cidrs == {"172.20.1.0/24", "198.51.100.0/29"}
+
+
+def test_addresses_skip_ipv4_link_local_too() -> None:
+    """169.254/16 is as per-link as fe80::/10 and equally uninteresting."""
+    ifaces = _interfaces_from_ifconfig(
+        {"igc9": {"device": "igc9", "ipv4": [{"ipaddr": "169.254.1.5", "subnetbits": 16}]}}
+    )
+    assert ifaces == []
+
+
+def test_addresses_skip_unspecified() -> None:
+    ifaces = _interfaces_from_ifconfig(
+        {"igc9": {"device": "igc9", "ipv4": [{"ipaddr": "0.0.0.0", "subnetbits": 0}]}}
+    )
+    assert ifaces == []
+
+
+def test_overview_all_rows_filtered_is_a_clean_zero_not_a_shape_error() -> None:
+    """A WAN-only DHCP box parses to zero for a reason we understand.
+
+    Shape detection must therefore run before the enabled/link_type
+    filters — otherwise this raises the degraded-read error and aborts
+    the pass, instead of reaching the zero-interface warning that exists
+    for exactly this case.
+    """
+    rows = [
+        {
+            "identifier": "wan",
+            "device": "igc0",
+            "link_type": "dhcp",
+            "ipv4": [{"ipaddr": "198.51.100.2", "subnetbits": 29}],
+            "ipv6": [],
+        },
+        {
+            "identifier": "opt1",
+            "device": "igc1",
+            "enabled": False,
+            "ipv4": [{"ipaddr": "10.0.0.1", "subnetbits": 24}],
+            "ipv6": [],
+        },
+    ]
+    assert _interfaces_from_overview(rows) == []
+
+
+def test_overview_unknown_link_type_vocabulary_does_not_raise() -> None:
+    """An unrecognised link_type is skipped, not treated as shape drift."""
+    rows = [
+        {
+            "identifier": "opt9",
+            "device": "igc9",
+            "link_type": "some-future-mode",
+            "ipv4": [],
+            "ipv6": [],
+        }
+    ]
+    assert _interfaces_from_overview(rows) == []
+
+
+@pytest.mark.asyncio
+async def test_interfaces_fall_back_to_ifconfig_on_403_not_just_404() -> None:
+    """An API user provisioned against the OLD docs has no Interfaces:
+    Overview privilege. Upgrading must degrade to the fallback, not turn
+    a working mirror into a hard failure."""
+    client = _client_with_handler(
+        _routes(
+            {"/api/diagnostics/interface/getInterfaceConfig": _IFCONFIG_26_1},
+            status={"/api/interfaces/overview/export": 403},
+        )
+    )
+    ifaces = await _run(client, "list_interfaces")
+    assert {i.cidr for i in ifaces} == {"172.20.1.0/24", "198.51.100.0/29"}
+
+
+@pytest.mark.asyncio
+async def test_interfaces_5xx_on_overview_still_aborts() -> None:
+    """Only 404/403 fall back; a transient failure must propagate."""
+    client = _client_with_handler(_routes({}, status={"/api/interfaces/overview/export": 503}))
+    with pytest.raises(OPNsenseClientError, match="503"):
+        await _run(client, "list_interfaces")
+
+
+@pytest.mark.asyncio
+async def test_isc_lease_403_degrades_like_the_other_backends() -> None:
+    """The ISC reader is a POST so it can't use ``_get_optional``, but it
+    must not be stricter than the readers that can."""
+    client = _client_with_handler(
+        _routes(
+            {"/api/dnsmasq/leases/search": _DNSMASQ_LEASES},
+            status={"/api/dhcpv4/leases/searchLease": 403},
+        )
+    )
+    result = await _run(client, "list_leases")
+    assert result.sources_found == ["dnsmasq"]
+    assert "isc leases" in result.sources_forbidden
+
+
+@pytest.mark.asyncio
+async def test_isc_reservation_403_degrades_too() -> None:
+    client = _client_with_handler(_routes({}, status={"/api/dhcpv4/settings/getReservation": 403}))
+    result = await _run(client, "list_reservations")
+    assert result.reservations == []
+    assert "isc reservations" in result.sources_forbidden
+
+
+@pytest.mark.asyncio
+async def test_kea_numeric_zero_state_is_active_not_unknown() -> None:
+    """``str(0 or "")`` is ``""`` — so an integer 0, which is Kea's ACTIVE
+    state, would collapse to "unknown" and mark every live lease stale."""
+    client = _client_with_handler(
+        _routes(
+            {
+                "/api/kea/leases4/search": {
+                    "rows": [
+                        {"address": "172.20.1.50", "hwaddr": "aa:bb:cc:dd:ee:ff", "state": 0},
+                        {"address": "172.20.1.51", "hwaddr": "aa:bb:cc:dd:ee:01", "state": 2},
+                    ]
+                }
+            }
+        )
+    )
+    result = await _run(client, "list_leases")
+    by_addr = {x.address: x for x in result.leases}
+    assert by_addr["172.20.1.50"].state == "active"
+    assert by_addr["172.20.1.51"].state == "expired"
+
+
+@pytest.mark.asyncio
+async def test_kea_missing_state_is_unknown() -> None:
+    client = _client_with_handler(
+        _routes({"/api/kea/leases4/search": {"rows": [{"address": "172.20.1.52"}]}})
+    )
+    result = await _run(client, "list_leases")
+    assert result.leases[0].state == "unknown"

--- a/backend/tests/test_opnsense_reconcile.py
+++ b/backend/tests/test_opnsense_reconcile.py
@@ -25,7 +25,9 @@ from app.services.opnsense.client import (
     _OPNFirmwareInfo,
     _OPNInterface,
     _OPNLease,
+    _OPNLeaseResult,
     _OPNReservation,
+    _OPNReservationResult,
     _OPNVlan,
 )
 from app.services.opnsense.reconcile import reconcile_router
@@ -82,13 +84,24 @@ class _FakeClient:
         leases: list[_OPNLease] | None = None,
         reservations: list[_OPNReservation] | None = None,
         arp: list[_OPNArpEntry] | None = None,
+        lease_sources: list[str] | None = None,
+        reservation_sources: list[str] | None = None,
+        forbidden: list[str] | None = None,
     ) -> None:
-        self.firmware = firmware or _OPNFirmwareInfo(version="OPNsense 24.7")
+        self.firmware = firmware or _OPNFirmwareInfo(version="OPNsense 26.1")
         self.interfaces = interfaces or []
         self.vlans = vlans or []
         self.leases = leases or []
         self.reservations = reservations or []
         self.arp = arp or []
+        # #797 — the real client reports WHICH DHCP backends answered, so
+        # the reconciler can tell "DHCP is off" from "we asked a firmware
+        # that no longer has these endpoints". Default to a backend having
+        # answered, so existing tests exercise the normal path; the
+        # no-backend case is asserted explicitly in its own test.
+        self.lease_sources = ["kea"] if lease_sources is None else lease_sources
+        self.reservation_sources = ["kea"] if reservation_sources is None else reservation_sources
+        self.forbidden = forbidden or []
 
     async def __aenter__(self):
         return self
@@ -106,10 +119,18 @@ class _FakeClient:
         return self.vlans
 
     async def list_leases(self):
-        return self.leases
+        return _OPNLeaseResult(
+            leases=self.leases,
+            sources_found=self.lease_sources,
+            sources_forbidden=self.forbidden,
+        )
 
     async def list_reservations(self):
-        return self.reservations
+        return _OPNReservationResult(
+            reservations=self.reservations,
+            sources_found=self.reservation_sources,
+            sources_forbidden=self.forbidden,
+        )
 
     async def list_arp(self):
         return self.arp
@@ -575,7 +596,11 @@ async def test_list_leases_swallows_404_but_reraises_5xx(db_session: AsyncSessio
         base_url="https://fw.test:443", transport=httpx.MockTransport(_handler_404)
     )
     try:
-        assert await client.list_leases() == []
+        result = await client.list_leases()
+        assert result.leases == []
+        # #797 — and no backend claimed to have answered, which is what
+        # lets the reconciler warn instead of reporting a clean zero.
+        assert result.sources_found == []
     finally:
         await client._client.aclose()
 
@@ -695,3 +720,132 @@ async def test_no_api_secret_records_error(db_session: AsyncSession) -> None:
     assert router.last_synced_at is not None
     # Watermark is recent.
     assert (datetime.now(UTC) - router.last_synced_at).total_seconds() < 60
+
+
+# ── #797 — a green sync that mirrors nothing must say why ─────────────
+
+
+@pytest.mark.asyncio
+async def test_no_dhcp_backend_warns_instead_of_reporting_a_clean_zero(
+    db_session: AsyncSession,
+) -> None:
+    """The reported bug, asserted at the reconcile level.
+
+    OPNsense 25.7+ retired the ISC endpoints this integration used to be
+    the only consumer of. Every request succeeded, the counts were all
+    zero, and ``last_sync_error`` stayed NULL — so the UI showed a
+    healthy integration that had never mirrored a single row. The pass
+    still succeeds (nothing is wrong with the firewall), but it now
+    carries a warning that names the cause.
+    """
+    space = await _make_space(db_session)
+    router = await _make_router(db_session, space)
+    fake = _FakeClient(
+        interfaces=[_iface("lan", "igc0", "172.20.1.1", "172.20.1.0/24")],
+        leases=[],
+        reservations=[],
+        lease_sources=[],  # no Kea, no Dnsmasq, no ISC
+        reservation_sources=[],
+    )
+    with _patch_client(fake):
+        summary = await reconcile_router(db_session, router)
+
+    assert summary.ok  # not an error — the firewall is fine
+    assert any("no DHCP backend responded" in w for w in summary.warnings)
+    await db_session.refresh(router)
+    assert router.last_sync_error is None
+    assert router.last_sync_warning is not None
+    assert "no DHCP backend responded" in router.last_sync_warning
+
+
+@pytest.mark.asyncio
+async def test_backend_present_with_zero_leases_does_not_warn(
+    db_session: AsyncSession,
+) -> None:
+    """A backend that answered and had nothing to say is a real zero.
+
+    This is the other half of the distinction — without it the warning
+    would fire on every quiet firewall and be trained away as noise.
+    """
+    space = await _make_space(db_session)
+    router = await _make_router(db_session, space)
+    fake = _FakeClient(
+        interfaces=[_iface("lan", "igc0", "172.20.1.1", "172.20.1.0/24")],
+        leases=[],
+        reservations=[],
+        lease_sources=["kea"],
+        reservation_sources=["kea"],
+    )
+    with _patch_client(fake):
+        summary = await reconcile_router(db_session, router)
+
+    assert summary.ok
+    assert not any("no DHCP backend" in w for w in summary.warnings)
+    await db_session.refresh(router)
+    assert router.last_sync_warning is None
+
+
+@pytest.mark.asyncio
+async def test_forbidden_backend_warns_about_the_privilege_not_the_firmware(
+    db_session: AsyncSession,
+) -> None:
+    """Kea's lease endpoints carry their own ACL (opnsense/core#7770).
+
+    A 403 there has a different remedy from a 404 — add a privilege, not
+    upgrade a firmware — so it gets its own message rather than being
+    folded into "no backend responded".
+    """
+    space = await _make_space(db_session)
+    router = await _make_router(db_session, space)
+    fake = _FakeClient(
+        interfaces=[_iface("lan", "igc0", "172.20.1.1", "172.20.1.0/24")],
+        lease_sources=["dnsmasq"],
+        reservation_sources=["dnsmasq"],
+        forbidden=["kea leases"],
+    )
+    with _patch_client(fake):
+        summary = await reconcile_router(db_session, router)
+
+    assert summary.ok
+    assert any("refused by kea leases" in w for w in summary.warnings)
+    # A backend DID answer, so the no-backend warning must not also fire.
+    assert not any("no DHCP backend responded" in w for w in summary.warnings)
+
+
+@pytest.mark.asyncio
+async def test_zero_interfaces_warns_that_nothing_can_be_mirrored(
+    db_session: AsyncSession,
+) -> None:
+    """Subnets come only from interfaces, and addresses need an enclosing
+    subnet — so zero interfaces silently zeroes the entire mirror."""
+    space = await _make_space(db_session)
+    router = await _make_router(db_session, space)
+    fake = _FakeClient(interfaces=[], lease_sources=["kea"], reservation_sources=["kea"])
+    with _patch_client(fake):
+        summary = await reconcile_router(db_session, router)
+
+    assert summary.ok
+    assert any("no addressed interfaces found" in w for w in summary.warnings)
+
+
+@pytest.mark.asyncio
+async def test_warning_clears_once_the_condition_is_resolved(
+    db_session: AsyncSession,
+) -> None:
+    """A stale amber chip is its own bug — the field is set to NULL on a
+    clean pass rather than left at its last value."""
+    space = await _make_space(db_session)
+    router = await _make_router(db_session, space)
+    iface = _iface("lan", "igc0", "172.20.1.1", "172.20.1.0/24")
+
+    with _patch_client(_FakeClient(interfaces=[iface], lease_sources=[], reservation_sources=[])):
+        await reconcile_router(db_session, router)
+    await db_session.refresh(router)
+    assert router.last_sync_warning is not None
+
+    with _patch_client(
+        _FakeClient(interfaces=[iface], lease_sources=["kea"], reservation_sources=["kea"])
+    ):
+        await reconcile_router(db_session, router)
+    await db_session.refresh(router)
+    assert router.last_sync_warning is None

--- a/docs/features/INTEGRATIONS.md
+++ b/docs/features/INTEGRATIONS.md
@@ -470,12 +470,41 @@ OPNsense API keys are minted per-user under **System → Access → Users → AP
 
 ### Mirror semantics
 
-- **Interfaces are real LANs.** Unlike Kubernetes pod CIDRs (routed overlays with no broadcast), OPNsense LAN / OPT* / VLAN interfaces are genuine subnets: the firewall's interface IP is the gateway and the broadcast is real. So subnets are created with normal LAN semantics (gateway reserved, network + broadcast excluded from usable hosts). Interface config comes from `diagnostics/interface/getInterfaceConfig`; VLAN labels from `interfaces/vlan_settings/get` decorate the subnet description.
+- **Interfaces are real LANs.** Unlike Kubernetes pod CIDRs (routed overlays with no broadcast), OPNsense LAN / OPT* / VLAN interfaces are genuine subnets: the firewall's interface IP is the gateway and the broadcast is real. So subnets are created with normal LAN semantics (gateway reserved, network + broadcast excluded from usable hosts). Interface config comes from `interfaces/overview/export`, which carries the logical identifier, the operator's description and the VLAN tag in one payload; `diagnostics/interface/getInterfaceConfig` is the fallback on firmware that lacks it, and `interfaces/vlan_settings/get` still supplies VLAN labels on that path. Interfaces that are administratively disabled, or whose address is DHCP-assigned, are skipped — they don't describe a subnet this IPAM should own. Only the primary address per family is mirrored; secondaries and VIPs are ignored.
 - **Interface gateway IP** → one `reserved` `IPAddress` per subnet under the firewall's identity.
-- **DHCPv4 leases** (`dhcpv4/leases/searchLease`) → `IPAddress` with `status="dhcp"` + `auto_from_lease=True` (Kea-shape parity), description noting the lease state.
-- **Static reservations** (`dhcpv4/settings/getReservation`) → `IPAddress` with `status="reserved"`. Added before leases so an IP that has both prefers the richer reservation description.
+- **DHCPv4 leases** → `IPAddress` with `status="dhcp"` + `auto_from_lease=True` (Kea-shape parity), description noting the lease state. Sourced from every DHCP backend present (see below).
+- **Static reservations** → `IPAddress` with `status="reserved"`. Added before leases so an IP that has both prefers the richer reservation description.
 - **ARP table** (`diagnostics/interface/getArp`, opt-in) → `IPAddress` with `status="opnsense-arp"`, lowest priority.
 - **Smart parent block**: a mirrored CIDR with no enclosing operator block gets the canonical RFC 1918 / CGNAT supernet auto-created as an unowned top-level block (shared by all integrations).
+
+### DHCP backends
+
+OPNsense has shipped three DHCPv4 servers across the supported firmware range, and which one answers depends on both the version and what the operator configured. ISC `dhcpd` was deprecated through 24.x / 25.1 and **moved out of core to a plugin in 25.7** ([opnsense/core#9155](https://github.com/opnsense/core/issues/9155)), with Dnsmasq becoming the wizard default and Kea the advanced option.
+
+| Backend | Leases | Reservations | Present on |
+|---|---|---|---|
+| **Kea** | `kea/leases4/search` | `kea/dhcpv4/searchReservation` | 24.x+ when enabled |
+| **Dnsmasq** | `dnsmasq/leases/search` | `dnsmasq/settings/searchHost` (rows with a MAC) | 25.7+ default |
+| **ISC** (legacy) | `dhcpv4/leases/searchLease` | `dhcpv4/settings/getReservation` | core ≤25.1; 25.7+ only with the plugin |
+
+SpatiumDDI queries **all three every pass and unions the results** rather than making the operator pick — 25.7+ can genuinely run Kea and Dnsmasq side by side on different interfaces. A backend that 404s is simply absent and contributes nothing; a 5xx or timeout still aborts the pass, so a transient failure can never be mistaken for an empty lease table.
+
+A Dnsmasq "host" doubles as a static DNS entry, so only rows carrying a MAC are mirrored as reservations. Kea reports lease state numerically (`0` = active); it is normalised to the same vocabulary the ISC path produces.
+
+> **Why this is called out at such length.** Until [#797](https://github.com/spatiumddi/spatiumddi/issues/797) this integration queried the ISC endpoints *only*. On any 25.7+ firewall they 404, the client treated that as an empty table, and the sync reported success with zero leases on every pass — indefinitely, and with nothing in the UI to suggest anything was wrong.
+
+### When a sync succeeds but mirrors nothing
+
+`last_sync_warning` records non-fatal findings from the last pass and surfaces as an amber line beside the sync time (red `last_sync_error` still means the pass failed outright). It fires when:
+
+- **No DHCP backend responded** — Kea, Dnsmasq and ISC are all absent, disabled, or not permitted. Nothing can mirror while this is true.
+- **A backend refused the API user (403)** — the backend exists but the credentials lack its privilege. Different remedy: grant the privilege rather than change firmware.
+- **No addressed interfaces were found** — every mirrored address needs an enclosing subnet, so zero interfaces zeroes the whole mirror downstream.
+- **A subnet or address is owned by another integration** and was therefore not claimed.
+
+A backend that answered and had nothing to report is a genuine zero and does **not** warn — otherwise the signal would fire on every quiet firewall and be trained away as noise.
+
+Separately, a non-empty interface payload that parses to zero interfaces is treated as a **degraded read** and fails the pass rather than reporting an empty mirror. That combination means the response shape isn't the one this client parses, which is exactly how #797 stayed invisible.
 
 ### Lock semantics
 
@@ -486,8 +515,20 @@ Same ownership shape as the other integrations: pre-existing operator rows at a 
 The admin page at `/opnsense` ships a copy-paste guide (expand **Setup guide**). In the OPNsense web UI:
 
 1. Create a dedicated read-only user (**System → Access → Users → +**), e.g. `spatiumddi` with no shell access.
-2. Grant it read access — the built-in **GUI – All pages (read only)** privilege is simplest, or scope it to Diagnostics + DHCPv4 + Interfaces for least privilege.
+2. Grant it read access — the built-in **GUI – All pages (read only)** privilege is simplest, or scope it for least privilege (table below).
 3. Edit the user → **API keys → +** to generate a key / secret pair. OPNsense downloads an `apikey.txt` with `key=` and `secret=` lines.
+
+**Least-privilege scoping.** Grant the pages matching what you're mirroring:
+
+| Mirrors | Privileges needed |
+|---|---|
+| Interfaces → subnets | Interfaces: Overview, Interfaces: VLAN, Diagnostics: Interface |
+| DHCP leases + reservations (Kea) | Services: Kea DHCP, **plus Kea's own lease privileges** |
+| DHCP leases + reservations (Dnsmasq) | Services: Dnsmasq DNS/DHCP |
+| DHCP leases + reservations (ISC, legacy) | Services: DHCPv4 |
+| ARP table (opt-in) | Diagnostics: ARP Table |
+
+The Kea lease and service endpoints carry **separate ACL entries** from the Kea settings pages ([opnsense/core#7770](https://github.com/opnsense/core/issues/7770)), so a user granted only the Kea page still gets 403 on the leases. SpatiumDDI does not fail the pass for this — the interface mirror keeps working — but it raises a `last_sync_warning` naming the backend, because the alternative is leases that silently never appear.
 
 Paste `key` into **API Key** and `secret` into **API Secret**. **Test Connection** (`POST /routers/test`) verifies HTTPS reachability + auth + firmware version before save.
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12435,6 +12435,11 @@ export interface OPNsenseRouter {
   sync_interval_seconds: number;
   last_synced_at: string | null;
   last_sync_error: string | null;
+  // #797 — non-fatal findings from the last pass, newline-joined. A sync
+  // can report ok and still mirror nothing (no DHCP backend on the
+  // firmware, a subnet another integration already owns); this is what
+  // distinguishes that from a genuinely idle firewall.
+  last_sync_warning: string | null;
   firmware_version: string | null;
   interface_count: number | null;
   lease_count: number | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9455,6 +9455,8 @@ export interface IntegrationsDashboardTargetRow {
   sync_interval_seconds: number;
   last_synced_at: string | null;
   last_sync_error: string | null;
+  // #797 — non-fatal findings; null for integrations that don't compute them.
+  last_sync_warning: string | null;
   is_stale: boolean;
 }
 export interface IntegrationsDashboardPanel {
@@ -9465,6 +9467,7 @@ export interface IntegrationsDashboardPanel {
   healthy_count: number;
   stale_count: number;
   error_count: number;
+  warning_count: number;
   targets: IntegrationsDashboardTargetRow[];
 }
 export interface IntegrationsDashboardErrorRow {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3901,8 +3901,15 @@ function IntegrationsDashboardTabPanel() {
 }
 
 function IntegrationCard({ panel }: { panel: IntegrationsDashboardPanel }) {
+  // #797 — a warned target syncs on time and without error but isn't
+  // producing what it was configured to produce, so it must not read as
+  // green here while the IPAM-tab panel shows it amber.
   const tone: Tone =
-    panel.error_count > 0 ? "bad" : panel.stale_count > 0 ? "warn" : "good";
+    panel.error_count > 0
+      ? "bad"
+      : panel.stale_count > 0 || panel.warning_count > 0
+        ? "warn"
+        : "good";
   const cls = TONE_CLASS[tone];
   return (
     <div className="rounded-lg border bg-card p-3">
@@ -3927,6 +3934,14 @@ function IntegrationCard({ panel }: { panel: IntegrationsDashboardPanel }) {
             </span>
           </>
         )}
+        {panel.warning_count > 0 && (
+          <>
+            {" · "}
+            <span className="text-amber-600 dark:text-amber-400">
+              {panel.warning_count} warning
+            </span>
+          </>
+        )}
         {panel.error_count > 0 && (
           <>
             {" · "}
@@ -3943,7 +3958,10 @@ function IntegrationCard({ panel }: { panel: IntegrationsDashboardPanel }) {
               key={t.id}
               className="flex items-baseline justify-between gap-2"
             >
-              <span className="truncate" title={t.display}>
+              <span
+                className="truncate"
+                title={t.last_sync_warning ?? t.display}
+              >
                 {t.display}
               </span>
               <span
@@ -3951,10 +3969,11 @@ function IntegrationCard({ panel }: { panel: IntegrationsDashboardPanel }) {
                   "shrink-0 tabular-nums",
                   t.last_sync_error
                     ? "text-red-600 dark:text-red-400"
-                    : t.is_stale
+                    : t.is_stale || t.last_sync_warning
                       ? "text-amber-600 dark:text-amber-400"
                       : "text-muted-foreground",
                 )}
+                title={t.last_sync_error ?? t.last_sync_warning ?? undefined}
               >
                 {t.last_synced_at ? humanTime(t.last_synced_at) : "never"}
               </span>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -2340,9 +2340,15 @@ function integrationDotCls(
   lastSyncedAt: string | null,
   lastSyncError: string | null,
   intervalSeconds: number,
+  lastSyncWarning?: string | null,
 ): string {
   if (lastSyncError) return "bg-red-500";
   if (!lastSyncedAt) return "bg-muted-foreground/40";
+  // #797 — a pass can be on time and error-free and still mirror nothing
+  // (no DHCP backend on the firmware, credentials refused by one backend).
+  // Amber rather than green, or the dashboard vouches for an integration
+  // that has never produced a row.
+  if (lastSyncWarning) return "bg-amber-500";
   const age = (Date.now() - new Date(lastSyncedAt).getTime()) / 1000;
   // Amber when the last sync is older than ~3 intervals — implies the
   // reconcile beat sweep is stalled or the target is unreachable.
@@ -2619,6 +2625,7 @@ function IntegrationsPanel({
                       }
                       lastSyncedAt={r.last_synced_at}
                       lastSyncError={r.last_sync_error}
+                      lastSyncWarning={r.last_sync_warning}
                       intervalSeconds={r.sync_interval_seconds}
                       enabled={r.enabled}
                     />
@@ -2951,6 +2958,7 @@ function IntegrationRow({
   meta,
   lastSyncedAt,
   lastSyncError,
+  lastSyncWarning,
   intervalSeconds,
   enabled,
 }: {
@@ -2960,17 +2968,24 @@ function IntegrationRow({
   meta: string;
   lastSyncedAt: string | null;
   lastSyncError: string | null;
+  // Optional — only integrations that compute non-fatal findings pass it.
+  lastSyncWarning?: string | null;
   intervalSeconds: number;
   enabled: boolean;
 }) {
   const dotCls = !enabled
     ? "bg-muted-foreground/40"
-    : integrationDotCls(lastSyncedAt, lastSyncError, intervalSeconds);
+    : integrationDotCls(
+        lastSyncedAt,
+        lastSyncError,
+        intervalSeconds,
+        lastSyncWarning,
+      );
   return (
     <Link
       to={to}
       className="flex items-center gap-3 px-4 py-2 text-[11px] hover:bg-muted/30"
-      title={lastSyncError ?? undefined}
+      title={lastSyncError ?? lastSyncWarning ?? undefined}
     >
       <span className={cn("h-1.5 w-1.5 flex-shrink-0 rounded-full", dotCls)} />
       <span className="w-28 truncate font-semibold" title={name}>

--- a/frontend/src/pages/opnsense/OpnsensePage.tsx
+++ b/frontend/src/pages/opnsense/OpnsensePage.tsx
@@ -250,6 +250,19 @@ export function OpnsensePage() {
                               {r.last_sync_error}
                             </div>
                           )}
+                          {/* #797 — a pass can succeed and still mirror
+                              nothing. Amber, below any red error, with the
+                              full multi-line text on hover. */}
+                          {!r.last_sync_error && r.last_sync_warning && (
+                            <div
+                              className="text-[11px] text-amber-600 dark:text-amber-500 max-w-xs truncate"
+                              title={r.last_sync_warning}
+                            >
+                              {r.last_sync_warning.split("\n")[0]}
+                              {r.last_sync_warning.includes("\n") &&
+                                ` (+${r.last_sync_warning.split("\n").length - 1} more)`}
+                            </div>
+                          )}
                         </td>
                         <td className="whitespace-nowrap px-3 py-2">
                           <button


### PR DESCRIPTION
Closes #797

The OPNsense integration reported a **successful sync with zero results on every pass** against a current firewall — indefinitely, with nothing in the UI suggesting anything was wrong. Three independent causes, all confirmed in the code before fixing.

## 1. The interface parser was written against a shape that doesn't exist

`list_interfaces` expected `getInterfaceConfig` to return flat `ipaddr` / `subnet` string keys on a logical-name-keyed dict. That endpoint is a passthrough of configd `interface list ifconfig`: keyed by **OS device**, addresses in `ipv4[]` / `ipv6[]` arrays of `{ipaddr, subnetbits}` — and always has been. The parser matched nothing on every real firewall, and because the response is a non-empty dict, the #430 degraded-read guard didn't trip. It just parsed to zero.

Measured directly against the payload from the report:

```
OLD parser: 0 interfaces
NEW parser: 1 interface
```

The read now leads with **`interfaces/overview/export`** — the only endpoint carrying the logical identifier, operator description and VLAN tag alongside the addresses — and falls back to the real device-keyed ifconfig shape. Disabled and DHCP-addressed interfaces are skipped; only the primary address per family is mirrored, so VIPs no longer become phantom subnets.

## 2. ISC dhcpd is gone, and it was the only backend we asked

ISC moved out of core to a plugin in 25.7 ([opnsense/core#9155](https://github.com/opnsense/core/issues/9155)), with Dnsmasq the wizard default and Kea the advanced option. On 25.7+ the `/api/dhcpv4/*` paths 404 — and the client treated 404 as "empty table", so leases and reservations could never mirror.

Leases and reservations are now **unioned across all three backends** every pass, because 25.7+ can genuinely run Kea and Dnsmasq side by side on different interfaces. Per-source 404 means absent; 5xx still aborts, so a transient failure can't be mistaken for an empty table (non-negotiable #5). Kea's numeric lease state is normalised; Dnsmasq hosts without a MAC are dropped, being static DNS entries rather than reservations.

## 3. Warnings were computed and then dropped on the floor

`ReconcileSummary.warnings` was populated in three places and read by nothing — no column, no API field, no UI, absent from the audit row and the log line. Combined with 404-to-empty, that is the entire "green with zero counts" experience, and it would have stayed silent even after the first two fixes.

New `opnsense_router.last_sync_warning` (migration `f4c81a37e0b2`) persists the joined warnings, surfaced as an amber line on the admin page, an amber dot on the IPAM-tab panel, and a `warning_count` on the Integrations dashboard tab — plus the audit payload and the `opnsense_reconcile_ok` log line.

**The judgement call:** a backend that answered with zero leases does **not** warn — only *no backend answering* does. Without that distinction the warning fires on every quiet firewall and gets trained away as noise, recreating the original problem in a new form. There's a test for each side.

## Why this survived a green test suite

The old fixtures encoded the **same fiction as the parser**, so tests and code agreed with each other and disagreed with every OPNsense firewall in existence. Two rules are now written into the client docstring:

1. Fixtures are captured payloads, not imagined ones — the 26.1 sample from the report is used verbatim.
2. A non-empty payload that parses to zero rows raises as a **degraded read** rather than reporting an empty mirror. That property is what would have surfaced this on day one.

## Second commit — code-review findings

Six, all confirmed by execution. Most severe: the fallback parser **mirrored `lo0`**, producing a 16.7-million-address `127.0.0.0/8` subnet plus a "gateway" reservation for 127.0.0.1 on every firewall — and the new test asserted that bad value. Also: shape detection ran *after* the policy filters (so a WAN-only DHCP box aborted the pass instead of warning); the ISC readers swallowed 404 but not 403, reintroducing the #797 failure for least-privilege users; the interface read fell back only on 404, so upgrading would break existing users' mirrors; `str(state or "")` turned Kea's integer `0` — ACTIVE — into `"unknown"`; and the Integrations dashboard tab still classified on `last_sync_error` alone, breaking the both-surfaces rule this branch had just created work for.

## Verification

**70 tests pass** — 49 client (incl. a backend matrix over Kea-only / Dnsmasq-only / ISC-only / both / none / 403 / 5xx, and 11 regression tests one per review finding), 19 reconcile, 2 dashboard. `make ci` green, mypy clean, migration applied and lint baseline updated.

Docs: `INTEGRATIONS.md` gains the backend matrix, the warning semantics, and a least-privilege privilege table — including the Kea lease-ACL trap ([opnsense/core#7770](https://github.com/opnsense/core/issues/7770)).

**Deferred:** IPv6 leases via `kea/leases6/search`, per the plan's optional follow-up.
