### PR TITLE
ci: deny agent/, appliance/ and .github/ in the backend-test gate, with enforced carve-outs

### DIFF
--- a/.github/scripts/ci-backend-must-run.txt
+++ b/.github/scripts/ci-backend-must-run.txt
@@ -1,0 +1,32 @@
+# Paths OUTSIDE backend/ that must run the backend test suite (#821).
+#
+# ci-backend-relevant.sh checks these prefixes BEFORE its deny-list, so a
+# subtree can be denied wholesale (agent/, appliance/, .github/) while the
+# specific files the suite actually depends on keep running it.
+#
+# One prefix per line; a line ending in "/" matches the whole subtree,
+# otherwise it is a plain prefix (in practice: an exact file). Blank lines
+# and "#" comments are ignored.
+#
+# This file is enforced against reality in both directions by
+# backend/tests/test_ci_backend_relevant.py:
+#   - every entry must exist on disk (no stale carve-outs), and
+#   - every repo-root escape in backend/tests (a ``parents[2+]`` read) must
+#     be covered by an entry here — so a new cross-boundary read that nobody
+#     declared fails the suite loudly instead of silently losing coverage.
+# Editing THIS file runs the suite too (it lives under .github/scripts/).
+
+# test_spatium_console.py loads the console script directly — 52 tests.
+appliance/mkosi.extra/usr/local/bin/
+
+# test_appliance_firewall_render.py imports the renderer by path.
+agent/supervisor/spatium_supervisor/
+
+# The gate machinery itself: the script, this manifest, and the tests that
+# pin them. Any edit here must run the suite that contains those tests.
+.github/scripts/
+
+# The workflow that orchestrates the shards. Not a "read", but a change to
+# how the suite is invoked should exercise the suite. Other workflows are
+# denied — none of them runs backend tests.
+.github/workflows/ci.yml

--- a/.github/scripts/ci-backend-relevant.sh
+++ b/.github/scripts/ci-backend-relevant.sh
@@ -1,39 +1,55 @@
 #!/usr/bin/env bash
 #
-# Does a change set require the backend test suite? (issue #813)
+# Does a change set require the backend test suite? (issues #813, #821)
 #
 # Reads changed paths on stdin, one per line. Prints "true" if the suite must
 # run, "false" if every changed path is known not to affect it.
 #
-# ── The list below is a DENY-list, and that is the whole design ──────────────
+# ── Two lists, checked in order ──────────────────────────────────────────────
 #
-# An allow-list ("run when backend/** changes") fails open in the wrong
-# direction: a new top-level directory nobody remembered to add silently stops
-# running the tests, and the failure is invisible — a green PR that was never
-# tested. A deny-list fails the other way. Anything unrecognised runs the
-# suite, so the worst case of forgetting to update this file is a few wasted
-# runner-minutes.
+# 1. ci-backend-must-run.txt (sibling file) — prefixes OUTSIDE backend/ that
+#    must run the suite anyway: files backend tests read directly, plus the
+#    gate machinery itself. Checked FIRST, so a subtree can be denied below
+#    while the specific paths the suite depends on keep running it. The
+#    manifest is enforced against reality by
+#    backend/tests/test_ci_backend_relevant.py — a scan fails when a backend
+#    test grows a new repo-root read that isn't declared, so the carve-outs
+#    cannot go stale in the direction that loses coverage.
 #
-# So: only add a path here when you can say why the backend suite cannot
-# possibly care about it.
+# 2. The IRRELEVANT deny-list below. An allow-list ("run when backend/**
+#    changes") fails open in the wrong direction: a new top-level directory
+#    nobody remembered to add silently stops running the tests, and the
+#    failure is invisible — a green PR that was never tested. A deny-list
+#    fails the other way. Anything unrecognised runs the suite, so the worst
+#    case of forgetting to update this file is a few wasted runner-minutes.
 #
