### PR TITLE
ci: never run the publishing workflows on forks

### DIFF
--- a/.github/workflows/build-appliance-builder.yml
+++ b/.github/workflows/build-appliance-builder.yml
@@ -19,6 +19,10 @@ on:
 
 jobs:
   build-and-publish:
+    # Forks inherit this workflow (#830); never push the builder image
+    # outside the canonical repo. PRs to us run here anyway (the base
+    # repo's owner matches), so contributor scan builds are unaffected.
+    if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -66,6 +66,9 @@ env:
 jobs:
   publish:
     name: Mirror docs/ to the site repo
+    # Forks inherit this workflow (#830); never run the publisher outside
+    # the canonical repo. (Single-job workflow.)
+    if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     steps:
       - name: Check out source ref

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,6 +77,10 @@ jobs:
   # ── Should this run at all, and what is it building? ──────────────────
   gate:
     name: Decide
+    # Forks inherit this workflow (#830); never run the publisher outside
+    # the canonical repo. Every other job needs this one, so the guard
+    # cascades.
+    if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/prune-release-assets.yml
+++ b/.github/workflows/prune-release-assets.yml
@@ -38,6 +38,9 @@ concurrency:
 jobs:
   prune:
     name: Prune old appliance release assets
+    # Forks inherit this workflow (#830); never run the publisher outside
+    # the canonical repo. (Single-job workflow.)
+    if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
   # ── Extract version metadata ───────────────────────────────────────────────
   meta:
     name: Extract version
+    # Forks inherit this workflow (#830); never run the publisher outside
+    # the canonical repo. Every other job needs this one, so the guard
+    # cascades.
+    if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.ver.outputs.version }}

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -37,6 +37,9 @@ permissions:
 jobs:
   scan:
     name: Trivy — all shipped images
+    # Forks inherit this workflow (#830); never run the publisher outside
+    # the canonical repo. (Single-job workflow.)
+    if: github.repository_owner == 'spatiumddi'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
Closes #830

GitHub copies `.github/workflows/` into every fork, and a fork owner who enables Actions gets **working** publishers, not failing ones: `IMAGE_PREFIX` derives from `github.repository_owner` and the fork's `GITHUB_TOKEN` can push packages to its own namespace. So a fork could nightly-build and push `ghcr.io/<fork-owner>/*` images (plus, since #823, a 1.5 GB appliance ISO on their runners), maintain a `nightly` pre-release and "Nightly build failing" issues in their fork, and cut a full look-alike release from any CalVer tag push.

## Fix

`if: github.repository_owner == 'spatiumddi'` on the **entry job** of each publishing/scheduled workflow — every downstream job `needs:` it, so the whole graph skips on forks:

| Workflow | Guarded job |
|---|---|
| `nightly.yml` | `gate` (images / appliance / publish / prune / finalize all cascade) |
| `release.yml` | `meta` (all 12 downstream jobs cascade) |
| `trivy-scheduled.yml` | `scan` |
| `prune-release-assets.yml` | `prune` |
| `docs-publish.yml` | `publish` |
| `build-appliance-builder.yml` | `build-and-publish` |

Verified the one non-obvious cascade: nightly's `finalize` runs under `always()`, but its existing `needs.gate.result != 'skipped'` condition means an owner-skipped gate skips it too — forks don't even get the failure-tracking issue.

## Deliberately not gated

`ci.yml`, `agent-e2e.yml`, and the PR-triggered `build-*-images.yml` scan workflows: fork contributors need those for their own development, they publish nothing on the PR path, and PRs *to* us always run in our repo where the owner matches anyway.

## Notes

- Validated with YAML parse + actionlint (clean).
- Existing forks keep their copied workflows until they sync — the guard takes effect per-fork as they pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)