### PR TITLE
ci(nightly): build + attach the appliance ISO and slot image via a shared reusable workflow

### DIFF
--- a/.github/workflows/build-appliance.yml
+++ b/.github/workflows/build-appliance.yml
@@ -1,0 +1,292 @@
+name: Build appliance (reusable)
+
+# Reusable appliance ISO + slot-image build (#823).
+#
+# ONE copy of the most safety-critical assembly in the repo — fetch-k3s,
+# three chart bakes, the ghcr image bake, mkosi in the privileged builder
+# container, ISO wrap, slot compression — invoked by BOTH release.yml (on a
+# CalVer tag) and nightly.yml (daily from main). That sharing is the whole
+# point: before #823 these steps only ever ran when a release was cut, so a
+# regression in any of them sat invisible until the worst possible moment.
+# The nightly now exercises the exact code path the next release will run.
+#
+# Callers differ only in the inputs:
+#
+#   release: version = image_tag = the CalVer tag; stable_copies on, so the
+#            un-versioned spatiumddi-appliance-amd64.* names exist for the
+#            /releases/latest/download/ stable URLs.
+#   nightly: version is the gate's non-CalVer stamp string, image_tag is
+#            the immutable nightly-YYYYMMDD date tag (never the mutable
+#            :nightly pointer — the bake must record which bytes it baked);
+#            stable_copies off, short artifact retention, and the caller
+#            renames to its own nightly asset names at attach time.
+#
+# The GITHUB_TOKEN is implicitly available to a called workflow; its
+# permissions come from the CALLER's job (needs contents: read +
+# packages: read for the ghcr pulls).
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: >-
+          Version string stamped into /etc/spatiumddi/appliance-release
+          (surfaced by spatiumddi-firstboot / spatium-upgrade-slot /
+          spatium-console as APPLIANCE_VERSION).
+        required: true
+        type: string
+      image_tag:
+        description: >-
+          ghcr.io tag to pull for the baked container images, and the
+          version component of every artifact filename.
+        required: true
+        type: string
+      stable_copies:
+        description: >-
+          Also emit the un-versioned spatiumddi-appliance-amd64.* copies
+          that /releases/latest/download/ URLs point at.
+        required: false
+        type: boolean
+        default: true
+      artifact_retention_days:
+        description: Retention for the appliance-artifacts upload.
+        required: false
+        type: number
+        default: 7
+    outputs:
+      iso_name:
+        description: Filename of the versioned ISO.
+        value: ${{ jobs.build.outputs.iso_name }}
+      slot_name:
+        description: Filename of the versioned slot .raw.xz.
+        value: ${{ jobs.build.outputs.slot_name }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  # #170 Phase A4 — the ISO is **fully baked**: every image the appliance
+  # can run is pulled from ghcr.io at ``image_tag``, saved as a zstd
+  # tarball under ``mkosi.extra/usr/local/share/spatiumddi/images/``
+  # BEFORE mkosi runs, and ends up inside the rootfs. Firstboot ``docker
+  # load``s them and skips ``docker pull`` entirely — air-gap support out
+  # of the box, container-version drift from the OS slot becomes
+  # structurally impossible. Callers therefore must not invoke this until
+  # every image exists at ``image_tag`` (both callers ``needs:`` their
+  # image-build jobs).
+  build:
+    name: Build appliance ISO
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      iso_name: ${{ steps.wrap.outputs.iso_name }}
+      slot_name: ${{ steps.slot.outputs.slot_name }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Stamp /etc/spatiumddi/appliance-release
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          # Drop the build-time version stamp into mkosi.extra so it
+          # gets baked into the rootfs at build. ``spatiumddi-firstboot``
+          # + ``spatium-upgrade-slot`` + ``spatium-console`` all read
+          # this file to surface APPLIANCE_VERSION. Without this stamp
+          # every built appliance reports the placeholder "0.1.0"
+          # regardless of which ISO it came from.
+          mkdir -p appliance/mkosi.extra/etc/spatiumddi
+          {
+              echo "APPLIANCE_VERSION=\"${VERSION}\""
+              echo "BUILD_TIME=\"$(date -u -Iseconds)\""
+              echo "GIT_SHA=\"${GITHUB_SHA}\""
+          } > appliance/mkosi.extra/etc/spatiumddi/appliance-release
+          echo "→ Stamped appliance-release:"
+          cat appliance/mkosi.extra/etc/spatiumddi/appliance-release
+      - name: Install zstd
+        run: sudo apt-get update && sudo apt-get install -y zstd
+      - name: Install helm
+        # Use the upstream-published azure/setup-helm action — it
+        # downloads the helm static binary from get.helm.sh (which
+        # resolves via the GitHub Releases CDN; reachable from the
+        # Azure runner). The Helm-stable apt repo at baltocdn.com is
+        # NOT reachable from GitHub Actions runners ("Could not resolve
+        # host: baltocdn.com" — Azure runner network policy).
+        # bake-chart.sh shells out to ``helm package`` so helm must be
+        # on PATH before the chart-bake step.
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.20.2
+      - name: Fetch k3s binary + airgap tarball
+        run: |
+          set -euo pipefail
+          # Issue #183 — without this step the slot rootfs ships zero
+          # k3s, ``/usr/local/bin/k3s`` is missing on every appliance,
+          # ``k3s.service`` crash-loops, firstboot wedges forever at
+          # "Waiting for k3s /readyz". Mirrors what
+          # ``make appliance-fetch-k3s`` does locally.
+          chmod +x appliance/scripts/fetch-k3s.sh
+          appliance/scripts/fetch-k3s.sh
+          ls -lh appliance/mkosi.extra/usr/local/bin/k3s
+          ls -lh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/k3s-airgap-images-*.tar.zst
+      - name: Bake helm charts (appliance + control)
+        run: |
+          set -euo pipefail
+          # Issue #183 — without these steps the slot rootfs ships an
+          # empty /usr/lib/spatiumddi/charts/ directory; firstboot's
+          # WARN "missing — control plane won't auto-deploy" fires and
+          # the appliance never installs anything via the HelmChart CR.
+          # Mirrors ``make appliance-bake-chart appliance-bake-control-chart
+          # appliance-bake-metallb-chart``.
+          chmod +x appliance/scripts/bake-chart.sh
+          appliance/scripts/bake-chart.sh
+          CHART_NAME=spatiumddi appliance/scripts/bake-chart.sh
+          # #272 — the control-plane VIP ships in its own spatiumddi-metallb
+          # chart (deployed to metallb-system); firstboot renders a
+          # spatium-metallb HelmChart that references this .tgz. Without it
+          # MetalLB never deploys on a built appliance.
+          CHART_NAME=spatiumddi-metallb appliance/scripts/bake-chart.sh
+          ls -lh appliance/mkosi.extra/usr/lib/spatiumddi/charts/*.tgz
+      - name: Bake container images into rootfs overlay
+        env:
+          SPATIUMDDI_VERSION: ${{ inputs.image_tag }}
+          BAKE_SOURCE: ghcr
+        run: |
+          set -euo pipefail
+          echo "→ Pulling every image at ${SPATIUMDDI_VERSION} + baking per-image tarballs"
+          chmod +x appliance/scripts/bake-images.sh
+          # Post-#183 bake script writes per-image zst tarballs to
+          # ``appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/``
+          # which k3s auto-imports at startup. The pre-#183 path that
+          # built a single ``docker-overlay.img`` overlay file via a
+          # docker:dind sandbox is gone (no docker on the appliance
+          # post-Phase-7).
+          # ``sudo -E`` preserves SPATIUMDDI_VERSION + BAKE_SOURCE
+          # from the job env. Without ``-E``, sudo strips them and
+          # bake-images.sh falls back to its ``SPATIUMDDI_VERSION=dev``
+          # / ``BAKE_SOURCE=local`` defaults — which then fails on the
+          # runner with "no local image found" because no :dev tags
+          # exist (the runner pulls from ghcr, not local).
+          #
+          # ``DOCKER_CONFIG=$HOME/.docker`` re-points root's docker CLI
+          # at the runner-user's ``~/.docker/config.json`` where the
+          # docker/login-action step above stamped the GHCR creds. Our
+          # ghcr.io/spatiumddi/* images are private; without this redirect
+          # root would docker-pull anonymously and 401 on every image.
+          sudo DOCKER_CONFIG="$HOME/.docker" -E appliance/scripts/bake-images.sh
+          echo "→ Baked image tarballs:"
+          ls -lh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/*.tar.zst
+          echo "→ Total size:"
+          du -sh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/
+      - name: Build raw image (mkosi)
+        run: |
+          set -euo pipefail
+          BUILDER=${{ env.IMAGE_PREFIX }}/appliance-builder:latest
+          echo "→ Pulling $BUILDER"
+          docker pull "$BUILDER"
+          mkdir -p appliance/build
+          echo "→ Running mkosi build (this takes 5–10 min)"
+          docker run --rm --privileged \
+            -v "$PWD/appliance:/work" \
+            "$BUILDER" \
+            --output-directory=build --force build
+          ls -lh appliance/build/
+      - name: Wrap as hybrid USB/CD ISO
+        id: wrap
+        env:
+          TAG: ${{ inputs.image_tag }}
+          STABLE_COPIES: ${{ inputs.stable_copies }}
+        run: |
+          set -euo pipefail
+          BUILDER=${{ env.IMAGE_PREFIX }}/appliance-builder:latest
+          RAW=$(ls appliance/build/spatiumddi-appliance*.raw | head -1)
+          [ -f "$RAW" ] || { echo "✗ no raw image found"; exit 1; }
+          ISO_INTERIM="${RAW%.raw}.iso"
+          docker run --rm --privileged \
+            --entrypoint /work/scripts/wrap-iso.sh \
+            -v "$PWD/appliance:/work" \
+            "$BUILDER" \
+            "/work/build/$(basename "$RAW")" \
+            "/work/build/$(basename "$ISO_INTERIM")"
+          # Up to two copies emitted:
+          #   - Versioned (archive trail — for a release, of every release
+          #     ever cut)
+          #   - Stable filename (un-versioned, so the README can link to
+          #     https://.../releases/latest/download/spatiumddi-appliance-amd64.iso
+          #     and that URL always 302s to the current release's ISO).
+          #     Skipped when stable_copies is off — the nightly caller
+          #     names its own assets and a byte-identical duplicate would
+          #     only bloat the artifact.
+          # mkosi's own ImageVersion in mkosi.conf is ``0.1.0`` (internal
+          # scheme); we rename to the operator-visible tag here.
+          VERSIONED="appliance/build/spatiumddi-appliance-${TAG}.iso"
+          mv "$ISO_INTERIM" "$VERSIONED"
+          if [ "$STABLE_COPIES" = "true" ]; then
+            cp "$VERSIONED" "appliance/build/spatiumddi-appliance-amd64.iso"
+          fi
+          ls -lh appliance/build/spatiumddi-appliance-*.iso
+          echo "iso_name=spatiumddi-appliance-${TAG}.iso" >> "$GITHUB_OUTPUT"
+      # Phase 8b-4 — build the slot upgrade image alongside the ISO so
+      # operators can apply atomic OS upgrades from the /appliance UI
+      # without manually building images locally. Same docker invocation
+      # the local Makefile uses, just inlined for CI.
+      - name: Build slot-upgrade image (.raw.xz + sha256)
+        id: slot
+        env:
+          TAG: ${{ inputs.image_tag }}
+          STABLE_COPIES: ${{ inputs.stable_copies }}
+        run: |
+          set -euo pipefail
+          BUILDER=${{ env.IMAGE_PREFIX }}/appliance-builder:latest
+          RAW=$(ls appliance/build/spatiumddi-appliance*.raw | head -1)
+          [ -f "$RAW" ] || { echo "✗ no raw image found"; exit 1; }
+          chmod +x appliance/scripts/build-slot-image.sh
+          docker run --rm --privileged \
+            --entrypoint /work/scripts/build-slot-image.sh \
+            -v "$PWD/appliance:/work" \
+            "$BUILDER" \
+            "/work/build/$(basename "$RAW")" \
+            "/work/build"
+          # build-slot-image.sh writes spatiumddi-appliance-slot-<mkosi-
+          # ImageVersion>.{raw.xz,sha256}. Rename to operator-visible
+          # names: versioned (archive) + optional stable (latest-link
+          # target).
+          SRC_XZ=$(ls appliance/build/spatiumddi-appliance-slot-*.raw.xz | head -1)
+          [ -f "$SRC_XZ" ] || { echo "✗ no slot .raw.xz built"; exit 1; }
+          VERSIONED_XZ="appliance/build/spatiumddi-appliance-slot-${TAG}-amd64.raw.xz"
+          VERSIONED_SHA="appliance/build/spatiumddi-appliance-slot-${TAG}-amd64.sha256"
+          mv "$SRC_XZ" "$VERSIONED_XZ"
+          # Regenerate sha files so the hash inside them references the
+          # correct (renamed) filename — important for `sha256sum -c`.
+          ( cd appliance/build && sha256sum "$(basename "$VERSIONED_XZ")" > "$(basename "$VERSIONED_SHA")" )
+          if [ "$STABLE_COPIES" = "true" ]; then
+            STABLE_XZ="appliance/build/spatiumddi-appliance-slot-amd64.raw.xz"
+            STABLE_SHA="appliance/build/spatiumddi-appliance-slot-amd64.sha256"
+            cp "$VERSIONED_XZ" "$STABLE_XZ"
+            ( cd appliance/build && sha256sum "$(basename "$STABLE_XZ")" > "$(basename "$STABLE_SHA")" )
+          fi
+          # Drop the mkosi-ImageVersion-named sha sidecar that
+          # build-slot-image.sh wrote next to the original .raw.xz (e.g.
+          # spatiumddi-appliance-slot-0.1.0.sha256). The .raw.xz itself was
+          # renamed by the mv above; only this stray sha is left, and the
+          # upload globs below would otherwise attach the bogus 0.1.0 name
+          # to every release (#392).
+          SRC_SHA="${SRC_XZ%.raw.xz}.sha256"
+          rm -f "$SRC_SHA"
+          ls -lh appliance/build/spatiumddi-appliance-slot-*
+          echo "slot_name=spatiumddi-appliance-slot-${TAG}-amd64.raw.xz" >> "$GITHUB_OUTPUT"
+      - name: Upload appliance artifacts (ISO + slot image)
+        uses: actions/upload-artifact@v7
+        with:
+          name: appliance-artifacts
+          path: |
+            appliance/build/spatiumddi-appliance-*.iso
+            appliance/build/spatiumddi-appliance-slot-*.raw.xz
+            appliance/build/spatiumddi-appliance-slot-*.sha256
+          retention-days: ${{ inputs.artifact_retention_days }}
+          if-no-files-found: error

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,22 +23,16 @@ name: Nightly
 #     reference them (see the prune job). Orphaned layers are GHCR's
 #     untagged-retention policy to collect, not this workflow's.
 #
-# THE APPLIANCE ISO IS DEFERRED, deliberately. Its retention answer is easy
-# (~1.5 GB each, so exactly one, assets replaced in place on the reused
-# pre-release below) but its BUILD is not: release.yml assembles it over 223
-# lines of sequenced steps — fetch-k3s, three chart bakes, an image bake with
-# BAKE_SOURCE=ghcr behind `sudo -E` and a DOCKER_CONFIG redirect for the
-# private registry, mkosi in a privileged builder container, then ISO wrap and
-# slot-image compression. The `make appliance-baked-iso` shortcut does NOT
-# work here: it chains `appliance-stamp-dev` (stamps a dev version) and
-# defaults to BAKE_SOURCE=local (no local tags on a runner).
-#
-# Copying those steps would leave two divergent copies of the most
-# safety-critical workflow in the repo, and no way to test the copy short of
-# cutting a release. The right fix is to extract that job into a
-# `workflow_call` reusable workflow that both release.yml and this file
-# invoke — a change that deserves its own PR and its own release to verify,
-# not a ride-along on a new nightly. Tracked as a follow-up on #805.
+#   Appliance ISO + slot image — exactly ONE copy each (~1.5 GB), attached
+#     as assets on the reused pre-release below and replaced in place every
+#     build (#823). No dated ring: an older appliance build is reproducible
+#     from its dated image tags, and the asset budget must not grow by
+#     1.5 GB/night. The BUILD is the same `workflow_call` reusable workflow
+#     release.yml invokes (build-appliance.yml) — one copy of the most
+#     safety-critical assembly in the repo, exercised nightly so a
+#     regression in it surfaces the next morning instead of at the next
+#     release cut. (#805 deferred this exactly because a copied job would
+#     have been a second divergent copy, untestable short of a release.)
 #
 # NIGHTLY IS NEVER `:latest`. That tag means "latest release" and has to
 # keep meaning that. There is also no GitHub Release per nightly — one
@@ -66,9 +60,9 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
-  # A reused pre-release used purely as the RECORD of which commit the last
-  # nightly was built from. It carries no assets today; when the ISO lands
-  # (see the header) it is where those assets go.
+  # A reused pre-release: the RECORD of which commit the last nightly was
+  # built from, and the home of the appliance ISO + slot-image assets
+  # (replaced in place each build — see the header).
   NIGHTLY_TAG: nightly
 
 permissions:
@@ -240,6 +234,82 @@ jobs:
           cache-from: type=gha,scope=nightly-${{ matrix.image }}
           cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}
 
+  # ── Build the appliance ISO + slot image ──────────────────────────────
+  # The same reusable workflow release.yml invokes (#823) — which is the
+  # point: this assembly used to run only when a release was cut, so a
+  # regression in it sat invisible until the worst moment. image_tag is
+  # the immutable dated tag, not `:nightly` — the bake must record which
+  # bytes it baked, and the mutable pointer could move under a re-run.
+  # Skipped on dry_run: the images job pushed nothing, so there is
+  # nothing at the dated tag to bake.
+  appliance:
+    name: Appliance
+    needs: [gate, images]
+    if: needs.gate.outputs.should_build == 'true' && github.event.inputs.dry_run != 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/build-appliance.yml
+    with:
+      version: ${{ needs.gate.outputs.version }}
+      image_tag: ${{ needs.gate.outputs.date_tag }}
+      # The un-versioned spatiumddi-appliance-amd64.* names are the
+      # RELEASE's /releases/latest/download/ link targets; emitting them
+      # here would only bloat the artifact with byte-identical copies.
+      stable_copies: false
+      # The artifact only has to survive the hand-off to appliance-publish.
+      artifact_retention_days: 1
+
+  # ── Attach the appliance artifacts to the nightly pre-release ─────────
+  appliance-publish:
+    name: Attach appliance artifacts
+    runs-on: ubuntu-latest
+    needs: [gate, appliance]
+    if: needs.gate.outputs.should_build == 'true' && github.event.inputs.dry_run != 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Download appliance artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: appliance-artifacts
+          path: dist/
+      - name: Upload to the nightly pre-release (replace in place)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}  # no checkout in this job
+          DATE_TAG: ${{ needs.gate.outputs.date_tag }}
+        run: |
+          set -euo pipefail
+          # Rename the dated build outputs to STABLE nightly asset names so
+          # --clobber replaces yesterday's copy instead of accumulating a
+          # 1.5 GB/night ring (see the retention note in the header). The
+          # dated identity isn't lost — it lives in the release body's
+          # date-tag line and in /etc/spatiumddi/appliance-release inside
+          # the image.
+          ISO="dist/spatiumddi-appliance-${DATE_TAG}.iso"
+          XZ="dist/spatiumddi-appliance-slot-${DATE_TAG}-amd64.raw.xz"
+          [ -f "$ISO" ] || { echo "✗ expected $ISO"; ls -l dist/; exit 1; }
+          [ -f "$XZ" ]  || { echo "✗ expected $XZ";  ls -l dist/; exit 1; }
+          mv "$ISO" dist/spatiumddi-appliance-nightly-amd64.iso
+          mv "$XZ"  dist/spatiumddi-appliance-slot-nightly-amd64.raw.xz
+          # Regenerate the checksum so the filename inside it matches the
+          # renamed asset — important for `sha256sum -c`.
+          rm -f dist/spatiumddi-appliance-slot-*.sha256
+          ( cd dist && sha256sum spatiumddi-appliance-slot-nightly-amd64.raw.xz \
+              > spatiumddi-appliance-slot-nightly-amd64.sha256 )
+          ls -lh dist/
+
+          # First-ever run: finalize hasn't created the pre-release yet
+          # (it runs after this job). Same guard it uses.
+          if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
+            gh release create "$NIGHTLY_TAG" --title "Nightly build" --prerelease --notes "init"
+          fi
+          gh release upload "$NIGHTLY_TAG" --clobber \
+            dist/spatiumddi-appliance-nightly-amd64.iso \
+            dist/spatiumddi-appliance-slot-nightly-amd64.raw.xz \
+            dist/spatiumddi-appliance-slot-nightly-amd64.sha256
+
   # ── Prune the dated tag ring ──────────────────────────────────────────
   prune:
     name: Prune old nightly tags
@@ -336,7 +406,7 @@ jobs:
   finalize:
     name: Finalize
     runs-on: ubuntu-latest
-    needs: [gate, images, prune]
+    needs: [gate, images, appliance, appliance-publish, prune]
     # `always()`, and NOT gated on `should_build` alone: a gate job that
     # FAILS emits no outputs at all, so that condition would be false and
     # this job would be skipped — the nightly would die without opening the
@@ -348,7 +418,15 @@ jobs:
       issues: write
     steps:
       - name: Update the nightly pre-release record
-        if: needs.images.result == 'success' && github.event.inputs.dry_run != 'true'
+        # Appliance success is required too: `built-from:` is what makes the
+        # next run skip when main hasn't moved, so stamping it after a
+        # failed appliance build would leave the assets stale (or missing)
+        # with no retry until the next commit lands.
+        if: >-
+          needs.images.result == 'success' &&
+          needs.appliance.result == 'success' &&
+          needs['appliance-publish'].result == 'success' &&
+          github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This job has no checkout, so `gh` cannot infer the repo from git
@@ -375,6 +453,10 @@ jobs:
           \`\`\`
           The dated tag \`${{ needs.gate.outputs.date_tag }}\` pins this exact build;
           the newest 7 are kept.
+
+          The appliance ISO (\`spatiumddi-appliance-nightly-amd64.iso\`) and slot
+          upgrade image (\`spatiumddi-appliance-slot-nightly-amd64.raw.xz\` +
+          \`.sha256\`) are attached below, replaced in place each build.
           EOF
           )"
 
@@ -382,7 +464,12 @@ jobs:
         # A nightly that fails silently is worth nothing — that is the whole
         # reason for a scheduled build. One issue, reused, so a broken week
         # doesn't open seven.
-        if: needs.gate.result == 'failure' || needs.images.result == 'failure' || needs.prune.result == 'failure'
+        if: >-
+          needs.gate.result == 'failure' ||
+          needs.images.result == 'failure' ||
+          needs.appliance.result == 'failure' ||
+          needs['appliance-publish'].result == 'failure' ||
+          needs.prune.result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}  # no checkout in this job — see above
@@ -393,6 +480,8 @@ jobs:
 
           - gate: ${{ needs.gate.result }}
           - images: ${{ needs.images.result }}
+          - appliance: ${{ needs.appliance.result }}
+          - appliance-publish: ${{ needs['appliance-publish'].result }}
           - prune: ${{ needs.prune.result }}
 
           Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,23 +382,17 @@ jobs:
             "oci://ghcr.io/${{ github.repository_owner }}/charts"
 
   # ── Build appliance ISO ─────────────────────────────────────────────────────
-  # Drives mkosi inside the published appliance-builder container the
-  # same way ``make appliance && make appliance-iso`` does on a laptop,
-  # then publishes the resulting hybrid USB/CD ISO as a release asset.
+  # The build itself lives in build-appliance.yml (reusable, #823), so the
+  # nightly exercises the exact same assembly daily instead of it only ever
+  # running when a release is cut. The CalVer tag serves as both the
+  # appliance-release stamp and the baked-image tag, and stable_copies
+  # stays on (default) so the un-versioned spatiumddi-appliance-amd64.*
+  # names exist for the /releases/latest/download/ stable URLs.
   #
-  # #170 Phase A4 — the ISO is now **fully baked**: every image the
-  # appliance can run is pulled from ghcr.io at the cut tag, saved as
-  # a zstd tarball under ``mkosi.extra/usr/local/share/spatiumddi/
-  # images/`` BEFORE mkosi runs, and ends up inside the rootfs.
-  # Firstboot ``docker load``s them and skips ``docker pull`` entirely
-  # — air-gap support out of the box, container-version drift from the
-  # OS slot becomes structurally impossible.
-  #
-  # The job therefore depends on every image-build job: we can't bake
-  # what hasn't been pushed yet.
+  # Depends on every image-build job: the ISO is fully baked (#170 A4) —
+  # we can't bake what hasn't been pushed yet.
   build-appliance-iso:
     name: Build appliance ISO
-    runs-on: ubuntu-latest
     needs:
       [
         meta,
@@ -415,207 +409,10 @@ jobs:
     permissions:
       contents: read
       packages: read
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v7
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Stamp /etc/spatiumddi/appliance-release with CalVer
-        run: |
-          set -euo pipefail
-          VERSION="${{ needs.meta.outputs.version }}"
-          # Drop the build-time version stamp into mkosi.extra so it
-          # gets baked into the rootfs at build. ``spatiumddi-firstboot``
-          # + ``spatium-upgrade-slot`` + ``spatium-console`` all read
-          # this file to surface APPLIANCE_VERSION. Without this stamp
-          # every released appliance reports the placeholder "0.1.0"
-          # regardless of which release ISO they came from.
-          mkdir -p appliance/mkosi.extra/etc/spatiumddi
-          {
-              echo "APPLIANCE_VERSION=\"${VERSION}\""
-              echo "BUILD_TIME=\"$(date -u -Iseconds)\""
-              echo "GIT_SHA=\"${GITHUB_SHA}\""
-          } > appliance/mkosi.extra/etc/spatiumddi/appliance-release
-          echo "→ Stamped appliance-release:"
-          cat appliance/mkosi.extra/etc/spatiumddi/appliance-release
-      - name: Install zstd
-        run: sudo apt-get update && sudo apt-get install -y zstd
-      - name: Install helm
-        # Use the upstream-published azure/setup-helm action — it
-        # downloads the helm static binary from get.helm.sh (which
-        # resolves via the GitHub Releases CDN; reachable from the
-        # Azure runner). The Helm-stable apt repo at baltocdn.com is
-        # NOT reachable from GitHub Actions runners ("Could not resolve
-        # host: baltocdn.com" — Azure runner network policy).
-        # bake-chart.sh shells out to ``helm package`` so helm must be
-        # on PATH before the chart-bake step.
-        uses: azure/setup-helm@v4
-        with:
-          version: v3.20.2
-      - name: Fetch k3s binary + airgap tarball
-        run: |
-          set -euo pipefail
-          # Issue #183 — without this step the slot rootfs ships zero
-          # k3s, ``/usr/local/bin/k3s`` is missing on every appliance,
-          # ``k3s.service`` crash-loops, firstboot wedges forever at
-          # "Waiting for k3s /readyz". Mirrors what
-          # ``make appliance-fetch-k3s`` does locally.
-          chmod +x appliance/scripts/fetch-k3s.sh
-          appliance/scripts/fetch-k3s.sh
-          ls -lh appliance/mkosi.extra/usr/local/bin/k3s
-          ls -lh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/k3s-airgap-images-*.tar.zst
-      - name: Bake helm charts (appliance + control)
-        run: |
-          set -euo pipefail
-          # Issue #183 — without these steps the slot rootfs ships an
-          # empty /usr/lib/spatiumddi/charts/ directory; firstboot's
-          # WARN "missing — control plane won't auto-deploy" fires and
-          # the appliance never installs anything via the HelmChart CR.
-          # Mirrors ``make appliance-bake-chart appliance-bake-control-chart
-          # appliance-bake-metallb-chart``.
-          chmod +x appliance/scripts/bake-chart.sh
-          appliance/scripts/bake-chart.sh
-          CHART_NAME=spatiumddi appliance/scripts/bake-chart.sh
-          # #272 — the control-plane VIP ships in its own spatiumddi-metallb
-          # chart (deployed to metallb-system); firstboot renders a
-          # spatium-metallb HelmChart that references this .tgz. Without it
-          # MetalLB never deploys on a release-built appliance.
-          CHART_NAME=spatiumddi-metallb appliance/scripts/bake-chart.sh
-          ls -lh appliance/mkosi.extra/usr/lib/spatiumddi/charts/*.tgz
-      - name: Bake container images into rootfs overlay
-        env:
-          SPATIUMDDI_VERSION: ${{ needs.meta.outputs.version }}
-          BAKE_SOURCE: ghcr
-        run: |
-          set -euo pipefail
-          echo "→ Pulling every image at ${SPATIUMDDI_VERSION} + baking per-image tarballs"
-          chmod +x appliance/scripts/bake-images.sh
-          # Post-#183 bake script writes per-image zst tarballs to
-          # ``appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/``
-          # which k3s auto-imports at startup. The pre-#183 path that
-          # built a single ``docker-overlay.img`` overlay file via a
-          # docker:dind sandbox is gone (no docker on the appliance
-          # post-Phase-7).
-          # ``sudo -E`` preserves SPATIUMDDI_VERSION + BAKE_SOURCE
-          # from the job env. Without ``-E``, sudo strips them and
-          # bake-images.sh falls back to its ``SPATIUMDDI_VERSION=dev``
-          # / ``BAKE_SOURCE=local`` defaults — which then fails on the
-          # runner with "no local image found" because no :dev tags
-          # exist (the release runner pulls from ghcr, not local).
-          #
-          # ``DOCKER_CONFIG=$HOME/.docker`` re-points root's docker CLI
-          # at the runner-user's ``~/.docker/config.json`` where the
-          # docker/login-action step above stamped the GHCR creds. Our
-          # ghcr.io/spatiumddi/* images are private; without this redirect
-          # root would docker-pull anonymously and 401 on every image.
-          sudo DOCKER_CONFIG="$HOME/.docker" -E appliance/scripts/bake-images.sh
-          echo "→ Baked image tarballs:"
-          ls -lh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/*.tar.zst
-          echo "→ Total size:"
-          du -sh appliance/mkosi.extra/var/lib/rancher/k3s/agent/images/
-      - name: Build raw image (mkosi)
-        run: |
-          set -euo pipefail
-          BUILDER=${{ env.IMAGE_PREFIX }}/appliance-builder:latest
-          echo "→ Pulling $BUILDER"
-          docker pull "$BUILDER"
-          mkdir -p appliance/build
-          echo "→ Running mkosi build (this takes 5–10 min)"
-          docker run --rm --privileged \
-            -v "$PWD/appliance:/work" \
-            "$BUILDER" \
-            --output-directory=build --force build
-          ls -lh appliance/build/
-      - name: Wrap as hybrid USB/CD ISO
-        id: wrap
-        run: |
-          set -euo pipefail
-          BUILDER=${{ env.IMAGE_PREFIX }}/appliance-builder:latest
-          VERSION="${{ needs.meta.outputs.version }}"
-          RAW=$(ls appliance/build/spatiumddi-appliance*.raw | head -1)
-          [ -f "$RAW" ] || { echo "✗ no raw image found"; exit 1; }
-          ISO_INTERIM="${RAW%.raw}.iso"
-          docker run --rm --privileged \
-            --entrypoint /work/scripts/wrap-iso.sh \
-            -v "$PWD/appliance:/work" \
-            "$BUILDER" \
-            "/work/build/$(basename "$RAW")" \
-            "/work/build/$(basename "$ISO_INTERIM")"
-          # Two copies attached per release:
-          #   - Versioned (archive trail of every release ever cut)
-          #   - Stable filename (un-versioned, so the README can link to
-          #     https://.../releases/latest/download/spatiumddi-appliance-amd64.iso
-          #     and that URL always 302s to the current release's ISO)
-          # mkosi's own ImageVersion in mkosi.conf is ``0.1.0`` (internal
-          # scheme); we rename to operator-visible CalVer here.
-          VERSIONED="appliance/build/spatiumddi-appliance-${VERSION}.iso"
-          STABLE="appliance/build/spatiumddi-appliance-amd64.iso"
-          mv "$ISO_INTERIM" "$VERSIONED"
-          cp "$VERSIONED" "$STABLE"
-          ls -lh "$VERSIONED" "$STABLE"
-          echo "iso_path=$VERSIONED" >> "$GITHUB_OUTPUT"
-          echo "iso_name=spatiumddi-appliance-${VERSION}.iso" >> "$GITHUB_OUTPUT"
-      # Phase 8b-4 — build the slot upgrade image alongside the ISO so
-      # operators can apply atomic OS upgrades from the /appliance UI
-      # without manually building images locally. Same docker invocation
-      # the local Makefile uses, just inlined for CI.
-      - name: Build slot-upgrade image (.raw.xz + sha256)
-        id: slot
-        run: |
-          set -euo pipefail
-          BUILDER=${{ env.IMAGE_PREFIX }}/appliance-builder:latest
-          VERSION="${{ needs.meta.outputs.version }}"
-          RAW=$(ls appliance/build/spatiumddi-appliance*.raw | head -1)
-          [ -f "$RAW" ] || { echo "✗ no raw image found"; exit 1; }
-          chmod +x appliance/scripts/build-slot-image.sh
-          docker run --rm --privileged \
-            --entrypoint /work/scripts/build-slot-image.sh \
-            -v "$PWD/appliance:/work" \
-            "$BUILDER" \
-            "/work/build/$(basename "$RAW")" \
-            "/work/build"
-          # build-slot-image.sh writes spatiumddi-appliance-slot-<mkosi-
-          # ImageVersion>.{raw.xz,sha256}. Rename to operator-visible
-          # names: versioned (archive) + stable (latest-link target).
-          SRC_XZ=$(ls appliance/build/spatiumddi-appliance-slot-*.raw.xz | head -1)
-          [ -f "$SRC_XZ" ] || { echo "✗ no slot .raw.xz built"; exit 1; }
-          VERSIONED_XZ="appliance/build/spatiumddi-appliance-slot-${VERSION}-amd64.raw.xz"
-          STABLE_XZ="appliance/build/spatiumddi-appliance-slot-amd64.raw.xz"
-          VERSIONED_SHA="appliance/build/spatiumddi-appliance-slot-${VERSION}-amd64.sha256"
-          STABLE_SHA="appliance/build/spatiumddi-appliance-slot-amd64.sha256"
-          mv "$SRC_XZ" "$VERSIONED_XZ"
-          cp "$VERSIONED_XZ" "$STABLE_XZ"
-          # Regenerate sha files so the hash inside them references the
-          # correct (renamed) filename — important for `sha256sum -c`.
-          ( cd appliance/build && sha256sum "$(basename "$VERSIONED_XZ")" > "$(basename "$VERSIONED_SHA")" )
-          ( cd appliance/build && sha256sum "$(basename "$STABLE_XZ")" > "$(basename "$STABLE_SHA")" )
-          # Drop the mkosi-ImageVersion-named sha sidecar that
-          # build-slot-image.sh wrote next to the original .raw.xz (e.g.
-          # spatiumddi-appliance-slot-0.1.0.sha256). The .raw.xz itself was
-          # renamed by the mv above; only this stray sha is left, and the
-          # upload globs below would otherwise attach the bogus 0.1.0 name
-          # to every release (#392).
-          SRC_SHA="${SRC_XZ%.raw.xz}.sha256"
-          rm -f "$SRC_SHA"
-          ls -lh "$VERSIONED_XZ" "$STABLE_XZ" "$VERSIONED_SHA" "$STABLE_SHA"
-          echo "slot_name=spatiumddi-appliance-slot-${VERSION}-amd64.raw.xz" >> "$GITHUB_OUTPUT"
-      - name: Upload appliance artifacts (ISO + slot image)
-        uses: actions/upload-artifact@v7
-        with:
-          name: appliance-artifacts
-          path: |
-            appliance/build/spatiumddi-appliance-*.iso
-            appliance/build/spatiumddi-appliance-slot-*.raw.xz
-            appliance/build/spatiumddi-appliance-slot-*.sha256
-          retention-days: 7
-          if-no-files-found: error
-    outputs:
-      iso_name: ${{ steps.wrap.outputs.iso_name }}
-      slot_name: ${{ steps.slot.outputs.slot_name }}
+    uses: ./.github/workflows/build-appliance.yml
+    with:
+      version: ${{ needs.meta.outputs.version }}
+      image_tag: ${{ needs.meta.outputs.version }}
 
   # ── Create GitHub Release ──────────────────────────────────────────────────
   release:


### PR DESCRIPTION
Closes #823

The nightly built and pushed all 9 container images but no appliance artifacts — the `nightly` pre-release carried only GitHub's auto source archives. #805 deferred the ISO deliberately, and its header prescribed the fix: don't copy release.yml's ~223-line `build-appliance-iso` job (two divergent copies of the most safety-critical assembly, testable only by cutting a release) — extract it into a `workflow_call` reusable workflow both files invoke. This is that follow-up.

## What changed

- **New `.github/workflows/build-appliance.yml`** (`workflow_call`) — the release job's steps verbatim (stamp → fetch-k3s → three chart bakes → ghcr image bake → mkosi → ISO wrap → slot compression), parameterized:
  - `version` — the `/etc/spatiumddi/appliance-release` stamp (release: CalVer; nightly: the gate's non-CalVer `0.0.0-nightly-…+sha` string, which the gate comment already earmarked for exactly this)
  - `image_tag` — ghcr tag to bake + artifact-name component (release: CalVer; nightly: the **immutable dated tag**, never the mutable `:nightly` pointer — the bake must record which bytes it baked)
  - `stable_copies` — the un-versioned `spatiumddi-appliance-amd64.*` names that `/releases/latest/download/` URLs point at (release: on; nightly: off)
  - outputs `iso_name` / `slot_name` pass through for the release-notes body
- **release.yml** — `build-appliance-iso` becomes a `uses:` call passing the CalVer tag for both inputs. Artifact name, attach globs, notes template, and job outputs all unchanged.
- **nightly.yml** —
  - `appliance` job invokes the shared workflow after `images` (skipped on `dry_run`: nothing was pushed to bake)
  - `appliance-publish` renames to stable nightly asset names (`spatiumddi-appliance-nightly-amd64.iso`, `spatiumddi-appliance-slot-nightly-amd64.raw.xz` + regenerated `.sha256`) and `gh release upload --clobber`s onto the reused pre-release — exactly one ~1.5 GB copy each, replaced in place, per the retention design in the header
  - finalize now requires appliance + publish success before stamping `built-from:` (a failed appliance nightly must retry next night, not count as done) and reports both new jobs in the failure tracking issue
  - the pre-release body now documents the attached assets

## Why this shape

The nightly now exercises the exact assembly the next release will run, daily — a regression in fetch-k3s / chart bake / image bake / mkosi surfaces the next morning instead of at the release cut. The release-side call is fully proven at the next cut; until then the nightly runs the identical code path (that being the point of the extraction).

## Verified

- YAML parses on all three workflows; actionlint clean (only pre-existing info-level shellcheck style notes carried over verbatim from the original job).
- `needs['appliance-publish']` hyphen-key expressions validated by actionlint.
- After merge, a `workflow_dispatch` with `force=true` exercises the whole nightly path immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)