-# ── Why appliance/ and agent/ are NOT here ───────────────────────────────────
+# So: only add a path to the deny-list when you can say why the backend suite
+# cannot possibly care about it — and if a denied subtree contains something
+# the suite DOES care about, declare that in the manifest instead of undoing
+# the deny.
 #
-# They look like other people's code, but two backend tests load files out of
-# them directly:
+# ── Why agent/, appliance/ and .github/ are denied WITH carve-outs ───────────
+#
+# All three used to run the suite wholesale (#813 left them off the deny-list)
+# because a handful of backend tests read files out of them:
 #
 #   backend/tests/test_spatium_console.py
 #       → appliance/mkosi.extra/usr/local/bin/spatium-console  (52 tests)
 #   backend/tests/test_appliance_firewall_render.py
 #       → agent/supervisor/spatium_supervisor/firewall_renderer.py
+#   backend/tests/test_ci_backend_relevant.py
+#       → this script + its manifest
 #
-# Skipping the suite on an appliance-only PR would have dropped every one of
-# those. Check for new cross-boundary reads before adding either.
+# Those reads are now declared in the manifest, which lets the rest of each
+# subtree skip: the agent packages and appliance image have their own
+# unconditional jobs (Agent — Tests, Appliance — Tests), and no workflow
+# other than ci.yml runs backend tests. If the backend shards ever move to a
+# different workflow file, add it to the manifest.
 #
 # ── Testability ──────────────────────────────────────────────────────────────
 #
 # Path matching lives here rather than inline in ci.yml so it can be exercised
-# without pushing a branch: backend/tests/test_ci_backend_relevant.sh.py pipes
+# without pushing a branch: backend/tests/test_ci_backend_relevant.py pipes
 # synthetic change sets through it. The workflow computes the diff and pipes
 # it in; this script never shells out to git.
 
@@ -48,17 +64,48 @@ set -euo pipefail
 #   charts/     Helm templates. test_upgrades_chart_bump.py exercises the
 #               chart-bump LOGIC against inline YAML, never the real chart.
 #   k8s/        Static manifests, read by nothing in the suite.
+#   agent/      Agent packages, covered by the Agent — Tests jobs. The one
+#               subtree backend tests read from is carved out in the manifest.
+#   appliance/  Image build tree, covered by Appliance — Tests. The host
+#               scripts backend tests load are carved out in the manifest.
+#   .github/    Workflows + repo config. ci.yml and the gate machinery are
+#               carved out in the manifest; nothing else here runs the suite.
 #   *.md        Root-level prose (README, CHANGELOG, CLAUDE.md, ...). Nested
 #               *.md are covered by their own directory's entry, or fall
 #               through and run the suite — which is the safe direction.
 #   NOTICE      Third-party attribution.
 #   LICENSE     Apache 2.0 text.
-IRRELEVANT='^(docs/|website/|frontend/|charts/|k8s/|[^/]+\.md$|NOTICE$|LICENSE$)'
+IRRELEVANT='^(docs/|website/|frontend/|charts/|k8s/|agent/|appliance/|\.github/|[^/]+\.md$|NOTICE$|LICENSE$)'
+
+# Load the must-run carve-outs. A missing or unreadable manifest fails toward
+# running the suite — same direction as every other failure here.
+MANIFEST="$(dirname "${BASH_SOURCE[0]}")/ci-backend-must-run.txt"
+MUST_RUN=()
+if [ -r "$MANIFEST" ]; then
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        # Trim surrounding whitespace without forking a process per line.
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [ -n "$line" ] && MUST_RUN+=("$line")
+    done < "$MANIFEST"
+else
+    echo "true"
+    exit 0
+fi
 
 saw_any=0
 while IFS= read -r path; do
     [ -n "$path" ] || continue
     saw_any=1
