### PR TITLE
fix(frontend): Vite dev proxy for /health + /metrics, and layered error boundaries

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type FallbackRender = (reset: () => void) => ReactNode;
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode | FallbackRender;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * React error boundary. Catches render-time errors in descendants and renders
+ * a fallback UI instead of unmounting the whole tree.
+ *
+ * `fallback` may be a static React node or a render prop that receives a
+ * `reset` function so the UI can offer a retry button.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    this.props.onError?.(error, info);
+    // Browser-side log only. The backend has structured JSON logging; there is
+    // no frontend telemetry pipeline yet, so console.error is the safest sink.
+    console.error("ErrorBoundary caught error:", error, info.componentStack);
+  }
+
+  reset = () => {
+    this.setState({ hasError: false });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (typeof this.props.fallback === "function") {
+        return this.props.fallback(this.reset);
+      }
+      return this.props.fallback ?? null;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/WidgetErrorBoundary.tsx
+++ b/frontend/src/components/WidgetErrorBoundary.tsx
@@ -19,7 +19,11 @@ export function WidgetErrorBoundary({
   return (
     <ErrorBoundary
       fallback={(reset) => (
-        <div className="rounded-lg border bg-card p-4" role="alert" aria-live="polite">
+        <div
+          className="rounded-lg border bg-card p-4"
+          role="alert"
+          aria-live="polite"
+        >
           <div className="flex items-start gap-2 text-sm text-destructive">
             <AlertTriangle
               className="mt-0.5 h-4 w-4 shrink-0"

--- a/frontend/src/components/WidgetErrorBoundary.tsx
+++ b/frontend/src/components/WidgetErrorBoundary.tsx
@@ -1,0 +1,45 @@
+import { AlertTriangle } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { ErrorBoundary } from "./ErrorBoundary";
+
+interface WidgetErrorBoundaryProps {
+  children: ReactNode;
+  title?: string;
+}
+
+/**
+ * Card-sized error boundary for dashboard panels and other self-contained
+ * widgets. Keeps a single failed panel from taking down the whole page.
+ */
+export function WidgetErrorBoundary({
+  children,
+  title = "This panel",
+}: WidgetErrorBoundaryProps) {
+  return (
+    <ErrorBoundary
+      fallback={(reset) => (
+        <div className="rounded-lg border bg-card p-4" role="alert" aria-live="polite">
+          <div className="flex items-start gap-2 text-sm text-destructive">
+            <AlertTriangle
+              className="mt-0.5 h-4 w-4 shrink-0"
+              aria-hidden="true"
+            />
+            <div className="flex-1">
+              <p className="font-medium">{title} failed to load.</p>
+              <button
+                type="button"
+                onClick={reset}
+                className="mt-2 text-xs text-primary hover:underline"
+              >
+                Try again
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Sidebar } from "./Sidebar";
@@ -22,6 +22,13 @@ export function AppLayout() {
   const { enabled } = useFeatureModules();
   const copilotEnabled = enabled("ai.copilot");
 
+  // Keys the route-level error boundary below. Without it the boundary's
+  // hasError state survives navigation: a crashed page would keep showing
+  // the fallback for every route the user clicks to next, making the whole
+  // app look broken until a full reload. Remounting on path change gives
+  // each page a fresh boundary.
+  const { pathname } = useLocation();
+
   return (
     <div className="flex h-screen overflow-hidden bg-background">
       <Sidebar
@@ -36,9 +43,12 @@ export function AppLayout() {
         <Header onMobileMenu={() => setMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
           <ErrorBoundary
+            key={pathname}
             fallback={
               <div className="m-6 rounded-lg border bg-card p-6 text-center">
-                <h2 className="text-base font-semibold">This page failed to load</h2>
+                <h2 className="text-base font-semibold">
+                  This page failed to load
+                </h2>
                 <p className="mt-2 text-sm text-muted-foreground">
                   Something went wrong while rendering this page.
                 </p>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 import { Outlet } from "react-router-dom";
+
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { DemoBanner } from "./DemoBanner";
@@ -33,7 +35,25 @@ export function AppLayout() {
         <MaintenanceModeBanner />
         <Header onMobileMenu={() => setMobileOpen(true)} />
         <main className="flex-1 overflow-auto">
-          <Outlet />
+          <ErrorBoundary
+            fallback={
+              <div className="m-6 rounded-lg border bg-card p-6 text-center">
+                <h2 className="text-base font-semibold">This page failed to load</h2>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Something went wrong while rendering this page.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => window.location.reload()}
+                  className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+                >
+                  Reload
+                </button>
+              </div>
+            }
+          >
+            <Outlet />
+          </ErrorBoundary>
         </main>
       </div>
       {/* Issue #90 — Operator Copilot floating button. Hidden when no

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import { queryClient } from "@/lib/queryClient";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import App from "./App";
 import "./index.css";
 
@@ -24,7 +25,25 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
-        <App />
+        <ErrorBoundary
+          fallback={
+            <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-center">
+              <h1 className="text-lg font-semibold">Something went wrong</h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                The application crashed. Please reload the page.
+              </p>
+              <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="mt-4 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Reload
+              </button>
+            </div>
+          }
+        >
+          <App />
+        </ErrorBoundary>
         <ReactQueryDevtools initialIsOpen={false} />
       </QueryClientProvider>
     </BrowserRouter>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1551,7 +1551,7 @@ export function DashboardPage() {
             <WidgetErrorBoundary title="Domain summary">
               <DomainsSummaryCard />
             </WidgetErrorBoundary>
-            <WidgetErrorBoundary title="Subnet decomposition">
+            <WidgetErrorBoundary title="Subnet decommissioning">
               <SubnetDecomCard />
             </WidgetErrorBoundary>
             <WidgetErrorBoundary title="Looking Glass health">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -102,6 +102,7 @@ import { includeInUtilization } from "@/lib/utilization";
 import { useSessionState } from "@/lib/useSessionState";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { DHCPTrafficCard, DNSQueryRateCard } from "@/components/MetricsCharts";
+import { WidgetErrorBoundary } from "@/components/WidgetErrorBoundary";
 
 /**
  * Dashboard — the home page.
@@ -1533,29 +1534,51 @@ export function DashboardPage() {
               KPI row so the colour-coded health ribbon is the next
               thing the eye lands on after the headline counters). ──── */}
         {tab === "overview" && platformHealth && (
-          <PlatformHealthCard health={platformHealth} />
+          <WidgetErrorBoundary title="Platform health">
+            <PlatformHealthCard health={platformHealth} />
+          </WidgetErrorBoundary>
         )}
 
         {/* ── Network overview cards (Overview tab) ─────────────────── */}
         {tab === "overview" && (
           <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
-            <AsnSummaryCard />
-            <VrfSummaryCard />
-            <DomainsSummaryCard />
-            <SubnetDecomCard />
-            <LookingGlassHealthCard />
+            <WidgetErrorBoundary title="ASN summary">
+              <AsnSummaryCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="VRF summary">
+              <VrfSummaryCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="Domain summary">
+              <DomainsSummaryCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="Subnet decomposition">
+              <SubnetDecomCard />
+            </WidgetErrorBoundary>
+            <WidgetErrorBoundary title="Looking Glass health">
+              <LookingGlassHealthCard />
+            </WidgetErrorBoundary>
           </div>
         )}
 
         {/* ── DNS query rate (DNS tab only) ──────────────────────────── */}
-        {tab === "dns" && <DNSQueryRateCard dnsServers={allDnsServers} />}
+        {tab === "dns" && (
+          <WidgetErrorBoundary title="DNS query rate">
+            <DNSQueryRateCard dnsServers={allDnsServers} />
+          </WidgetErrorBoundary>
+        )}
 
         {/* ── DHCP traffic (DHCP tab only) ───────────────────────────── */}
-        {tab === "dhcp" && <DHCPTrafficCard dhcpServers={dhcpServers} />}
+        {tab === "dhcp" && (
+          <WidgetErrorBoundary title="DHCP traffic">
+            <DHCPTrafficCard dhcpServers={dhcpServers} />
+          </WidgetErrorBoundary>
+        )}
 
         {/* ── Heatmap (Overview + IPAM) ──────────────────────────────── */}
         {(tab === "overview" || tab === "ipam") && (
-          <SubnetHeatmap subnets={reporting} />
+          <WidgetErrorBoundary title="Subnet heatmap">
+            <SubnetHeatmap subnets={reporting} />
+          </WidgetErrorBoundary>
         )}
 
         {/* ── IPAM-specific summary cards ───────────────────────────── */}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { readFileSync } from "fs";
 
-const pkg = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf-8")) as {
+const pkg = JSON.parse(
+  readFileSync(new URL("./package.json", import.meta.url), "utf-8"),
+) as {
   version: string;
 };
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -29,6 +29,22 @@ export default defineConfig({
         target: "http://localhost:8000",
         changeOrigin: true,
       },
+      // Backend endpoints also live outside /api — notably
+      // /health/* (platform health) and /metrics. The production
+      // nginx config proxies these to the API (see
+      // default.conf.template → `location ~ ^/(health|metrics)`),
+      // but the Vite dev proxy only forwarded /api, so requests to
+      // /health/platform fell through to the SPA fallback and
+      // returned index.html — crashing the dashboard's platform
+      // health card. Mirror those two proxy entries here.
+      "/health": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
+      "/metrics": {
+        target: "http://localhost:8000",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
Combines and supersedes #817 and #818 by @tristanbob — adopted in-repo (fork PRs hang on the Code Quality gate, whose dynamic runs are never created for forks) with both original commits cherry-picked so authorship is preserved, plus one review-fix commit on top.

## From #817 — Vite dev proxy (1 file, dev-only)

`platformHealthApi` fetches `/health/platform` with `baseURL: "/"` — outside `/api`. Production nginx proxies `/health/*` + `/metrics` to the API (`default.conf.template`), but the Vite dev proxy only forwarded `/api`, so in `npm run dev` the request fell through to the SPA fallback, returned `index.html` (truthy), and `PlatformHealthCard`'s `health.components.map(...)` threw — unmounting the entire React tree and blanking the dashboard ~1s after login. Adds `/health` + `/metrics` proxy entries mirroring nginx. Zero production impact.

## From #818 — layered error boundaries

A generic `ErrorBoundary` + card-styled `WidgetErrorBoundary`, applied at three layers: app root (`main.tsx` — crash shows a reloadable fallback instead of a blank page), route level (`AppLayout` — a crashing page keeps the sidebar/header chrome), and per-widget on nine dashboard cards (one bad panel shows its own error card + retry, the rest of the dashboard survives). Defense-in-depth for exactly the failure mode #817 fixed one instance of.

## Review fixes (this repo's commit on top)

- **Remount the route boundary on navigation**: the boundary's `hasError` state survived route changes — after one page crashed, every sidebar link kept rendering the fallback until a full reload, making the whole app look broken. Keyed by `location.pathname` so each route gets a fresh boundary.
- `"Subnet decomposition"` → `"Subnet decommissioning"` (`SubnetDecomCard` is the #46 decom-date card).
- prettier normalization.

## Verified

- `npm run build`, eslint, prettier all clean on the combined branch
- Exercised in the rebuilt dev frontend container
- Both original diffs reviewed line-by-line: no new dependencies, no network calls beyond the localhost proxy targets, no CI/workflow changes

Credit: @tristanbob for the diagnosis and both implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)