### PR TITLE
fix(dns): widen the Copilot DNSSEC gate to match REST, publish Technitium's encrypted ports (#798, #799)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -350,7 +350,7 @@ DHCP_LEASE_SYNC_INTERVAL_MINUTES=5
 # For a real DNS server use 53 directly with `network_mode: host`.
 # DNS_HOST_PORT=1053
 
-# ── Encrypted DNS transports — DoT / DoH (issue #50) ────────────────────────
+# ── Encrypted DNS transports — DoT / DoH / DoQ (issues #50, #741, #799) ─────
 # Off by default. Turn the listeners on per server group under
 # DNS → Server Groups → Options → Encrypted transports, then publish the
 # ports with the overlay:
@@ -360,10 +360,13 @@ DHCP_LEASE_SYNC_INTERVAL_MINUTES=5
 #                  --profile dns-bind9 up -d
 #
 # CONTAINER-side ports — these MUST match the ports you chose in the UI.
-# The agent renders named.conf from the database, not from these variables,
-# so a mismatch publishes a mapping to a port nothing is listening on.
+# The agent renders the daemon config from the database, not from these
+# variables, so a mismatch publishes a mapping to a port nothing is
+# listening on. DoQ is UDP, and 853 is the RFC default for both it and DoT
+# — sharing the number is correct, not a collision.
 # DNS_DOT_PORT=853
 # DNS_DOH_PORT=443
+# DNS_DOQ_PORT=853
 #
 # HOST-side ports — just where the listeners land; change freely if the
 # default is taken. DoH defaults to 8443 rather than 443 so nothing has to
@@ -373,9 +376,18 @@ DHCP_LEASE_SYNC_INTERVAL_MINUTES=5
 #
 # Same, for the PowerDNS path (the listeners run on the dnsdist front —
 # pdns Authoritative speaks neither protocol). Distinct host-port defaults
-# so a side-by-side bind9 + powerdns stack doesn't collide.
+# so a side-by-side bind9 + powerdns stack doesn't collide. No DoQ: the
+# shipped dnsdist front serves DoT + DoH only.
 # DNS_DOT_HOST_PORT_PDNS=5853
 # DNS_DOH_HOST_PORT_PDNS=5444