+    for prefix in "${MUST_RUN[@]}"; do
+        case "$path" in
+            "$prefix"*)
+                echo "true"
+                exit 0
+                ;;
+        esac
+    done
     if ! printf '%s\n' "$path" | grep -qE "$IRRELEVANT"; then
         # One relevant file is enough — no need to read the rest.
         echo "true"

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -1,4 +1,4 @@
-"""The CI change-detection filter that decides whether THIS suite runs (#813).
+"""The CI change-detection filter that decides whether THIS suite runs (#813, #821).
 
 ``.github/scripts/ci-backend-relevant.sh`` gates the 8 backend test shards. A
 bug in it is uniquely bad: it doesn't fail loudly, it makes a PR go green
@@ -6,20 +6,49 @@ without having been tested. So the path list gets pinned here rather than
 being validated by pushing branches and squinting at Actions.
 
 The circularity is deliberate and safe in the direction that matters. The
-script lives under ``.github/``, which is *not* in its own deny-list, so any
-edit to it runs the suite that contains this test.
+script and its must-run manifest live under ``.github/scripts/``, which the
+manifest itself declares as must-run — so any edit to the gate runs the suite
+that contains this test.
+
+Since #821 the deny-list covers ``agent/``, ``appliance/`` and ``.github/``
+with carve-outs declared in ``ci-backend-must-run.txt``. Two tests here keep
+that manifest honest: every entry must exist on disk, and every repo-root
+escape in this test suite (a ``parents[2+]`` read) must be covered by an
+entry — so a new cross-boundary read that nobody declared fails loudly
+instead of silently losing coverage.
 """
 
 from __future__ import annotations
 
 import pathlib
+import re
 import subprocess
 
 import pytest
 
-_SCRIPT = (
-    pathlib.Path(__file__).resolve().parents[2] / ".github" / "scripts" / "ci-backend-relevant.sh"
-)
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / ".github" / "scripts" / "ci-backend-relevant.sh"
+_MANIFEST = _REPO_ROOT / ".github" / "scripts" / "ci-backend-must-run.txt"
+
+# Every file in backend/tests that reaches OUTSIDE backend/ (via a
+# ``parents[2]``-or-deeper path), mapped to what it reads. The scan test below
+# fails when this map and reality disagree in either direction, and the
+# coverage test pushes each read through the real gate script. Declaring a new
+# entry here is only half the job — the read's prefix must also be in
+# ci-backend-must-run.txt, or the gate would skip the suite on the very
+# changes that break the test doing the reading.
+_KNOWN_REPO_ROOT_READS: dict[str, str] = {
+    "test_spatium_console.py": "appliance/mkosi.extra/usr/local/bin/spatium-console",
+    "test_appliance_firewall_render.py": (
+        "agent/supervisor/spatium_supervisor/firewall_renderer.py"
+    ),
+    "test_ci_backend_relevant.py": ".github/scripts/ci-backend-relevant.sh",
+}
+
+# ``parents[2]`` from backend/tests/x.py is the repo root; anything at that
+# depth or deeper escapes backend/. ``parents[1]`` (backend/) is in-tree and
+# deliberately not matched.
+_ESCAPE_RE = re.compile(r"parents\[[2-9]\]")
 
 # The dev container copies only ``backend/`` into the image, so these skip
 # there and run for real in CI, which tests from a full checkout. Same
@@ -43,6 +72,15 @@ def _relevant(*paths: str) -> bool:
     out = proc.stdout.strip()
     assert out in ("true", "false"), f"unexpected output {out!r} (stderr: {proc.stderr})"
     return out == "true"
+
+
+def _manifest_entries() -> list[str]:
+    entries = []
+    for raw in _MANIFEST.read_text().splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            entries.append(line)
+    return entries
 
 
 def test_script_is_executable() -> None:
@@ -74,13 +112,26 @@ def test_backend_paths_run_the_suite(path: str) -> None:
             "agent/supervisor/spatium_supervisor/firewall_renderer.py",
             "test_appliance_firewall_render.py imports this by path",
         ),
+        (
+            ".github/scripts/ci-backend-relevant.sh",
+            "the gate itself — an edit must run the suite that pins it",
+        ),
+        (
+            ".github/scripts/ci-backend-must-run.txt",
+            "the carve-out manifest — an edit must run the tests that enforce it",
+        ),
+        (
+            ".github/workflows/ci.yml",
+            "the workflow that orchestrates the shards",
+        ),
     ],
 )
-def test_cross_boundary_reads_still_run_the_suite(path: str, why: str) -> None:
-    """The two directories that look unrelated but aren't.
+def test_must_run_carveouts_run_the_suite(path: str, why: str) -> None:
+    """Paths inside denied subtrees that the manifest carves back in.
 
-    An allow-list of ``backend/**`` would have skipped both, and the loss
-    would have been invisible — a green PR with the tests never run.
+    An allow-list of ``backend/**`` would have skipped every one of these,
+    and the loss would have been invisible — a green PR with the tests never
+    run.
     """
     assert _relevant(path), why
 
@@ -103,6 +154,33 @@ def test_cross_boundary_reads_still_run_the_suite(path: str, why: str) -> None:
     ],
 )
 def test_known_irrelevant_paths_skip_the_suite(path: str) -> None:
