### PR TITLE
fix(ci): clear the looking-glass Trivy HIGHs + let the nightly report its own failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -351,6 +351,11 @@ jobs:
         if: needs.images.result == 'success' && github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job has no checkout, so `gh` cannot infer the repo from git
+          # remotes — without GH_REPO every call dies with "not a git
+          # repository" (which is how the first nightly failed to report
+          # its own failure).
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
@@ -380,6 +385,7 @@ jobs:
         if: needs.gate.result == 'failure' || needs.images.result == 'failure' || needs.prune.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}  # no checkout in this job — see above
         run: |
           set -euo pipefail
           TITLE="Nightly build failing"

--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -53,9 +53,15 @@ RUN git clone --depth 1 --branch "v${GOBGP_VERSION}" https://github.com/osrg/gob
 # Bump vulnerable transitive deps above the versions gobgp pins so Trivy
 # (HIGH/CRITICAL) stays green. gobgp v4.7.0 pins golang.org/x/net v0.48,
 # which carries several HIGH CVEs (html XSS, IDNA punycode privilege
-# escalation, HTTP/2 DoS — fixed in 0.55). Re-check + drop/bump this pin
-# when GoBGP's own go.mod moves past it.
-RUN go get golang.org/x/net@v0.56.0
+# escalation, HTTP/2 DoS — fixed in 0.55); x/text v0.38 carries
+# CVE-2026-56852 (norm.Iter infinite loop, fixed in 0.39); grpc-go
+# v1.79.3 carries GHSA-hrxh-6v49-42gf (xDS RBAC + HTTP/2, fixed in
+# 1.82.1). Re-check + drop/bump these pins when GoBGP's own go.mod moves
+# past them.
+RUN go get \
+      golang.org/x/net@v0.57.0 \
+      golang.org/x/text@v0.40.0 \
+      google.golang.org/grpc@v1.83.0
 ENV CGO_ENABLED=0
 RUN GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
       go build -trimpath -ldflags="-s -w" -o /out/gobgpd ./cmd/gobgpd \


### PR DESCRIPTION
Closes #819

The first nightly run ([30788510353](https://github.com/spatiumddi/spatiumddi/actions/runs/30788510353)) failed twice over; this fixes both.

## looking-glass Trivy HIGHs

GoBGP v4.7.0 pins two vulnerable transitive deps that get compiled into `gobgp`/`gobgpd`:

| Module | Installed | Finding | Fixed in | Bumped to |
|---|---|---|---|---|
| `golang.org/x/text` | v0.38.0 | CVE-2026-56852 (`norm.Iter` infinite loop) | 0.39.0 | **v0.40.0** |
| `google.golang.org/grpc` | v1.79.3 | GHSA-hrxh-6v49-42gf (xDS RBAC + HTTP/2) | 1.82.1 | **v1.83.0** |

Bumped via the existing `go get` pin in the build stage (latest of the major, not the minimum fixing version), plus `x/net` 0.56 → 0.57 in the same line.

Verified locally:
- image builds; CI's exact Trivy gate (`--severity HIGH,CRITICAL --ignore-unfixed --exit-code 1`) reports **0 findings** on every target including both gobinaries
- `gobgpd` boots with the idle config and serves the `gobgp -j neighbor` gRPC healthcheck (the exact surface the grpc bump touches)

## Finalize job couldn't use `gh` at all

The Finalize job has no checkout step, so `gh` has no repo context and every call died with `fatal: not a git repository` — the failing nightly could not open its own tracking issue (#819 was filed by hand), and even a *green* run would have failed the same way on the pre-release-record step. Fixed by setting `GH_REPO: ${{ github.repository }}` on both steps. The prune job is unaffected (`gh api` with absolute paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)