### PR TITLE
ci: skip the backend test shards when a PR can't affect them (#813)

### DIFF
--- a/.github/scripts/ci-backend-relevant.sh
+++ b/.github/scripts/ci-backend-relevant.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Does a change set require the backend test suite? (issue #813)
+#
+# Reads changed paths on stdin, one per line. Prints "true" if the suite must
+# run, "false" if every changed path is known not to affect it.
+#
+# ── The list below is a DENY-list, and that is the whole design ──────────────
+#
+# An allow-list ("run when backend/** changes") fails open in the wrong
+# direction: a new top-level directory nobody remembered to add silently stops
+# running the tests, and the failure is invisible — a green PR that was never
+# tested. A deny-list fails the other way. Anything unrecognised runs the
+# suite, so the worst case of forgetting to update this file is a few wasted
+# runner-minutes.
+#
+# So: only add a path here when you can say why the backend suite cannot
+# possibly care about it.
+#
+# ── Why appliance/ and agent/ are NOT here ───────────────────────────────────
+#
+# They look like other people's code, but two backend tests load files out of
+# them directly:
+#
+#   backend/tests/test_spatium_console.py
+#       → appliance/mkosi.extra/usr/local/bin/spatium-console  (52 tests)
+#   backend/tests/test_appliance_firewall_render.py
+#       → agent/supervisor/spatium_supervisor/firewall_renderer.py
+#
+# Skipping the suite on an appliance-only PR would have dropped every one of
+# those. Check for new cross-boundary reads before adding either.
+#
+# ── Testability ──────────────────────────────────────────────────────────────
+#
+# Path matching lives here rather than inline in ci.yml so it can be exercised
+# without pushing a branch: backend/tests/test_ci_backend_relevant.sh.py pipes
+# synthetic change sets through it. The workflow computes the diff and pipes
+# it in; this script never shells out to git.
+
+set -euo pipefail
+
+# Paths that cannot affect the backend test suite.
+#
+#   docs/       Jekyll site + specs. No backend test reads them; the
+#               docs-diagrams job covers the SVG geometry separately.
+#   website/    Marketing site source, not built or imported by anything here.
+#   frontend/   Separate toolchain, covered by the frontend jobs.
+#   charts/     Helm templates. test_upgrades_chart_bump.py exercises the
+#               chart-bump LOGIC against inline YAML, never the real chart.
+#   k8s/        Static manifests, read by nothing in the suite.
+#   *.md        Root-level prose (README, CHANGELOG, CLAUDE.md, ...). Nested
+#               *.md are covered by their own directory's entry, or fall
+#               through and run the suite — which is the safe direction.
+#   NOTICE      Third-party attribution.
+#   LICENSE     Apache 2.0 text.
+IRRELEVANT='^(docs/|website/|frontend/|charts/|k8s/|[^/]+\.md$|NOTICE$|LICENSE$)'
+
+saw_any=0
+while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    saw_any=1
+    if ! printf '%s\n' "$path" | grep -qE "$IRRELEVANT"; then
+        # One relevant file is enough — no need to read the rest.
+        echo "true"
+        exit 0
+    fi
+done
+
+# An empty change set is not evidence that nothing needs testing; it means the
+# diff failed, the caller piped nothing, or something else went wrong upstream.
+# Run the suite.
+if [ "$saw_any" -eq 0 ]; then
+    echo "true"
+    exit 0
+fi
+
+echo "false"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,14 @@ on:
   # don't post the required check-runs the ``protect-main`` ruleset
   # waits for, so docs-only PRs (CHANGELOG bumps, README polish,
   # release-prep PRs) sit BLOCKED forever even though every code
-  # check would be a no-op. Cheaper to spend ~7 min of free runner
-  # time on a docs PR than to maintain the bypass-actor dance on
-  # every release.
+  # check would be a no-op.
+  #
+  # #813 gets the runtime back without that trade: the workflow still
+  # ALWAYS runs and always posts every check, and the expensive part
+  # (8 backend test shards, each with its own Postgres + Redis) is
+  # gated per-JOB on change detection instead. A docs-only PR now
+  # posts a green "Backend — Tests" in seconds rather than minutes,
+  # and no ruleset knows the difference.
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -21,6 +26,74 @@ permissions:
   contents: read
 
 jobs:
+  # ── Change detection (issue #813) ──────────────────────────────────────────
+  # Cheap (~15 s) job whose only output decides whether the 8 backend test
+  # shards run. Everything else in this workflow is unconditional.
+  #
+  # Deliberately NOT ``dorny/paths-filter``: a plain git diff needs no
+  # third-party action in the supply chain for something this small, and it
+  # sidesteps that action's base-ref handling on non-PR events.
+  #
+  # The matching itself lives in ``.github/scripts/ci-backend-relevant.sh`` so
+  # it can be tested without pushing a branch — see
+  # ``backend/tests/test_ci_backend_relevant.py``. Read that script's header
+  # before changing the path list; the deny-list shape is load-bearing.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.detect.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The diff is taken against the PR's merge base, so both sides of
+          # the history have to be present.
+          fetch-depth: 0
+
+      - id: detect
+        name: Does this change set need the backend suite?
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Push to main runs the full suite unconditionally: it is the
+          # post-merge safety net, and a squash-merge's diff is not the
+          # thing we filtered on when the PR was open.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "event=$EVENT — running the full backend suite"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Three dots: changes on the head branch since the merge base, not
+          # everything main has moved on by.
+          #
+          # ``--no-renames`` is load-bearing. With rename detection on (the
+          # default) ``git mv backend/thing.py docs/thing.md`` reports ONLY
+          # the destination — so a PR that deletes a backend file by moving
+          # it out of the tree would look docs-only and skip the whole suite.
+          # We want both sides of every rename in the list.
+          changed="$RUNNER_TEMP/changed-files.txt"
+          if ! git diff --no-renames --name-only "$BASE_SHA...$HEAD_SHA" > "$changed"; then
+            echo "::warning::could not diff $BASE_SHA...$HEAD_SHA — running the full backend suite"
+            echo "backend=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Changed files:"
+          sed 's/^/  /' "$changed"
+
+          relevant="$(.github/scripts/ci-backend-relevant.sh < "$changed")"
+          echo "backend=$relevant" >> "$GITHUB_OUTPUT"
+          if [ "$relevant" = "true" ]; then
+            echo "→ backend suite WILL run"
+          else
+            echo "→ nothing the backend suite covers changed; shards will be skipped"
+          fi
+
   # ── Backend ────────────────────────────────────────────────────────────────
   backend-lint:
     name: Backend — Lint & Type Check
@@ -76,6 +149,13 @@ jobs:
   backend-test-shard:
     name: Backend — Tests (shard ${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
+    # #813 — skipped when the PR touches nothing the suite covers. The
+    # aggregator below stays green in that case, so no required check
+    # notices. ``changes`` failing leaves this skipped too, and the
+    # aggregator treats THAT as a failure (it only accepts a skip that
+    # detection explicitly asked for).
+    needs: [changes]
+    if: needs.changes.outputs.backend == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -141,20 +221,41 @@ jobs:
         # 4 vCPUs, each xdist worker on its own ``spatiumddi_test_gw<N>`` DB.
         run: python -m pytest -n auto --splits 8 --group ${{ matrix.shard }}
 
-  # Required-status-check aggregator: branch protection gates on the stable
-  # name "Backend — Tests"; this job passes only if every shard did. Keep
-  # this name (and the shard count above) in sync with the required check.
+  # Aggregator that collapses the 8 shards into one stable check name,
+  # "Backend — Tests". Not currently in ``protect-main``'s required set (only
+  # the two Frontend jobs and Backend Lint are) but it is the name to point at
+  # if it ever is — which is precisely why the skip logic lives HERE and never
+  # on the shards' own check names.
+  #
+  # #813: a skip is a pass, but only the skip detection asked for.
   backend-test:
     name: Backend — Tests
     runs-on: ubuntu-latest
-    needs: [backend-test-shard]
+    needs: [changes, backend-test-shard]
     if: always()
     steps:
       - name: All shards passed
+        env:
+          SHARDS: ${{ needs.backend-test-shard.result }}
+          BACKEND_RELEVANT: ${{ needs.changes.outputs.backend }}
         run: |
-          result="${{ needs.backend-test-shard.result }}"
-          if [ "$result" != "success" ]; then
-            echo "::error::backend test shards did not all pass (result=$result)"
+          set -euo pipefail
+
+          if [ "$SHARDS" = "skipped" ]; then
+            # Only an explicit "false" justifies a skip. An empty value means
+            # the ``changes`` job itself failed or was cancelled, which took
+            # the shards down with it — that is a broken run, not a clean one,
+            # and must not report green.
+            if [ "$BACKEND_RELEVANT" != "false" ]; then
+              echo "::error::shards were skipped but change detection did not ask for it (backend='$BACKEND_RELEVANT')"
+              exit 1
+            fi
+            echo "no backend-relevant files changed — 8 shards skipped (#813)"
+            exit 0
+          fi
+
+          if [ "$SHARDS" != "success" ]; then
+            echo "::error::backend test shards did not all pass (result=$SHARDS)"
             exit 1
           fi
           echo "all 8 backend test shards passed"

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -1,0 +1,176 @@
+"""The CI change-detection filter that decides whether THIS suite runs (#813).
+
+``.github/scripts/ci-backend-relevant.sh`` gates the 8 backend test shards. A
+bug in it is uniquely bad: it doesn't fail loudly, it makes a PR go green
+without having been tested. So the path list gets pinned here rather than
+being validated by pushing branches and squinting at Actions.
+
+The circularity is deliberate and safe in the direction that matters. The
+script lives under ``.github/``, which is *not* in its own deny-list, so any
+edit to it runs the suite that contains this test.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+
+import pytest
+
+_SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[2] / ".github" / "scripts" / "ci-backend-relevant.sh"
+)
+
+# The dev container copies only ``backend/`` into the image, so these skip
+# there and run for real in CI, which tests from a full checkout. Same
+# convention as test_spatium_console.py. A deleted script is caught loudly by
+# the workflow step that invokes it, not by a silent skip here.
+pytestmark = pytest.mark.skipif(
+    not _SCRIPT.exists(),
+    reason="CI change-detection script not present in this checkout",
+)
+
+
+def _relevant(*paths: str) -> bool:
+    """Run the real script over a synthetic change set."""
+    proc = subprocess.run(
+        ["bash", str(_SCRIPT)],
+        input="".join(f"{p}\n" for p in paths),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = proc.stdout.strip()
+    assert out in ("true", "false"), f"unexpected output {out!r} (stderr: {proc.stderr})"
+    return out == "true"
+
+
+def test_script_is_executable() -> None:
+    """The workflow invokes it by path, so the +x bit has to be committed."""
+    assert _SCRIPT.stat().st_mode & 0o111, f"{_SCRIPT} is not executable"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "backend/app/main.py",
+        "backend/tests/test_health.py",
+        "backend/alembic/versions/abc123_thing.py",
+        "backend/pyproject.toml",
+    ],
+)
+def test_backend_paths_run_the_suite(path: str) -> None:
+    assert _relevant(path)
+
+
+@pytest.mark.parametrize(
+    ("path", "why"),
+    [
+        (
+            "appliance/mkosi.extra/usr/local/bin/spatium-console",
+            "test_spatium_console.py loads this file directly — 52 tests",
+        ),
+        (
+            "agent/supervisor/spatium_supervisor/firewall_renderer.py",
+            "test_appliance_firewall_render.py imports this by path",
+        ),
+    ],
+)
+def test_cross_boundary_reads_still_run_the_suite(path: str, why: str) -> None:
+    """The two directories that look unrelated but aren't.
+
+    An allow-list of ``backend/**`` would have skipped both, and the loss
+    would have been invisible — a green PR with the tests never run.
+    """
+    assert _relevant(path), why
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "docs/features/DNS.md",
+        "docs/index.md",
+        "website/index.html",
+        "frontend/src/App.tsx",
+        "frontend/package.json",
+        "charts/spatiumddi/values.yaml",
+        "k8s/base/api.yaml",
+        "CHANGELOG.md",
+        "README.md",
+        "CLAUDE.md",
+        "NOTICE",
+        "LICENSE",
+    ],
+)
+def test_known_irrelevant_paths_skip_the_suite(path: str) -> None:
+    assert not _relevant(path)
+
+
+def test_one_relevant_file_among_many_irrelevant_ones_runs_the_suite() -> None:
+    """The decision is "any", not "most" — a single backend file counts."""
+    assert _relevant(
+        "docs/features/DNS.md",
+        "CHANGELOG.md",
+        "frontend/src/App.tsx",
+        "backend/app/drivers/dns/bind9.py",
+    )
+
+
+def test_an_all_irrelevant_change_set_skips() -> None:
+    assert not _relevant("docs/a.md", "docs/b.md", "frontend/src/x.ts", "CHANGELOG.md")
+
+
+def test_an_empty_change_set_runs_the_suite() -> None:
+    """Empty is not evidence of anything.
+
+    It means the diff failed, or the caller piped nothing — both of which are
+    upstream breakage, not "there is nothing to test".
+    """
+    assert _relevant()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "terraform/main.tf",
+        "ansible/playbook.yml",
+        "perf/locustfile.py",
+        "some-new-top-level-thing/x.py",
+        "Makefile",
+        "docker-compose.yml",
+        ".github/workflows/ci.yml",
+        ".github/scripts/ci-backend-relevant.sh",
+        "scripts/lint_migrations.py",
+        ".env.example",
+    ],
+)
+def test_unrecognised_paths_default_to_running(path: str) -> None:
+    """The deny-list's whole point.
+
+    Adding a directory nobody thought about must cost runner-minutes, never
+    test coverage. If this test starts failing because someone widened the
+    deny-list, the question to answer is "can the backend suite really not
+    care about this?" — not "how do I make the test pass?".
+    """
+    assert _relevant(path)
+
+
+def test_nested_markdown_is_not_blanket_skipped() -> None:
+    """Only ROOT-level *.md is deny-listed.
+
+    ``backend/app/README.md`` is unlikely to matter, but the pattern that
+    would skip it would also skip a nested .md in a directory that does.
+    """
+    assert _relevant("backend/some/README.md")
+
+
+def test_a_file_moved_out_of_backend_still_runs_the_suite() -> None:
+    """Both sides of a rename have to reach the filter.
+
+    ``git diff --name-only`` with rename detection ON — the default —
+    reports only the DESTINATION, so ``git mv backend/thing.py
+    docs/thing.md`` reads as a docs-only change while actually deleting a
+    backend file. The workflow passes ``--no-renames`` to get both paths;
+    this pins the filter's half of that contract.
+    """
+    assert _relevant("backend/thing.py", "docs/thing.md")

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -241,7 +241,7 @@ Three of the four events have distinct jobs:
 
 | Event | Runs | Why |
 |---|---|---|
-| **Pull request** | `ci.yml`, the per-image builds (single-arch + **Trivy**), `agent-e2e.yml` | Where correctness is gated. Nothing merges without it. |
+| **Pull request** | `ci.yml` (backend shards gated on change detection — see below), the per-image builds (single-arch + **Trivy**), `agent-e2e.yml` | Where correctness is gated. Nothing merges without it. |
 | **Push to `main`** | `ci.yml`, `docs-publish.yml`, `build-appliance-builder.yml` | Post-merge safety net + the two things that must be *published* from `main`. |
 | **Release tag** | `release.yml` only | Builds and publishes every image multi-arch, the chart, and the appliance ISO. |
 | **Schedule** | `nightly.yml`, `trivy-scheduled.yml`, `prune-release-assets.yml` | Work that is about *elapsed time*, not about a change. |
@@ -267,6 +267,48 @@ Two rules follow, and both were violations once:
 run in the common case — GitHub tests the merge result — but it validates
 the actual squashed commit, and it is the only check that covers a direct
 push or a merge made with `--admin` while shards were still pending.
+
+### Skipping the backend shards on a PR that can't affect them
+
+The workflow has no `paths-ignore` and never will: a skipped workflow run
+posts none of the check-runs `protect-main` waits for, so a docs-only PR
+would sit blocked forever. What [#813](https://github.com/spatiumddi/spatiumddi/issues/813)
+added instead is **per-job** change detection, which keeps the workflow —
+and every check name — unconditional:
+
+1. A `changes` job diffs the PR against its merge base and pipes the file
+   list through [`.github/scripts/ci-backend-relevant.sh`](../.github/scripts/ci-backend-relevant.sh).
+2. The 8 `backend-test-shard` jobs are gated on its output.
+3. The `Backend — Tests` aggregator treats a skip as a pass — but **only a
+   skip that detection asked for**. An empty output (the `changes` job
+   itself failed, taking the shards with it) fails the aggregator.
+
+Push to `main` always runs the full suite; the filter applies to
+`pull_request` only.
+
+The path list is a **deny-list**, and that shape is the point. An
+allow-list (`run when backend/** changes`) fails silently in the worst
+direction — a new top-level directory nobody added stops running the
+tests, and the tell is a green PR that was never tested. A deny-list makes
+the cost of forgetting a few runner-minutes instead.
+
+Two directories look unrelated to the backend and are deliberately *not*
+deny-listed, because backend tests load files out of them by path:
+
+| Test | Reads |
+|---|---|
+| `test_spatium_console.py` (52 tests) | `appliance/mkosi.extra/usr/local/bin/spatium-console` |
+| `test_appliance_firewall_render.py` | `agent/supervisor/spatium_supervisor/firewall_renderer.py` |
+
+Check for new cross-boundary reads before widening the list.
+`backend/tests/test_ci_backend_relevant.py` pins the whole table, so
+edits to the script are exercised without pushing a branch.
+
+Not yet filtered, and each for a reason: the frontend jobs and
+`Backend — Lint` are `protect-main`'s **required** checks, and a skipped
+required check is exactly the blocked-PR failure mode above; `agent-test`
+and `appliance-test` are seconds each, so the detection would cost more
+than it saves.
 
 ### Nightly builds
 


### PR DESCRIPTION
The 8 backend shards are by far the longest thing in CI — each spins up
Postgres and Redis, installs deps, migrates, and runs its pytest-split slice.
All 8 ran on **every** PR, including docs-only, frontend-only and chart-only
ones where nothing they cover had changed.

`paths-ignore` stays off the table for the reason the file already documents:
a skipped workflow run posts none of the check-runs `protect-main` waits for,
so a docs-only PR would sit blocked forever. So the filtering moved down a
level — the workflow still always runs and still posts every check:

1. A new `changes` job diffs the PR against its merge base.
2. `backend-test-shard` is gated on its output.
3. `Backend — Tests` — the aggregator that collapses the 8 shards into one
   stable name — treats a skip as a pass, **but only a skip detection asked
   for**. An empty output means the `changes` job itself failed and took the
   shards with it: a broken run, not a clean one.

Push to `main` always runs the full suite; the filter is `pull_request` only.

## The path list is a deny-list, and that's the design

An allow-list (*"run when `backend/**` changes"*) fails silently in the worst
direction: a new top-level directory nobody remembered to add stops running
the tests, and the tell is a green PR that was never tested. A deny-list makes
the cost of forgetting a few runner-minutes instead.

Two directories look unrelated to the backend and are pointedly **not**
deny-listed, because backend tests load files out of them by path:

| Test | Reads |
|---|---|
| `test_spatium_console.py` (52 tests) | `appliance/mkosi.extra/usr/local/bin/spatium-console` |
| `test_appliance_firewall_render.py` | `agent/supervisor/spatium_supervisor/firewall_renderer.py` |

The console tests are the ones added three days ago in #803. The filter the
issue proposed — `backend/**` + compose + `Makefile` + `ci.yml` — would have
dropped both sets on an appliance-only PR.

## `--no-renames`

`git diff --name-only` with rename detection (the default) reports only the
**destination** of a rename, so `git mv backend/thing.py docs/thing.md` reads
as a docs-only change while actually deleting a backend file. Found by testing
the plumbing before committing it:

```
$ git mv backend/x.py docs/x.md && git diff --name-only HEAD~1...HEAD
docs/x.md                      # ← would have skipped the suite

$ git diff --no-renames --name-only HEAD~1...HEAD
backend/x.py
docs/x.md
```

Both the workflow flag and the filter's half of the contract are pinned by a
test.

## Not filtered, and why

The frontend jobs and `Backend — Lint` are `protect-main`'s **required**
checks, and a skipped required check is exactly the blocked-PR failure mode
above. `agent-test` and `appliance-test` are seconds each, so detection would
cost more than it saves.

Worth recording while I was in the ruleset: the old comment called
`Backend — Tests` a "required-status-check aggregator", but `protect-main`'s
required set is only `Backend — Lint & Type Check`, `Frontend — Build` and
`Frontend — Lint & Type Check`. Comment corrected. It doesn't change the
design — the skip logic belongs on the aggregator either way, precisely so
this keeps working if it's ever made required.

## Cost/benefit, honestly

The `changes` job serialises ahead of the shards, so a PR that *does* touch
the backend gets ~20-30s slower. A PR that doesn't saves ~4 min of wall clock
and 8 runners × ~4 min of compute. There's no way to gate without the
dependency.

## Verification

- 34 tests in `backend/tests/test_ci_backend_relevant.py` pin the whole path
  table and every fail-safe: empty change set, unreadable diff, unrecognised
  path, renames, root vs nested `*.md`.
- Every inline `run:` block in `ci.yml` extracted and `bash -n`'d; the
  workflow YAML parsed and the job graph asserted.
- Adversarial inputs all err toward running the suite — paths with spaces,
  git's `core.quotePath` escaping, a bare `.md`, a file literally named
  `docs`.
- `make ci` green.

Closes #813

🤖 Generated with [Claude Code](https://claude.com/claude-code)