+    assert not _relevant(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        # The concrete change set that motivated #821: a nightly-workflow +
+        # looking-glass-Dockerfile PR ran all 8 shards for nothing.
+        ".github/workflows/nightly.yml",
+        "agent/looking-glass/images/gobgp/Dockerfile",
+        ".github/workflows/release.yml",
+        ".github/workflows/build-dns-images.yml",
+        ".github/dependabot.yml",
+        "agent/dns/spatium_dns_agent/sync.py",
+        "agent/dhcp/images/kea/Dockerfile",
+        "agent/looking-glass/spatium_lg_agent/rib.py",
+        "appliance/mkosi.conf",
+        "appliance/mkosi.extra/etc/motd",
+    ],
+)
+def test_denied_subtrees_skip_the_suite(path: str) -> None:
+    """agent/, appliance/ and .github/ outside the carve-outs (#821).
+
+    These have their own coverage — Agent — Tests, Appliance — Tests, and
+    per-image build workflows — and nothing in the backend suite reads them
+    (enforced by test_repo_root_escapes_match_the_declared_map below).
+    """
     assert not _relevant(path)
 
 
@@ -138,8 +216,6 @@ def test_an_empty_change_set_runs_the_suite() -> None:
         "some-new-top-level-thing/x.py",
         "Makefile",
         "docker-compose.yml",
-        ".github/workflows/ci.yml",
-        ".github/scripts/ci-backend-relevant.sh",
         "scripts/lint_migrations.py",
         ".env.example",
     ],
