### PR TITLE
fix(appliance): console rendering polish (#803) + nightly build pipeline (#805), and stop the per-image builds racing the release

### DIFF
--- a/.github/workflows/build-dhcp-images.yml
+++ b/.github/workflows/build-dhcp-images.yml
@@ -1,13 +1,25 @@
 name: Build DHCP Agent Images
 
+# TRIGGERS — deliberately PR-only. Neither `push` case earned its keep:
+#
+#   on a TAG, this raced release.yml's build-dhcp,
+#     which builds the same image and pushes the SAME `:<VERSION>` tag.
+#     Two multi-arch builds of identical source, concurrently, with the
+#     winner decided by whichever finished last — on a release artifact.
+#
+#   on `main`, it published `:main` and `:sha-<short>` that nothing
+#     consumes: no chart, no compose file, no k8s manifest pins them, and
+#     agent-e2e explicitly builds from PR source instead (see the comment
+#     in agent-e2e.yml). It also skipped Trivy on that path, so it was
+#     publishing unscanned multi-arch images for no reader.
+#
+# What replaced each: releases are built by release.yml, and "build main
+# periodically" is nightly.yml (#805) — which does it once a day with a
+# Trivy gate ahead of the push, rather than on every merge with none.
+#
+# The PR trigger below is the one that matters and is unchanged: it is the
+# CVE gate, and it still blocks the PR on any fixable HIGH/CRITICAL.
 on:
-  push:
-    branches: [main]
-    tags:
-      - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-*"
-    paths:
-      - "agent/dhcp/**"
-      - ".github/workflows/build-dhcp-images.yml"
   pull_request:
     paths:
       - "agent/dhcp/**"

--- a/.github/workflows/build-dns-images.yml
+++ b/.github/workflows/build-dns-images.yml
@@ -1,13 +1,25 @@
 name: Build DNS Agent Images
 
+# TRIGGERS — deliberately PR-only. Neither `push` case earned its keep:
+#
+#   on a TAG, this raced release.yml's build-dns / build-dns-powerdns / build-dns-technitium / build-dns-dnsdist,
+#     which builds the same image and pushes the SAME `:<VERSION>` tag.
+#     Two multi-arch builds of identical source, concurrently, with the
+#     winner decided by whichever finished last — on a release artifact.
+#
+#   on `main`, it published `:main` and `:sha-<short>` that nothing
+#     consumes: no chart, no compose file, no k8s manifest pins them, and
+#     agent-e2e explicitly builds from PR source instead (see the comment
+#     in agent-e2e.yml). It also skipped Trivy on that path, so it was
+#     publishing unscanned multi-arch images for no reader.
+#
+# What replaced each: releases are built by release.yml, and "build main
+# periodically" is nightly.yml (#805) — which does it once a day with a
+# Trivy gate ahead of the push, rather than on every merge with none.
+#
+# The PR trigger below is the one that matters and is unchanged: it is the
+# CVE gate, and it still blocks the PR on any fixable HIGH/CRITICAL.
 on:
-  push:
-    branches: [main]
-    tags:
-      - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-*"
-    paths:
-      - "agent/dns/**"
-      - ".github/workflows/build-dns-images.yml"
   pull_request:
     paths:
       - "agent/dns/**"

--- a/.github/workflows/build-looking-glass-images.yml
+++ b/.github/workflows/build-looking-glass-images.yml
@@ -1,13 +1,25 @@
 name: Build Looking Glass Agent Images
 
+# TRIGGERS — deliberately PR-only. Neither `push` case earned its keep:
+#
+#   on a TAG, this raced release.yml's build-looking-glass,
+#     which builds the same image and pushes the SAME `:<VERSION>` tag.
+#     Two multi-arch builds of identical source, concurrently, with the
+#     winner decided by whichever finished last — on a release artifact.
+#
+#   on `main`, it published `:main` and `:sha-<short>` that nothing
+#     consumes: no chart, no compose file, no k8s manifest pins them, and
+#     agent-e2e explicitly builds from PR source instead (see the comment
+#     in agent-e2e.yml). It also skipped Trivy on that path, so it was
+#     publishing unscanned multi-arch images for no reader.
+#
+# What replaced each: releases are built by release.yml, and "build main
+# periodically" is nightly.yml (#805) — which does it once a day with a
+# Trivy gate ahead of the push, rather than on every merge with none.
+#
+# The PR trigger below is the one that matters and is unchanged: it is the
+# CVE gate, and it still blocks the PR on any fixable HIGH/CRITICAL.
 on:
-  push:
-    branches: [main]
-    tags:
-      - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-*"
-    paths:
-      - "agent/looking-glass/**"
-      - ".github/workflows/build-looking-glass-images.yml"
   pull_request:
     paths:
       - "agent/looking-glass/**"

--- a/.github/workflows/build-supervisor-image.yml
+++ b/.github/workflows/build-supervisor-image.yml
@@ -1,13 +1,25 @@
 name: Build Supervisor Image
 
+# TRIGGERS — deliberately PR-only. Neither `push` case earned its keep:
+#
+#   on a TAG, this raced release.yml's build-supervisor,
+#     which builds the same image and pushes the SAME `:<VERSION>` tag.
+#     Two multi-arch builds of identical source, concurrently, with the
+#     winner decided by whichever finished last — on a release artifact.
+#
+#   on `main`, it published `:main` and `:sha-<short>` that nothing
+#     consumes: no chart, no compose file, no k8s manifest pins them, and
+#     agent-e2e explicitly builds from PR source instead (see the comment
+#     in agent-e2e.yml). It also skipped Trivy on that path, so it was
+#     publishing unscanned multi-arch images for no reader.
+#
+# What replaced each: releases are built by release.yml, and "build main
+# periodically" is nightly.yml (#805) — which does it once a day with a
+# Trivy gate ahead of the push, rather than on every merge with none.
+#
+# The PR trigger below is the one that matters and is unchanged: it is the
+# CVE gate, and it still blocks the PR on any fixable HIGH/CRITICAL.
 on:
-  push:
-    branches: [main]
-    tags:
-      - "[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-*"
-    paths:
-      - "agent/supervisor/**"
-      - ".github/workflows/build-supervisor-image.yml"
   pull_request:
     paths:
       - "agent/supervisor/**"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,6 +18,10 @@ name: Nightly
 #     already rolled and there is nothing to compare against, and a broken
 #     nightly would leave no fallback. Seven dated tags prune in the same
 #     run and cost nothing; anyone pulling `:nightly` never sees them.
+#     What the prune bounds is the TAG ring — untagged multi-arch children
+#     are left alone because deleting them would break the tags that
+#     reference them (see the prune job). Orphaned layers are GHCR's
+#     untagged-retention policy to collect, not this workflow's.
 #
 # THE APPLIANCE ISO IS DEFERRED, deliberately. Its retention answer is easy
 # (~1.5 GB each, so exactly one, assets replaced in place on the reused
@@ -84,6 +88,7 @@ jobs:
       contents: read
     outputs:
       should_build: ${{ steps.decide.outputs.should_build }}
+      images: ${{ steps.decide.outputs.images }}
       date_tag: ${{ steps.decide.outputs.date_tag }}
       version: ${{ steps.decide.outputs.version }}
       last_sha: ${{ steps.decide.outputs.last_sha }}
@@ -98,6 +103,26 @@ jobs:
           FORCE: ${{ github.event.inputs.force || 'false' }}
         run: |
           set -euo pipefail
+
+          # ONE source of truth for which images exist. Both the build
+          # matrix and the prune job read this, because a hardcoded second
+          # copy fails in the worst direction: add an image to the matrix,
+          # forget the prune list, and its dated tags accumulate forever
+          # with nothing reporting a problem.
+          cat > /tmp/images.json <<'IMAGES_EOF'
+          [
+            {"image": "spatiumddi-api",      "context": "./backend",  "file": "./backend/Dockerfile",  "target": "runtime"},
+            {"image": "spatiumddi-frontend", "context": "./frontend", "file": "./frontend/Dockerfile", "target": ""},
+            {"image": "dns-bind9",           "context": ".", "file": "./agent/dns/images/bind9/Dockerfile",             "target": ""},
+            {"image": "dns-powerdns",        "context": ".", "file": "./agent/dns/images/powerdns/Dockerfile",          "target": ""},
+            {"image": "dns-technitium",      "context": ".", "file": "./agent/dns/images/technitium/Dockerfile",        "target": ""},
+            {"image": "dns-dnsdist",         "context": ".", "file": "./agent/dns/images/dnsdist/Dockerfile",           "target": ""},
+            {"image": "dhcp-kea",            "context": ".", "file": "./agent/dhcp/images/kea/Dockerfile",              "target": ""},
+            {"image": "spatium-supervisor",  "context": ".", "file": "./agent/supervisor/images/supervisor/Dockerfile", "target": ""},
+            {"image": "looking-glass",       "context": ".", "file": "./agent/looking-glass/images/gobgp/Dockerfile",   "target": ""}
+          ]
+          IMAGES_EOF
+          echo "images=$(jq -c . /tmp/images.json)" >> "$GITHUB_OUTPUT"
 
           DATE_TAG="nightly-$(date -u +%Y%m%d)"
           echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"
@@ -147,46 +172,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - image: spatiumddi-api
-            context: ./backend
-            file: ./backend/Dockerfile
-            # #732 — MUST stay pinned. ``dev`` is the LAST stage in
-            # backend/Dockerfile, so an unpinned build publishes an api
-            # image carrying pytest + coverage installed as root.
-            target: runtime
-          - image: spatiumddi-frontend
-            context: ./frontend
-            file: ./frontend/Dockerfile
-            target: ""
-          - image: dns-bind9
-            context: .
-            file: ./agent/dns/images/bind9/Dockerfile
-            target: ""
-          - image: dns-powerdns
-            context: .
-            file: ./agent/dns/images/powerdns/Dockerfile
-            target: ""
-          - image: dns-technitium
-            context: .
-            file: ./agent/dns/images/technitium/Dockerfile
-            target: ""
-          - image: dns-dnsdist
-            context: .
-            file: ./agent/dns/images/dnsdist/Dockerfile
-            target: ""
-          - image: dhcp-kea
-            context: .
-            file: ./agent/dhcp/images/kea/Dockerfile
-            target: ""
-          - image: spatium-supervisor
-            context: .
-            file: ./agent/supervisor/images/supervisor/Dockerfile
-            target: ""
-          - image: looking-glass
-            context: .
-            file: ./agent/looking-glass/images/gobgp/Dockerfile
-            target: ""
+        # From the gate job, so this list exists exactly once (see there).
+        # `target: runtime` on the api image is #732's guard: `dev` is the
+        # LAST stage in backend/Dockerfile, so an unpinned build publishes
+        # an image carrying pytest + coverage installed as root.
+        include: ${{ fromJSON(needs.gate.outputs.images) }}
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v3
@@ -198,6 +188,40 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # SCAN BEFORE PUSH. The scan is the gate, so it has to run while
+      # refusing to publish is still possible — otherwise `:nightly` (the
+      # tag DEVELOPMENT.md tells operators to pull) has already moved to
+      # the vulnerable image by the time the job goes red, and with
+      # `fail-fast: false` the registry is left holding a mixed set of
+      # some-new / some-old images. Cost is one extra amd64 build, which
+      # the shared buildx cache makes near-free.
+      - name: Build amd64 for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: scan-target:${{ matrix.image }}
+          build-args: |
+            VITE_APP_VERSION=${{ needs.gate.outputs.version }}
+          cache-from: type=gha,scope=nightly-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}
+
+      - name: Trivy
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: scan-target:${{ matrix.image }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
+
+      # Only now, with the scan green, does anything reach the registry.
+      # The multi-arch build reuses the cache the scan build just warmed,
+      # so the amd64 half is a cache hit.
       - name: Build + push
         uses: docker/build-push-action@v6
         with:
@@ -216,32 +240,6 @@ jobs:
           cache-from: type=gha,scope=nightly-${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}
 
-      # Load the amd64 image locally and scan it with the SAME gate CI uses
-      # on PRs. This is the cheapest fix for the detection gap in the header
-      # comment: a base-image CVE gets caught the night the Dockerfile
-      # changes, not at the next release.
-      - name: Build amd64 for scanning
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.file }}
-          target: ${{ matrix.target }}
-          platforms: linux/amd64
-          load: true
-          tags: scan-target:${{ matrix.image }}
-          build-args: |
-            VITE_APP_VERSION=${{ needs.gate.outputs.version }}
-          cache-from: type=gha,scope=nightly-${{ matrix.image }}
-
-      - name: Trivy
-        uses: aquasecurity/trivy-action@0.33.1
-        with:
-          image-ref: scan-target:${{ matrix.image }}
-          severity: HIGH,CRITICAL
-          ignore-unfixed: true
-          exit-code: "1"
-          format: table
-
   # ── Prune the dated tag ring ──────────────────────────────────────────
   prune:
     name: Prune old nightly tags
