### PR TITLE
fix(frontend): proxy /health and /metrics to the backend in the Vite dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,6 +29,22 @@ export default defineConfig({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      // Backend endpoints also live outside /api — notably
+      // /health/* (platform health) and /metrics. The production
+      // nginx config proxies these to the API (see
+      // default.conf.template → `location ~ ^/(health|metrics)`),
+      // but the Vite dev proxy only forwarded /api, so requests to
+      // /health/platform fell through to the SPA fallback and
+      // returned index.html — crashing the dashboard's platform
+      // health card. Mirror those two proxy entries here.
+      "/health": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/metrics": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## What changed
Added `/health` and `/metrics` Vite dev-server proxy entries to `frontend/vite.config.ts`, matching the production nginx config.

## Why
`platformHealthApi` fetches `/health/platform` with `baseURL: "/"` (outside `/api`). The production nginx config (`frontend/default.conf.template`, `location ~ ^/(health|metrics)`) already proxies these to the backend, but the Vite dev proxy only forwarded `/api`. So in `vite dev`, `/health/platform` fell through to the SPA fallback and returned `index.html`.

The dashboard resolved `platformHealth` to an HTML string (truthy) and rendered `<PlatformHealthCard health={platformHealth} />`, which calls `health.components.map(...)` — `undefined.map` threw. With no error boundary, that unmounted the whole React tree, so the dashboard flashed then went blank ~1s after login. Affects anyone running `npm run dev`, not just containerized setups.

## How verified
- Before: `curl http://localhost:3000/health/platform` returned `index.html`.
- After: returns the real JSON `{"status":…,"components":[…]}`; dashboard renders without crashing.
- Diff vs `origin/main` is one file, purely additive (16 lines).
