### PR TITLE
feat(frontend): add layered error boundaries to isolate dashboard crashes

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type FallbackRender = (reset: () => void) => ReactNode;
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode | FallbackRender;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * React error boundary. Catches render-time errors in descendants and renders
+ * a fallback UI instead of unmounting the whole tree.
+ *
+ * `fallback` may be a static React node or a render prop that receives a
+ * `reset` function so the UI can offer a retry button.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+    // Browser-side log only. The backend has structured JSON logging; there is
+    // no frontend telemetry pipeline yet, so console.error is the safest sink.
+    console.error("ErrorBoundary caught error:", error, info.componentStack);
+  }
+
+  reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (typeof this.props.fallback === "function") {
+        return this.props.fallback(this.reset);
+      }
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/WidgetErrorBoundary.tsx
+++ b/frontend/src/components/WidgetErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { ErrorBoundary } from "./ErrorBoundary";
+
+interface WidgetErrorBoundaryProps {
+  children: ReactNode;
+  title?: string;
+}
+
+/**
+ * Card-sized error boundary for dashboard panels and other self-contained
+ * widgets. Keeps a single failed panel from taking down the whole page.
+ */
+export function WidgetErrorBoundary({
+  children,
+  title = "This panel",
+}: WidgetErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallback={(reset) => (
+        <div className="rounded-lg border bg-card p-4" role="alert" aria-live="polite">
+          <div className="flex items-start gap-2 text-sm text-destructive">
+            <AlertTriangle
+              className="mt-0.5 h-4 w-4 shrink-0"
+              aria-hidden="true"
+            />
+            <div className="flex-1">
+              <p className="font-medium">{title} failed to load.</p>
+              <button
+                type="button"
+                onClick={reset}
+                className="mt-2 text-xs text-primary hover:underline"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { Outlet } from "react-router-dom";
+
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { DemoBanner } from "./DemoBanner";
@@ -33,7 +35,25 @@ export function AppLayout() {
         <MaintenanceModeBanner />
         <Header onMobileMenu={() => setMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
-          <Outlet />
+          <ErrorBoundary
+            fallback={
+              <div className="m-6 rounded-lg border bg-card p-6 text-center">
+                <h2 className="text-base font-semibold">This page failed to load</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Something went wrong while rendering this page.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => window.location.reload()}
+                  className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  Reload
+                </button>
+              </div>
+            }
+          >
+            <Outlet />
+          </ErrorBoundary>
         </main>
       </div>
       {/* Issue #90 — Operator Copilot floating button. Hidden when no

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { queryClient } from "@/lib/queryClient";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import App from "./App";
 import "./index.css";
 
@@ -24,7 +25,25 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <ErrorBoundary
+          fallback={
+            <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-center">
+              <h1 className="text-lg font-semibold">Something went wrong</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                The application crashed. Please reload the page.
+              </p>
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Reload
+              </button>
+            </div>
+          }
+        >
+          <App />
+        </ErrorBoundary>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </BrowserRouter>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -102,6 +102,7 @@ import { includeInUtilization } from "@/lib/utilization";
 import { useSessionState } from "@/lib/useSessionState";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { DHCPTrafficCard, DNSQueryRateCard } from "@/components/MetricsCharts";
+import { WidgetErrorBoundary } from "@/components/WidgetErrorBoundary";
 
 /**
  * Dashboard — the home page.
@@ -1533,29 +1534,51 @@ export function DashboardPage() {
               KPI row so the colour-coded health ribbon is the next
               thing the eye lands on after the headline counters). ──── */}
         {tab === "overview" && platformHealth && (
-          <PlatformHealthCard health={platformHealth} />
+          <WidgetErrorBoundary title="Platform health">
+            <PlatformHealthCard health={platformHealth} />
+          </WidgetErrorBoundary>
         )}
 
         {/* ── Network overview cards (Overview tab) ─────────────────── */}
         {tab === "overview" && (
           <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
-            <AsnSummaryCard />
-            <VrfSummaryCard />
-            <DomainsSummaryCard />
-            <SubnetDecomCard />
-            <LookingGlassHealthCard />
+            <WidgetErrorBoundary title="ASN summary">
+              <AsnSummaryCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="VRF summary">
+              <VrfSummaryCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="Domain summary">
+              <DomainsSummaryCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="Subnet decomposition">
+              <SubnetDecomCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="Looking Glass health">
+              <LookingGlassHealthCard />
+            </WidgetErrorBoundary>
           </div>
         )}
 
         {/* ── DNS query rate (DNS tab only) ──────────────────────────── */}
-        {tab === "dns" && <DNSQueryRateCard dnsServers={allDnsServers} />}
+        {tab === "dns" && (
+          <WidgetErrorBoundary title="DNS query rate">
+            <DNSQueryRateCard dnsServers={allDnsServers} />
+          </WidgetErrorBoundary>
+        )}
 
         {/* ── DHCP traffic (DHCP tab only) ───────────────────────────── */}
-        {tab === "dhcp" && <DHCPTrafficCard dhcpServers={dhcpServers} />}
+        {tab === "dhcp" && (
+          <WidgetErrorBoundary title="DHCP traffic">
+            <DHCPTrafficCard dhcpServers={dhcpServers} />
+          </WidgetErrorBoundary>
+        )}
 
         {/* ── Heatmap (Overview + IPAM) ──────────────────────────────── */}
         {(tab === "overview" || tab === "ipam") && (
-          <SubnetHeatmap subnets={reporting} />
+          <WidgetErrorBoundary title="Subnet heatmap">
+            <SubnetHeatmap subnets={reporting} />
+          </WidgetErrorBoundary>
         )}
 
         {/* ── IPAM-specific summary cards ───────────────────────────── */}


### PR DESCRIPTION
## What changed

Added a generic `ErrorBoundary` class component and a `WidgetErrorBoundary` wrapper, then applied them at three layers:

1. **Top-level** in `frontend/src/main.tsx` — wraps `<App />` so a total crash shows a reloadable fallback instead of a blank page.
2. **Route-level** in `frontend/src/components/layout/AppLayout.tsx` — wraps `<Outlet />` so a route that crashes keeps the sidebar and header intact.
3. **Widget-level** in `frontend/src/pages/DashboardPage.tsx` — wraps the major dashboard cards (`PlatformHealthCard`, `AsnSummaryCard`, `VrfSummaryCard`, `DomainsSummaryCard`, `SubnetDecomCard`, `LookingGlassHealthCard`, `DNSQueryRateCard`, `DHCPTrafficCard`, `SubnetHeatmap`) so a single bad panel shows its own error card and the rest of the dashboard keeps rendering.

## Why

The Vite dev proxy fix (#817) stops `/health/platform` from returning `index.html`, but the dashboard still has multiple panels that call `.map()` or traverse API data without runtime guards. A single malformed response (or any future render-time bug) currently throws `undefined.map` and unmounts the whole React tree. Error boundaries are defense-in-depth: they confine a crash to the widget that caused it and keep the rest of the app usable.

## How verified

- `npm run typecheck` — passed.
- `npm run lint` — passed.
- `npm run build` — passed.
- Wrote a temporary `jsdom` + `createRoot` integration test that confirmed both `ErrorBoundary` and `WidgetErrorBoundary` catch render-time errors and display the expected fallback UI. The test script and the temporary `jsdom` install were removed afterward.
- Started `npm run dev` and confirmed the dev server serves `index.html` at `http://127.0.0.1:5173/` with HTTP 200.

This is intended to land after #817 (the Vite proxy fix) but does not depend on it.