@@ -255,12 +253,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
+          IMAGES_JSON: ${{ needs.gate.outputs.images }}
         run: |
           set -euo pipefail
           KEEP=7
-          IMAGES="spatiumddi-api spatiumddi-frontend dns-bind9 dns-powerdns \
-                  dns-technitium dns-dnsdist dhcp-kea spatium-supervisor looking-glass"
+          # Same list the build matrix used — see the gate job.
+          IMAGES=$(printf '%s' "$IMAGES_JSON" | jq -r '.[].image')
 
+          failures=0
           for img in $IMAGES; do
             echo "── $img"
             # A version is a prune candidate ONLY when every tag it carries
@@ -269,6 +269,21 @@ jobs:
             # shares a version with the newest dated tag, which the sort
             # keeps anyway, but the all-tags-match rule means we would never
             # delete it even if it did not.
+            #
+            # UNTAGGED versions are deliberately left alone, and this is a
+            # real limitation rather than an oversight. A multi-arch push
+            # creates one untagged child manifest per platform plus a
+            # provenance attestation, all referenced BY the tagged manifest
+            # — deleting them by "is it untagged" would break the very tags
+            # this job is protecting. Working out which untagged versions
+            # are orphaned by a prune means resolving each manifest's
+            # references, which is more machinery than the problem deserves
+            # here.
+            #
+            # So what is bounded is the TAG ring, not total storage: the
+            # children of pruned manifests become orphaned garbage. GHCR's
+            # own "delete untagged versions" retention policy is the right
+            # tool for that and is configured on the package, not here.
             # Distinguish "no candidates" from "the API call failed". A
             # silently-empty list would print "nothing to prune" and read as
             # success while the ring grew without bound — the same
@@ -292,23 +307,42 @@ jobs:
             fi
             echo "   ${total} dated tag(s) — pruning $((total - KEEP))"
 
+            # Failures are COUNTED, not just logged. A prune that 403s every
+            # night (GITHUB_TOKEN without delete:packages, say) would
+            # otherwise report green forever while the ring grew without
+            # bound — the same silence-as-success this job's list branch
+            # already guards against. Counted in a file because the loop
+            # body runs in a subshell.
+            : > /tmp/prune-failures
             printf '%s\n' "$versions" | tail -n +$((KEEP + 1)) | while IFS=$'\t' read -r created id tags; do
               [ -n "$id" ] || continue
               echo "   deleting $tags (created $created)"
-              gh api -X DELETE \
-                "/orgs/${OWNER}/packages/container/${img}/versions/${id}" || \
-                echo "   ! delete failed for $id — continuing"
+              if ! err=$(gh api -X DELETE \
+                   "/orgs/${OWNER}/packages/container/${img}/versions/${id}" 2>&1); then
+                echo "   ! delete FAILED for ${tags}: $(printf '%s' "$err" | head -1)"
+                echo "x" >> /tmp/prune-failures
+              fi
             done
+            failures=$((failures + $(wc -l < /tmp/prune-failures)))
           done
+
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::${failures} prune operation(s) failed — the dated-tag"
+            echo "::error::ring is NOT bounded until this is fixed."
+            exit 1
+          fi
 
   # ── Record what was built, and make a failure impossible to miss ──────
   finalize:
     name: Finalize
     runs-on: ubuntu-latest
     needs: [gate, images, prune]
-    # `always()` so this runs even when a build job failed — recording the
-    # outcome, and surfacing a failure, is the whole point.
-    if: always() && needs.gate.outputs.should_build == 'true'
+    # `always()`, and NOT gated on `should_build` alone: a gate job that
+    # FAILS emits no outputs at all, so that condition would be false and
+    # this job would be skipped — the nightly would die without opening the
+    # tracking issue that is the only reason anyone finds out. Run whenever
+    # the gate didn't cleanly decide to skip.
+    if: always() && needs.gate.result != 'skipped' && needs.gate.outputs.should_build != 'false'
     permissions:
       contents: write
       issues: write
@@ -343,7 +377,7 @@ jobs:
         # A nightly that fails silently is worth nothing — that is the whole
         # reason for a scheduled build. One issue, reused, so a broken week
         # doesn't open seven.
-        if: needs.images.result == 'failure'
+        if: needs.gate.result == 'failure' || needs.images.result == 'failure' || needs.prune.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -351,7 +385,9 @@ jobs:
           TITLE="Nightly build failing"
           BODY="Nightly build failed on \`main\` @ \`${GITHUB_SHA::12}\`.
 
+          - gate: ${{ needs.gate.result }}
           - images: ${{ needs.images.result }}
+          - prune: ${{ needs.prune.result }}
 
           Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,367 @@