@@ -174,3 +250,57 @@ def test_a_file_moved_out_of_backend_still_runs_the_suite() -> None:
     this pins the filter's half of that contract.
     """
     assert _relevant("backend/thing.py", "docs/thing.md")
+
+
+# ── Manifest enforcement (#821) ──────────────────────────────────────────────
+# The deny-list only stays safe because the carve-out manifest cannot drift
+# from what the suite actually reads. These three tests are that guarantee.
+
+
+def test_manifest_entries_exist_on_disk() -> None:
+    """No stale carve-outs.
+
+    A prefix that matches nothing is not harmless: it documents a dependency
+    that no longer exists, and the next person widening the deny-list will
+    trust it.
+    """
+    entries = _manifest_entries()
+    assert entries, f"{_MANIFEST} parsed to nothing"
+    for entry in entries:
+        target = _REPO_ROOT / entry.rstrip("/")
+        assert target.exists(), f"manifest entry {entry!r} matches nothing on disk"
+
+
+def test_repo_root_escapes_match_the_declared_map() -> None:
+    """Every ``parents[2+]`` read in backend/tests is declared, and nothing else.
+
+    This is what makes denying agent/ and appliance/ safe: a new test that
+    reaches outside backend/ fails HERE with instructions, instead of the
+    gate silently skipping the suite on the paths that test depends on. A
+    comment or string that merely mentions ``parents[2]`` trips the scan too —
+    that is the conservative direction; reword it or declare it.
+    """
+    found = {
+        p.name
+        for p in (_REPO_ROOT / "backend" / "tests").rglob("*.py")
+        if _ESCAPE_RE.search(p.read_text())
+    }
+    declared = set(_KNOWN_REPO_ROOT_READS)
+    assert found == declared, (
+        f"repo-root escapes changed: undeclared={sorted(found - declared)} "
+        f"stale={sorted(declared - found)}. Update _KNOWN_REPO_ROOT_READS and, "
+        f"for new reads, add a covering prefix to {_MANIFEST.name}."
+    )
+
+
+def test_every_declared_read_is_covered_by_the_manifest() -> None:
+    """The declared reads must actually run the suite through the real gate.
+
+    Goes through the script rather than string-matching the manifest so the
+    whole chain is exercised: read → manifest prefix → gate verdict.
+    """
+    for test_file, read_path in _KNOWN_REPO_ROOT_READS.items():
+        assert _relevant(read_path), (
+            f"{test_file} reads {read_path}, but the gate would skip the "
+            f"suite on that path — add a covering prefix to {_MANIFEST.name}"
+        )


### PR DESCRIPTION
Closes #821

The #813 gate left `agent/`, `appliance/` and `.github/` off its deny-list because a handful of backend tests read files out of them — so a PR touching only a nightly workflow + a looking-glass Dockerfile (#820) ran all 8 backend shards for nothing. This implements directions 1+2 from the issue together: the carve-outs, made safe by enforcement.

## What changed

- **New manifest `.github/scripts/ci-backend-must-run.txt`** — the four prefixes outside `backend/` that must run the suite, each with its rationale inline:
  - `appliance/mkosi.extra/usr/local/bin/` — `test_spatium_console.py` loads the console script directly (52 tests)
  - `agent/supervisor/spatium_supervisor/` — `test_appliance_firewall_render.py` imports the renderer by path
  - `.github/scripts/` — the gate machinery itself (script + manifest + preserves the deliberate circularity from #813)
  - `.github/workflows/ci.yml` — the workflow that orchestrates the shards
- **`ci-backend-relevant.sh`** checks manifest prefixes *before* the deny-list, then denies `agent/`, `appliance/` and `.github/` wholesale. A missing/unreadable manifest fails toward running, same as every other failure path.
- **Enforcement** (the part that makes the deny safe): `test_ci_backend_relevant.py` gains three tests that keep the manifest honest in both directions —
  - every manifest entry must exist on disk (no stale carve-outs);
  - a scan of `backend/tests` for repo-root escapes (`parents[2+]` reads) must exactly match a declared map — a new undeclared cross-boundary read fails the suite loudly with instructions, instead of the gate silently skipping the coverage that read represents;
  - each declared read is pushed through the real script, so the whole chain (read → manifest prefix → gate verdict) is exercised.

## Invariants kept from #813

- Unrecognised paths still default to running (`terraform/`, `Makefile`, new top-level dirs → suite runs).
- Matching stays testable without pushing a branch.
- Editing the gate, the manifest, or ci.yml runs the suite that pins them.

## Verified

- All 48 gate test cases pass (driven on the host; the file skips in the dev container and runs for real in CI).
- The exact #820 change set (`.github/workflows/nightly.yml` + `agent/looking-glass/images/gobgp/Dockerfile`) now returns `false`.
- A canary undeclared `parents[2]` escape trips the scan test.
- `bash -n`, shellcheck, ruff, black, mypy all clean.

Not pursued: direction 3 from the issue (per-shard scoping instead of all-or-nothing). Re-file if the remaining shard cost ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)