+#
+# And for the Technitium path, which serves all three natively with no
+# sidecar. Host-port defaults sit in the 6xxx band to match its 6053:53
+# base mapping. DoQ is Technitium-only — BIND has no QUIC transport, and
+# the API refuses doq_enabled on a group with any non-Technitium member.
+# DNS_DOT_HOST_PORT_TECHNITIUM=6853
+# DNS_DOH_HOST_PORT_TECHNITIUM=6444
+# DNS_DOQ_HOST_PORT_TECHNITIUM=6853
 
 # ── Standalone DHCP agent (Kea) ─────────────────────────────────────────────
 # URL of the SpatiumDDI control plane API. Required by

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -2146,11 +2146,29 @@ register(
 
 
 _DNS_DRIVER_HINTS = {"bind9", "powerdns", "technitium", "windows_dns"}
-# DNSSEC online signing + ALIAS + LUA records require the PowerDNS
-# driver — the preview rejects when ``dnssec_enabled=true`` lands in a
-# group whose servers don't include any PowerDNS member, since signing
-# would fail at apply time and confuse the operator.
-_POWERDNS_ONLY_FEATURES = ("dnssec_enabled",)
+
+# ``CreateDNSZoneArgs`` fields only some drivers can honour, mapped to
+# ``(REST operation whose driver gate governs them, operator-facing label)``.
+#
+# The driver set is NOT restated here — it is read from the DNS router's
+# ``_DRIVER_GATED_OPERATIONS`` at preview time. Issue #798: this used to be a
+# hardcoded ``_POWERDNS_ONLY_FEATURES = ("dnssec_enabled",)`` tuple tested with
+# ``"powerdns" not in drivers``, written when PowerDNS was the only online
+# signer. BIND9 inline-signing (#49) and Technitium online signing (#740)
+# widened the REST gate; this constant was not widened with it, so the Copilot
+# spent two releases refusing work the REST API accepted. Seeding from the
+# single source of truth is the fix — do not inline the driver names again.
+_DRIVER_GATED_ZONE_ARGS: dict[str, tuple[str, str]] = {
+    "dnssec_enabled": ("dnssec_sign", "online DNSSEC signing"),
+}
+
+
+def _drivers_for_gated_arg(arg: str) -> frozenset[str]:
+    """Return the drivers allowed to use ``arg``, read from the REST gate."""
+    from app.api.v1.dns.router import _DRIVER_GATED_OPERATIONS  # noqa: PLC0415
+
+    op, _label = _DRIVER_GATED_ZONE_ARGS[arg]
+    return _DRIVER_GATED_OPERATIONS[op]
 
 
 class CreateDNSZoneArgs(BaseModel):
@@ -2158,8 +2176,8 @@ class CreateDNSZoneArgs(BaseModel):
 
     ``driver_hint`` (issue #127 Phase 4e) lets the model express the
     operator's intent — "I need DNSSEC online signing, so this zone
-    has to land on a PowerDNS group" — without forcing it to know the
-    exact group UUID. When supplied, the preview either:
+    has to land on a group that can sign" — without forcing it to know
+    the exact group UUID. When supplied, the preview either:
 
     * uses ``driver_hint`` to select a matching group when
       ``group_id`` is omitted, OR
@@ -2188,10 +2206,12 @@ class CreateDNSZoneArgs(BaseModel):
         default=None,
         description=(
             "Preferred backend driver — one of ``bind9``, "
-            "``powerdns``, or ``windows_dns``. Required for "
-            "``dnssec_enabled=true`` (only PowerDNS supports online "
-            "signing). When ``group_id`` is set, this is validated "
-            "against the group's actual driver mix."
+            "``powerdns``, ``technitium``, or ``windows_dns``. Pair it "
+            "with ``dnssec_enabled=true`` to auto-select a group whose "
+            "driver can sign online (``bind9``, ``powerdns`` and "
+            "``technitium`` all can; ``windows_dns`` cannot). When "
+            "``group_id`` is set, this is validated against the group's "
+            "actual driver mix."
         ),
     )
     zone_type: str = Field(
@@ -2213,10 +2233,11 @@ class CreateDNSZoneArgs(BaseModel):
     dnssec_enabled: bool = Field(
         default=False,
         description=(
-            "Turn on DNSSEC for this zone. Requires a PowerDNS group "
-            "(BIND9 + Windows DNS don't support online signing here). "
-            'Pair with ``driver_hint="powerdns"`` to auto-select a '
-            "compatible group."
+            "Turn on DNSSEC for this zone. Requires a group with a "
+            "server whose driver signs online — ``bind9`` "
+            "(inline-signing), ``powerdns`` or ``technitium``. "
+            "``windows_dns`` and the cloud drivers cannot. Pair with a "
+            "matching ``driver_hint`` to auto-select a compatible group."
         ),
     )
     ttl: int = Field(
@@ -2338,19 +2359,32 @@ async def _preview_create_dns_zone(
     if grp is None:
         return PreviewResult(ok=False, detail=err)
 
-    # PowerDNS-only features (currently DNSSEC) — reject if the
-    # selected group has no PowerDNS member. Without this guard the
-    # apply would land the row but the agent would refuse to sign.
-    for feat in _POWERDNS_ONLY_FEATURES:
-        if getattr(args, feat) and "powerdns" not in drivers:
+    # Driver-gated zone features (currently DNSSEC). Semantics are copied
+    # from ``_check_driver_gated_operation`` in the DNS router, deliberately
+    # and exactly:
+    #
+    #   * SUBSET, not intersection — EVERY server in the group has to support
+    #     the feature, not merely one of them. An "any member matches" test
+    #     would pass a bind9 + windows_dns group here, land a zone flagged
+    #     dnssec_enabled, and then the sign/unsign endpoints would 422 it:
+    #     signed according to the UI, unsigned on the wire, and unfixable
+    #     through the API.
+    #   * Empty groups fail SOFT — a group with no servers yet has nobody to
+    #     disagree, and the REST gate re-runs once a driver is known.
+    for feat, (_op, label) in _DRIVER_GATED_ZONE_ARGS.items():
+        if not getattr(args, feat) or not drivers:
+            continue
+        allowed = _drivers_for_gated_arg(feat)
+        incompatible = drivers - allowed
+        if incompatible:
             return PreviewResult(
                 ok=False,
                 detail=(
-                    f"{feat}=true requires a PowerDNS-driver server in "
-                    f"the group, but {grp.name!r} has drivers "
-                    f"{sorted(drivers) or ['(none)']}. Add a PowerDNS "
-                    f"server to the group, pick a different group, or "
-                    f'set driver_hint="powerdns" without group_id.'
+                    f"{feat}=true requires every server in the group to support "
+                    f"{label} ({', '.join(sorted(allowed))}), but {grp.name!r} "
+                    f"also has {sorted(incompatible)}. Move those servers to "
+                    f"their own group, pick a different group, or set "
+                    f"driver_hint to one of {sorted(allowed)} without group_id."
                 ),
             )
 
@@ -2374,7 +2408,23 @@ async def _preview_create_dns_zone(
     parts.append(f"drivers={sorted(drivers) or ['(none)']}")
     parts.append(f"type={args.zone_type}/{args.kind}")
     if args.dnssec_enabled:
-        parts.append("DNSSEC=on (PowerDNS online signing)")
+        # Zone-create records INTENT. BIND9 converges from that alone — it
+        # signs inline from the rendered config bundle — but PowerDNS and
+        # Technitium sign only in response to the ``dnssec_sign`` record op,
+        # which neither this path nor the REST ``create_zone`` enqueues
+        # (issue #811). Say which of the two the operator is getting rather
+        # than implying the zone comes up signed everywhere. Once #811 lands
+        # this branch collapses back to a plain "DNSSEC=on".
+        deferred = sorted(drivers - {"bind9"})
+        if not drivers:
+            parts.append("DNSSEC=on (no servers in the group yet)")
+        elif deferred:
+            parts.append(
+                "DNSSEC=on — flag only; run the zone's DNSSEC Sign action to "
+                f"sign on {', '.join(deferred)}"
+            )
+        else:
+            parts.append("DNSSEC=on (bind9 signs inline from the config bundle)")
     return PreviewResult(ok=True, detail="ready", preview_text=", ".join(parts))
 
 
@@ -2446,8 +2496,9 @@ register(
         name="create_dns_zone",
         description=(
             "Create a new DNS zone. Honors driver_hint to route the "
-            "zone onto a PowerDNS / BIND9 / Windows DNS group; "
-            "DNSSEC zones require a PowerDNS group."
+            "zone onto a BIND9 / PowerDNS / Technitium / Windows DNS "
+            "group; DNSSEC zones require a group whose driver signs "
+            "online (bind9, powerdns or technitium)."
         ),
         args_model=CreateDNSZoneArgs,
         preview=_preview_create_dns_zone,

--- a/backend/tests/test_ai_dns_zone_dnssec_gate.py
+++ b/backend/tests/test_ai_dns_zone_dnssec_gate.py
@@ -1,0 +1,246 @@
+"""The Copilot's ``create_dns_zone`` DNSSEC gate must match the REST gate.
+
+Issue #798. ``_POWERDNS_ONLY_FEATURES`` in ``app.services.ai.operations``
+hardcoded ``"powerdns" not in drivers`` and was written when PowerDNS was the
+only online signer. BIND9 inline-signing (#49) and Technitium online signing
+(#740) widened the REST layer's ``_DRIVER_GATED_OPERATIONS["dnssec_sign"]``;
+the Copilot constant was not widened with it, so the tool refused work the
+REST API accepted for two releases.
+
+The fix reads the REST gate instead of restating it. These tests exist so the
+two cannot silently diverge again: the parametrised case walks *every* driver
+the REST layer knows about, so widening (or narrowing) the REST gate without
+touching the Copilot is a test failure rather than a shipped inconsistency.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dns.router import _DRIVER_GATED_OPERATIONS
+from app.core.security import hash_password
+from app.models.auth import User
+from app.models.dns import DNSServer, DNSServerGroup
+from app.services.ai.operations import (
+    _DNS_DRIVER_HINTS,
+    CreateDNSZoneArgs,
+    get_operation,
+)
+
+# Every driver the REST DNSSEC gate has an opinion about — the ones it allows
+# plus the ones it deliberately excludes. Both halves matter: the bug was an
+# over-tight allow set, and the obvious over-correction is a loose gate that
+# lets a zone land on Windows DNS and never get signed.
+_SIGNING_DRIVERS = _DRIVER_GATED_OPERATIONS["dnssec_sign"]
+_ALL_DRIVERS = sorted(_DNS_DRIVER_HINTS | set(_SIGNING_DRIVERS))
+
+
+async def _user(db: AsyncSession) -> User:
+    suffix = uuid.uuid4().hex[:8]
+    u = User(
+        username=f"dnssec-gate-{suffix}",
+        email=f"dnssec-gate-{suffix}@example.test",
+        display_name="DNSSEC Gate",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    u.groups = []  # mark loaded — is_effective_superadmin walks .groups (#351)
+    db.add(u)
+    await db.commit()
+    return u
+
+
+async def _group_with_driver(db: AsyncSession, driver: str) -> DNSServerGroup:
+    grp = DNSServerGroup(name=f"g-{driver}-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    db.add(
+        DNSServer(
+            group_id=grp.id,
+            name=f"s-{uuid.uuid4().hex[:6]}",
+            driver=driver,
+            host="192.0.2.10",
+        )
+    )
+    await db.flush()
+    return grp
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("driver", _ALL_DRIVERS)
+async def test_dnssec_preview_agrees_with_rest_gate(db_session: AsyncSession, driver: str) -> None:
+    """For every driver: the Copilot preview accepts DNSSEC iff REST would."""
+    user = await _user(db_session)
+    grp = await _group_with_driver(db_session, driver)
+    op = get_operation("create_dns_zone")
+    assert op is not None
+
+    preview = await op.preview(
+        db_session,
+        user,
+        CreateDNSZoneArgs(
+            name=f"z{uuid.uuid4().hex[:6]}.example.com",
+            group_id=str(grp.id),
+            dnssec_enabled=True,
+        ),
+    )
+
+    rest_would_allow = driver in _SIGNING_DRIVERS
+    assert preview.ok is rest_would_allow, (
+        f"driver {driver!r}: REST gate allows={rest_would_allow} but the "
+        f"Copilot preview returned ok={preview.ok} ({preview.detail})"
+    )
+    if not rest_would_allow:
+        # The rejection has to name the drivers that WOULD work — the old one
+        # said "PowerDNS" and sent operators to the wrong driver.
+        for allowed in _SIGNING_DRIVERS:
+            assert allowed in preview.detail
+
+
+@pytest.mark.asyncio
+async def test_dnssec_preview_rejects_mixed_group_with_one_non_signer(
+    db_session: AsyncSession,
+) -> None:
+    """One incapable member disqualifies the whole group.
+
+    SUBSET semantics, matching ``_check_driver_gated_operation``. The
+    tempting over-correction after #798 is an intersection test ("some
+    server can sign"), which would pass this group, land a zone flagged
+    ``dnssec_enabled``, and then have the sign/unsign endpoints 422 it —
+    signed in the UI, unsigned on the wire, unfixable through the API.
+    """
+    user = await _user(db_session)
+    grp = await _group_with_driver(db_session, "windows_dns")
+    db_session.add(
+        DNSServer(
+            group_id=grp.id,
+            name=f"s-{uuid.uuid4().hex[:6]}",
+            driver="bind9",
+            host="192.0.2.11",
+        )
+    )
+    await db_session.flush()
+
+    op = get_operation("create_dns_zone")
+    assert op is not None
+    preview = await op.preview(
+        db_session,
+        user,
+        CreateDNSZoneArgs(
+            name=f"z{uuid.uuid4().hex[:6]}.example.com",
+            group_id=str(grp.id),
+            dnssec_enabled=True,
+        ),
+    )
+    assert not preview.ok
+    assert "windows_dns" in preview.detail
+
+
+@pytest.mark.asyncio
+async def test_dnssec_preview_fails_soft_on_an_empty_group(
+    db_session: AsyncSession,
+) -> None:
+    """A group with no servers passes — nobody to disagree yet.
+
+    Also matching ``_check_driver_gated_operation``, which returns early on
+    an empty driver set. The REST gate re-runs once a driver is known.
+    """
+    user = await _user(db_session)
+    grp = DNSServerGroup(name=f"g-empty-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+
+    op = get_operation("create_dns_zone")
+    assert op is not None
+    preview = await op.preview(
+        db_session,
+        user,
+        CreateDNSZoneArgs(
+            name=f"z{uuid.uuid4().hex[:6]}.example.com",
+            group_id=str(grp.id),
+            dnssec_enabled=True,
+        ),
+    )
+    assert preview.ok, preview.detail
+    assert "no servers in the group yet" in (preview.preview_text or "")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("driver", sorted(_SIGNING_DRIVERS))
+async def test_preview_text_does_not_promise_signing_the_create_wont_do(
+    db_session: AsyncSession, driver: str
+) -> None:
+    """Say what actually happens, per driver.
+
+    Zone-create records intent. BIND9 converges from that alone (it signs
+    inline from the config bundle); PowerDNS and Technitium sign only in
+    response to the ``dnssec_sign`` record op, which neither this path nor
+    the REST ``create_zone`` enqueues. The preview must not imply otherwise.
+    """
+    user = await _user(db_session)
+    grp = await _group_with_driver(db_session, driver)
+    op = get_operation("create_dns_zone")
+    assert op is not None
+    preview = await op.preview(
+        db_session,
+        user,
+        CreateDNSZoneArgs(
+            name=f"z{uuid.uuid4().hex[:6]}.example.com",
+            group_id=str(grp.id),
+            dnssec_enabled=True,
+        ),
+    )
+    assert preview.ok, preview.detail
+    text = preview.preview_text or ""
+    if driver == "bind9":
+        assert "signs inline" in text
+    else:
+        assert "flag only" in text
+        assert driver in text
+
+
+@pytest.mark.asyncio
+async def test_non_dnssec_zone_is_ungated(db_session: AsyncSession) -> None:
+    """The gate must fire only when the feature is actually requested."""
+    user = await _user(db_session)
+    grp = await _group_with_driver(db_session, "windows_dns")
+    op = get_operation("create_dns_zone")
+    assert op is not None
+    preview = await op.preview(
+        db_session,
+        user,
+        CreateDNSZoneArgs(
+            name=f"z{uuid.uuid4().hex[:6]}.example.com",
+            group_id=str(grp.id),
+            dnssec_enabled=False,
+        ),
+    )
+    assert preview.ok, preview.detail
+    assert "DNSSEC" not in (preview.preview_text or "")
+
+
+def test_tool_schema_descriptions_name_every_signing_driver() -> None:
+    """The operator-visible schema text ships to the model — it steers the LLM.
+
+    Three descriptions stated "only PowerDNS supports online signing" as fact
+    long after that stopped being true, which pushed the model toward PowerDNS
+    even where the guard would have allowed BIND9 or Technitium. Assert the
+    prose stays in step with the gate it describes.
+    """
+    fields = CreateDNSZoneArgs.model_fields
+    hint_desc = fields["driver_hint"].description or ""
+    dnssec_desc = fields["dnssec_enabled"].description or ""
+    op = get_operation("create_dns_zone")
+    assert op is not None
+
+    for driver in _SIGNING_DRIVERS:
+        assert driver in hint_desc, f"driver_hint description omits {driver!r}"
+        assert driver in dnssec_desc, f"dnssec_enabled description omits {driver!r}"
+        assert driver in op.description, f"operation description omits {driver!r}"
+
+    # The claim that used to be here, and must not come back.
+    for text in (hint_desc, dnssec_desc, op.description):
+        assert "only PowerDNS" not in text

--- a/charts/spatiumddi-appliance/templates/dns-technitium.yaml
+++ b/charts/spatiumddi-appliance/templates/dns-technitium.yaml
@@ -79,6 +79,37 @@ spec:
             - name: dns-tcp
               containerPort: 53
               protocol: TCP
+            {{- /* #741 / #799 — encrypted transports. The listener ports
+                   live in the DB (dns_server_options), not here: the agent
+                   configures the daemon from the config bundle, and this pod
+                   is hostNetwork so it binds the host directly regardless of
+                   what's declared. These entries exist so the ports are
+                   visible to kubectl / Service routing / network policy —
+                   set them to match the group's configured ports.
+
+                   They stop being cosmetic under dns.useMetalLBVIP: the pod
+                   drops hostNetwork and sits behind an L2 LoadBalancer that
+                   forwards only what the Service declares, so an undeclared
+                   port means encrypted DNS simply stops answering. */}}
+            {{- with .Values.dnsTechnitium.dotPort }}
+            - name: dns-dot
+              containerPort: {{ . }}
+              protocol: TCP
+            {{- end }}
+            {{- with .Values.dnsTechnitium.dohPort }}
+            - name: dns-doh
+              containerPort: {{ . }}
+              protocol: TCP
+            {{- end }}
+            {{- /* DoQ is UDP, and 853 is the RFC default for both it and
+                   DoT — so this may legitimately repeat dotPort's number
+                   under a different protocol. Kubernetes allows that; the
+                   port NAMES are what must stay unique. */}}
+            {{- with .Values.dnsTechnitium.doqPort }}
+            - name: dns-doq
+              containerPort: {{ . }}
+              protocol: UDP
+            {{- end }}
           # #296 Phase A2 — marker + a live query, same shape as bind9/
           # powerdns's readiness probe. Technitium REFUSES CHAOS-class
           # queries entirely (confirmed empirically — id.server/
@@ -149,4 +180,19 @@ spec:
     - name: dns-tcp
       port: 53
       protocol: TCP
+    {{- with .Values.dnsTechnitium.dotPort }}
+    - name: dns-dot
+      port: {{ . }}
+      protocol: TCP
+    {{- end }}
+    {{- with .Values.dnsTechnitium.dohPort }}
+    - name: dns-doh
+      port: {{ . }}
+      protocol: TCP
+    {{- end }}
+    {{- with .Values.dnsTechnitium.doqPort }}
+    - name: dns-doq
+      port: {{ . }}
+      protocol: UDP
+    {{- end }}
 {{- end }}

--- a/charts/spatiumddi-appliance/values.yaml
+++ b/charts/spatiumddi-appliance/values.yaml
@@ -106,11 +106,10 @@ dnsPowerdns:
   # docker-compose-only too: pdns auth speaks neither protocol, so the
   # listeners live on the dnsdist front. BIND9 needs no such sidecar.
 
-# DNS — Technitium backend. Same shape as dnsBind9. v1 supports primary
-# zones + standard record CRUD; DNSSEC and native DoT/DoH/DoQ listener
-# wiring (a real differentiator — Technitium needs no dnsdist-style
-# sidecar, unlike PowerDNS) are fast-follow, so no dotPort/dohPort knobs
-# here yet.
+# DNS — Technitium backend. Same shape as dnsBind9. Supports primary
+# zones + standard record CRUD, online DNSSEC signing (#740) and native
+# DoT / DoH / DoQ listeners (#741) — a real differentiator, since
+# Technitium needs no dnsdist-style sidecar the way PowerDNS does.
 dnsTechnitium:
   enabled: false
   image:
@@ -119,6 +118,24 @@ dnsTechnitium:
   inClusterApiUrl: ""  # #292 — see dnsBind9.inClusterApiUrl
   agentKey: ""
   serverGroupName: ""
+  #
+  # #741 / #799 — encrypted transports. Same contract as
+  # dnsBind9.dotPort/dohPort above: the listeners are configured in the
+  # DB (DNS → group → options), NOT here. The agent renders the daemon
+  # config from the bundle, and this pod is hostNetwork so it binds the
+  # host regardless of what the manifest declares. Set these to MATCH
+  # the group's configured ports so they show up in `kubectl get svc`,
+  # get routed by the MetalLB VIP Service, and are visible to any
+  # NetworkPolicy. Empty = not declared (the default: all three off).
+  #
+  # doqPort is UDP where the other two are TCP, and 853 is the RFC
+  # default for BOTH DoT and DoQ — so doqPort == dotPort is normal and
+  # correct, not a misconfiguration. DoQ has no dnsBind9 equivalent
+  # because BIND has no QUIC transport; the API refuses doq_enabled on
+  # any group with a non-Technitium member.
+  dotPort: ""   # e.g. 853
+  dohPort: ""   # e.g. 8443 — 443 collides with the appliance web UI
+  doqPort: ""   # e.g. 853  — UDP; may equal dotPort
 
 # DHCP — Kea backend. DaemonSet (single node) with ``hostNetwork:
 # true`` + ``CAP_NET_BIND_SERVICE`` so Kea sees DHCP-discover

--- a/charts/spatiumddi/templates/dns-agent.yaml
+++ b/charts/spatiumddi/templates/dns-agent.yaml
@@ -106,15 +106,25 @@ spec:
           ports:
             - { name: dns-udp, containerPort: 53, protocol: UDP }
             - { name: dns-tcp, containerPort: 53, protocol: TCP }
-            {{- /* #50 — encrypted transports. Listener ports are configured
-                   in the DB (DNS -> group -> options); these declarations
-                   only make them routable + visible. Set per server to
-                   match. */}}
+            {{- /* #50 / #799 — encrypted transports. Listener ports are
+                   configured in the DB (DNS -> group -> options); these
+                   declarations only make them routable + visible. Set per
+                   server to match.
+
+                   doqPort is UDP and applies to flavor: technitium only —
+                   BIND has no QUIC transport and the API refuses
+                   doq_enabled on any group with a non-Technitium member.
+                   It may carry the SAME number as dotPort: 853 is the RFC
+                   default for both DoT (TCP) and DoQ (UDP), and Kubernetes
+                   allows the repeat because the port NAMES differ. */}}
             {{- with $server.dotPort }}
             - { name: dns-dot, containerPort: {{ . }}, protocol: TCP }
             {{- end }}
             {{- with $server.dohPort }}
             - { name: dns-doh, containerPort: {{ . }}, protocol: TCP }
+            {{- end }}
+            {{- with $server.doqPort }}
+            - { name: dns-doq, containerPort: {{ . }}, protocol: UDP }
             {{- end }}
           readinessProbe:
             tcpSocket: { port: 53 }
@@ -161,6 +171,9 @@ spec:
     {{- with $server.dohPort }}
     - { name: dns-doh, port: {{ . }}, targetPort: {{ . }}, protocol: TCP }
     {{- end }}
+    {{- with $server.doqPort }}
+    - { name: dns-doq, port: {{ . }}, targetPort: {{ . }}, protocol: UDP }
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -183,6 +196,9 @@ spec:
     {{- end }}
     {{- with $server.dohPort }}
     - { name: dns-doh, port: {{ . }}, protocol: TCP }
+    {{- end }}
+    {{- with $server.doqPort }}
+    - { name: dns-doq, port: {{ . }}, protocol: UDP }
     {{- end }}
 ---
 {{- end }}

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -645,15 +645,21 @@ dnsAgents:
     #   resources:
     #     requests: { cpu: 100m, memory: 128Mi }
     #     limits:   { cpu: 500m, memory: 512Mi }
-    #   # Encrypted transports — DoT / DoH (issue #50). Both OFF by default.
-    #   # The listener ports are configured in the DATABASE (DNS → Server
-    #   # Groups → Options → Encrypted transports) — the agent renders
-    #   # named.conf from the config bundle, not from these values. Set
-    #   # these to MATCH the ports you chose there; they only declare the
-    #   # containerPort + Service port so the listener is routable through
-    #   # the Service and visible to NetworkPolicy. Omit = not declared.
+    #   # Encrypted transports — DoT / DoH / DoQ (issues #50, #741, #799).
+    #   # All OFF by default. The listener ports are configured in the
+    #   # DATABASE (DNS → Server Groups → Options → Encrypted transports) —
+    #   # the agent renders the daemon config from the config bundle, not
+    #   # from these values. Set these to MATCH the ports you chose there;
+    #   # they only declare the containerPort + Service port so the listener
+    #   # is routable through the Service and visible to NetworkPolicy.
+    #   # Omit = not declared.
     #   dotPort: 853
     #   dohPort: 8443            # 443 usually collides with an Ingress
+    #   # doqPort is flavor: technitium ONLY — BIND has no QUIC transport,
+    #   # and the API refuses doq_enabled on a group with any non-Technitium
+    #   # member. It renders protocol: UDP, so it may carry the SAME number
+    #   # as dotPort: 853 is the RFC default for both.
+    #   doqPort: 853
     # - name: ns1-pdns
     #   flavor: powerdns         # PowerDNS group; LMDB-backed zone storage
     #   role: primary

--- a/docker-compose.agent-dns-technitium.yml
+++ b/docker-compose.agent-dns-technitium.yml
@@ -80,9 +80,13 @@ services:
       # will listen on whatever the group is configured for in the UI,
       # but Compose cannot publish a port conditionally, so binding them
       # unconditionally would break ``up -d`` on any host already using
-      # them — for a feature that ships off by default. Add the mappings
-      # by hand (container-side ports must MATCH the UI values, since the
-      # agent configures the daemon from the database, not from here):
+      # them — for a feature that ships off by default.
+      #
+      # This file is the STANDALONE agent, so it can't use the
+      # ``docker-compose.dns-encrypted.yml`` overlay (that one targets the
+      # full-stack file's service names). Add the mappings by hand instead
+      # — container-side ports must MATCH the UI values, since the agent
+      # configures the daemon from the database, not from here:
       #   - "${DNS_DOT_HOST_PORT:-1853}:853/tcp"   # DoT
       #   - "${DNS_DOQ_HOST_PORT:-1853}:853/udp"   # DoQ — UDP, so no clash
       #   - "${DNS_DOH_HOST_PORT:-8443}:443/tcp"   # DoH

--- a/docker-compose.dns-encrypted.yml
+++ b/docker-compose.dns-encrypted.yml
@@ -1,11 +1,17 @@
-# Encrypted DNS transports — DoT / DoH host-port publishing (issue #50).
+# Encrypted DNS transports — DoT / DoH / DoQ host-port publishing
+# (issues #50, #741, #799).
 #
-# Overlay for operators who have turned DoT and/or DoH on for a server
+# Overlay for operators who have turned DoT, DoH and/or DoQ on for a server
 # group under DNS → Server Groups → Options → Encrypted transports.
 #
 #   docker compose -f docker-compose.yml \
 #                  -f docker-compose.dns-encrypted.yml \
 #                  --profile dns-bind9 up -d
+#
+# Substitute --profile dns-technitium or --profile dns-powerdns-with-dnsdist
+# for the other two paths. Only the service belonging to the profile you
+# start is affected; Compose ignores port entries for services that never
+# come up.
 #
 # Why an overlay rather than ports in the base file: Compose cannot publish
 # a port conditionally, so binding 853 / 443 unconditionally would break
@@ -24,27 +30,58 @@
 # taken. DoH defaults to host 8443 rather than 443 so nothing has to bind a
 # privileged port, and because 443 is usually already spoken for.
 #
-#   DNS_DOT_PORT            container port for DoT   (UI value, default 853)
-#   DNS_DOH_PORT            container port for DoH   (UI value, default 443)
-#   DNS_DOT_HOST_PORT       host port for DoT        (default 1853)
-#   DNS_DOH_HOST_PORT       host port for DoH        (default 8443)
-#   DNS_DOT_HOST_PORT_PDNS  host port, PowerDNS path (default 5853)
-#   DNS_DOH_HOST_PORT_PDNS  host port, PowerDNS path (default 5444)
+#   DNS_DOT_PORT             container port for DoT    (UI value, default 853)
+#   DNS_DOH_PORT             container port for DoH    (UI value, default 443)
+#   DNS_DOQ_PORT             container port for DoQ    (UI value, default 853)
+#   DNS_DOT_HOST_PORT        host port for DoT, BIND9  (default 1853)
+#   DNS_DOH_HOST_PORT        host port for DoH, BIND9  (default 8443)
+#   DNS_DOT_HOST_PORT_PDNS   host port, PowerDNS path  (default 5853)
+#   DNS_DOH_HOST_PORT_PDNS   host port, PowerDNS path  (default 5444)
+#   DNS_DOT_HOST_PORT_TECHNITIUM  host port, Technitium path (default 6853)
+#   DNS_DOH_HOST_PORT_TECHNITIUM  host port, Technitium path (default 6444)
+#   DNS_DOQ_HOST_PORT_TECHNITIUM  host port, Technitium path (default 6853/udp)
+#
+# ── DoQ shares DoT's port NUMBER, not its port ───────────────────────────
+# 853 is the RFC default for both DoT (TCP) and DoQ (UDP), so the defaults
+# below deliberately collide on the number and differ on the protocol. That
+# is correct and is why `doq_port` is a separate field from `dot_port` in
+# the UI — do not "fix" it by moving DoQ to another number unless you also
+# change it in the group's options.
 #
 # Compose MERGES port lists across files, so these add to the base :53
 # mappings rather than replacing them — do not repeat the :53 entries here.
 
 services:
-  # BIND9 serves DoT + DoH natively.
+  # BIND9 serves DoT + DoH natively. It has no client- or server-side QUIC
+  # transport, so there is no DoQ entry here — the group's doq_enabled
+  # toggle is refused for a bind9 group (#741).
   dns-bind9:
     ports:
       - "${DNS_DOT_HOST_PORT:-1853}:${DNS_DOT_PORT:-853}/tcp"
       - "${DNS_DOH_HOST_PORT:-8443}:${DNS_DOH_PORT:-443}/tcp"
 
-  # PowerDNS Authoritative speaks neither protocol, so on that driver the
+  # Technitium serves all three natively (#741), so unlike PowerDNS it needs
+  # no sidecar. HOST ports sit in the 6xxx band to match its base 6053:53
+  # mapping, so all three drivers can be up at once without colliding there.
+  #
+  # The CONTAINER side is a different story: DNS_DOT_PORT / DNS_DOH_PORT are
+  # shared by every service in this file, because each is "the port the
+  # listener is on", and there is only one such value per variable. Running
+  # two drivers whose GROUPS are configured for different listener ports is
+  # therefore not expressible here — one of the published mappings would
+  # point at a port nothing is listening on. Give the two groups the same
+  # listener port, or publish the odd one out by hand.
+  dns-technitium:
+    ports:
+      - "${DNS_DOT_HOST_PORT_TECHNITIUM:-6853}:${DNS_DOT_PORT:-853}/tcp"
+      - "${DNS_DOH_HOST_PORT_TECHNITIUM:-6444}:${DNS_DOH_PORT:-443}/tcp"
+      - "${DNS_DOQ_HOST_PORT_TECHNITIUM:-6853}:${DNS_DOQ_PORT:-853}/udp"
+
+  # PowerDNS Authoritative speaks none of the three, so on that driver the
   # listeners run on the dnsdist front, which terminates TLS and forwards
   # plaintext to pdns:53. Nothing to publish on dns-powerdns itself.
-  # Requires the dns-powerdns-with-dnsdist profile.
+  # Requires the dns-powerdns-with-dnsdist profile. No DoQ: the shipped
+  # dnsdist front is configured for DoT + DoH only.
   dns-dnsdist:
     ports:
       - "${DNS_DOT_HOST_PORT_PDNS:-5853}:${DNS_DOT_PORT:-853}/tcp"

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -60,7 +60,9 @@ Manual rollover stays BIND9-only on purpose: PowerDNS and Technitium each roll o
 
 The Operator Copilot's `propose_create_dns_zone` tool accepts an explicit `driver_hint` argument (`bind9` / `powerdns` / `technitium` / `windows_dns`) so the LLM can route a zone to a matching group without operators having to specify the group UUID by hand. See `app.services.ai.operations.CreateDNSZoneArgs`.
 
-> **Known gap.** That tool's `dnssec_enabled=true` path is stricter than the REST gate above: `_POWERDNS_ONLY_FEATURES` still rejects a signed zone unless the group has a **PowerDNS** member, so the Copilot refuses on a BIND9 or Technitium group that the REST API would accept. Use the zone page (or the REST endpoint) to sign on those drivers until it is widened.
+Its `dnssec_enabled=true` path reads the same `dnssec_sign` row of the table above rather than restating it, with the same subset rule — *every* server in the group must run a signing driver, and an empty group passes — so the tool accepts exactly the groups the REST API accepts (issue #798; a test asserts the two agree for every driver, because they had drifted once).
+
+Note that creating a zone with `dnssec_enabled=true` records **intent**. BIND9 converges from that alone, signing inline from the rendered config; PowerDNS and Technitium sign in response to the `dnssec_sign` record op, which only the zone's **Sign** action enqueues. This is true of `POST /api/v1/dns/groups/{id}/zones` as well as the Copilot tool — on those two drivers, create-then-sign is two steps today, tracked in [#811](https://github.com/spatiumddi/spatiumddi/issues/811).
 
 ### 0a. Cloud DNS providers — Cloudflare / Route 53 / Azure DNS / Google Cloud DNS (issue #37)
 
@@ -1338,9 +1340,9 @@ topology needs a different thing:
 | Deployment | What to change | 443 conflict? |
 |---|---|---|
 | **Appliance (k3s)** | Nothing — the DNS workload is `hostNetwork`, so it binds the host directly. The supervisor opens the port automatically (above). | **Yes** — the web UI owns 80/443. The API rejects either listener on those ports here; use 8443. |
-| **Docker Compose (main stack)** | Add the `docker-compose.dns-encrypted.yml` overlay. | **No** — the frontend publishes `${HTTP_PORT:-8077}:80` and never binds 443. Container-side 443 is private to the DNS container. |
-| **Compose (standalone agent files)** | Uncomment the two port lines in `docker-compose.agent-dns-bind9.yml`. PowerDNS's standalone file has no dnsdist front, so DoT/DoH is unavailable there. | No. |
-| **Kubernetes / Helm** | Set `dnsBind9.dotPort` / `dohPort` (appliance chart) or per-server `dotPort` / `dohPort` (umbrella chart) to declare the containerPort + Service port. Raw manifests: uncomment the blocks in `k8s/dns/`. | Depends on your Ingress/LoadBalancer — you own the topology, so 443 is allowed. |
+| **Docker Compose (main stack)** | Add the `docker-compose.dns-encrypted.yml` overlay. It carries entries for `dns-bind9`, `dns-technitium` and `dns-dnsdist`; only the service in the profile you start comes up. | **No** — the frontend publishes `${HTTP_PORT:-8077}:80` and never binds 443. Container-side 443 is private to the DNS container. |
+| **Compose (standalone agent files)** | Uncomment the port lines in `docker-compose.agent-dns-bind9.yml` / `-technitium.yml`. The overlay does **not** apply to these files — it names the main stack's services, and merging it here would try to create image-less `dns-bind9` / `dns-dnsdist` services. PowerDNS's standalone file has no dnsdist front, so DoT/DoH is unavailable there. | No. |
+| **Kubernetes / Helm** | Set `dnsBind9.dotPort` / `dohPort` or `dnsTechnitium.dotPort` / `dohPort` / `doqPort` (appliance chart), or the same per-server keys (umbrella chart), to declare the containerPort + Service port. Raw manifests: uncomment the blocks in `k8s/dns/`. | Depends on your Ingress/LoadBalancer — you own the topology, so 443 is allowed. |
 
 ```bash
 docker compose -f docker-compose.yml \
@@ -1362,11 +1364,25 @@ The vars split host and container side deliberately:
 ```
 
 The **container** side must match the port configured in the UI — the
-agent renders `named.conf` from the DB, not from these variables, so a
-mismatch publishes a mapping to a port nothing is listening on. The
+agent renders the daemon config from the DB, not from these variables, so
+a mismatch publishes a mapping to a port nothing is listening on. The
 **host** side is just where it lands; the DoH default is 8443 so nothing
-has to bind a privileged port. All six variables are documented in
+has to bind a privileged port. Every variable is documented in
 `.env.example`.
+
+Technitium gets its own host-port band (`DNS_DOT_HOST_PORT_TECHNITIUM` and
+friends, defaulting to 6853 / 6444 to match its 6053:53 base mapping) so
+all three drivers can run side by side, plus a third mapping the other two
+don't have:
+
+```
+- "${DNS_DOQ_HOST_PORT_TECHNITIUM:-6853}:${DNS_DOQ_PORT:-853}/udp"
+```
+
+DoQ shares DoT's port **number** and differs in protocol — 853 is the RFC
+default for both — which is why `doq_port` is a separate field from
+`dot_port` rather than a checkbox on the DoT listener, and why the two
+defaults above collide on purpose.
 
 ### 20.3 Upstream forwarding
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -269,12 +269,16 @@ work the same on either flavor; on the PowerDNS flavor they run on the
 dnsdist front, which has no Kubernetes deployment yet (docker-compose
 only).
 
-> **DoQ has no chart knob yet.** Technitium also serves DNS-over-QUIC,
-> which is UDP and therefore shares :853 with DoT without colliding —
-> but `dotPort` renders `protocol: TCP` and there is no `doqPort`, so
-> the UDP listener cannot be declared on the Pod or routed through the
-> Service. It still answers on a `hostNetwork` node. Tracked in
-> [#799](https://github.com/spatiumddi/spatiumddi/issues/799).
+**DoQ** (`doqPort`, issue #799) is Technitium-only: BIND has no QUIC
+transport, and the API refuses `doq_enabled` on any group with a
+non-Technitium member. It renders `protocol: UDP`, which is why it may
+carry the **same number** as `dotPort` — 853 is the RFC default for both
+DoT (TCP) and DoQ (UDP), and Kubernetes permits the repeat because the
+port *names* differ:
+
+```bash
+--set-json 'dnsAgents.servers=[{"name":"ns1","flavor":"technitium","group":"tech","dotPort":853,"doqPort":853,"dohPort":8443}]'
+```
 
 ### How servers register
 


### PR DESCRIPTION
Two findings from the Technitium documentation sweep. Both are the same
shape: a list written once, never widened when the feature grew.

## #798 — the Copilot refused DNSSEC work the REST API accepts

`propose_create_dns_zone` rejected `dnssec_enabled=true` on any group
without a PowerDNS member. The REST gate it fronts has allowed BIND9
since #49 and Technitium since #740; `_POWERDNS_ONLY_FEATURES` was never
widened alongside it, so the tool declined work the product supports —
create the same zone through the UI and hit **Sign** and it succeeds.

Replaced with a map from arg name → the REST operation whose gate governs
it, read from `_DRIVER_GATED_OPERATIONS` at preview time rather than
restated. The semantics are copied exactly, and that detail is
load-bearing:

- **Subset, not intersection.** Every server in the group must support the
  feature. An "any member matches" test would pass a `bind9 +
  windows_dns` group, land a zone flagged `dnssec_enabled`, and then have
  the sign/unsign endpoints 422 it — signed in the UI, unsigned on the
  wire, unfixable through the API.
- **Empty groups fail soft**, matching `_check_driver_gated_operation`.

Four operator-visible descriptions still stated the old rule as fact.
They ship to the model as tool-schema text, so they steered it toward
PowerDNS even where the guard was correct. All four rewritten; a test
asserts every signing driver is named in each.

The preview text also stops over-promising. Zone-create records *intent*,
and only BIND9 converges from that alone (it signs inline from the config
bundle). PowerDNS and Technitium sign in response to the `dnssec_sign`
record op, which neither this path nor `POST .../zones` enqueues — filed
as **#811** and referenced from both the code and DNS.md. Until it lands
the preview says which of the two behaviours the operator is getting.

## #799 — Technitium's encrypted listeners were unroutable

#741 shipped native DoT / DoH / DoQ and the supervisor already opens the
host firewall ports. No deployment artifact ever declared them:

| Artifact | Consequence |
|---|---|
| `docker-compose.dns-encrypted.yml` | No `dns-technitium` block, so on the documented evaluation path the daemon listened inside the container with nothing routed to it. No error — just no answer. |
| `charts/spatiumddi-appliance/templates/dns-technitium.yaml` | Declared only `:53`. Cosmetic under hostNetwork — but with `dns.useMetalLBVIP` the pod drops hostNetwork and sits behind an L2 LoadBalancer forwarding only what the Service declares. Enabling the DNS VIP silently took encrypted DNS away from a Technitium group while leaving it working for a BIND9 one. |
| `charts/spatiumddi/templates/dns-agent.yaml` | No `doqPort` key at all, and both existing keys render `protocol: TCP`. DoQ was not expressible. |

**On DoQ sharing 853.** 853 is the RFC default for both DoT (TCP) and DoQ
(UDP), so the defaults here collide on the number by design. That is why
it needs its own key rather than a flag on `dotPort`, and Kubernetes
permits the repeat because the port *names* differ. It is Technitium-only:
BIND has no QUIC transport, and the API refuses `doq_enabled` on any group
with a non-Technitium member.

Host ports for Technitium land in the 6xxx band to match its `6053:53`
base mapping, so all three drivers can be up at once. The container side
can't be per-driver — `DNS_DOT_PORT` is "the port the listener is on" and
there's one such value — which is now stated in the overlay rather than
left to be discovered.

Also updated: `.env.example`, `k8s/README.md` (its "DoQ has no chart knob
yet" callout pointed at this issue), and DNS.md §20.2.1's per-deployment
table, including the fact that the overlay can't be merged onto the
standalone agent compose files.

## Verification

- `helm template` on both charts with the new knobs, plus `helm lint`
- `docker compose config` on the merged overlay for the `dns-technitium`
  and `dns-bind9` profiles
- 11 new tests in `test_ai_dns_zone_dnssec_gate.py`, parametrised over
  every driver the REST gate has an opinion about, so widening or
  narrowing that gate without touching the Copilot is a test failure
- `make ci` green; `ruff` / `black` clean on the touched files

Closes #798, Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)