+name: Nightly
+
+# Nightly build of `main` (#805).
+#
+# WHY THIS EXISTS. Every published image and ISO comes from release.yml,
+# which fires only on a CalVer tag — so nothing builds the *release* image
+# except a release. That is how #732 survived: the api image shipped its
+# `dev` stage (pytest, as root) and nobody noticed until a release cut it.
+# It is also why a base-image CVE introduced by a Dockerfile change sits
+# undetected until the next release publishes something for
+# trivy-scheduled.yml to scan.
+#
+# RETENTION, split by artifact because they fail differently:
+#
+#   Images — `:nightly` is the mutable pointer everyone pulls, plus a ring
+#     of `:nightly-YYYYMMDD` pruned to the newest 7. Keeping literally one
+#     would mean that when somebody reports "nightly broke X" the tag has
+#     already rolled and there is nothing to compare against, and a broken
+#     nightly would leave no fallback. Seven dated tags prune in the same
+#     run and cost nothing; anyone pulling `:nightly` never sees them.
+#
+# THE APPLIANCE ISO IS DEFERRED, deliberately. Its retention answer is easy
+# (~1.5 GB each, so exactly one, assets replaced in place on the reused
+# pre-release below) but its BUILD is not: release.yml assembles it over 223
+# lines of sequenced steps — fetch-k3s, three chart bakes, an image bake with
+# BAKE_SOURCE=ghcr behind `sudo -E` and a DOCKER_CONFIG redirect for the
+# private registry, mkosi in a privileged builder container, then ISO wrap and
+# slot-image compression. The `make appliance-baked-iso` shortcut does NOT
+# work here: it chains `appliance-stamp-dev` (stamps a dev version) and
+# defaults to BAKE_SOURCE=local (no local tags on a runner).
+#
+# Copying those steps would leave two divergent copies of the most
+# safety-critical workflow in the repo, and no way to test the copy short of
+# cutting a release. The right fix is to extract that job into a
+# `workflow_call` reusable workflow that both release.yml and this file
+# invoke — a change that deserves its own PR and its own release to verify,
+# not a ride-along on a new nightly. Tracked as a follow-up on #805.
+#
+# NIGHTLY IS NEVER `:latest`. That tag means "latest release" and has to
+# keep meaning that. There is also no GitHub Release per nightly — one
+# reused pre-release — so the Releases page stays a list of real releases.
+
+on:
+  schedule:
+    # 02:23 UTC. Off-the-hour minute for the same reason
+    # prune-release-assets.yml uses one: the top-of-hour cron stampede
+    # delays runner scheduling on GitHub's shared infrastructure.
+    - cron: "23 2 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Build even if main has not moved since the last nightly"
+        type: boolean
+        required: false
+        default: false
+      dry_run:
+        description: "Build and scan, but push nothing and prune nothing"
+        type: boolean
+        required: false
+        default: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  # A reused pre-release used purely as the RECORD of which commit the last
+  # nightly was built from. It carries no assets today; when the ISO lands
+  # (see the header) it is where those assets go.
+  NIGHTLY_TAG: nightly
+
+permissions:
+  contents: read
+
+# A manual dispatch must never race the scheduled run onto the same tags.
+concurrency:
+  group: nightly
+  cancel-in-progress: false
+
+jobs:
+  # ── Should this run at all, and what is it building? ──────────────────
+  gate:
+    name: Decide
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_build: ${{ steps.decide.outputs.should_build }}
+      date_tag: ${{ steps.decide.outputs.date_tag }}
+      version: ${{ steps.decide.outputs.version }}
+      last_sha: ${{ steps.decide.outputs.last_sha }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FORCE: ${{ github.event.inputs.force || 'false' }}
+        run: |
+          set -euo pipefail
+
+          DATE_TAG="nightly-$(date -u +%Y%m%d)"
+          echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"
+          # Informational version string baked into the frontend build and
+          # the appliance release stamp. Deliberately NOT CalVer-shaped, so
+          # it can never be mistaken for a release by a human or a sort.
+          echo "version=0.0.0-${DATE_TAG}+${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+          # The last nightly's commit is recorded in the reused pre-release's
+          # body. One source of truth, and a human can read it.
+          LAST_SHA=$(gh release view "$NIGHTLY_TAG" --json body \
+                       --jq '.body' 2>/dev/null \
+                     | sed -n 's/^built-from: \([0-9a-f]\{40\}\).*/\1/p' | head -1 || true)
+          LAST_SHA="${LAST_SHA:-}"
+          echo "last_sha=${LAST_SHA}" >> "$GITHUB_OUTPUT"
+          echo "last nightly commit: ${LAST_SHA:-<none>}"
+          echo "current main commit: ${GITHUB_SHA}"
+
+          # Skip when main has not moved. Republishing byte-identical images
+          # over a quiet weekend burns runner time and, worse, makes the
+          # 7-tag ring cover 7 calendar days instead of 7 CHANGED days —
+          # which is the thing the ring is for.
+          if [ "$FORCE" = "true" ]; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+            echo "→ forced by dispatch"
+          elif [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$GITHUB_SHA" ]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "→ main unchanged since the last nightly; skipping"
+          else
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+
+
+  # ── Build + push every image release.yml publishes ────────────────────
+  # A matrix over IMAGES (never over platforms — see the note in
+  # release.yml: a platform matrix pushes each arch to the same tag and the
+  # second push overwrites the first, yielding a single-arch image wearing
+  # a multi-arch tag).
+  images:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    needs: gate
+    if: needs.gate.outputs.should_build == 'true'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: spatiumddi-api
+            context: ./backend
+            file: ./backend/Dockerfile
+            # #732 — MUST stay pinned. ``dev`` is the LAST stage in
+            # backend/Dockerfile, so an unpinned build publishes an api
+            # image carrying pytest + coverage installed as root.
+            target: runtime
+          - image: spatiumddi-frontend
+            context: ./frontend
+            file: ./frontend/Dockerfile
+            target: ""
+          - image: dns-bind9
+            context: .
+            file: ./agent/dns/images/bind9/Dockerfile
+            target: ""
+          - image: dns-powerdns
+            context: .
+            file: ./agent/dns/images/powerdns/Dockerfile
+            target: ""
+          - image: dns-technitium
+            context: .
+            file: ./agent/dns/images/technitium/Dockerfile
+            target: ""
+          - image: dns-dnsdist
+            context: .
+            file: ./agent/dns/images/dnsdist/Dockerfile
+            target: ""
+          - image: dhcp-kea
+            context: .
+            file: ./agent/dhcp/images/kea/Dockerfile
+            target: ""
+          - image: spatium-supervisor
+            context: .
+            file: ./agent/supervisor/images/supervisor/Dockerfile
+            target: ""
+          - image: looking-glass
+            context: .
+            file: ./agent/looking-glass/images/gobgp/Dockerfile
+            target: ""
+    steps:
+      - uses: actions/checkout@v7
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: github.event.inputs.dry_run != 'true'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event.inputs.dry_run != 'true' }}
+          # `:nightly` is the mutable pointer; the dated tag is the
+          # immutable snapshot the ring keeps.
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:nightly
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ needs.gate.outputs.date_tag }}
+          build-args: |
+            VITE_APP_VERSION=${{ needs.gate.outputs.version }}
+          cache-from: type=gha,scope=nightly-${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}
+
+      # Load the amd64 image locally and scan it with the SAME gate CI uses
+      # on PRs. This is the cheapest fix for the detection gap in the header
+      # comment: a base-image CVE gets caught the night the Dockerfile
+      # changes, not at the next release.
+      - name: Build amd64 for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.file }}
+          target: ${{ matrix.target }}
+          platforms: linux/amd64
+          load: true
+          tags: scan-target:${{ matrix.image }}
+          build-args: |
+            VITE_APP_VERSION=${{ needs.gate.outputs.version }}
+          cache-from: type=gha,scope=nightly-${{ matrix.image }}
+
+      - name: Trivy
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: scan-target:${{ matrix.image }}
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: "1"
+          format: table
+
+  # ── Prune the dated tag ring ──────────────────────────────────────────
+  prune:
+    name: Prune old nightly tags
+    runs-on: ubuntu-latest
+    needs: [gate, images]
+    if: needs.gate.outputs.should_build == 'true' && github.event.inputs.dry_run != 'true'
+    permissions:
+      packages: write
+    steps:
+      - name: Keep the newest 7 dated tags per image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          KEEP=7
+          IMAGES="spatiumddi-api spatiumddi-frontend dns-bind9 dns-powerdns \
+                  dns-technitium dns-dnsdist dhcp-kea spatium-supervisor looking-glass"
+
+          for img in $IMAGES; do
+            echo "── $img"
+            # A version is a prune candidate ONLY when every tag it carries
+            # is a dated nightly tag. That is what protects `latest`, the
+            # CalVer release tags, and the `:nightly` pointer — the pointer
+            # shares a version with the newest dated tag, which the sort
+            # keeps anyway, but the all-tags-match rule means we would never
+            # delete it even if it did not.
+            # Distinguish "no candidates" from "the API call failed". A
+            # silently-empty list would print "nothing to prune" and read as
+            # success while the ring grew without bound — the same
+            # silence-as-success failure this whole workflow exists to catch.
+            if ! raw=$(gh api --paginate \
+              "/orgs/${OWNER}/packages/container/${img}/versions" 2>&1); then
+              echo "   ! could not list versions — skipping (is ${OWNER} an org?)"
+              echo "     ${raw}" | head -3
+              continue
+            fi
+            versions=$(printf '%s' "$raw" | jq -r '.[] | select(
+                      (.metadata.container.tags | length) > 0 and
+                      (.metadata.container.tags | all(test("^nightly-[0-9]{8}$")))
+                    ) | "\(.created_at)\t\(.id)\t\(.metadata.container.tags | join(","))"' \
+              | sort -r)
+
+            total=$(printf '%s' "$versions" | grep -c . || true)
+            if [ "${total:-0}" -le "$KEEP" ]; then
+              echo "   ${total:-0} dated tag(s) — nothing to prune"
+              continue
+            fi
+            echo "   ${total} dated tag(s) — pruning $((total - KEEP))"
+
+            printf '%s\n' "$versions" | tail -n +$((KEEP + 1)) | while IFS=$'\t' read -r created id tags; do
+              [ -n "$id" ] || continue
+              echo "   deleting $tags (created $created)"
+              gh api -X DELETE \
+                "/orgs/${OWNER}/packages/container/${img}/versions/${id}" || \
+                echo "   ! delete failed for $id — continuing"
+            done
+          done
+
+  # ── Record what was built, and make a failure impossible to miss ──────
+  finalize:
+    name: Finalize
+    runs-on: ubuntu-latest
+    needs: [gate, images, prune]
+    # `always()` so this runs even when a build job failed — recording the
+    # outcome, and surfacing a failure, is the whole point.
+    if: always() && needs.gate.outputs.should_build == 'true'
+    permissions:
+      contents: write
+      issues: write
+    steps:
+      - name: Update the nightly pre-release record
+        if: needs.images.result == 'success' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
+            gh release create "$NIGHTLY_TAG" --title "Nightly build" --prerelease --notes "init"
+          fi
+          # `built-from:` is parsed by the gate job on the next run. Keep the
+          # 40-hex shape; the sed there anchors on it.
+          gh release edit "$NIGHTLY_TAG" --notes "$(cat <<EOF
+          Automated nightly build of \`main\`. **Not a release** — no support, no upgrade path.
+
+          built-from: ${GITHUB_SHA}
+          date-tag: ${{ needs.gate.outputs.date_tag }}
+
+          Pull the images:
+          \`\`\`
+          docker pull ghcr.io/${{ github.repository_owner }}/spatiumddi-api:nightly
+          \`\`\`
+          The dated tag \`${{ needs.gate.outputs.date_tag }}\` pins this exact build;
+          the newest 7 are kept.
+          EOF
+          )"
+
+      - name: Open or update a tracking issue on failure
+        # A nightly that fails silently is worth nothing — that is the whole
+        # reason for a scheduled build. One issue, reused, so a broken week
+        # doesn't open seven.
+        if: needs.images.result == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="Nightly build failing"
+          BODY="Nightly build failed on \`main\` @ \`${GITHUB_SHA::12}\`.
+
+          - images: ${{ needs.images.result }}
+
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+
+          This issue is reused by every failing nightly — close it once the
+          build is green again."
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+                       --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "${EXISTING:-}" ] && [ "${EXISTING}" != "null" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            gh issue create --title "$TITLE" --body "$BODY" --label "area:ops" || \
+              gh issue create --title "$TITLE" --body "$BODY"
+          fi

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -1622,8 +1622,11 @@ class AppLogTail(threading.Thread):
         # these are the same category. Field-checking on a live appliance
         # (#803) showed them at 16 of 38 visible log lines.
         re.compile(r'"GET /metrics HTTP'),
+        # ``[\w-]+`` because sub-paths are kebab-case (``k8s-proxy/poll``),
+        # and the ``(…/)?`` because the bare ``/supervisor/poll`` — the
+        # endpoint this comment names — has no sub-path at all.
         re.compile(r'"(GET|POST) /api/v1/appliance/supervisor/'
-                   r'(heartbeat|\w+/poll)\b'),
+                   r'(heartbeat|([\w-]+/)?poll)\b'),
     )
 
     # A completed task whose result reports no work done. ``'status':
@@ -1636,8 +1639,16 @@ class AppLogTail(threading.Thread):
     _TASK_RESULT_RE = re.compile(r"Task \S+ succeeded in [\d.e-]+s?: (.*)$")
     # Values that mean "nothing happened". Anything else — a non-zero
     # count, an unrecognised status — makes the whole result interesting.
+    # NOTE ``false`` is deliberately absent. It reads like "nothing", but a
+    # boolean field is almost always an ASSERTION — ``{'ok': False,
+    # 'rows_checked': 0, 'broken': 0}`` is a health check reporting a
+    # problem, and treating False as boring would classify it as
+    # nothing-happened and drop it. Since this predicate runs ahead of the
+    # error veto, nothing downstream would rescue it. The polarity is also
+    # backwards from ``True``, which is (correctly) not boring and keeps
+    # the line. Booleans of either value make a result interesting.
     _BORING_VALUES = {"0", "0.0", "none", "[]", "{}", "''", '""',
-                      "'ok'", "'idle'", "'disabled'", "'skipped'", "false"}
+                      "'ok'", "'idle'", "'disabled'", "'skipped'"}
 
     @classmethod
     def _is_noop_result(cls, line: str) -> bool:
@@ -1654,6 +1665,11 @@ class AppLogTail(threading.Thread):
             return False
         payload = m.group(1).strip()
         if payload.lower() in {"none", "0", "[]", "{}"}:
+            return True
+        # A bare scalar result gets the same treatment as the same value
+        # inside a dict — ``beat_tick`` returning ``'ok'`` every 30 s says
+        # exactly as little as ``{'status': 'ok'}`` does.
+        if payload.lower() in cls._BORING_VALUES:
             return True
         if not (payload.startswith("{") and payload.endswith("}")):
             return False
@@ -1707,8 +1723,18 @@ class AppLogTail(threading.Thread):
         line = _sanitize_console_text(line)
         m = cls._CELERY_PREFIX_RE.match(line)
         if m:
-            line = f"{m.group(1)} {m.group(2):<5} {line[m.end():]}"
-        return cls._TASK_UUID_RE.sub("", line).replace("  ", " ").strip()
+            # Width 8, not 5: the level set runs DEBUG / INFO / WARNING /
+            # ERROR / CRITICAL, so a narrower field leaves the two that
+            # matter most unaligned against the rest and the message column
+            # ragged. Three columns for a scannable left edge, out of the
+            # ~73 this compaction reclaims.
+            line = f"{m.group(1)} {m.group(2):<8} {line[m.end():]}"
+        # Only the UUID is removed. A blanket ``.replace("  ", " ")`` here
+        # would immediately undo the ``:<5`` level padding above (INFO and
+        # WARNING would render ragged against each other) and would collapse
+        # column-aligned payload text that ``_sanitize_console_text``
+        # deliberately preserved.
+        return cls._TASK_UUID_RE.sub("", line).rstrip()
 
     def __init__(self, sink: "deque[str]"):
         super().__init__(daemon=True)
@@ -1747,18 +1773,18 @@ class AppLogTail(threading.Thread):
                 line = line.rstrip("\n")
                 if not line or self._PROBE_RE.search(line):
                     continue
+                # Split the component prefix off ONCE and keep the two parts
+                # separate, rather than re-slicing the formatted string at a
+                # hardcoded offset — that offset silently encodes the ``:<9``
+                # width above, so a component name longer than it would leak
+                # its tail into the body and render twice.
                 comp = self._PREFIX_RE.match(line)
-                if comp:
-                    line = f"{comp.group(1):<9} {line[comp.end():]}"
-                    body = line[10:]
-                else:
-                    body = line
+                component = comp.group(1) if comp else ""
+                body = line[comp.end():] if comp else line
                 if self._is_noise(body):
                     continue
-                if comp:
-                    line = f"{comp.group(1):<9} {self._compact(body)}"
-                else:
-                    line = self._compact(line)
+                body = self._compact(body)
+                line = f"{component:<9} {body}" if component else body
                 self.lines.append("app  " + line[:240])
             self._proc = None
             if self._stop.is_set():
@@ -2539,6 +2565,7 @@ def render_services(
     ps_rows: list[dict],
     cap: int | None = None,
     overflow: int = 0,
+    node_count: int | None = None,
 ) -> Panel:
     """Render the Pods panel — every pod on the local k3s cluster
     with status + node + ports (the image column was dropped — on an
@@ -2568,11 +2595,20 @@ def render_services(
     # single-node appliance — the common case — it was the same hostname
     # repeated down all 11 rows, while NAME (the one flexible column) got
     # squeezed to ellipsis because the 12 fixed columns already eat ~97
-    # cols. Derived from the pods themselves rather than ``state.nodes`` so
-    # the signature stays put, and so the column reflects where pods
-    # actually are. ``render_top_pods`` has conditioned its node column
-    # this way since #272.
-    multi_node = len({(r.get("Node") or "") for r in ps_rows if r.get("Node")}) > 1
+    # cols.
+    #
+    # ``node_count`` is the CLUSTER's node count, which is the actual
+    # question. Counting distinct Node values across the pods instead would
+    # answer a different one: pods that are Pending or being rescheduled
+    # carry no node, so a two-node cluster that has just lost one — exactly
+    # when an operator needs to see WHERE things are — would render as
+    # single-node and hide the column. ``render_top_pods`` uses
+    # ``len(state.nodes)`` for the same reason; the pod-derived fallback is
+    # only for callers that have no cluster view to pass (tests, and any
+    # future embedding).
+    if node_count is None:
+        node_count = len({(r.get("Node") or "") for r in ps_rows if r.get("Node")})
+    multi_node = node_count > 1
 
     tbl = Table.grid(padding=(0, 1), expand=True)
     tbl.add_column(width=1, no_wrap=True)          # health glyph
@@ -3980,6 +4016,7 @@ def render_frame(state: "DashboardState", mono_t: float) -> Layout:
         layout["header"].update(render_header(state, mono_t, compact=True))
         layout["main"].update(
             render_services(state.role, pod_rows, cap=max_pod_rows,
+                            node_count=len(state.nodes),
                             overflow=pods_overflow)
         )
         layout["log"].update(render_log(state.tail, log_h))
@@ -4035,6 +4072,7 @@ def render_frame(state: "DashboardState", mono_t: float) -> Layout:
 
     layout["main"]["pods"].update(
         render_services(state.role, pod_rows, cap=max_pod_rows,
+                        node_count=len(state.nodes),
                         overflow=pods_overflow)
     )
     layout["main"]["top"].update(render_top_pods(state, main_h))

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -1546,6 +1546,29 @@ _KLOG_HEADER_RE = re.compile(
 )
 
 
+# Escape sequences + control bytes. Pod stdout is arbitrary — a coloured
+# library, a progress spinner, a stray \r — and it lands in ``Text(line)``
+# verbatim. The console font carries 256 glyphs, so anything outside it
+# renders as mojibake: one screenshot showed a line as
+# ``…INFO/MainProcess¿?±? Task'app¿?±s?±oden…``. Strip CSI/OSC sequences and
+# any remaining C0/C1 control character before the line reaches Rich.
+_ANSI_RE = re.compile(r"\x1b(?:\[[0-9;?]*[A-Za-z]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[@-Z\\-_])")
+_CTRL_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def _sanitize_console_text(line: str) -> str:
+    """Make an arbitrary log line safe for the 256-glyph console font.
+
+    Applied to BOTH log sources — journal lines can carry colour from a
+    unit that thinks it has a TTY, and pod stdout can carry anything at
+    all. Tabs are expanded rather than dropped so column-aligned output
+    doesn't run together.
+    """
+    line = _ANSI_RE.sub("", line)
+    line = line.replace("\t", " ")
+    return _CTRL_RE.sub("", line)
+
+
 def _compact_journal_line(line: str) -> str:
     """Trim the journal date+host+pid prefix + klog's redundant
     duplicate timestamp/pid header.
@@ -1553,6 +1576,7 @@ def _compact_journal_line(line: str) -> str:
     Lines that don't match the short-iso format are returned as-is
     so a journalctl format change doesn't blank the log pane.
     """
+    line = _sanitize_console_text(line)
     m = _JOURNAL_ISO_RE.match(line)
     if not m:
         return line
@@ -1578,6 +1602,113 @@ class AppLogTail(threading.Thread):
     _SELECTOR = "app.kubernetes.io/instance=spatium-control"
     _PROBE_RE = re.compile(r"/health/(ready|live)|/healthz|kube-probe")
     _PREFIX_RE = re.compile(r"^\[pod/\S*?spatiumddi-([a-z0-9]+)-\S*?\]\s*")
+
+    # Celery beat/worker sweep churn. Every enabled-or-not integration gets
+    # a periodic sweep task, and each one emits three lines per tick —
+    # "Sending due task" → "received" → "succeeded ... {'status':
+    # 'disabled'}". With ~15 integrations disabled that is ~45 lines per
+    # tick of pure bookkeeping, which filled the 200-line deque and left
+    # nothing else visible: on the screenshot that opened #803, EVERY line
+    # of the Live log was this. Same failure mode P0.10 fixed for k3s/etcd
+    # internals, and filtered the same way — vetoed by ``_REAL_ERROR_RE``,
+    # so a task that fails, retries, or succeeds with real work survives.
+    # Only a *disabled* sweep completing is zero-information.
+    _APP_NOISE_PATTERNS = (
+        re.compile(r"Scheduler: Sending due task"),
+        re.compile(r"Task app\.tasks\.\S+ received"),
+        # Prometheus scrapes and the supervisor's own long-polls. Both are
+        # by-design periodic traffic against endpoints whose whole job is
+        # to be hit constantly; `_PROBE_RE` already drops /health*, and
+        # these are the same category. Field-checking on a live appliance
+        # (#803) showed them at 16 of 38 visible log lines.
+        re.compile(r'"GET /metrics HTTP'),
+        re.compile(r'"(GET|POST) /api/v1/appliance/supervisor/'
+                   r'(heartbeat|\w+/poll)\b'),
+    )
+
+    # A completed task whose result reports no work done. ``'status':
+    # 'disabled'`` — the case #803 named — turns out to be the minority on
+    # a real box: most sweeps are ENABLED and simply had nothing to do, so
+    # they return ``{'checked': 0, 'revoked': 0}`` or ``None``. Those carry
+    # exactly as little information, and field-checking showed 18 of 38
+    # visible lines were this shape. Dropping only the literal 'disabled'
+    # string left the pane just as drowned as before.
+    _TASK_RESULT_RE = re.compile(r"Task \S+ succeeded in [\d.e-]+s?: (.*)$")
+    # Values that mean "nothing happened". Anything else — a non-zero
+    # count, an unrecognised status — makes the whole result interesting.
+    _BORING_VALUES = {"0", "0.0", "none", "[]", "{}", "''", '""',
+                      "'ok'", "'idle'", "'disabled'", "'skipped'", "false"}
+
+    @classmethod
+    def _is_noop_result(cls, line: str) -> bool:
+        """True when a task-succeeded line reports that nothing happened.
+
+        Parsed rather than pattern-matched because the interesting case is
+        defined by the VALUES: every field zero/absent means no work, and a
+        single non-zero count anywhere means the line is worth showing.
+        Anything unparseable is treated as interesting — the filter must
+        fail toward showing too much, never toward hiding a real event.
+        """
+        m = cls._TASK_RESULT_RE.search(line)
+        if not m:
+            return False
+        payload = m.group(1).strip()
+        if payload.lower() in {"none", "0", "[]", "{}"}:
+            return True
+        if not (payload.startswith("{") and payload.endswith("}")):
+            return False
+        inner = payload[1:-1].strip()
+        if not inner:
+            return True
+        for part in inner.split(","):
+            if ":" not in part:
+                return False  # nested/unparseable — assume interesting
+            value = part.split(":", 1)[1].strip().lower()
+            if value not in cls._BORING_VALUES:
+                return False
+        return True
+
+    # Celery's default worker prefix — ``[2026-08-02 16:55:49,504:
+    # INFO/ForkPoolWorker-4]`` — spends ~33 columns before the message
+    # starts. ``render_log`` renders no_wrap + ellipsis, so those 33
+    # columns are paid for out of the payload: what got cut was the task
+    # RESULT, the only part worth reading. The date duplicates the header
+    # clock and the pool-worker id is noise, so compact to ``HH:MM:SS LVL``.
+    _CELERY_PREFIX_RE = re.compile(
+        r"^\[\d{4}-\d{2}-\d{2} (\d{2}:\d{2}:\d{2}),\d+: "
+        r"([A-Z]+)/[A-Za-z0-9-]+\]\s*"
+    )
+    # Task UUIDs are 36 chars of pure noise on a 100-col line.
+    _TASK_UUID_RE = re.compile(
+        r"\[[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\]"
+    )
+
+    @classmethod
+    def _is_noise(cls, line: str) -> bool:
+        # A fully-parsed all-zero result is checked FIRST, and deliberately
+        # ahead of the error veto. ``_REAL_ERROR_RE`` matches the bare word
+        # "failed", which appears as a dict KEY in half these payloads —
+        # ``{'claimed': 0, 'delivered': 0, 'failed': 0, 'dead': 0}`` would
+        # be vetoed by a key that explicitly says nothing failed. Having
+        # parsed every value and found them all zero, the line is proof of
+        # its own uneventfulness; no keyword scan can add to that.
+        if cls._is_noop_result(line):
+            return True
+        # Pattern-based drops keep the veto: those are matched on shape, not
+        # parsed, so a real error mentioning /metrics must still survive.
+        if JournalTail._REAL_ERROR_RE.search(line):
+            return False
+        return any(p.search(line) for p in cls._APP_NOISE_PATTERNS)
+
+    @classmethod
+    def _compact(cls, line: str) -> str:
+        """Strip the Celery prefix down to ``HH:MM:SS LVL`` and drop the
+        task UUID, returning ~55 columns of payload per line."""
+        line = _sanitize_console_text(line)
+        m = cls._CELERY_PREFIX_RE.match(line)
+        if m:
+            line = f"{m.group(1)} {m.group(2):<5} {line[m.end():]}"
+        return cls._TASK_UUID_RE.sub("", line).replace("  ", " ").strip()
 
     def __init__(self, sink: "deque[str]"):
         super().__init__(daemon=True)
@@ -1619,6 +1750,15 @@ class AppLogTail(threading.Thread):
                 comp = self._PREFIX_RE.match(line)
                 if comp:
                     line = f"{comp.group(1):<9} {line[comp.end():]}"
+                    body = line[10:]
+                else:
+                    body = line
+                if self._is_noise(body):
+                    continue
+                if comp:
+                    line = f"{comp.group(1):<9} {self._compact(body)}"
+                else:
+                    line = self._compact(line)
                 self.lines.append("app  " + line[:240])
             self._proc = None
             if self._stop.is_set():
@@ -2424,12 +2564,23 @@ def render_services(
     """
     _ = role  # signature kept for compatibility
 
+    # Only show NODE when there is more than one to distinguish. On a
+    # single-node appliance — the common case — it was the same hostname
+    # repeated down all 11 rows, while NAME (the one flexible column) got
+    # squeezed to ellipsis because the 12 fixed columns already eat ~97
+    # cols. Derived from the pods themselves rather than ``state.nodes`` so
+    # the signature stays put, and so the column reflects where pods
+    # actually are. ``render_top_pods`` has conditioned its node column
+    # this way since #272.
+    multi_node = len({(r.get("Node") or "") for r in ps_rows if r.get("Node")}) > 1
+
     tbl = Table.grid(padding=(0, 1), expand=True)
     tbl.add_column(width=1, no_wrap=True)          # health glyph
     tbl.add_column(width=11, no_wrap=True)         # namespace
     tbl.add_column(min_width=16, no_wrap=False)    # pod name (prefix-stripped)
     tbl.add_column(width=8, no_wrap=True)          # workload type (Deploy/Daemon/…)
-    tbl.add_column(width=8, no_wrap=True)          # node (#272 multi-node)
+    if multi_node:
+        tbl.add_column(width=8, no_wrap=True)      # node (#272 multi-node)
     tbl.add_column(width=5, no_wrap=True)          # ready (n/m)
     tbl.add_column(width=4, no_wrap=True, justify="right")  # restarts
     tbl.add_column(width=7, no_wrap=True, justify="right")  # restart age
@@ -2444,12 +2595,15 @@ def render_services(
     # with bold-dim styling — same shape as the bottom-row F-key
     # footer.
     header_style = "bold dim"
-    tbl.add_row(
+    header_cells = [
         Text("", style=header_style),
         Text("NAMESPACE", style=header_style),
         Text("NAME", style=header_style),
         Text("TYPE", style=header_style),
-        Text("NODE", style=header_style),
+    ]
+    if multi_node:
+        header_cells.append(Text("NODE", style=header_style))
+    header_cells += [
         Text("READY", style=header_style),
         Text("RST", style=header_style),
         Text("RST-AGE", style=header_style),
@@ -2457,7 +2611,8 @@ def render_services(
         Text("STATE", style=header_style),
         Text("IP", style=header_style),
         Text("PORTS", style=header_style),
-    )
+    ]
+    tbl.add_row(*header_cells)
 
     # #284 — drop completed one-shot pods (``Succeeded`` Jobs). Shares
     # the ``visible_pods`` filter with the SVC_ROWS panel-height calc in
@@ -2599,12 +2754,15 @@ def render_services(
             row.get("LastExitReason") or "", row.get("LastExitCode"),
         )
 
-        tbl.add_row(
+        cells = [
             Text(glyph, style=style),
             Text(row.get("Namespace") or "—", style="dim"),
             Text(_pod_display_name(row), style="bold"),
             Text(row.get("Type") or "—", style="dim"),
-            Text(row.get("Node") or "—", style="dim"),
+        ]
+        if multi_node:
+            cells.append(Text(row.get("Node") or "—", style="dim"))
+        cells += [
             Text(ready, style=ready_style),
             Text(rst_text, style=rst_style),
             Text(rage, style="dim"),
@@ -2612,7 +2770,8 @@ def render_services(
             Text(state_cell, style=state_style),
             Text(pod_ip, style="dim"),
             Text(ports or "—", style=ports_style),
-        )
+        ]
+        tbl.add_row(*cells)
 
     # Phase 2 (§3c) — overflow indicator in the SUBTITLE (bottom border)
     # rather than a table row (see the clamp comment above for why). F3
@@ -3115,10 +3274,12 @@ def render_log(tail: JournalTail, height: int) -> Panel:
             Text(line, style=_log_line_style(line), overflow="ellipsis", no_wrap=True)
             for line in list(tail.lines)[-(max(height - 2, 1)):]
         ))
-    # P0.10 — honest title: this pane tails the k3s system journal (the
-    # SpatiumDDI app pods log to pod stdout, surfaced via F3, not here).
-    # The "· k3s system" suffix stops the operator from expecting app
-    # events until the P1 app-log tail lands.
+    # Honest title: this pane carries BOTH sources. ``JournalTail`` feeds
+    # the k3s system journal and ``AppLogTail`` feeds the SpatiumDDI app
+    # pods' stdout into the same deque, hence "k3s + app". (The P0.10
+    # comment here used to say app pods were "surfaced via F3, not here",
+    # which the P1 app-log tail made untrue — and the title two lines down
+    # had already been updated to say so.)
     return Panel(body, box=SQUARE, border_style="cyan",
                  title="[bold]Live log[/bold] · k3s + app", title_align="left")
 
@@ -3328,6 +3489,24 @@ def _human_bytes(b: float) -> str:
     return f"{b:.0f}"
 
 
+def _human_cpu(c: float) -> str:
+    """Compact CPU cores -> ``1.25`` / ``0.30`` / ``4m``.
+
+    Below a centicore, ``f"{c:.2f}"`` renders ``0.00`` for everything —
+    a pod using 4 millicores looks identical to one using none, which on
+    an idle appliance is most of the column. Fall back to ``kubectl
+    top``-style millicores there so the reading stays honest, and to a
+    plain ``0`` only when it really is zero. Same spirit as
+    ``_human_bytes`` on the memory side.
+    """
+    if c >= 0.01:
+        return f"{c:.2f}"
+    milli = c * 1000.0
+    if milli >= 0.5:
+        return f"{milli:.0f}m"
+    return "0"
+
+
 def render_top_pods(state: "DashboardState", height: int) -> Panel:
     """Top pods by CPU with cpu + mem bar-fills, from the kubelet stats API.
     On a multi-node cluster this is CLUSTER-WIDE (INC 9) with a NODE column;
@@ -3343,9 +3522,18 @@ def render_top_pods(state: "DashboardState", height: int) -> Panel:
         cpu, mem = val[0], val[1]
         node = val[2] if len(val) > 2 else ""
         rows.append((cpu, mem, ns, nm, node))
-    rows.sort(reverse=True)
-    total = len(state.ps_rows)
-    running = sum(1 for r in state.ps_rows if (r.get("K8sState") or "") == "Running")
+    # Descending by usage, ascending a→z on ties. A bare ``reverse=True``
+    # on the whole tuple also reverses the name, so equal-usage pods sat in
+    # reverse-alphabetical order AND swapped places whenever a reading
+    # wobbled — motion the eye tracks for nothing.
+    rows.sort(key=lambda r: (-r[0], -r[1], r[2], r[3]))
+    # Count what the operator can actually see. ``ps_rows`` includes the
+    # Succeeded one-shot Jobs that ``visible_pods`` hides (#284), so
+    # counting it here put "15 pods" next to a Pods panel listing 11, with
+    # nothing on screen to explain the gap.
+    visible = visible_pods(state.ps_rows)
+    total = len(visible)
+    running = sum(1 for r in visible if (r.get("K8sState") or "") == "Running")
     head = Text()
     head.append(f"{total} pods", style="bold")
     if running:
@@ -3353,8 +3541,13 @@ def render_top_pods(state: "DashboardState", height: int) -> Panel:
         head.append(f"{running} Running", style="bold green")
     maxcpu = max((r[0] for r in rows), default=0.0) or 1.0
     maxmem = max((r[1] for r in rows), default=0) or 1
-    tbl = Table.grid(padding=(0, 1))
-    tbl.add_column(no_wrap=True)                              # pod
+    # ``expand=True`` + a ratio pod column. Without it the grid sizes to its
+    # content and leaves 10-15 dead columns to the right of the mem bar while
+    # names ellipsize on the left — which cost real identity: two
+    # CloudNativePG pods both rendered as ``cloudnative-pg-8cc7b88``, the cut
+    # falling exactly on the hash that tells them apart.
+    tbl = Table.grid(padding=(0, 1), expand=True)
+    tbl.add_column(ratio=1, overflow="ellipsis", no_wrap=True)  # pod
     if multi:
         tbl.add_column(no_wrap=True)                         # node
     tbl.add_column(justify="right", no_wrap=True)            # cpu
@@ -3368,11 +3561,13 @@ def render_top_pods(state: "DashboardState", height: int) -> Panel:
     tbl.add_row(*header)
     cap = max(height - 4, 1)
     for cpu, mem, _ns, nm, node in rows[:cap]:
-        cells = [Text(_short_pod_name(nm)[:22], style="cyan")]
+        # No hard slice — the ratio column ellipsizes to whatever the TTY
+        # actually has, so a wide console shows the full name.
+        cells = [Text(_short_pod_name(nm), style="cyan")]
         if multi:
             cells.append(Text((node or "")[:8], style="dim"))
         cells += [
-            Text(f"{cpu:.2f}", style="bold"),
+            Text(_human_cpu(cpu), style="bold"),
             Text(_bar_gauge(cpu, maxcpu, 6), style="bold green"),
             Text(_human_bytes(mem), style="bold"),
             Text(_bar_gauge(mem, maxmem, 6), style="bold cyan"),

--- a/backend/tests/test_spatium_console.py
+++ b/backend/tests/test_spatium_console.py
@@ -483,3 +483,96 @@ def test_unparseable_result_is_treated_as_interesting(m) -> None:
     assert not m.AppLogTail._is_noop_result(
         "Task app.tasks.x succeeded in 0.02s: {'rows': [{'a': 0}]}"
     )
+
+
+# ── #803 code-review follow-ups ───────────────────────────────────────
+
+
+def test_boolean_false_makes_a_result_interesting(m) -> None:
+    """A boolean field is an ASSERTION, not a count. ``{'ok': False}`` is a
+    health check reporting a problem; treating False as "nothing" would drop
+    it — and since the no-op parse runs ahead of the error veto, nothing
+    downstream would rescue it."""
+    line = "Task app.tasks.x succeeded in 0.02s: {'ok': False, 'rows_checked': 0, 'broken': 0}"
+    assert not m.AppLogTail._is_noop_result(line)
+    assert not m.AppLogTail._is_noise(line)
+    # And the same shape reporting success stays visible too — polarity
+    # must not be the thing that decides.
+    assert not m.AppLogTail._is_noise(
+        "Task app.tasks.x succeeded in 0.02s: {'ok': True, 'checked': 0}"
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/v1/appliance/supervisor/poll",
+        "/api/v1/appliance/supervisor/heartbeat",
+        "/api/v1/appliance/supervisor/pcap/poll",
+        "/api/v1/appliance/supervisor/k8s-proxy/poll",
+    ],
+)
+def test_every_supervisor_poll_shape_is_filtered(m, path: str) -> None:
+    """The bare ``/poll`` has no sub-path, and sub-paths are kebab-case —
+    both missed by a naive ``\\w+/poll``."""
+    assert m.AppLogTail._is_noise(f'INFO:   10.42.0.52:1 - "POST {path} HTTP/1.1" 200 OK')
+
+
+def test_level_padding_survives_compaction(m) -> None:
+    """A blanket double-space collapse would undo the ``:<5`` padding and
+    leave INFO and WARNING ragged against each other."""
+    info = m.AppLogTail._compact("[2026-08-02 16:55:49,504: INFO/ForkPoolWorker-4] hello")
+    warn = m.AppLogTail._compact("[2026-08-02 16:55:49,504: WARNING/ForkPoolWorker-4] hello")
+    assert info.index("hello") == warn.index("hello")
+
+
+def test_compaction_preserves_column_aligned_payload(m) -> None:
+    """``_sanitize_console_text`` deliberately keeps runs of spaces so
+    structlog's column-aligned output stays readable."""
+    out = m.AppLogTail._compact(
+        "[2026-08-02 16:55:49,504: WARNING/MainProcess] "
+        "[warning ] alert_unknown_rule_type    rule=abc type=x"
+    )
+    assert "rule=abc" in out
+    assert "    rule=abc" in out  # the alignment run survived
+
+
+def test_long_component_name_does_not_leak_into_the_body(m) -> None:
+    """The prefix used to be re-sliced off the FORMATTED string at a
+    hardcoded offset that encoded the padding width, so a component longer
+    than it would render its tail twice."""
+    line = m.AppLogTail._compact("some message")
+    assert line == "some message"
+    # The formatting path itself: component and body stay separate.
+    for comp in ("api", "spatium-supervisor-extra-long"):
+        rendered = f"{comp:<9} {m.AppLogTail._compact('payload here')}"
+        assert rendered.endswith("payload here")
+        assert rendered.count("payload here") == 1
+
+
+def test_node_column_uses_the_cluster_node_count_not_pod_placement(m) -> None:
+    """A two-node cluster that just lost a node has its pods Pending with no
+    Node value — exactly when the operator needs to see WHERE things are.
+    Deriving multi-node from pod placement would hide the column then."""
+    rows = [_pod592("a", ""), _pod592("b", "")]
+    for r in rows:
+        r["K8sState"] = "Pending"
+        r["Node"] = ""
+    text = _panel_text_nodes(m, rows, node_count=2)
+    assert "NODE" in text
+
+
+def _panel_text_nodes(m, rows: list[dict], node_count: int) -> str:
+    buf = Console(width=200, record=True, file=io.StringIO())
+    buf.print(m.render_services("control-plane", rows, node_count=node_count))
+    return _ANSI.sub("", buf.export_text())
+
+
+def test_bare_scalar_result_is_boring_like_the_dict_form(m) -> None:
+    """``beat_tick`` returns ``'ok'`` every 30s; that says exactly as
+    little as ``{'status': 'ok'}``, which was already filtered."""
+    assert m.AppLogTail._is_noise("Task app.tasks.heartbeat.beat_tick succeeded in 0.004s: 'ok'")
+    # A scalar that reports actual work still shows.
+    assert not m.AppLogTail._is_noise(
+        "Task app.tasks.ipam_discovery.dispatch succeeded in 0.04s: 7"
+    )

--- a/backend/tests/test_spatium_console.py
+++ b/backend/tests/test_spatium_console.py
@@ -435,8 +435,11 @@ NOISE_LINES = [
     "Task app.tasks.foo received",
     "Task app.tasks.x succeeded in 0.02s: {'status': 'disabled'}",
     # The majority case on a real box: enabled sweeps with nothing to do.
-    "Task app.tasks.event_outbox.process succeeded in 0.02s: "
-    "{'claimed': 0, 'delivered': 0, 'failed': 0, 'dead': 0}",
+    # Kept to one source line — a wrapped string inside a list reads as a
+    # missing comma, which is exactly the mistake the lint guards against.
+    # (The four-key form and the `failed`-key veto interaction have their
+    # own test below.)
+    "Task app.tasks.event_outbox.process succeeded in 0.02s: {'delivered': 0, 'failed': 0}",
     "Task app.tasks.dns.check_all succeeded in 0.02s: None",
     "Task app.tasks.snmp.dispatch succeeded in 0.02s: 0",
     'INFO:   10.42.0.1:8742 - "GET /metrics HTTP/1.1" 200 OK',

--- a/backend/tests/test_spatium_console.py
+++ b/backend/tests/test_spatium_console.py
@@ -366,3 +366,120 @@ def test_clamped_rows_are_reported_not_silently_dropped(m) -> None:
     # 21 visible (the Succeeded job is filtered out), 3 shown → 18 hidden.
     assert "+18 more pods" in text
     assert "F3 to list" in text
+
+
+# ── #803 — dashboard rendering polish ─────────────────────────────────
+
+
+def test_node_column_hidden_on_a_single_node_cluster(m) -> None:
+    """It was the same hostname repeated down every row, while NAME — the
+    one flexible column — got squeezed to ellipsis behind 12 fixed ones."""
+    rows = [_pod592(f"pod-{i}", "ddi1") for i in range(4)]
+    text = _panel_text(m, rows)
+    assert "NODE" not in text
+    assert "ddi1" not in text
+
+
+def test_node_column_returns_when_there_is_more_than_one_node(m) -> None:
+    rows = [_pod592("a", "ddi1"), _pod592("b", "ddi2")]
+    text = _panel_text(m, rows)
+    assert "NODE" in text
+    assert "ddi2" in text
+
+
+def test_long_pod_names_survive_on_a_wide_console(m) -> None:
+    """Two CloudNativePG replicas differ only in their pod hash; the old
+    22-char cap cut exactly there and rendered them identically."""
+    rows = [
+        _pod592("cloudnative-pg-8cc7b886c-g5svx", "ddi1"),
+        _pod592("cloudnative-pg-8cc7b886c-r4mgt", "ddi1"),
+    ]
+    text = _panel_text(m, rows)
+    assert "g5svx" in text and "r4mgt" in text
+
+
+def test_human_cpu_keeps_sub_centicore_readings_honest(m) -> None:
+    """``f"{c:.2f}"`` renders 0.00 for every idle pod, which is most of an
+    appliance — indistinguishable from truly zero."""
+    assert m._human_cpu(1.25) == "1.25"
+    assert m._human_cpu(0.30) == "0.30"
+    assert m._human_cpu(0.004) == "4m"
+    assert m._human_cpu(0.0) == "0"
+
+
+def test_sanitize_strips_ansi_and_control_bytes(m) -> None:
+    """Pod stdout is arbitrary; the console font has 256 glyphs, so an
+    escape sequence renders as mojibake."""
+    assert m._sanitize_console_text("\x1b[31mred\x1b[0m") == "red"
+    assert m._sanitize_console_text("a\x00b\x07c") == "abc"
+    assert m._sanitize_console_text("a\tb") == "a b"
+    assert m._sanitize_console_text("plain text") == "plain text"
+
+
+def test_celery_prefix_compaction_returns_the_payload(m) -> None:
+    raw = (
+        "[2026-08-02 16:55:49,504: INFO/ForkPoolWorker-4] "
+        "Task app.tasks.dns_health.probe"
+        "[3f2a1b4c-1111-2222-3333-444455556666] succeeded in 0.31s: {'ok': 3}"
+    )
+    out = m.AppLogTail._compact(raw)
+    assert out.startswith("16:55:49 INFO")
+    assert "ForkPoolWorker" not in out
+    assert "3f2a1b4c" not in out
+    assert "{'ok': 3}" in out  # the part worth reading survives
+    assert len(out) < len(raw) - 50
+
+
+NOISE_LINES = [
+    "Scheduler: Sending due task app.tasks.x",
+    "Task app.tasks.foo received",
+    "Task app.tasks.x succeeded in 0.02s: {'status': 'disabled'}",
+    # The majority case on a real box: enabled sweeps with nothing to do.
+    "Task app.tasks.event_outbox.process succeeded in 0.02s: "
+    "{'claimed': 0, 'delivered': 0, 'failed': 0, 'dead': 0}",
+    "Task app.tasks.dns.check_all succeeded in 0.02s: None",
+    "Task app.tasks.snmp.dispatch succeeded in 0.02s: 0",
+    'INFO:   10.42.0.1:8742 - "GET /metrics HTTP/1.1" 200 OK',
+    'INFO:   10.42.0.52:1 - "POST /api/v1/appliance/supervisor/heartbeat HTTP/1.1" 200 OK',
+]
+
+SIGNAL_LINES = [
+    "Task app.tasks.ipam_discovery.dispatch succeeded in 0.04s: 3",
+    "Task app.tasks.x succeeded in 0.1s: {'created': 4, 'deleted': 0}",
+    "Task app.tasks.x succeeded in 0.02s: {'claimed': 0, 'failed': 2}",
+    "Task app.tasks.x received but Failed to connect",
+    "Task app.tasks.x succeeded in 0.02s: {'status': 'error'}",
+    'INFO:   10.42.0.1 - "GET /api/v1/ipam/subnets HTTP/1.1" 200 OK',
+    'INFO:   10.42.0.1 - "GET /metrics HTTP/1.1" 500 Internal Server Error',
+    "Task app.tasks.x raised unexpected: ValueError()",
+]
+
+
+@pytest.mark.parametrize("line", NOISE_LINES)
+def test_app_log_noise_is_dropped(m, line: str) -> None:
+    assert m.AppLogTail._is_noise(line), line
+
+
+@pytest.mark.parametrize("line", SIGNAL_LINES)
+def test_app_log_signal_always_survives(m, line: str) -> None:
+    """The filter must fail toward showing too much. A single non-zero
+    count, an unrecognised status, or any error marker keeps the line."""
+    assert not m.AppLogTail._is_noise(line), line
+
+
+def test_all_zero_result_beats_the_error_veto_on_a_key_named_failed(m) -> None:
+    """``_REAL_ERROR_RE`` matches the bare word "failed", which appears as a
+    dict KEY in half these payloads. Having parsed every value and found
+    them zero, the line is proof of its own uneventfulness — so the parse
+    is checked before the keyword scan, or a key that says nothing failed
+    would veto its own filtering."""
+    line = "Task app.tasks.x succeeded in 0.02s: {'delivered': 0, 'failed': 0}"
+    assert m.AppLogTail._is_noop_result(line)
+    assert m.AppLogTail._is_noise(line)
+
+
+def test_unparseable_result_is_treated_as_interesting(m) -> None:
+    """Nested structures aren't parsed; assume they matter."""
+    assert not m.AppLogTail._is_noop_result(
+        "Task app.tasks.x succeeded in 0.02s: {'rows': [{'a': 0}]}"
+    )

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -234,6 +234,40 @@ Branch protection on `main` gates on these checks. `make ci` reproduces
 the two lint jobs and the frontend build locally; `make test` reproduces
 the backend test job (single-runner rather than sharded).
 
+### What runs when — the trigger policy
+
+Every workflow trigger should answer "what would we miss without it?".
+Three of the four events have distinct jobs:
+
+| Event | Runs | Why |
+|---|---|---|
+| **Pull request** | `ci.yml`, the per-image builds (single-arch + **Trivy**), `agent-e2e.yml` | Where correctness is gated. Nothing merges without it. |
+| **Push to `main`** | `ci.yml`, `docs-publish.yml`, `build-appliance-builder.yml` | Post-merge safety net + the two things that must be *published* from `main`. |
+| **Release tag** | `release.yml` only | Builds and publishes every image multi-arch, the chart, and the appliance ISO. |
+| **Schedule** | `nightly.yml`, `trivy-scheduled.yml`, `prune-release-assets.yml` | Work that is about *elapsed time*, not about a change. |
+
+Two rules follow, and both were violations once:
+
+- **Per-image build workflows do not trigger on push.** On a tag they raced
+  `release.yml`, which builds the same image and pushes the same
+  `:<VERSION>` tag — two concurrent multi-arch builds of identical source,
+  with the winner decided by whichever finished last, on a release
+  artifact. On `main` they published `:main` and `:sha-<short>` that
+  nothing consumes (no chart, compose file or manifest pins them, and
+  `agent-e2e.yml` deliberately builds from PR source instead) *and* skipped
+  Trivy on that path. Both jobs are covered better elsewhere: releases by
+  `release.yml`, "build `main` periodically" by `nightly.yml` — which
+  scans before it publishes.
+- **`build-appliance-builder.yml` is the exception and must stay on
+  `main`.** `release.yml`'s ISO job and the `APPLIANCE_BUILDER` default in
+  the Makefile both pull `appliance-builder:latest`; that tag is how the
+  builder image gets published at all.
+
+`ci.yml` stays on push to `main` on purpose. It is redundant with the PR
+run in the common case — GitHub tests the merge result — but it validates
+the actual squashed commit, and it is the only check that covers a direct
+push or a merge made with `--admin` while shards were still pending.
+
 ### Nightly builds
 
 [`.github/workflows/nightly.yml`](../.github/workflows/nightly.yml) builds

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -234,6 +234,45 @@ Branch protection on `main` gates on these checks. `make ci` reproduces
 the two lint jobs and the frontend build locally; `make test` reproduces
 the backend test job (single-runner rather than sharded).
 
+### Nightly builds
+
+[`.github/workflows/nightly.yml`](../.github/workflows/nightly.yml) builds
+and publishes every image from `main` at 02:23 UTC. It exists because
+nothing else builds the *release* image except a release — which is how
+[#732](https://github.com/spatiumddi/spatiumddi/issues/732) shipped an api
+image carrying pytest as root, undetected until the next release cut it.
+The nightly also runs the same Trivy gate CI uses on PRs, so a base-image
+CVE surfaces the night the Dockerfile changes rather than at the next tag.
+
+To run current `main` without cutting a release:
+
+```bash
+docker pull ghcr.io/spatiumddi/spatiumddi-api:nightly
+```
+
+| Tag | Meaning |
+|---|---|
+| `:nightly` | The most recent successful nightly. Mutable — it moves. |
+| `:nightly-YYYYMMDD` | Immutable snapshot of that build. The newest **7** are kept, the rest pruned in the same run. |
+
+The dated ring exists so "nightly broke X" is answerable: without it the
+pointer has already rolled and there is nothing to compare against, and a
+broken nightly leaves no fallback. Seven is deliberately small — anyone
+pulling `:nightly` never sees the rest.
+
+A run is **skipped entirely when `main` has not moved** since the last
+nightly, so the seven tags cover seven *changed* days rather than seven
+calendar days. The last built commit is recorded as `built-from:` in the
+body of the reused `nightly` pre-release, which is also where the appliance
+ISO will be published once that lands (deferred — see the workflow header
+for why). A failing nightly opens or comments on a single reused tracking
+issue rather than one per night.
+
+`workflow_dispatch` takes `force` (build anyway) and `dry_run` (build and
+scan, push and prune nothing).
+
+**Nightly is never tagged `:latest`.** That tag means "latest release".
+
 ---
 
 ## 7. Repo Layout


### PR DESCRIPTION
Closes #803
Closes #805

Three pieces: the console polish pass, the nightly build, and a CI-trigger audit that came out of reviewing the second.

## #803 — console rendering polish

All nine items, **deployed to a live single-node appliance and checked on the real screen** rather than reasoned about. That mattered: it disproved one of the issue's own fixes.

| # | Was | Now |
|---|---|---|
| 1 | 22-char cap ellipsized names beside 10–15 dead columns; two CNPG replicas both read `cloudnative-pg-8cc7b88` | `expand=True` + ratio column, no slice |
| 2 | NODE column repeated the hostname down every row on a single node while NAME starved | Conditioned on the **cluster's** node count |
| 3 | `15 pods` next to a panel showing `11` | Both count `visible_pods()` |
| 4 | Every visible log line was Celery sweep churn | See below |
| 5 | ~33 columns of Celery prefix, paid out of the payload | `HH:MM:SS LVL`, UUID stripped — **73 columns reclaimed** |
| 6 | Escape sequences rendered as mojibake on the 256-glyph font | ANSI/control strip on both log sources |
| 7–9 | Stale comment, reverse-alphabetical tie-break, `0.00` for every idle pod | Fixed; CPU falls back to millicores (`4m`) |

**Item 4 is where the field test earned its keep.** Adding the three patterns the issue named removed two lines per task and left the pane just as full — because the assumption behind the third was wrong. Most sweeps on a real box are *enabled* and simply have nothing to do, returning `{'checked': 0, 'revoked': 0}`, not `'status': 'disabled'`. Measured: **34 of 38 visible lines were noise.**

So the filter parses the result instead of matching a literal — every value zero means nothing happened, one non-zero count anywhere keeps the line. The pane now shows real browser requests, a redis BGSAVE, health checks.

One ordering subtlety worth knowing: the all-zero parse runs **before** the `_REAL_ERROR_RE` veto, because that pattern matches the bare word `failed` — which appears as a dict *key* in half these payloads. `{'delivered': 0, 'failed': 0}` would otherwise be vetoed by a key explicitly saying nothing failed.

## #805 — nightly build of `main`

Nothing built the *release* image except a release, which is how [#732](https://github.com/spatiumddi/spatiumddi/issues/732) shipped an api image carrying pytest as root. Same gap hides base-image CVEs: `trivy-scheduled.yml` scans *published* images, so a Dockerfile change introducing one is invisible until the next release publishes something to scan.

- `:nightly` mutable pointer + a ring of `:nightly-YYYYMMDD` pruned to the newest **7**. Keeping literally one would mean "nightly broke X" is unanswerable — the tag has rolled, nothing to compare against, no fallback.
- **Trivy runs before the push**, so the gate can actually refuse to publish.
- Skipped entirely when `main` hasn't moved, so the ring covers seven *changed* days.
- Prune deletes a version only when **every** tag it carries matches `nightly-\d{8}` — that's what protects `latest`, the CalVer tags and the pointer.
- A failure opens or comments on **one** reused tracking issue.

**The appliance ISO is deferred, deliberately.** Its build is 223 sequenced lines in `release.yml`, and `make appliance-baked-iso` doesn't work on a runner (it chains `appliance-stamp-dev` and defaults to `BAKE_SOURCE=local`). Copying it would leave two divergent copies of the most safety-critical workflow in the repo with no way to test the copy short of cutting a release. The right fix is extracting it into a `workflow_call` workflow both files invoke — its own PR, verified by its own release. Reasoning is in the workflow header.

## CI trigger audit — the per-image builds were racing the release

Reviewing what fires on a push to `main` turned up something worse than redundancy.

The four per-image workflows carried a `tags:` trigger matching the CalVer pattern, and `metadata-action`'s `type=ref,event=tag` resolves to **exactly the `:<VERSION>` tag `release.yml` already pushes**. Every release ran two concurrent multi-arch builds of identical source onto the same tag, winner decided by whichever finished last.

On `main` they published `:main` and `:sha-<short>`, which **nothing consumes** — verified across `charts/`, `k8s/`, `docker-compose*.yml` and the Makefile; the only mention in the tree is the `agent-e2e.yml` comment explaining why it builds from PR source instead. That path also skipped Trivy.

Both triggers removed; PR-only now. Kept on purpose, and documented so the next audit doesn't undo them:

- **`build-appliance-builder.yml`** stays on `main` — `release.yml`'s ISO job and the Makefile both pull `appliance-builder:latest`.
- **`ci.yml`** stays — it validates the actual squashed commit and covers `--admin` merges with shards pending.
- **`docs-publish.yml`** stays — per-push publishing was a deliberate call in CLAUDE.md.

## Verification

- **52 console tests** (30 new), covering both directions of the noise filter — every pattern that must drop, every line that must survive.
- Console **redeployed and re-checked on `ddi1`** after the review fixes: levels align, structlog column alignment survives, no crash.
- Workflow validated by **extracting every `run:` block and shell-checking it**, and by executing the gate's image-list step to assert every Dockerfile it names exists.
- `make ci` green.

## Code-review round

Ten findings, all fixed in `0b3b3da4`. The two that mattered were both "the guard exists but cannot fire": Trivy ran *after* the push, and a failed `gate` job emitted no outputs so `finalize` was skipped and **no tracking issue opened** — the nightly would have died silently. Writing the test for the level-padding fix then found something the review hadn't: `:<5` can't align `WARNING` or `CRITICAL`, so they stayed ragged for a second reason.

One finding was fixed by correcting the claim rather than the code: untagged multi-arch children can't be safely pruned (the tagged manifest references them), so what's bounded is the **tag ring**, not total storage. Saying "bounded" without that caveat was the actual defect.
