### PR TITLE
feat(appliance): first-boot + timer self-check that the Web UI is reachable through the firewall

### DIFF
--- a/appliance/mkosi.extra/etc/systemd/system/spatium-firewall-reload.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatium-firewall-reload.service
@@ -12,4 +12,10 @@ Requires=etc.mount
 [Service]
 Type=oneshot
 ExecStart=/usr/local/bin/spatium-firewall-reload
+# #779 — re-run the Web UI reachability self-check after every firewall
+# apply, so the console's verdict follows the ruleset immediately instead
+# of lagging up to one 5-min timer period (in both directions: a fix
+# clears the red banner now; a bad re-render raises it now). `-` prefix:
+# a self-check failure must never mark the firewall apply failed.
+ExecStartPost=-/usr/local/bin/spatiumddi-webui-selfcheck
 # No Install — only invoked by the matching .path unit.

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-webui-selfcheck.service
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-webui-selfcheck.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Check the Web UI is reachable through the firewall (issue #779)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/779
+# Reasons about the kernel-active ruleset, so the base config must have
+# been applied. Deliberately NOT ordered after the supervisor or k3s —
+# independence from the supervisor is the whole point (#777 is a live
+# example of a heartbeat that never happens).
+After=nftables.service
+# Don't run in the live installer environment.
+ConditionKernelCommandLine=!boot=live
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/spatiumddi-webui-selfcheck
+# Exit 1 (blocked) is a *finding*, not a unit failure — the verdict
+# surfaces on the console via the state file, and a red failed unit
+# would double-report it into systemctl --failed noise.
+SuccessExitStatus=1 2
+# Driven by spatiumddi-webui-selfcheck.timer — no [Install].

--- a/appliance/mkosi.extra/etc/systemd/system/spatiumddi-webui-selfcheck.timer
+++ b/appliance/mkosi.extra/etc/systemd/system/spatiumddi-webui-selfcheck.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Recheck Web UI firewall reachability (issue #779)
+Documentation=https://github.com/spatiumddi/spatiumddi/issues/779
+# Don't run in the live installer environment.
+ConditionKernelCommandLine=!boot=live
+
+[Timer]
+# First run shortly after boot (firstboot also runs the check inline for
+# an immediate first verdict; this catches non-first boots), then every
+# 5 min — the supervisor rewrites the drop-in on role/scope changes and
+# the verdict must follow it. /run state resets per boot, so a stale
+# verdict can never outlive the ruleset it described.
+OnBootSec=45s
+OnUnitActiveSec=5min
+Persistent=false
+
+[Install]
+WantedBy=timers.target

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -178,6 +178,48 @@ def supervisor_watchdog_status() -> tuple[str, str] | None:
     return (f"Loop ticking · {age}s ago", "bold green")
 
 
+# Web UI firewall reachability self-check (#779) — host-side script +
+# timer that reasons about the kernel-active nftables ruleset and asks
+# "would a NEW off-box TCP connection to 443 be accepted?". Independent
+# of the supervisor by design: the supervisor's own drift check can't
+# run before it registers (#777), and it verifies its drop-in, not
+# reachability. The script writes its verdict to /run (ephemeral — a
+# verdict must never outlive the ruleset it describes).
+_WEBUI_SELFCHECK_STATE = Path("/run/spatiumddi/webui-selfcheck.json")
+# The timer re-checks every 5 min; a verdict older than 3 timer periods
+# means the timer itself is broken — say nothing rather than alert on
+# information that may predate a fixed firewall.
+_WEBUI_SELFCHECK_MAX_AGE_S = 900
+
+
+def webui_selfcheck_status() -> tuple[str, str] | None:
+    """Return a ``(label, rich-style)`` chip when the last Web UI
+    self-check verdict is ``blocked`` and fresh; ``None`` otherwise.
+
+    Deliberately red-only: ``open`` / ``scoped`` (hardened via
+    web_ui_allowed_cidrs) / ``indeterminate`` / missing / stale all
+    return ``None``. The check exists to volunteer the one answer
+    nothing else on the box will (#776 took a full diagnostic session
+    to find a missing accept rule) — not to add a green light.
+    """
+    try:
+        raw = json.loads(_WEBUI_SELFCHECK_STATE.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(raw, dict) or raw.get("status") != "blocked":
+        return None
+    checked = raw.get("checked_at")
+    if not isinstance(checked, (int, float)):
+        return None
+    if time.time() - checked > _WEBUI_SELFCHECK_MAX_AGE_S:
+        return None
+    return (
+        "Web UI unreachable from LAN — no accept for tcp/443 "
+        "(nft list chain inet filter input)",
+        "bold red",
+    )
+
+
 def watchdog_expected_services() -> list[str]:
     """Read the supervisor's role-compose.env to discover which
     service containers the watchdog expects to be running.
@@ -2226,6 +2268,7 @@ def overall_verdict(
     state: "DashboardState",
     k3s_state: tuple[str, str] | None = None,
     wd_status: tuple[str, str] | None = None,
+    webui_status: tuple[str, str] | None = None,
 ) -> tuple[str, str]:
     """P0.3 — roll the per-panel signals up into one box-level verdict.
 
@@ -2242,6 +2285,7 @@ def overall_verdict(
       * a red-tier pod: flapping now (``_rst_verdict``) or in a broken
         k8s state — CRITICAL
       * a degraded (failing) host-config plane — CRITICAL
+      * Web UI self-check verdict `blocked` (#779) — CRITICAL
       * k3s unit failed — CRITICAL
       * disk >90% on any mount — CRITICAL
       * k3s not yet ready / starting — DEGRADED
@@ -2265,6 +2309,13 @@ def overall_verdict(
     failing = list(hh.get("failing") or [])  # type: ignore[arg-type]
     if failing:
         return ("CRITICAL", f"host config failing: {failing[0]}")
+    # #779 — the management surface itself is firewalled off. Everything
+    # else on this dashboard can be green while the operator's browser
+    # times out (#776); the self-check chip is non-None only for a fresh
+    # `blocked` verdict, so this never fires on a scoped (hardened) or
+    # indeterminate state.
+    if webui_status is not None:
+        return ("CRITICAL", "Web UI blocked by firewall (tcp/443)")
     # Phase 2 INC 3 — etcd quorum. Multi-node only: a single-node etcd is
     # always its own leader (has_leader=1), so this never false-fires on a
     # single-node appliance; an empty state.etcd (sqlite backend) is skipped.
@@ -2511,7 +2562,9 @@ def render_header(
     # the ``wd_status`` file-stat computed above so overall_verdict adds
     # no subprocess. A red border is visible across a room on a VGA
     # console; uniform cyan never was. (Unchanged from Phase 1.)
-    verdict, offender = overall_verdict(state, state.k3s_state, wd_status)
+    verdict, offender = overall_verdict(
+        state, state.k3s_state, wd_status, webui_selfcheck_status()
+    )
     vglyph, vcolor = _VERDICT_STYLES.get(verdict, ("●", "cyan"))
     if verdict == "HEALTHY":
         title = "[bold]SpatiumDDI[/bold]  [green]● HEALTHY[/green]"
@@ -4851,7 +4904,7 @@ def _render_health_screen(
     ``state`` plus the already-fetched ``events``."""
     console.clear()
     wd = supervisor_watchdog_status() if state.role in ("appliance", "application") else None
-    verdict, offender = overall_verdict(state, state.k3s_state, wd)
+    verdict, offender = overall_verdict(state, state.k3s_state, wd, webui_selfcheck_status())
     vglyph, vcolor = _VERDICT_STYLES.get(verdict, ("●", "cyan"))
     banner = Text()
     banner.append(f" {vglyph} {verdict} ", style=f"bold {vcolor}")

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -184,40 +184,80 @@ def supervisor_watchdog_status() -> tuple[str, str] | None:
 # of the supervisor by design: the supervisor's own drift check can't
 # run before it registers (#777), and it verifies its drop-in, not
 # reachability. The script writes its verdict to /run (ephemeral — a
-# verdict must never outlive the ruleset it describes).
+# verdict must never outlive the ruleset it describes). Surfaced in two
+# places: a warning appended to the identity row's Web UI URL (the URL
+# the verdict invalidates), and the box-level health verdict.
 _WEBUI_SELFCHECK_STATE = Path("/run/spatiumddi/webui-selfcheck.json")
-# The timer re-checks every 5 min; a verdict older than 3 timer periods
-# means the timer itself is broken — say nothing rather than alert on
-# information that may predate a fixed firewall.
-_WEBUI_SELFCHECK_MAX_AGE_S = 900
+# Fallback freshness window when the state file predates the ttl_s field;
+# the authoritative value ships IN the file so a timer-cadence change
+# can't silently outrun a constant hardcoded here.
+_WEBUI_SELFCHECK_DEFAULT_TTL_S = 900
+# mtime-memoized parse so the 0.5 s render loop pays one stat() per tick,
+# not a read+parse — same tier discipline as supervisor_watchdog_status
+# (see the P1.2 comment on DashboardState). Keyed by (path, mtime): the
+# path is constant in production but monkeypatched per-test.
+_webui_state_cache: tuple[str, float, dict | None] = ("", -1.0, None)
 
 
-def webui_selfcheck_status() -> tuple[str, str] | None:
-    """Return a ``(label, rich-style)`` chip when the last Web UI
-    self-check verdict is ``blocked`` and fresh; ``None`` otherwise.
-
-    Deliberately red-only: ``open`` / ``scoped`` (hardened via
-    web_ui_allowed_cidrs) / ``indeterminate`` / missing / stale all
-    return ``None``. The check exists to volunteer the one answer
-    nothing else on the box will (#776 took a full diagnostic session
-    to find a missing accept rule) — not to add a green light.
-    """
+def _webui_selfcheck_raw() -> dict | None:
+    global _webui_state_cache
+    path = str(_WEBUI_SELFCHECK_STATE)
+    try:
+        mtime = _WEBUI_SELFCHECK_STATE.stat().st_mtime
+    except OSError:
+        return None
+    if (path, mtime) == _webui_state_cache[:2]:
+        return _webui_state_cache[2]
     try:
         raw = json.loads(_WEBUI_SELFCHECK_STATE.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return None
-    if not isinstance(raw, dict) or raw.get("status") != "blocked":
+        raw = None
+    if not isinstance(raw, dict):
+        raw = None
+    _webui_state_cache = (path, mtime, raw)
+    return raw
+
+
+def webui_selfcheck_status() -> tuple[str, str] | None:
+    """Return a ``(label, rich-style)`` warning for the identity row, or
+    ``None`` when there is nothing worth saying.
+
+    Two states speak, everything else is silent:
+
+    * fresh ``blocked`` → bold red, carrying the script's own detail (an
+      explicit drop rule and a missing accept read differently, and the
+      operator should see which one it is). ``overall_verdict`` keys the
+      box-level CRITICAL off this style, mirroring how it reads
+      ``wd_status``.
+    * ``indeterminate`` for 3+ consecutive runs → dim yellow note that
+      the checker itself can't read the firewall — otherwise a broken
+      nft / changed JSON format would disable this safety net silently,
+      forever.
+
+    ``open`` / ``scoped`` (hardened via web_ui_allowed_cidrs) / missing /
+    stale return ``None``: the check exists to volunteer the one answer
+    nothing else on the box will (#776 took a full diagnostic session to
+    find a missing accept rule) — not to add a green light. Freshness
+    uses the ``ttl_s`` the script writes alongside the verdict.
+    """
+    raw = _webui_selfcheck_raw()
+    if raw is None:
         return None
     checked = raw.get("checked_at")
     if not isinstance(checked, (int, float)):
         return None
-    if time.time() - checked > _WEBUI_SELFCHECK_MAX_AGE_S:
+    ttl = raw.get("ttl_s")
+    if not isinstance(ttl, (int, float)) or ttl <= 0:
+        ttl = _WEBUI_SELFCHECK_DEFAULT_TTL_S
+    if time.time() - checked > ttl:
         return None
-    return (
-        "Web UI unreachable from LAN — no accept for tcp/443 "
-        "(nft list chain inet filter input)",
-        "bold red",
-    )
+    status = raw.get("status")
+    if status == "blocked":
+        detail = raw.get("detail") or "no accept rule for tcp/443"
+        return (f"BLOCKED by firewall — {detail}", "bold red")
+    if status == "indeterminate" and int(raw.get("consecutive_indeterminate") or 0) >= 3:
+        return ("firewall self-check unavailable", "yellow")
+    return None
 
 
 def watchdog_expected_services() -> list[str]:
@@ -2311,10 +2351,10 @@ def overall_verdict(
         return ("CRITICAL", f"host config failing: {failing[0]}")
     # #779 — the management surface itself is firewalled off. Everything
     # else on this dashboard can be green while the operator's browser
-    # times out (#776); the self-check chip is non-None only for a fresh
-    # `blocked` verdict, so this never fires on a scoped (hardened) or
-    # indeterminate state.
-    if webui_status is not None:
+    # times out (#776). Style-gated like wd_status below: bold red means
+    # a fresh `blocked` verdict; the yellow persistent-indeterminate note
+    # renders on the identity row but must not flip the box CRITICAL.
+    if webui_status is not None and webui_status[1] == "bold red":
         return ("CRITICAL", "Web UI blocked by firewall (tcp/443)")
     # Phase 2 INC 3 — etcd quorum. Multi-node only: a single-node etcd is
     # always its own leader (has_leader=1), so this never false-fires on a
@@ -2441,6 +2481,14 @@ def render_header(
         identity.append(f"https://{webui_host}", style="bold bright_cyan")
     else:
         identity.append("—", style="dim")
+    # #779 — firewall self-check warning, rendered ON the URL it
+    # invalidates (same shape as the #556 CP-reachability chip below).
+    # None in the healthy / hardened / unchecked cases, so this adds
+    # nothing to a green box.
+    webui_check = webui_selfcheck_status()
+    if webui_check is not None:
+        identity.append("  ", style="dim")
+        identity.append(webui_check[0], style=webui_check[1])
     identity.append("   ·   ", style="dim")
     identity.append("IPs ", style="dim")
     if v4_ips:

--- a/appliance/mkosi.extra/usr/local/bin/spatium-console
+++ b/appliance/mkosi.extra/usr/local/bin/spatium-console
@@ -195,26 +195,27 @@ _WEBUI_SELFCHECK_DEFAULT_TTL_S = 900
 # mtime-memoized parse so the 0.5 s render loop pays one stat() per tick,
 # not a read+parse — same tier discipline as supervisor_watchdog_status
 # (see the P1.2 comment on DashboardState). Keyed by (path, mtime): the
-# path is constant in production but monkeypatched per-test.
-_webui_state_cache: tuple[str, float, dict | None] = ("", -1.0, None)
+# path is constant in production but monkeypatched per-test. Mutated in
+# place (no rebinding) so no `global` statement is needed.
+_WEBUI_STATE_CACHE: dict[str, object] = {"path": "", "mtime": -1.0, "raw": None}
 
 
 def _webui_selfcheck_raw() -> dict | None:
-    global _webui_state_cache
     path = str(_WEBUI_SELFCHECK_STATE)
     try:
         mtime = _WEBUI_SELFCHECK_STATE.stat().st_mtime
     except OSError:
         return None
-    if (path, mtime) == _webui_state_cache[:2]:
-        return _webui_state_cache[2]
+    if path == _WEBUI_STATE_CACHE["path"] and mtime == _WEBUI_STATE_CACHE["mtime"]:
+        cached = _WEBUI_STATE_CACHE["raw"]
+        return cached if isinstance(cached, dict) else None
     try:
         raw = json.loads(_WEBUI_SELFCHECK_STATE.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         raw = None
     if not isinstance(raw, dict):
         raw = None
-    _webui_state_cache = (path, mtime, raw)
+    _WEBUI_STATE_CACHE.update(path=path, mtime=mtime, raw=raw)
     return raw
 
 

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -1181,6 +1181,13 @@ if [ "$ready" = 1 ]; then
     echo "Ready: k3s up on ${IP:-<appliance-ip>}; supervisor pod auto-deploys via $BOOTSTRAP_MANIFEST"
     place_deferred_control_manifest
     commit_slot_if_healthy
+    # #779 — immediate first verdict on Web UI firewall reachability, so a
+    # missing accept rule (#776's failure) is volunteered right here in the
+    # firstboot log next to the URL we just promised, instead of surfacing
+    # as a silent browser timeout. The systemd timer re-checks every 5 min;
+    # the console renders the verdict as a chip. Never fails firstboot —
+    # the finding lands in the state file + log either way.
+    /usr/local/bin/spatiumddi-webui-selfcheck || true
     exit 0
 fi
 echo "WARN: k3s /readyz did not respond within 5 minutes." >&2

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -1184,9 +1184,11 @@ if [ "$ready" = 1 ]; then
     # #779 — immediate first verdict on Web UI firewall reachability, so a
     # missing accept rule (#776's failure) is volunteered right here in the
     # firstboot log next to the URL we just promised, instead of surfacing
-    # as a silent browser timeout. The systemd timer re-checks every 5 min;
-    # the console renders the verdict as a chip. Never fails firstboot —
-    # the finding lands in the state file + log either way.
+    # as a silent browser timeout. The systemd timer re-checks every 5 min
+    # (plus after every firewall apply); the console shows a blocked
+    # verdict on the identity row's Web UI URL and in the health verdict.
+    # Never fails firstboot — the finding lands in the state file + log
+    # either way.
     /usr/local/bin/spatiumddi-webui-selfcheck || true
     exit 0
 fi

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-webui-selfcheck
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-webui-selfcheck
@@ -6,15 +6,16 @@ so — #776 was a full diagnostic session (pods, services, ss, curl,
 Test-NetConnection) to arrive at "one nftables accept rule is missing",
 and every intermediate step confirmed something healthy. This check makes
 the appliance volunteer that answer: it reasons about the kernel-active
-ruleset and surfaces a verdict on the console dashboard.
+ruleset and surfaces the verdict on the console (identity-row warning on
+the Web UI URL + the box-level health verdict).
 
-Independence is the point. The supervisor's own 5-minute firewall drift
-check verifies its rendered drop-in against its own expectations — it
-cannot run before the supervisor registers (#777), and it answers "did my
-drop-in apply", not "can anyone reach the management surface". This
-script runs from firstboot + a systemd timer, reads the live ruleset via
-``nft -j``, and never touches the supervisor. (It is Python rather than
-the watchdog's bash-only posture because the reasoning needs real JSON
+Independence is the point. The supervisor's firewall handling verifies
+its rendered drop-in — it cannot run before the supervisor registers
+(#777), and it answers "did my drop-in apply", not "can anyone reach the
+management surface". This script runs from firstboot, a systemd timer,
+and after every firewall apply (spatium-firewall-reload ExecStartPost);
+it never touches the supervisor. (It is Python rather than the
+watchdog's bash-only posture because the reasoning needs real JSON
 walking; host python3 is baked into the OS image — spatium-console
 depends on it — and is independent of the supervisor's container
 runtime, which is the dependency #779 routes around.)
@@ -29,26 +30,45 @@ ruleset does not.
 The traffic model (documented limits, kept honest):
 
 * We evaluate a NEW inbound TCP connection to dport 443 (and 80) from a
-  non-loopback source against ``inet filter input``.
-* Rules that constrain ``tcp dport`` to include the port decide the
-  verdict, first match wins (accept → reachable, drop/reject → blocked).
-* Rules that cannot match that packet are skipped: ``iif lo`` guarded
-  rules (we are off-box), ``ct state established,related`` accepts and
-  ``ct state invalid`` drops (we are NEW), and rules for other
-  ports/protocols.
-* No matching rule → the chain policy decides.
-* An accept carrying a ``saddr`` restriction is REACHABLE-SCOPED: once
-  ``web_ui_allowed_cidrs`` (#285 Phase 6) is set, unreachable-from-
-  arbitrary-sources is the *correct* state, and reporting a hardened
-  appliance as broken would be worse than no check. The scope prefixes
-  ride along in the verdict detail.
+  non-loopback source against EVERY input-hooked chain, independently —
+  kernel semantics: the packet is delivered only if no input-hook chain
+  drops it, so per-chain verdicts are combined worst-wins
+  (blocked > indeterminate > scoped > open). This matters on a live
+  appliance: k3s's iptables-nft layer keeps ``ip``/``ip6 filter INPUT``
+  chains alongside our ``inet filter input``, and an accept in one chain
+  must never mask a drop in another.
+* Within a chain, rules whose ``tcp dport`` provably includes the port
+  decide first-match: an unqualified drop/reject → blocked; an accept →
+  open, or REACHABLE-SCOPED when it carries a ``saddr`` restriction
+  (``web_ui_allowed_cidrs``, #285 Phase 6 — a hardened appliance must
+  not be reported as broken; the scope prefixes ride in the detail).
+* Rules that cannot match the modelled packet are skipped: ``iif lo``
+  guards (we are off-box), ``ct state established,related`` accepts and
+  ``ct state invalid`` drops (we are NEW), other ports/protocols.
+* QUALIFIED drops are skipped, not treated as blocks: a drop scoped by
+  ``saddr`` (one abusive subnet), a non-lo interface guard, or a
+  ``limit rate over`` flood protector does not make the UI unreachable
+  from the LAN at large — treating it as blocked would cry wolf on a
+  healthy box, the failure mode #779 names as worse than no check.
+* UNMODELED constructs degrade to honesty instead of confidence.
+  Negated matches (``op !=``), named-set references (``@webports``) and
+  dport vmaps are legal in operator drop-ins / ``firewall_extra`` but
+  outside the model: a chain whose decision would depend on one reports
+  ``indeterminate`` (say nothing) rather than a wrong verdict in either
+  direction. Likewise a drop-policy chain whose accept might live behind
+  a ``jump``/``goto`` we do not follow. Sub-chain contents are never
+  evaluated; k3s's dport-less jumps sit in accept-policy chains and are
+  skipped (service-layer rejects are the pods panel's frame, not this
+  check's).
 
 Verdict lands in ``/run/spatiumddi/webui-selfcheck.json`` (ephemeral by
-design — a verdict must never outlive the ruleset it describes, and
-/run resets per boot) where spatium-console renders it as a Web UI chip
-next to the Watchdog line. Exit 0 reachable / 1 blocked / 2
-indeterminate (nft unavailable etc. — the timer must not cry wolf on a
-transient).
+design — a verdict must never outlive the ruleset it describes, and /run
+resets per boot) where spatium-console reads it. The payload carries
+``ttl_s`` so the console's freshness window follows this file, not a
+constant duplicated in another repo path, and ``consecutive_indeterminate``
+so a permanently-broken checker (nft output format change, missing
+binary) surfaces as a console note instead of dying silently. Exit 0
+reachable / 1 blocked / 2 indeterminate.
 
 Searchable log tag: ``spatiumddi-webui-selfcheck``.
 """
@@ -56,6 +76,7 @@ Searchable log tag: ``spatiumddi-webui-selfcheck``.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import time
@@ -64,86 +85,52 @@ from typing import Any
 
 STATE_PATH = Path("/run/spatiumddi/webui-selfcheck.json")
 WEB_PORTS = (443, 80)
+# Freshness contract shipped WITH the verdict: 3 timer periods (5 min) —
+# if the console sees a verdict older than this, the checker itself is
+# broken and the verdict may predate a fixed (or re-broken) firewall.
+TTL_S = 900
 
-# Chains hooked at input for the inet/ip/ip6 families all filter our
-# packet; the appliance base config uses exactly one: inet filter input.
-_INPUT_HOOK = "input"
+_MODELED_OPS = {None, "==", "in"}
+
+# Combined worst-wins across chains: a packet must survive every
+# input-hooked chain, so any chain's block is the packet's fate, and an
+# uncertain chain caps our confidence below "open".
+_SEVERITY = {"blocked": 3, "indeterminate": 2, "scoped": 1, "open": 0}
 
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else [value]
 
 
-def _match_parts(rule_exprs: list[dict[str, Any]]) -> dict[str, Any]:
-    """Split a rule's expressions into the aspects the model cares about."""
-    parts: dict[str, Any] = {
-        "dports": None,  # set[int] | None — None means no dport constraint
-        "iif_lo": False,
-        "ct_state": None,  # list[str] | None
-        "saddr": None,  # list[str] rendered prefixes | None
-        "l4proto_tcp": None,  # True / False / None (unconstrained)
-        "verdict": None,  # "accept" | "drop" | "reject" | None
-    }
-    for expr in rule_exprs:
-        if not isinstance(expr, dict):
-            continue
-        if "accept" in expr:
-            parts["verdict"] = "accept"
-        elif "drop" in expr:
-            parts["verdict"] = "drop"
-        elif "reject" in expr:
-            parts["verdict"] = "reject"
-        match = expr.get("match")
-        if not isinstance(match, dict):
-            continue
-        left, right = match.get("left"), match.get("right")
-        if not isinstance(left, dict):
-            continue
-        if "payload" in left:
-            payload = left["payload"]
-            proto = payload.get("protocol")
-            field = payload.get("field")
-            if field == "dport":
-                parts["l4proto_tcp"] = proto == "tcp"
-                parts["dports"] = _extract_ports(right)
-            elif field == "saddr":
-                parts["saddr"] = _render_prefixes(right)
-        elif "meta" in left:
-            key = left["meta"].get("key")
-            if key in ("iif", "iifname") and right in ("lo", 1):
-                parts["iif_lo"] = True
-            elif key == "l4proto":
-                protos = {p for p in _as_list(right) if isinstance(p, str)}
-                if protos:
-                    parts["l4proto_tcp"] = "tcp" in protos
-        elif "ct" in left and left["ct"].get("key") == "state":
-            states: list[str] = []
-            for item in _as_list(right):
-                if isinstance(item, str):
-                    states.append(item)
-                elif isinstance(item, dict) and "set" in item:
-                    states.extend(s for s in _as_list(item["set"]) if isinstance(s, str))
-            parts["ct_state"] = states
-    return parts
+class _PortSpec:
+    """A rule's dport constraint: concrete ints + ranges, or unmodeled."""
+
+    __slots__ = ("ints", "ranges", "unmodeled")
+
+    def __init__(self) -> None:
+        self.ints: set[int] = set()
+        self.ranges: list[tuple[int, int]] = []
+        self.unmodeled = False
+
+    def contains(self, port: int) -> bool:
+        return port in self.ints or any(lo <= port <= hi for lo, hi in self.ranges)
 
 
-def _extract_ports(right: Any) -> set[int]:
-    """Flatten a dport match RHS (int, set, range) into concrete ports.
-
-    Ranges are expanded only for membership testing against WEB_PORTS, so
-    an 1-65535 range costs two containment checks, not 65k inserts.
-    """
-    ports: set[int] = set()
+def _extract_ports(right: Any, spec: _PortSpec) -> None:
     for item in _as_list(right):
         if isinstance(item, int):
-            ports.add(item)
+            spec.ints.add(item)
         elif isinstance(item, dict):
             if "set" in item:
-                ports |= _extract_ports(item["set"])
+                _extract_ports(item["set"], spec)
             elif "range" in item:
                 lo, hi = item["range"]
-                ports |= {p for p in WEB_PORTS if lo <= p <= hi}
-    return ports
+                spec.ranges.append((int(lo), int(hi)))
+            else:
+                spec.unmodeled = True
+        else:
+            # e.g. "@webports" — a named-set reference we don't resolve.
+            spec.unmodeled = True
 
 
 def _render_prefixes(right: Any) -> list[str]:
@@ -160,94 +147,296 @@ def _render_prefixes(right: Any) -> list[str]:
     return out
 
 
-def evaluate_port(nft_doc: dict[str, Any], port: int) -> tuple[str, str]:
-    """Return ``(status, detail)`` for a NEW off-box TCP connection to ``port``.
-
-    status: ``open`` | ``scoped`` | ``blocked`` | ``indeterminate``.
-    """
-    entries = nft_doc.get("nftables")
-    if not isinstance(entries, list):
-        return ("indeterminate", "nft output has no ruleset")
-
-    input_chains: dict[tuple[str, str], str] = {}  # (table, name) -> policy
-    for entry in entries:
-        chain = entry.get("chain") if isinstance(entry, dict) else None
-        if isinstance(chain, dict) and chain.get("hook") == _INPUT_HOOK:
-            input_chains[(chain.get("table"), chain.get("name"))] = chain.get(
-                "policy", "accept"
-            )
-    if not input_chains:
-        # No input-hooked chain at all: nothing filters inbound traffic.
-        return ("open", "no input-hooked chain (unfiltered)")
-
-    for entry in entries:
-        rule = entry.get("rule") if isinstance(entry, dict) else None
-        if not isinstance(rule, dict):
+def _match_parts(rule_exprs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Split a rule's expressions into the aspects the model cares about."""
+    parts: dict[str, Any] = {
+        "dports": None,  # _PortSpec | None — None means no dport constraint
+        "iif_lo": False,
+        "iif_other": False,  # constrained to a specific non-lo interface
+        "ct_state": None,  # list[str] | None
+        "saddr": None,  # list[str] rendered prefixes | None
+        "l4proto_tcp": None,  # True / False / None (unconstrained)
+        "verdict": None,  # "accept" | "drop" | "reject" | None
+        "has_jump": False,  # jump/goto — sub-chain we do not follow
+        "has_limit": False,  # rate limiter (e.g. `limit rate over ... drop`)
+        "unmodeled_op": False,  # any match op outside ==/in (e.g. !=)
+    }
+    for expr in rule_exprs:
+        if not isinstance(expr, dict):
             continue
-        if (rule.get("table"), rule.get("chain")) not in input_chains:
+        if "accept" in expr:
+            parts["verdict"] = "accept"
+        elif "drop" in expr:
+            parts["verdict"] = "drop"
+        elif "reject" in expr:
+            parts["verdict"] = "reject"
+        elif "jump" in expr or "goto" in expr:
+            parts["has_jump"] = True
+        elif "limit" in expr:
+            parts["has_limit"] = True
+        match = expr.get("match")
+        if not isinstance(match, dict):
             continue
-        parts = _match_parts(_as_list(rule.get("expr") or []))
-        if parts["verdict"] is None:
+        if match.get("op") not in _MODELED_OPS:
+            parts["unmodeled_op"] = True
+        left, right = match.get("left"), match.get("right")
+        # A dport vmap ({"vmap": ...} on the right of a payload dport
+        # match) carries verdicts we do not follow — mark unmodeled.
+        if isinstance(right, dict) and "vmap" in right:
+            parts["unmodeled_op"] = True
+        if not isinstance(left, dict):
             continue
+        if "payload" in left:
+            payload = left["payload"]
+            proto = payload.get("protocol")
+            field = payload.get("field")
+            if field == "dport":
+                # ``th`` (transport header) is protocol-agnostic — it must
+                # not overwrite a tcp/udp answer derived from a preceding
+                # ``meta l4proto`` expression.
+                if proto in ("tcp", "udp", "sctp", "dccp"):
+                    parts["l4proto_tcp"] = proto == "tcp"
+                spec = _PortSpec()
+                _extract_ports(right, spec)
+                parts["dports"] = spec
+            elif field == "saddr":
+                parts["saddr"] = _render_prefixes(right)
+        elif "meta" in left:
+            key = left["meta"].get("key")
+            if key in ("iif", "iifname"):
+                if right in ("lo", 1):
+                    parts["iif_lo"] = True
+                else:
+                    parts["iif_other"] = True
+            elif key == "l4proto":
+                protos: set[str] = set()
+                for item in _as_list(right):
+                    if isinstance(item, str):
+                        protos.add(item)
+                    elif isinstance(item, dict) and "set" in item:
+                        protos |= {s for s in _as_list(item["set"]) if isinstance(s, str)}
+                if protos:
+                    parts["l4proto_tcp"] = "tcp" in protos
+        elif "ct" in left and left["ct"].get("key") == "state":
+            states: list[str] = []
+            for item in _as_list(right):
+                if isinstance(item, str):
+                    states.append(item)
+                elif isinstance(item, dict) and "set" in item:
+                    states.extend(s for s in _as_list(item["set"]) if isinstance(s, str))
+            parts["ct_state"] = states
+    return parts
+
+
+def _evaluate_chain(rules: list[dict[str, Any]], policy: str, port: int) -> tuple[str, str]:
+    """Verdict for one input-hooked chain: does IT let the packet through?"""
+    maybe_accepted = False  # an unmodeled rule that might accept the port
+    maybe_dropped = False  # an unmodeled rule that might drop the port
+    jumps_seen = False
+    for parts in rules:
         if parts["iif_lo"]:
             continue  # cannot match: our packet arrives off-box
         ct = parts["ct_state"]
         if ct is not None and "new" not in ct:
             continue  # established/related accepts, invalid drops: not NEW
-        dports = parts["dports"]
-        if dports is None:
-            continue  # no dport constraint — the base config's blanket
-            # rules (ssh, icmp) name their ports/protocols; a truly
-            # unconditional verdict would be policy-shaped and is out of
-            # the model (documented limit)
-        if parts["l4proto_tcp"] is False or port not in dports:
+        if parts["has_jump"] and parts["dports"] is None:
+            jumps_seen = True
+            continue
+        spec = parts["dports"]
+        unmodeled = parts["unmodeled_op"] or (spec is not None and spec.unmodeled)
+        if unmodeled and (spec is not None or parts["verdict"] is not None):
+            # A rule we can't reason about that carries (or gates) a
+            # verdict: it MIGHT have matched this port first. Record which
+            # direction it could push and keep scanning — a modeled
+            # decision found later is only trustworthy if no unmodeled
+            # rule could have pre-empted it in that direction.
+            if parts["verdict"] == "accept" or parts["has_jump"]:
+                maybe_accepted = True
+            if parts["verdict"] in ("drop", "reject") or parts["has_jump"]:
+                maybe_dropped = True
+            if parts["verdict"] is None and not parts["has_jump"]:
+                # A verdict map (vmap) — the verdicts live inside the map
+                # we don't follow, so it could push either way.
+                maybe_accepted = True
+                maybe_dropped = True
+            continue
+        if parts["verdict"] is None:
+            continue
+        if spec is None:
+            # No dport constraint. The base config's blanket verdicts all
+            # name their protocol/ports; a truly unconditional accept/drop
+            # here would be policy-shaped and is out of the model
+            # (documented limit).
+            continue
+        if parts["l4proto_tcp"] is False or not spec.contains(port):
             continue
         if parts["verdict"] in ("drop", "reject"):
+            if parts["saddr"] or parts["iif_other"] or parts["has_limit"]:
+                # Qualified drop: blocks one subnet / NIC / flood rate, not
+                # the LAN at large — treating it as "blocked" would cry
+                # wolf on a healthy box.
+                continue
+            if maybe_accepted:
+                return ("indeterminate", f"unmodeled rule may accept {port} before its drop")
             return ("blocked", f"explicit {parts['verdict']} rule for {port}")
+        # accept
+        if maybe_dropped:
+            return ("indeterminate", f"unmodeled rule may drop {port} before its accept")
         if parts["saddr"]:
             return ("scoped", "accept scoped to " + ", ".join(parts["saddr"]))
         return ("open", f"accept rule for {port}")
 
-    policies = set(input_chains.values())
-    if policies == {"accept"}:
+    if policy == "accept":
+        if maybe_dropped:
+            # e.g. ``tcp dport != 80 drop`` — really drops this port, but
+            # we can't model the negation; don't claim open.
+            return ("indeterminate", "unmodeled rule may drop before policy accept")
         return ("open", "no matching rule; chain policy accept")
+    if maybe_accepted or jumps_seen:
+        # The accept might live in a rule/sub-chain we can't follow —
+        # say nothing rather than a confident wrong "blocked".
+        return ("indeterminate", "policy drop, but unmodeled/jumped rules present")
     return ("blocked", "no accept rule matches; chain policy drop")
 
 
-def run_check() -> dict[str, Any]:
-    try:
+def evaluate_ports(nft_doc: dict[str, Any], ports: tuple[int, ...]) -> dict[int, tuple[str, str]]:
+    """Per-port ``(status, detail)`` for a NEW off-box TCP connection.
+
+    One parse pass shared across ports; every input-hooked chain is
+    evaluated independently and combined worst-wins (see module
+    docstring for the model).
+    """
+    entries = nft_doc.get("nftables")
+    if not isinstance(entries, list):
+        return {p: ("indeterminate", "nft output has no ruleset") for p in ports}
+
+    # (family, table, name) -> policy. Keyed WITH family: k3s's
+    # iptables-nft layer keeps same-named INPUT chains in ip and ip6.
+    input_chains: dict[tuple[str, str, str], str] = {}
+    for entry in entries:
+        chain = entry.get("chain") if isinstance(entry, dict) else None
+        if isinstance(chain, dict) and chain.get("hook") == "input":
+            key = (chain.get("family"), chain.get("table"), chain.get("name"))
+            input_chains[key] = chain.get("policy", "accept")
+    if not input_chains:
+        # No input-hooked chain at all: nothing filters inbound traffic.
+        return {p: ("open", "no input-hooked chain (unfiltered)") for p in ports}
+
+    chain_rules: dict[tuple[str, str, str], list[dict[str, Any]]] = {
+        k: [] for k in input_chains
+    }
+    for entry in entries:
+        rule = entry.get("rule") if isinstance(entry, dict) else None
+        if not isinstance(rule, dict):
+            continue
+        key = (rule.get("family"), rule.get("table"), rule.get("chain"))
+        if key in chain_rules:
+            chain_rules[key].append(_match_parts(_as_list(rule.get("expr") or [])))
+
+    results: dict[int, tuple[str, str]] = {}
+    for port in ports:
+        worst: tuple[str, str] | None = None
+        for key, policy in input_chains.items():
+            status, detail = _evaluate_chain(chain_rules[key], policy, port)
+            if len(input_chains) > 1:
+                detail = f"{detail} ({'/'.join(str(k) for k in key)})"
+            if worst is None or _SEVERITY[status] > _SEVERITY[worst[0]]:
+                worst = (status, detail)
+        assert worst is not None  # input_chains is non-empty here
+        results[port] = worst
+    return results
+
+
+def evaluate_port(nft_doc: dict[str, Any], port: int) -> tuple[str, str]:
+    """Single-port convenience wrapper over :func:`evaluate_ports`."""
+    return evaluate_ports(nft_doc, (port,))[port]
+
+
+def _read_ruleset() -> dict[str, Any]:
+    """Fetch input-hooked chains only, merged into one nft-shaped doc.
+
+    ``nft -j list ruleset`` would work but serialises every kube-proxy /
+    flannel table on a k3s appliance — potentially megabytes parsed each
+    run just to be skipped. Two phases keep it cheap AND correct across
+    families: enumerate chains (tiny), then fetch only the input-hooked
+    ones.
+    """
+
+    def _nft(*args: str) -> dict[str, Any]:
         proc = subprocess.run(
-            ["nft", "-j", "list", "ruleset"],
+            ["nft", "-j", *args],
             capture_output=True,
             text=True,
             timeout=15,
             check=True,
         )
-        doc = json.loads(proc.stdout)
+        return json.loads(proc.stdout)
+
+    chains_doc = _nft("list", "chains")
+    merged: list[dict[str, Any]] = []
+    for entry in chains_doc.get("nftables") or []:
+        chain = entry.get("chain") if isinstance(entry, dict) else None
+        if not (isinstance(chain, dict) and chain.get("hook") == "input"):
+            continue
+        chain_doc = _nft(
+            "list", "chain", chain["family"], chain["table"], chain["name"]
+        )
+        merged.extend(chain_doc.get("nftables") or [])
+    return {"nftables": merged}
+
+
+def run_check(previous: dict[str, Any] | None = None) -> dict[str, Any]:
+    try:
+        doc = _read_ruleset()
+        results = evaluate_ports(doc, WEB_PORTS)
     except Exception as exc:  # noqa: BLE001 — any failure here is "can't tell",
         # never "blocked": a missing nft binary or a transient must not alert
+        prev_streak = int((previous or {}).get("consecutive_indeterminate") or 0)
         return {
             "status": "indeterminate",
             "detail": f"could not read ruleset: {exc}",
             "ports": {},
             "checked_at": int(time.time()),
+            "ttl_s": TTL_S,
+            "consecutive_indeterminate": prev_streak + 1,
         }
 
-    ports = {str(p): dict(zip(("status", "detail"), evaluate_port(doc, p))) for p in WEB_PORTS}
-    https = ports[str(WEB_PORTS[0])]["status"]
-    overall = https if https != "indeterminate" else "indeterminate"
+    https_status, https_detail = results[443]
+    if https_status == "indeterminate":
+        prev_streak = int((previous or {}).get("consecutive_indeterminate") or 0)
+        streak = prev_streak + 1
+    else:
+        streak = 0
     return {
-        "status": overall,  # verdict keys off 443 — the UI's real front door
-        "detail": ports[str(WEB_PORTS[0])]["detail"],
-        "ports": ports,
+        # The verdict keys off 443 — the UI's real front door. The
+        # per-port map below (including 80) is triage payload for the
+        # log/state file only; nothing branches on it.
+        "status": https_status,
+        "detail": https_detail,
+        "ports": {
+            str(p): {"status": results[p][0], "detail": results[p][1]} for p in WEB_PORTS
+        },
         "checked_at": int(time.time()),
+        "ttl_s": TTL_S,
+        "consecutive_indeterminate": streak,
     }
 
 
+def _read_previous_state() -> dict[str, Any] | None:
+    try:
+        raw = json.loads(STATE_PATH.read_text(encoding="utf-8"))
+        return raw if isinstance(raw, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
 def main() -> int:
-    result = run_check()
+    result = run_check(previous=_read_previous_state())
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = STATE_PATH.with_suffix(".json.tmp")
+    # PID-suffixed tmp: firstboot's inline run and the timer's first fire
+    # can overlap on first boot; a shared tmp name could rename a
+    # partially-written file into place.
+    tmp = STATE_PATH.with_name(f"{STATE_PATH.name}.{os.getpid()}.tmp")
     tmp.write_text(json.dumps(result), encoding="utf-8")
     tmp.replace(STATE_PATH)
 

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-webui-selfcheck
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-webui-selfcheck
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Confirm the Web UI (80/443) is reachable through the firewall (#779).
+
+When a fresh appliance's Web UI is unreachable, nothing on the box says
+so — #776 was a full diagnostic session (pods, services, ss, curl,
+Test-NetConnection) to arrive at "one nftables accept rule is missing",
+and every intermediate step confirmed something healthy. This check makes
+the appliance volunteer that answer: it reasons about the kernel-active
+ruleset and surfaces a verdict on the console dashboard.
+
+Independence is the point. The supervisor's own 5-minute firewall drift
+check verifies its rendered drop-in against its own expectations — it
+cannot run before the supervisor registers (#777), and it answers "did my
+drop-in apply", not "can anyone reach the management surface". This
+script runs from firstboot + a systemd timer, reads the live ruleset via
+``nft -j``, and never touches the supervisor. (It is Python rather than
+the watchdog's bash-only posture because the reasoning needs real JSON
+walking; host python3 is baked into the OS image — spatium-console
+depends on it — and is independent of the supervisor's container
+runtime, which is the dependency #779 routes around.)
+
+Why not just curl ourselves: ``curl https://<own-lan-ip>/`` from the
+appliance succeeds even when the port is firewalled, because
+locally-originated traffic to a local address is delivered via ``lo``
+and hits ``iif "lo" accept`` — the exact trap #776 walked into. A
+genuinely off-box probe needs a second host; reasoning about the
+ruleset does not.
+
+The traffic model (documented limits, kept honest):
+
+* We evaluate a NEW inbound TCP connection to dport 443 (and 80) from a
+  non-loopback source against ``inet filter input``.
+* Rules that constrain ``tcp dport`` to include the port decide the
+  verdict, first match wins (accept → reachable, drop/reject → blocked).
+* Rules that cannot match that packet are skipped: ``iif lo`` guarded
+  rules (we are off-box), ``ct state established,related`` accepts and
+  ``ct state invalid`` drops (we are NEW), and rules for other
+  ports/protocols.
+* No matching rule → the chain policy decides.
+* An accept carrying a ``saddr`` restriction is REACHABLE-SCOPED: once
+  ``web_ui_allowed_cidrs`` (#285 Phase 6) is set, unreachable-from-
+  arbitrary-sources is the *correct* state, and reporting a hardened
+  appliance as broken would be worse than no check. The scope prefixes
+  ride along in the verdict detail.
+
+Verdict lands in ``/run/spatiumddi/webui-selfcheck.json`` (ephemeral by
+design — a verdict must never outlive the ruleset it describes, and
+/run resets per boot) where spatium-console renders it as a Web UI chip
+next to the Watchdog line. Exit 0 reachable / 1 blocked / 2
+indeterminate (nft unavailable etc. — the timer must not cry wolf on a
+transient).
+
+Searchable log tag: ``spatiumddi-webui-selfcheck``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+STATE_PATH = Path("/run/spatiumddi/webui-selfcheck.json")
+WEB_PORTS = (443, 80)
+
+# Chains hooked at input for the inet/ip/ip6 families all filter our
+# packet; the appliance base config uses exactly one: inet filter input.
+_INPUT_HOOK = "input"
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else [value]
+
+
+def _match_parts(rule_exprs: list[dict[str, Any]]) -> dict[str, Any]:
+    """Split a rule's expressions into the aspects the model cares about."""
+    parts: dict[str, Any] = {
+        "dports": None,  # set[int] | None — None means no dport constraint
+        "iif_lo": False,
+        "ct_state": None,  # list[str] | None
+        "saddr": None,  # list[str] rendered prefixes | None
+        "l4proto_tcp": None,  # True / False / None (unconstrained)
+        "verdict": None,  # "accept" | "drop" | "reject" | None
+    }
+    for expr in rule_exprs:
+        if not isinstance(expr, dict):
+            continue
+        if "accept" in expr:
+            parts["verdict"] = "accept"
+        elif "drop" in expr:
+            parts["verdict"] = "drop"
+        elif "reject" in expr:
+            parts["verdict"] = "reject"
+        match = expr.get("match")
+        if not isinstance(match, dict):
+            continue
+        left, right = match.get("left"), match.get("right")
+        if not isinstance(left, dict):
+            continue
+        if "payload" in left:
+            payload = left["payload"]
+            proto = payload.get("protocol")
+            field = payload.get("field")
+            if field == "dport":
+                parts["l4proto_tcp"] = proto == "tcp"
+                parts["dports"] = _extract_ports(right)
+            elif field == "saddr":
+                parts["saddr"] = _render_prefixes(right)
+        elif "meta" in left:
+            key = left["meta"].get("key")
+            if key in ("iif", "iifname") and right in ("lo", 1):
+                parts["iif_lo"] = True
+            elif key == "l4proto":
+                protos = {p for p in _as_list(right) if isinstance(p, str)}
+                if protos:
+                    parts["l4proto_tcp"] = "tcp" in protos
+        elif "ct" in left and left["ct"].get("key") == "state":
+            states: list[str] = []
+            for item in _as_list(right):
+                if isinstance(item, str):
+                    states.append(item)
+                elif isinstance(item, dict) and "set" in item:
+                    states.extend(s for s in _as_list(item["set"]) if isinstance(s, str))
+            parts["ct_state"] = states
+    return parts
+
+
+def _extract_ports(right: Any) -> set[int]:
+    """Flatten a dport match RHS (int, set, range) into concrete ports.
+
+    Ranges are expanded only for membership testing against WEB_PORTS, so
+    an 1-65535 range costs two containment checks, not 65k inserts.
+    """
+    ports: set[int] = set()
+    for item in _as_list(right):
+        if isinstance(item, int):
+            ports.add(item)
+        elif isinstance(item, dict):
+            if "set" in item:
+                ports |= _extract_ports(item["set"])
+            elif "range" in item:
+                lo, hi = item["range"]
+                ports |= {p for p in WEB_PORTS if lo <= p <= hi}
+    return ports
+
+
+def _render_prefixes(right: Any) -> list[str]:
+    out: list[str] = []
+    for item in _as_list(right):
+        if isinstance(item, str):
+            out.append(item)
+        elif isinstance(item, dict):
+            if "set" in item:
+                out.extend(_render_prefixes(item["set"]))
+            elif "prefix" in item:
+                pfx = item["prefix"]
+                out.append(f"{pfx.get('addr')}/{pfx.get('len')}")
+    return out
+
+
+def evaluate_port(nft_doc: dict[str, Any], port: int) -> tuple[str, str]:
+    """Return ``(status, detail)`` for a NEW off-box TCP connection to ``port``.
+
+    status: ``open`` | ``scoped`` | ``blocked`` | ``indeterminate``.
+    """
+    entries = nft_doc.get("nftables")
+    if not isinstance(entries, list):
+        return ("indeterminate", "nft output has no ruleset")
+
+    input_chains: dict[tuple[str, str], str] = {}  # (table, name) -> policy
+    for entry in entries:
+        chain = entry.get("chain") if isinstance(entry, dict) else None
+        if isinstance(chain, dict) and chain.get("hook") == _INPUT_HOOK:
+            input_chains[(chain.get("table"), chain.get("name"))] = chain.get(
+                "policy", "accept"
+            )
+    if not input_chains:
+        # No input-hooked chain at all: nothing filters inbound traffic.
+        return ("open", "no input-hooked chain (unfiltered)")
+
+    for entry in entries:
+        rule = entry.get("rule") if isinstance(entry, dict) else None
+        if not isinstance(rule, dict):
+            continue
+        if (rule.get("table"), rule.get("chain")) not in input_chains:
+            continue
+        parts = _match_parts(_as_list(rule.get("expr") or []))
+        if parts["verdict"] is None:
+            continue
+        if parts["iif_lo"]:
+            continue  # cannot match: our packet arrives off-box
+        ct = parts["ct_state"]
+        if ct is not None and "new" not in ct:
+            continue  # established/related accepts, invalid drops: not NEW
+        dports = parts["dports"]
+        if dports is None:
+            continue  # no dport constraint — the base config's blanket
+            # rules (ssh, icmp) name their ports/protocols; a truly
+            # unconditional verdict would be policy-shaped and is out of
+            # the model (documented limit)
+        if parts["l4proto_tcp"] is False or port not in dports:
+            continue
+        if parts["verdict"] in ("drop", "reject"):
+            return ("blocked", f"explicit {parts['verdict']} rule for {port}")
+        if parts["saddr"]:
+            return ("scoped", "accept scoped to " + ", ".join(parts["saddr"]))
+        return ("open", f"accept rule for {port}")
+
+    policies = set(input_chains.values())
+    if policies == {"accept"}:
+        return ("open", "no matching rule; chain policy accept")
+    return ("blocked", "no accept rule matches; chain policy drop")
+
+
+def run_check() -> dict[str, Any]:
+    try:
+        proc = subprocess.run(
+            ["nft", "-j", "list", "ruleset"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=True,
+        )
+        doc = json.loads(proc.stdout)
+    except Exception as exc:  # noqa: BLE001 — any failure here is "can't tell",
+        # never "blocked": a missing nft binary or a transient must not alert
+        return {
+            "status": "indeterminate",
+            "detail": f"could not read ruleset: {exc}",
+            "ports": {},
+            "checked_at": int(time.time()),
+        }
+
+    ports = {str(p): dict(zip(("status", "detail"), evaluate_port(doc, p))) for p in WEB_PORTS}
+    https = ports[str(WEB_PORTS[0])]["status"]
+    overall = https if https != "indeterminate" else "indeterminate"
+    return {
+        "status": overall,  # verdict keys off 443 — the UI's real front door
+        "detail": ports[str(WEB_PORTS[0])]["detail"],
+        "ports": ports,
+        "checked_at": int(time.time()),
+    }
+
+
+def main() -> int:
+    result = run_check()
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_PATH.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(result), encoding="utf-8")
+    tmp.replace(STATE_PATH)
+
+    line = (
+        f"spatiumddi-webui-selfcheck: {result['status']} — {result['detail']} "
+        f"(ports: {json.dumps(result['ports'])})"
+    )
+    if result["status"] == "blocked":
+        print(line, file=sys.stderr)
+        print(
+            "spatiumddi-webui-selfcheck: the Web UI would NOT be reachable "
+            "from the LAN. Inspect 'nft list chain inet filter input' — "
+            "expected an accept for tcp dport { 80, 443 } (the "
+            "00-spatium-webui.nft sentinel or the supervisor drop-in).",
+            file=sys.stderr,
+        )
+        return 1
+    print(line)
+    return 0 if result["status"] in ("open", "scoped") else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/appliance/mkosi.postinst
+++ b/appliance/mkosi.postinst
@@ -63,6 +63,7 @@ for unit in chrony.service ssh.service \
             spatium-firewall-reload.path \
             spatiumddi-firewall-revert.timer \
             spatiumddi-image-prune.timer \
+            spatiumddi-webui-selfcheck.timer \
             spatium-install.service \
             spatium-live-banner.service \
             spatium-live-bootstrap.service \
@@ -299,6 +300,10 @@ chmod 0644 "$BUILDROOT/etc/systemd/system/spatium-firewall-reload.service"
 chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-firewall-revert"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-firewall-revert.timer"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-firewall-revert.service"
+# #779 — Web UI firewall reachability self-check (script + timer).
+chmod 0755 "$BUILDROOT/usr/local/bin/spatiumddi-webui-selfcheck"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-webui-selfcheck.timer"
+chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-webui-selfcheck.service"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-reboot.path"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatiumddi-reboot.service"
 chmod 0644 "$BUILDROOT/etc/systemd/system/spatium-console.service"

--- a/backend/tests/test_ci_backend_relevant.py
+++ b/backend/tests/test_ci_backend_relevant.py
@@ -39,6 +39,7 @@ _MANIFEST = _REPO_ROOT / ".github" / "scripts" / "ci-backend-must-run.txt"
 # changes that break the test doing the reading.
 _KNOWN_REPO_ROOT_READS: dict[str, str] = {
     "test_spatium_console.py": "appliance/mkosi.extra/usr/local/bin/spatium-console",
+    "test_webui_selfcheck.py": ("appliance/mkosi.extra/usr/local/bin/spatiumddi-webui-selfcheck"),
     "test_appliance_firewall_render.py": (
         "agent/supervisor/spatium_supervisor/firewall_renderer.py"
     ),

--- a/backend/tests/test_spatium_console.py
+++ b/backend/tests/test_spatium_console.py
@@ -581,12 +581,15 @@ def test_bare_scalar_result_is_boring_like_the_dict_form(m) -> None:
     )
 
 
-# ── #779 — Web UI firewall self-check chip ──────────────────────────────────
+# ── #779 — Web UI firewall self-check warning ───────────────────────────────
 # webui_selfcheck_status() reads the verdict spatiumddi-webui-selfcheck
-# writes to /run and returns a red chip ONLY for a fresh `blocked` — every
-# other state (open / scoped-hardened / indeterminate / stale / missing /
-# garbage) is None, so a correctly-hardened or merely-unchecked appliance
-# never shows a false alarm.
+# writes to /run and returns an identity-row warning for exactly two
+# states: a fresh `blocked` (bold red, carrying the script's own detail)
+# and a persistent-indeterminate streak (dim yellow — the checker itself
+# is broken and must not die silently). Everything else — open,
+# scoped-hardened, a single indeterminate, stale, missing, garbage — is
+# None, so a healthy or merely-unchecked appliance never shows a false
+# alarm. Freshness follows the ttl_s the script ships in the file.
 
 
 def _selfcheck_state(m, monkeypatch, tmp_path, payload):
@@ -598,39 +601,85 @@ def _selfcheck_state(m, monkeypatch, tmp_path, payload):
     return p
 
 
-def test_webui_selfcheck_fresh_blocked_is_red(m, monkeypatch, tmp_path):
+def test_webui_selfcheck_fresh_blocked_is_red_with_detail(m, monkeypatch, tmp_path):
     import time as _time
 
     _selfcheck_state(
         m,
         monkeypatch,
         tmp_path,
-        {"status": "blocked", "detail": "x", "checked_at": int(_time.time())},
+        {
+            "status": "blocked",
+            "detail": "explicit drop rule for 443",
+            "checked_at": int(_time.time()),
+            "ttl_s": 900,
+        },
     )
     chip = m.webui_selfcheck_status()
     assert chip is not None
     label, style = chip
-    assert "Web UI" in label
+    assert label.startswith("BLOCKED by firewall")
+    # The script's own detail rides along — an explicit drop rule and a
+    # missing accept read differently to the operator.
+    assert "explicit drop rule for 443" in label
     assert style == "bold red"
 
 
-@pytest.mark.parametrize("status", ["open", "scoped", "indeterminate"])
-def test_webui_selfcheck_non_blocked_is_none(m, monkeypatch, tmp_path, status):
+@pytest.mark.parametrize("status", ["open", "scoped"])
+def test_webui_selfcheck_healthy_states_are_none(m, monkeypatch, tmp_path, status):
     import time as _time
 
     _selfcheck_state(
         m,
         monkeypatch,
         tmp_path,
-        {"status": status, "detail": "x", "checked_at": int(_time.time())},
+        {"status": status, "detail": "x", "checked_at": int(_time.time()), "ttl_s": 900},
     )
     assert m.webui_selfcheck_status() is None
+
+
+def test_webui_selfcheck_single_indeterminate_is_none(m, monkeypatch, tmp_path):
+    import time as _time
+
+    _selfcheck_state(
+        m,
+        monkeypatch,
+        tmp_path,
+        {
+            "status": "indeterminate",
+            "detail": "x",
+            "checked_at": int(_time.time()),
+            "ttl_s": 900,
+            "consecutive_indeterminate": 1,
+        },
+    )
+    assert m.webui_selfcheck_status() is None
+
+
+def test_webui_selfcheck_persistent_indeterminate_is_yellow(m, monkeypatch, tmp_path):
+    import time as _time
+
+    _selfcheck_state(
+        m,
+        monkeypatch,
+        tmp_path,
+        {
+            "status": "indeterminate",
+            "detail": "x",
+            "checked_at": int(_time.time()),
+            "ttl_s": 900,
+            "consecutive_indeterminate": 3,
+        },
+    )
+    chip = m.webui_selfcheck_status()
+    assert chip is not None
+    assert chip[1] == "yellow"
 
 
 def test_webui_selfcheck_stale_blocked_is_none(m, monkeypatch, tmp_path):
     import time as _time
 
-    # 3 missed timer periods: the checker itself is broken; a verdict that
+    # Older than the file's own ttl: the checker is broken; a verdict that
     # may predate a fixed firewall must not keep alerting.
     _selfcheck_state(
         m,
@@ -639,10 +688,31 @@ def test_webui_selfcheck_stale_blocked_is_none(m, monkeypatch, tmp_path):
         {
             "status": "blocked",
             "detail": "x",
-            "checked_at": int(_time.time()) - (m._WEBUI_SELFCHECK_MAX_AGE_S + 60),
+            "checked_at": int(_time.time()) - 961,
+            "ttl_s": 900,
         },
     )
     assert m.webui_selfcheck_status() is None
+
+
+def test_webui_selfcheck_ttl_comes_from_the_file(m, monkeypatch, tmp_path):
+    import time as _time
+
+    # A slower timer ships a bigger ttl_s and stays alertable; the console
+    # must follow the file, not a hardcoded constant (a cadence change in
+    # the timer unit must not silently suppress the alarm).
+    _selfcheck_state(
+        m,
+        monkeypatch,
+        tmp_path,
+        {
+            "status": "blocked",
+            "detail": "x",
+            "checked_at": int(_time.time()) - 1200,
+            "ttl_s": 3600,
+        },
+    )
+    assert m.webui_selfcheck_status() is not None
 
 
 def test_webui_selfcheck_missing_or_garbage_is_none(m, monkeypatch, tmp_path):
@@ -655,12 +725,22 @@ def test_webui_selfcheck_missing_or_garbage_is_none(m, monkeypatch, tmp_path):
 
 
 def test_overall_verdict_webui_blocked_is_critical(m):
-    from types import SimpleNamespace
-
-    # Minimal state: healthy up to the #779 branch (no restore, no red
-    # pods, no failing host-config plane) — the webui chip alone must
-    # flip the verdict.
-    state = SimpleNamespace(host_health={}, ps_rows=[])
-    verdict, offender = m.overall_verdict(state, None, None, ("Web UI unreachable", "bold red"))
+    state = m.DashboardState({}, _FakeTail(), "/dev/tty1")
+    verdict, offender = m.overall_verdict(
+        state, None, None, ("BLOCKED by firewall — x", "bold red")
+    )
     assert verdict == "CRITICAL"
     assert "Web UI" in offender
+
+
+def test_overall_verdict_webui_yellow_note_is_not_critical(m):
+    # The persistent-indeterminate note renders on the identity row but
+    # must not flip the box CRITICAL. host_health retrying gives the
+    # traversal a deterministic DEGRADED exit before the slot probe.
+    state = m.DashboardState({}, _FakeTail(), "/dev/tty1")
+    state.host_health = {"verdict": "ok", "failing": [], "retrying": ["ntp"], "restore": False}
+    verdict, offender = m.overall_verdict(
+        state, None, None, ("firewall self-check unavailable", "yellow")
+    )
+    assert verdict == "DEGRADED"
+    assert "Web UI" not in offender

--- a/backend/tests/test_spatium_console.py
+++ b/backend/tests/test_spatium_console.py
@@ -579,3 +579,88 @@ def test_bare_scalar_result_is_boring_like_the_dict_form(m) -> None:
     assert not m.AppLogTail._is_noise(
         "Task app.tasks.ipam_discovery.dispatch succeeded in 0.04s: 7"
     )
+
+
+# ── #779 — Web UI firewall self-check chip ──────────────────────────────────
+# webui_selfcheck_status() reads the verdict spatiumddi-webui-selfcheck
+# writes to /run and returns a red chip ONLY for a fresh `blocked` — every
+# other state (open / scoped-hardened / indeterminate / stale / missing /
+# garbage) is None, so a correctly-hardened or merely-unchecked appliance
+# never shows a false alarm.
+
+
+def _selfcheck_state(m, monkeypatch, tmp_path, payload):
+    import json as _json
+
+    p = tmp_path / "webui-selfcheck.json"
+    p.write_text(_json.dumps(payload))
+    monkeypatch.setattr(m, "_WEBUI_SELFCHECK_STATE", p)
+    return p
+
+
+def test_webui_selfcheck_fresh_blocked_is_red(m, monkeypatch, tmp_path):
+    import time as _time
+
+    _selfcheck_state(
+        m,
+        monkeypatch,
+        tmp_path,
+        {"status": "blocked", "detail": "x", "checked_at": int(_time.time())},
+    )
+    chip = m.webui_selfcheck_status()
+    assert chip is not None
+    label, style = chip
+    assert "Web UI" in label
+    assert style == "bold red"
+
+
+@pytest.mark.parametrize("status", ["open", "scoped", "indeterminate"])
+def test_webui_selfcheck_non_blocked_is_none(m, monkeypatch, tmp_path, status):
+    import time as _time
+
+    _selfcheck_state(
+        m,
+        monkeypatch,
+        tmp_path,
+        {"status": status, "detail": "x", "checked_at": int(_time.time())},
+    )
+    assert m.webui_selfcheck_status() is None
+
+
+def test_webui_selfcheck_stale_blocked_is_none(m, monkeypatch, tmp_path):
+    import time as _time
+
+    # 3 missed timer periods: the checker itself is broken; a verdict that
+    # may predate a fixed firewall must not keep alerting.
+    _selfcheck_state(
+        m,
+        monkeypatch,
+        tmp_path,
+        {
+            "status": "blocked",
+            "detail": "x",
+            "checked_at": int(_time.time()) - (m._WEBUI_SELFCHECK_MAX_AGE_S + 60),
+        },
+    )
+    assert m.webui_selfcheck_status() is None
+
+
+def test_webui_selfcheck_missing_or_garbage_is_none(m, monkeypatch, tmp_path):
+    monkeypatch.setattr(m, "_WEBUI_SELFCHECK_STATE", tmp_path / "nope.json")
+    assert m.webui_selfcheck_status() is None
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json")
+    monkeypatch.setattr(m, "_WEBUI_SELFCHECK_STATE", bad)
+    assert m.webui_selfcheck_status() is None
+
+
+def test_overall_verdict_webui_blocked_is_critical(m):
+    from types import SimpleNamespace
+
+    # Minimal state: healthy up to the #779 branch (no restore, no red
+    # pods, no failing host-config plane) — the webui chip alone must
+    # flip the verdict.
+    state = SimpleNamespace(host_health={}, ps_rows=[])
+    verdict, offender = m.overall_verdict(state, None, None, ("Web UI unreachable", "bold red"))
+    assert verdict == "CRITICAL"
+    assert "Web UI" in offender

--- a/backend/tests/test_webui_selfcheck.py
+++ b/backend/tests/test_webui_selfcheck.py
@@ -6,17 +6,29 @@ living at ``appliance/mkosi.extra/usr/local/bin/`` — not part of the
 ``test_spatium_console.py``. Skips cleanly when the script isn't present
 in the checkout (the dev container copies only ``backend/``).
 
-The interesting surface is ``evaluate_port`` — the ruleset-reasoning that
-answers "would a NEW off-box TCP connection to 443 be accepted?" from
-``nft -j`` JSON. The fixtures below mirror the real appliance ruleset
-shapes: the base config (policy drop, ct rules, ``iif lo`` accept, ssh),
-the ``00-spatium-webui.nft`` bootstrap sentinel, the supervisor drop-in's
-scoped web-ui rule, and the #776 failure (no accept at all).
+The interesting surface is the ruleset-reasoning: "would a NEW off-box
+TCP connection to 443 be accepted?" answered from ``nft -j`` JSON. The
+fixtures mirror real appliance ruleset shapes (verified against live
+nft 1.1.x output during review): the base config (policy drop, ct rules,
+``iif lo`` accept, ssh), the ``00-spatium-webui.nft`` bootstrap sentinel,
+the supervisor drop-in's scoped web-ui rule, k3s's iptables-nft
+``ip filter INPUT`` chain, and the #776 failure (no accept at all).
 
-The one trap this file exists to pin: an ``iif lo accept`` must never
-count as reachability — ``curl`` from the appliance to its own LAN IP
-rides ``lo`` and succeeds against a firewalled port, which is exactly the
-false-green #776's diagnostic session fell into.
+Three traps this file exists to pin, all found in review:
+
+* ``iif lo accept`` must never count as reachability — ``curl`` from the
+  appliance to its own LAN IP rides ``lo`` and succeeds against a
+  firewalled port (the false-green #776's diagnostic session fell into).
+* input-hooked chains are evaluated INDEPENDENTLY and combined
+  worst-wins — an operator's stray ``iptables -A INPUT ... -j ACCEPT``
+  lands in kube-proxy's accept-policy ``ip filter INPUT`` and must not
+  mask a drop-policy ``inet filter input`` with no accept (false-open).
+* qualified drops (saddr / interface / rate-limit) and unmodeled
+  constructs (``!=`` ops, named sets, vmaps, jumps in drop-policy
+  chains) must never produce a confident wrong verdict — the qualified
+  drops are skipped, the unmodeled shapes degrade to ``indeterminate``
+  (crying wolf on a healthy hardened box is the failure mode #779 names
+  as worse than no check).
 """
 
 from __future__ import annotations
@@ -58,12 +70,18 @@ def m():
 # ── nft -j fixture builders ─────────────────────────────────────────────────
 
 
-def _chain(policy: str = "drop") -> dict[str, Any]:
+def _chain(
+    policy: str = "drop",
+    *,
+    family: str = "inet",
+    table: str = "filter",
+    name: str = "input",
+) -> dict[str, Any]:
     return {
         "chain": {
-            "family": "inet",
-            "table": "filter",
-            "name": "input",
+            "family": family,
+            "table": table,
+            "name": name,
             "handle": 1,
             "type": "filter",
             "hook": "input",
@@ -73,32 +91,51 @@ def _chain(policy: str = "drop") -> dict[str, Any]:
     }
 
 
-def _rule(*exprs: dict[str, Any]) -> dict[str, Any]:
+def _rule(
+    *exprs: dict[str, Any],
+    family: str = "inet",
+    table: str = "filter",
+    chain: str = "input",
+) -> dict[str, Any]:
     return {
         "rule": {
-            "family": "inet",
-            "table": "filter",
-            "chain": "input",
+            "family": family,
+            "table": table,
+            "chain": chain,
             "handle": 10,
             "expr": list(exprs),
         }
     }
 
 
-def _dport_match(right: Any) -> dict[str, Any]:
+def _dport_match(right: Any, *, proto: str = "tcp", op: str = "==") -> dict[str, Any]:
     return {
         "match": {
-            "op": "==",
-            "left": {"payload": {"protocol": "tcp", "field": "dport"}},
+            "op": op,
+            "left": {"payload": {"protocol": proto, "field": "dport"}},
             "right": right,
         }
     }
 
 
+def _saddr_match(prefixes: list[tuple[str, int]], *, proto: str = "ip") -> dict[str, Any]:
+    return {
+        "match": {
+            "op": "==",
+            "left": {"payload": {"protocol": proto, "field": "saddr"}},
+            "right": {"set": [{"prefix": {"addr": a, "len": ln}} for a, ln in prefixes]},
+        }
+    }
+
+
+def _iif_match(name: str) -> dict[str, Any]:
+    return {"match": {"op": "==", "left": {"meta": {"key": "iif"}}, "right": name}}
+
+
 def _base_rules() -> list[dict[str, Any]]:
     """The always-present base-config rules that must all be skipped."""
     return [
-        # ct state established,related accept
+        # ct state established,related accept (real nft: bare list RHS)
         _rule(
             {
                 "match": {
@@ -109,7 +146,7 @@ def _base_rules() -> list[dict[str, Any]]:
             },
             {"accept": None},
         ),
-        # ct state invalid drop
+        # ct state invalid drop (real nft: bare string RHS)
         _rule(
             {
                 "match": {
@@ -121,16 +158,14 @@ def _base_rules() -> list[dict[str, Any]]:
             {"drop": None},
         ),
         # iif lo accept — the #776 trap; must never count as reachability
-        _rule(
-            {"match": {"op": "==", "left": {"meta": {"key": "iif"}}, "right": "lo"}},
-            {"accept": None},
-        ),
+        _rule(_iif_match("lo"), {"accept": None}),
         # ssh
         _rule(_dport_match(22), {"accept": None}),
     ]
 
 
 def _doc(*entries: dict[str, Any], policy: str = "drop") -> dict[str, Any]:
+    """A single-chain doc: the appliance's ``inet filter input``."""
     return {
         "nftables": [
             {"metainfo": {"version": "1.0.9", "json_schema_version": 1}},
@@ -142,12 +177,15 @@ def _doc(*entries: dict[str, Any], policy: str = "drop") -> dict[str, Any]:
     }
 
 
-# ── evaluate_port ───────────────────────────────────────────────────────────
+_SENTINEL = {"set": [80, 443]}  # 00-spatium-webui.nft's dport form
+
+
+# ── single-chain shapes ─────────────────────────────────────────────────────
 
 
 def test_sentinel_accept_is_open(m) -> None:
     """The 00-spatium-webui.nft shape: tcp dport { 80, 443 } accept."""
-    doc = _doc(_rule(_dport_match({"set": [80, 443]}), {"accept": None}))
+    doc = _doc(_rule(_dport_match(_SENTINEL), {"accept": None}))
     status, _ = m.evaluate_port(doc, 443)
     assert status == "open"
     assert m.evaluate_port(doc, 80)[0] == "open"
@@ -155,8 +193,7 @@ def test_sentinel_accept_is_open(m) -> None:
 
 def test_missing_accept_is_blocked(m) -> None:
     """The #776 failure: base rules only, policy drop, no web accept."""
-    doc = _doc()
-    status, detail = m.evaluate_port(doc, 443)
+    status, detail = m.evaluate_port(_doc(), 443)
     assert status == "blocked"
     assert "policy drop" in detail
 
@@ -164,40 +201,37 @@ def test_missing_accept_is_blocked(m) -> None:
 def test_iif_lo_accept_alone_is_still_blocked(m) -> None:
     """The trap this whole check exists for: an lo-guarded accept for 443
     must not read as reachable — off-box traffic never arrives on lo."""
-    doc = _doc(
-        _rule(
-            {"match": {"op": "==", "left": {"meta": {"key": "iif"}}, "right": "lo"}},
-            _dport_match({"set": [80, 443]}),
-            {"accept": None},
-        )
-    )
+    doc = _doc(_rule(_iif_match("lo"), _dport_match(_SENTINEL), {"accept": None}))
     assert m.evaluate_port(doc, 443)[0] == "blocked"
 
 
 def test_scoped_accept_reports_scoped(m) -> None:
     """web_ui_allowed_cidrs set (#285 Phase 6): hardened, not broken."""
-    doc = _doc(
-        _rule(
-            {
-                "match": {
-                    "op": "==",
-                    "left": {"payload": {"protocol": "ip", "field": "saddr"}},
-                    "right": {"set": [{"prefix": {"addr": "10.20.0.0", "len": 16}}]},
-                }
-            },
-            _dport_match({"set": [80, 443]}),
-            {"accept": None},
-        )
-    )
+    doc = _doc(_rule(_saddr_match([("10.20.0.0", 16)]), _dport_match(_SENTINEL), {"accept": None}))
     status, detail = m.evaluate_port(doc, 443)
     assert status == "scoped"
     assert "10.20.0.0/16" in detail
 
 
-def test_explicit_drop_wins_first_match(m) -> None:
+def test_v6_only_scoped_accept_reports_scoped(m) -> None:
+    """A v6-only web_ui_allowed_cidrs renders only an ip6-saddr rule; that
+    is the operator's configured intent — scoped, never a false blocked."""
+    doc = _doc(
+        _rule(
+            _saddr_match([("2001:db8::", 32)], proto="ip6"),
+            _dport_match(_SENTINEL),
+            {"accept": None},
+        )
+    )
+    status, detail = m.evaluate_port(doc, 443)
+    assert status == "scoped"
+    assert "2001:db8::/32" in detail
+
+
+def test_explicit_unqualified_drop_wins_first_match(m) -> None:
     doc = _doc(
         _rule(_dport_match(443), {"drop": None}),
-        _rule(_dport_match({"set": [80, 443]}), {"accept": None}),
+        _rule(_dport_match(_SENTINEL), {"accept": None}),
     )
     assert m.evaluate_port(doc, 443)[0] == "blocked"
 
@@ -209,8 +243,7 @@ def test_port_range_containing_443_is_open(m) -> None:
 
 
 def test_policy_accept_with_no_rules_is_open(m) -> None:
-    doc = _doc(policy="accept")
-    status, detail = m.evaluate_port(doc, 443)
+    status, detail = m.evaluate_port(_doc(policy="accept"), 443)
     assert status == "open"
     assert "policy accept" in detail
 
@@ -230,43 +263,251 @@ def test_other_port_accept_does_not_leak(m) -> None:
     assert m.evaluate_port(doc, 443)[0] == "blocked"
 
 
+# ── qualified drops: skipped, never a blanket block ─────────────────────────
+
+
+def test_saddr_scoped_drop_does_not_block(m) -> None:
+    """Blocking one abusive /24 doesn't make the UI LAN-unreachable."""
+    doc = _doc(
+        _rule(_saddr_match([("203.0.113.0", 24)]), _dport_match(_SENTINEL), {"drop": None}),
+        _rule(_dport_match(_SENTINEL), {"accept": None}),
+    )
+    assert m.evaluate_port(doc, 443)[0] == "open"
+
+
+def test_interface_scoped_drop_does_not_block(m) -> None:
+    """No UI on the DMZ NIC ≠ no UI at all."""
+    doc = _doc(
+        _rule(_iif_match("eth1"), _dport_match(443), {"drop": None}),
+        _rule(_dport_match(_SENTINEL), {"accept": None}),
+    )
+    assert m.evaluate_port(doc, 443)[0] == "open"
+
+
+def test_rate_limit_drop_does_not_block(m) -> None:
+    """A `limit rate over ... drop` SYN-flood protector isn't a block."""
+    doc = _doc(
+        _rule(
+            _dport_match(443),
+            {"limit": {"rate": 10, "per": "second", "inv": True}},
+            {"drop": None},
+        ),
+        _rule(_dport_match(_SENTINEL), {"accept": None}),
+    )
+    assert m.evaluate_port(doc, 443)[0] == "open"
+
+
+# ── unmodeled constructs: indeterminate, never a confident wrong answer ─────
+
+
+def test_negated_drop_is_never_credited_as_explicit_drop(m) -> None:
+    """`tcp dport != 443 drop` never touches 443. Under a drop policy with
+    no accept the verdict is still blocked — but by the POLICY, not by a
+    phantom 'explicit drop rule for 443' (the old model's misattribution
+    that survived even when an accept followed)."""
+    doc = _doc(_rule(_dport_match(443, op="!="), {"drop": None}))
+    status, detail = m.evaluate_port(doc, 443)
+    assert status == "blocked"
+    assert "policy drop" in detail
+    assert "explicit" not in detail
+
+
+def test_negated_drop_before_accept_is_indeterminate(m) -> None:
+    """Ordering can't be trusted around an unmodeled rule — even with a
+    modeled accept after it, the negation may have dropped first."""
+    doc = _doc(
+        _rule(_dport_match(80, op="!="), {"drop": None}),  # really drops 443!
+        _rule(_dport_match(_SENTINEL), {"accept": None}),
+    )
+    assert m.evaluate_port(doc, 443)[0] == "indeterminate"
+
+
+def test_negated_drop_under_policy_accept_is_indeterminate(m) -> None:
+    """`tcp dport != 80 drop` + policy accept really blocks 443; claiming
+    open would be a false-green."""
+    doc = _doc(_rule(_dport_match(80, op="!="), {"drop": None}), policy="accept")
+    assert m.evaluate_port(doc, 443)[0] == "indeterminate"
+
+
+def test_named_set_accept_is_indeterminate(m) -> None:
+    """`tcp dport @webports accept` — we don't resolve named sets; under
+    policy drop the old model reported a confident false 'blocked'."""
+    doc = _doc(_rule(_dport_match("@webports"), {"accept": None}))
+    assert m.evaluate_port(doc, 443)[0] == "indeterminate"
+
+
+def test_dport_vmap_is_indeterminate(m) -> None:
+    doc = _doc(
+        _rule(
+            _dport_match({"vmap": [[443, {"accept": None}]]}),
+        )
+    )
+    assert m.evaluate_port(doc, 443)[0] == "indeterminate"
+
+
+def test_jump_in_drop_policy_chain_is_indeterminate(m) -> None:
+    """The accept may live in the jumped-to sub-chain we don't follow."""
+    doc = _doc(_rule({"jump": {"target": "websvc"}}))
+    assert m.evaluate_port(doc, 443)[0] == "indeterminate"
+
+
+def test_modeled_drop_before_unmodeled_rule_still_blocks(m) -> None:
+    """First-match ordering IS trustworthy up to the unmodeled rule."""
+    doc = _doc(
+        _rule(_dport_match(443), {"drop": None}),
+        _rule(_dport_match("@webports"), {"accept": None}),
+    )
+    assert m.evaluate_port(doc, 443)[0] == "blocked"
+
+
+def test_meta_l4proto_set_th_dport_is_open(m) -> None:
+    """`meta l4proto { tcp, udp } th dport { 80, 443 } accept` — the meta
+    set must unwrap, and the protocol-agnostic `th` payload must not
+    clobber the tcp answer (used to be skipped → false blocked)."""
+    doc = _doc(
+        _rule(
+            {
+                "match": {
+                    "op": "==",
+                    "left": {"meta": {"key": "l4proto"}},
+                    "right": {"set": ["tcp", "udp"]},
+                }
+            },
+            _dport_match(_SENTINEL, proto="th"),
+            {"accept": None},
+        )
+    )
+    assert m.evaluate_port(doc, 443)[0] == "open"
+
+
+# ── multi-chain: independent evaluation, worst wins ─────────────────────────
+
+
+def _k3s_input_chain(*extra: dict[str, Any]) -> list[dict[str, Any]]:
+    """kube-proxy's iptables-nft `ip filter INPUT`: policy accept, ct+jump."""
+    return [
+        {"table": {"family": "ip", "name": "filter", "handle": 2}},
+        _chain("accept", family="ip", table="filter", name="INPUT"),
+        _rule(
+            {
+                "match": {
+                    "op": "in",
+                    "left": {"ct": {"key": "state"}},
+                    "right": "new",
+                }
+            },
+            {"jump": {"target": "KUBE-EXTERNAL-SERVICES"}},
+            family="ip",
+            table="filter",
+            chain="INPUT",
+        ),
+        *extra,
+    ]
+
+
+def test_accept_in_other_chain_does_not_mask_blocked_inet(m) -> None:
+    """The reproduced false-open: an operator's `iptables -A INPUT -p tcp
+    --dport 443 -j ACCEPT` lands in accept-policy `ip filter INPUT` and
+    must NOT mask the drop-policy inet chain that still has no accept —
+    the packet dies in the inet chain regardless."""
+    doc = _doc()  # inet: policy drop, no web accept (the #776 state)
+    doc["nftables"].extend(
+        _k3s_input_chain(
+            _rule(
+                _dport_match(443),
+                {"accept": None},
+                family="ip",
+                table="filter",
+                chain="INPUT",
+            )
+        )
+    )
+    status, detail = m.evaluate_port(doc, 443)
+    assert status == "blocked"
+    assert "inet" in detail  # names the chain that drops
+
+
+def test_stock_k3s_chains_do_not_disturb_open_verdict(m) -> None:
+    """Real appliance shape: inet chain with the sentinel + kube's
+    ct/jump-only accept-policy INPUT chains. Jumps in accept-policy
+    chains are skipped (service-layer rejects are out of frame)."""
+    doc = _doc(_rule(_dport_match(_SENTINEL), {"accept": None}))
+    doc["nftables"].extend(_k3s_input_chain())
+    assert m.evaluate_port(doc, 443)[0] == "open"
+
+
+def test_blocked_chain_outranks_indeterminate_chain(m) -> None:
+    doc = _doc()  # inet: blocked
+    doc["nftables"].extend(
+        _k3s_input_chain(
+            _rule(
+                _dport_match(443, op="!="),
+                {"drop": None},
+                family="ip",
+                table="filter",
+                chain="INPUT",
+            )
+        )
+    )
+    assert m.evaluate_port(doc, 443)[0] == "blocked"
+
+
 # ── run_check / main ────────────────────────────────────────────────────────
 
 
 def test_run_check_indeterminate_when_nft_unavailable(m, monkeypatch) -> None:
-    def _boom(*a: Any, **k: Any) -> None:
+    def _boom() -> None:
         raise FileNotFoundError("nft")
 
-    monkeypatch.setattr(m.subprocess, "run", _boom)
+    monkeypatch.setattr(m, "_read_ruleset", _boom)
     result = m.run_check()
     assert result["status"] == "indeterminate"
     assert "could not read ruleset" in result["detail"]
+    assert result["consecutive_indeterminate"] == 1
+    assert result["ttl_s"] == m.TTL_S
+
+
+def test_run_check_indeterminate_streak_accumulates(m, monkeypatch) -> None:
+    """The persistent-indeterminate counter is what lets the console say
+    'the checker itself is broken' instead of dying silently."""
+    monkeypatch.setattr(m, "_read_ruleset", lambda: (_ for _ in ()).throw(FileNotFoundError("nft")))
+    result = m.run_check(previous={"consecutive_indeterminate": 4})
+    assert result["consecutive_indeterminate"] == 5
+
+    # A successful run resets the streak.
+    monkeypatch.setattr(
+        m, "_read_ruleset", lambda: _doc(_rule(_dport_match(_SENTINEL), {"accept": None}))
+    )
+    result = m.run_check(previous={"consecutive_indeterminate": 4})
+    assert result["status"] == "open"
+    assert result["consecutive_indeterminate"] == 0
 
 
 def test_main_writes_state_and_exits_by_verdict(m, monkeypatch, tmp_path) -> None:
     state = tmp_path / "webui-selfcheck.json"
     monkeypatch.setattr(m, "STATE_PATH", state)
 
-    class _Proc:
-        stdout = json.dumps(_doc(_rule(_dport_match({"set": [80, 443]}), {"accept": None})))
-
-    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: _Proc())
+    monkeypatch.setattr(
+        m, "_read_ruleset", lambda: _doc(_rule(_dport_match(_SENTINEL), {"accept": None}))
+    )
     assert m.main() == 0
     saved = json.loads(state.read_text())
     assert saved["status"] == "open"
     assert saved["ports"]["443"]["status"] == "open"
+    assert saved["ports"]["80"]["status"] == "open"
     assert isinstance(saved["checked_at"], int)
+    assert saved["ttl_s"] == m.TTL_S
 
-    class _ProcBlocked:
-        stdout = json.dumps(_doc())
-
-    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: _ProcBlocked())
+    monkeypatch.setattr(m, "_read_ruleset", lambda: _doc())
     assert m.main() == 1
     assert json.loads(state.read_text())["status"] == "blocked"
 
-    def _boom(*a: Any, **k: Any) -> None:
-        raise FileNotFoundError("nft")
-
-    monkeypatch.setattr(m.subprocess, "run", _boom)
+    monkeypatch.setattr(m, "_read_ruleset", lambda: (_ for _ in ()).throw(FileNotFoundError("nft")))
     assert m.main() == 2
-    assert json.loads(state.read_text())["status"] == "indeterminate"
+    saved = json.loads(state.read_text())
+    assert saved["status"] == "indeterminate"
+    # main() reads the previous state file, so the streak persists across
+    # process invocations.
+    assert saved["consecutive_indeterminate"] == 1
+    assert m.main() == 2
+    assert json.loads(state.read_text())["consecutive_indeterminate"] == 2

--- a/backend/tests/test_webui_selfcheck.py
+++ b/backend/tests/test_webui_selfcheck.py
@@ -1,0 +1,272 @@
+"""Unit tests for the appliance Web UI firewall self-check (#779).
+
+``spatiumddi-webui-selfcheck`` is a standalone host script (pure stdlib)
+living at ``appliance/mkosi.extra/usr/local/bin/`` — not part of the
+``app`` package, so it is loaded by path here, same convention as
+``test_spatium_console.py``. Skips cleanly when the script isn't present
+in the checkout (the dev container copies only ``backend/``).
+
+The interesting surface is ``evaluate_port`` — the ruleset-reasoning that
+answers "would a NEW off-box TCP connection to 443 be accepted?" from
+``nft -j`` JSON. The fixtures below mirror the real appliance ruleset
+shapes: the base config (policy drop, ct rules, ``iif lo`` accept, ssh),
+the ``00-spatium-webui.nft`` bootstrap sentinel, the supervisor drop-in's
+scoped web-ui rule, and the #776 failure (no accept at all).
+
+The one trap this file exists to pin: an ``iif lo accept`` must never
+count as reachability — ``curl`` from the appliance to its own LAN IP
+rides ``lo`` and succeeds against a firewalled port, which is exactly the
+false-green #776's diagnostic session fell into.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "appliance"
+    / "mkosi.extra"
+    / "usr"
+    / "local"
+    / "bin"
+    / "spatiumddi-webui-selfcheck"
+)
+
+pytestmark = pytest.mark.skipif(
+    not _SCRIPT_PATH.exists(),
+    reason="webui-selfcheck host script not present in this checkout",
+)
+
+
+@pytest.fixture(scope="module")
+def m():
+    loader = SourceFileLoader("webui_selfcheck_under_test", str(_SCRIPT_PATH))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    assert spec is not None
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+# ── nft -j fixture builders ─────────────────────────────────────────────────
+
+
+def _chain(policy: str = "drop") -> dict[str, Any]:
+    return {
+        "chain": {
+            "family": "inet",
+            "table": "filter",
+            "name": "input",
+            "handle": 1,
+            "type": "filter",
+            "hook": "input",
+            "prio": 0,
+            "policy": policy,
+        }
+    }
+
+
+def _rule(*exprs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "rule": {
+            "family": "inet",
+            "table": "filter",
+            "chain": "input",
+            "handle": 10,
+            "expr": list(exprs),
+        }
+    }
+
+
+def _dport_match(right: Any) -> dict[str, Any]:
+    return {
+        "match": {
+            "op": "==",
+            "left": {"payload": {"protocol": "tcp", "field": "dport"}},
+            "right": right,
+        }
+    }
+
+
+def _base_rules() -> list[dict[str, Any]]:
+    """The always-present base-config rules that must all be skipped."""
+    return [
+        # ct state established,related accept
+        _rule(
+            {
+                "match": {
+                    "op": "in",
+                    "left": {"ct": {"key": "state"}},
+                    "right": ["established", "related"],
+                }
+            },
+            {"accept": None},
+        ),
+        # ct state invalid drop
+        _rule(
+            {
+                "match": {
+                    "op": "in",
+                    "left": {"ct": {"key": "state"}},
+                    "right": "invalid",
+                }
+            },
+            {"drop": None},
+        ),
+        # iif lo accept — the #776 trap; must never count as reachability
+        _rule(
+            {"match": {"op": "==", "left": {"meta": {"key": "iif"}}, "right": "lo"}},
+            {"accept": None},
+        ),
+        # ssh
+        _rule(_dport_match(22), {"accept": None}),
+    ]
+
+
+def _doc(*entries: dict[str, Any], policy: str = "drop") -> dict[str, Any]:
+    return {
+        "nftables": [
+            {"metainfo": {"version": "1.0.9", "json_schema_version": 1}},
+            {"table": {"family": "inet", "name": "filter", "handle": 1}},
+            _chain(policy),
+            *_base_rules(),
+            *entries,
+        ]
+    }
+
+
+# ── evaluate_port ───────────────────────────────────────────────────────────
+
+
+def test_sentinel_accept_is_open(m) -> None:
+    """The 00-spatium-webui.nft shape: tcp dport { 80, 443 } accept."""
+    doc = _doc(_rule(_dport_match({"set": [80, 443]}), {"accept": None}))
+    status, _ = m.evaluate_port(doc, 443)
+    assert status == "open"
+    assert m.evaluate_port(doc, 80)[0] == "open"
+
+
+def test_missing_accept_is_blocked(m) -> None:
+    """The #776 failure: base rules only, policy drop, no web accept."""
+    doc = _doc()
+    status, detail = m.evaluate_port(doc, 443)
+    assert status == "blocked"
+    assert "policy drop" in detail
+
+
+def test_iif_lo_accept_alone_is_still_blocked(m) -> None:
+    """The trap this whole check exists for: an lo-guarded accept for 443
+    must not read as reachable — off-box traffic never arrives on lo."""
+    doc = _doc(
+        _rule(
+            {"match": {"op": "==", "left": {"meta": {"key": "iif"}}, "right": "lo"}},
+            _dport_match({"set": [80, 443]}),
+            {"accept": None},
+        )
+    )
+    assert m.evaluate_port(doc, 443)[0] == "blocked"
+
+
+def test_scoped_accept_reports_scoped(m) -> None:
+    """web_ui_allowed_cidrs set (#285 Phase 6): hardened, not broken."""
+    doc = _doc(
+        _rule(
+            {
+                "match": {
+                    "op": "==",
+                    "left": {"payload": {"protocol": "ip", "field": "saddr"}},
+                    "right": {"set": [{"prefix": {"addr": "10.20.0.0", "len": 16}}]},
+                }
+            },
+            _dport_match({"set": [80, 443]}),
+            {"accept": None},
+        )
+    )
+    status, detail = m.evaluate_port(doc, 443)
+    assert status == "scoped"
+    assert "10.20.0.0/16" in detail
+
+
+def test_explicit_drop_wins_first_match(m) -> None:
+    doc = _doc(
+        _rule(_dport_match(443), {"drop": None}),
+        _rule(_dport_match({"set": [80, 443]}), {"accept": None}),
+    )
+    assert m.evaluate_port(doc, 443)[0] == "blocked"
+
+
+def test_port_range_containing_443_is_open(m) -> None:
+    doc = _doc(_rule(_dport_match({"range": [400, 500]}), {"accept": None}))
+    assert m.evaluate_port(doc, 443)[0] == "open"
+    assert m.evaluate_port(doc, 80)[0] == "blocked"
+
+
+def test_policy_accept_with_no_rules_is_open(m) -> None:
+    doc = _doc(policy="accept")
+    status, detail = m.evaluate_port(doc, 443)
+    assert status == "open"
+    assert "policy accept" in detail
+
+
+def test_no_input_chain_is_open(m) -> None:
+    doc = {"nftables": [{"metainfo": {}}, {"table": {"family": "inet", "name": "filter"}}]}
+    assert m.evaluate_port(doc, 443)[0] == "open"
+
+
+def test_garbage_doc_is_indeterminate(m) -> None:
+    assert m.evaluate_port({"bogus": True}, 443)[0] == "indeterminate"
+
+
+def test_other_port_accept_does_not_leak(m) -> None:
+    """An accept for 8443 must not read as 443 reachability."""
+    doc = _doc(_rule(_dport_match(8443), {"accept": None}))
+    assert m.evaluate_port(doc, 443)[0] == "blocked"
+
+
+# ── run_check / main ────────────────────────────────────────────────────────
+
+
+def test_run_check_indeterminate_when_nft_unavailable(m, monkeypatch) -> None:
+    def _boom(*a: Any, **k: Any) -> None:
+        raise FileNotFoundError("nft")
+
+    monkeypatch.setattr(m.subprocess, "run", _boom)
+    result = m.run_check()
+    assert result["status"] == "indeterminate"
+    assert "could not read ruleset" in result["detail"]
+
+
+def test_main_writes_state_and_exits_by_verdict(m, monkeypatch, tmp_path) -> None:
+    state = tmp_path / "webui-selfcheck.json"
+    monkeypatch.setattr(m, "STATE_PATH", state)
+
+    class _Proc:
+        stdout = json.dumps(_doc(_rule(_dport_match({"set": [80, 443]}), {"accept": None})))
+
+    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: _Proc())
+    assert m.main() == 0
+    saved = json.loads(state.read_text())
+    assert saved["status"] == "open"
+    assert saved["ports"]["443"]["status"] == "open"
+    assert isinstance(saved["checked_at"], int)
+
+    class _ProcBlocked:
+        stdout = json.dumps(_doc())
+
+    monkeypatch.setattr(m.subprocess, "run", lambda *a, **k: _ProcBlocked())
+    assert m.main() == 1
+    assert json.loads(state.read_text())["status"] == "blocked"
+
+    def _boom(*a: Any, **k: Any) -> None:
+        raise FileNotFoundError("nft")
+
+    monkeypatch.setattr(m.subprocess, "run", _boom)
+    assert m.main() == 2
+    assert json.loads(state.read_text())["status"] == "indeterminate"

--- a/backend/tests/test_webui_selfcheck.py
+++ b/backend/tests/test_webui_selfcheck.py
@@ -498,7 +498,7 @@ def test_main_writes_state_and_exits_by_verdict(m, monkeypatch, tmp_path) -> Non
     assert isinstance(saved["checked_at"], int)
     assert saved["ttl_s"] == m.TTL_S
 
-    monkeypatch.setattr(m, "_read_ruleset", lambda: _doc())
+    monkeypatch.setattr(m, "_read_ruleset", _doc)
     assert m.main() == 1
     assert json.loads(state.read_text())["status"] == "blocked"
 

--- a/docs/deployment/APPLIANCE.md
+++ b/docs/deployment/APPLIANCE.md
@@ -516,6 +516,23 @@ The script is intentionally `bash` + stdlib (no Python, no docker SDK, no compos
 
 Per heartbeat the supervisor compared the live `/etc/nftables.d/spatium-role.nft` body against the desired body — but that only proves the FILE is right, not that the kernel-active ruleset includes those rules (e.g. an operator `nft flush ruleset` during a debugging session, or the master conf's `include` directive stops matching the drop-in path). Every 5 min the supervisor now reads the live ruleset via `nft -j list chain inet filter input`, confirms each expected per-role service port is present, and forces a re-apply if anything's missing. Logs `supervisor.firewall.drift_detected` with the missing tcp/udp port set. `FirewallProfile` now carries `expected_tcp_ports` + `expected_udp_ports` frozensets so the comparison is straightforward.
 
+### Web UI reachability self-check (#779)
+
+The supervisor's drift check answers "did my drop-in apply" — it cannot answer "can anyone actually reach the management surface", and it cannot run at all before the supervisor registers (#777). The Web UI self-check is the independent complement, born from #776 (a full diagnostic session to find one missing nftables accept rule that the appliance could have volunteered): a host-side script reasons about the kernel-active ruleset and answers *would a NEW off-box TCP connection to 443 (and 80) be accepted?* — a question a self-`curl` cannot answer, because locally-originated traffic to the box's own LAN IP rides `iif lo accept` and succeeds against a firewalled port.
+
+| Piece | Path | Role |
+| --- | --- | --- |
+| Script | `/usr/local/bin/spatiumddi-webui-selfcheck` | Reads input-hooked chains via `nft -j` (two-phase: `list chains`, then only the input-hooked ones — never the full kube-proxy ruleset), evaluates every chain independently and combines worst-wins. Exit 0 reachable / 1 blocked / 2 indeterminate |
+| Verdict file | `/run/spatiumddi/webui-selfcheck.json` | `{status, detail, ports, checked_at, ttl_s, consecutive_indeterminate}` — ephemeral by design; a verdict never outlives the ruleset it describes |
+| Service unit | `/etc/systemd/system/spatiumddi-webui-selfcheck.service` | Oneshot; `SuccessExitStatus=1 2` so a *finding* doesn't double-report as a failed unit |
+| Timer unit | `/etc/systemd/system/spatiumddi-webui-selfcheck.timer` | 45 s after boot, then every 5 min |
+| Apply hook | `spatium-firewall-reload.service` `ExecStartPost` | Re-checks immediately after every firewall apply, so the verdict follows the ruleset instead of lagging a timer period |
+| First-boot hook | `spatiumddi-firstboot` | Runs the check right after printing the Ready URL, so a blocked verdict lands next to the promise it breaks |
+
+The verdict is deliberately conservative in both directions. A `saddr`-scoped accept (`web_ui_allowed_cidrs`, #285 Phase 6) reports **scoped** — a hardened appliance is never reported as broken. Qualified drops (one subnet, one interface, a rate limiter) are not treated as blocks. Constructs outside the model — negated matches, named sets, dport vmaps, jumps in drop-policy chains (all legal in operator drop-ins / `firewall_extra`) — degrade the verdict to **indeterminate** rather than risk a confident wrong answer.
+
+Surfacing: a fresh `blocked` verdict renders in bold red on the console identity row, appended to the Web UI URL it invalidates, and flips the box-level health verdict to `CRITICAL — Web UI blocked by firewall (tcp/443)`. Three consecutive `indeterminate` runs render a dim-yellow `firewall self-check unavailable` note (a broken checker must not die silently). Everything else — open, scoped, fresh single indeterminate, stale, missing — renders nothing: the check exists to volunteer the one answer nothing else on the box will, not to add a green light.
+
 ### Console dashboard polish
 
 The Talos-style console got a wave of usability fixes:


### PR DESCRIPTION
Closes #779

When a fresh appliance's Web UI is unreachable, nothing on the box says so — #776 took a full diagnostic session (pods, services, `ss`, curl from the appliance, Test-NetConnection from a client) to arrive at "one nftables accept rule is missing", with every intermediate step confirming something healthy. The appliance had the answer the whole time; now it volunteers it.

## What it is

`spatiumddi-webui-selfcheck` — a host-side script (Python stdlib, baked into the OS image) that reads the kernel-active ruleset via `nft -j` and answers the question a self-`curl` cannot: **would a NEW off-box TCP connection to 443 (and 80) be accepted?** (`curl` to your own LAN IP rides `iif lo accept` and succeeds against a firewalled port — the exact trap #776 fell into, pinned by test.)

Deliberately **independent of the supervisor** per the issue's core requirement: the supervisor's drift check can't run before it registers (#777) and answers "did my drop-in apply", not "can anyone reach the management surface".

**Runs**: late in `spatiumddi-firstboot` (the blocked verdict lands next to the Ready URL it invalidates), every 5 min via systemd timer, and after every firewall apply (`ExecStartPost` on `spatium-firewall-reload.service`). **Surfaces**: a fresh `blocked` renders bold-red on the console identity row appended to the Web UI URL, and flips the box health verdict to `CRITICAL — Web UI blocked by firewall (tcp/443)`; 3+ consecutive `indeterminate` runs render a dim-yellow "self-check unavailable" note so a broken checker can't die silently. Open / scoped / stale / missing render nothing — no green lights, no crying wolf.

## The traffic model (the hard part, review-hardened)

- **Per-chain evaluation, worst-wins**: every input-hooked chain is evaluated independently (kernel semantics: the packet must survive all of them). This kills a review-**reproduced** false-open where an operator's stray `iptables -A INPUT -p tcp --dport 443 -j ACCEPT` (landing in kube-proxy's accept-policy `ip filter INPUT`) masked the drop-policy `inet` chain that still had no accept — in exactly the #776 scenario.
- **Scope-aware** (#285 Phase 6, shipped since the issue was filed): a `saddr`-restricted accept reports `scoped`, never `blocked` — a hardened appliance is never reported as broken.
- **Qualified drops are not blocks**: a drop scoped to one subnet, one interface, or a `limit rate over` flood protector doesn't make the UI LAN-unreachable (review-reproduced false-CRITICALs, all fixed).
- **Unmodeled constructs degrade to `indeterminate`**: negated matches (`!=`), named sets, dport vmaps, jumps in drop-policy chains — all legal in operator drop-ins / `firewall_extra`, all previously producing confident wrong verdicts in one direction or the other.
- **Cheap**: two-phase `nft -j list chains` → input-hooked chains only, never the full kube-proxy/flannel-dominated ruleset.

## Review

Two commits: the feature, then fixes from an 8-angle review (4 quality + 4 correctness agents, several driving the code against live nft). 15 verified findings, 13 fixed — including the two reproduced correctness bugs above, the dead never-rendered chip label, the freshness TTL now shipping *in* the state file (a timer-cadence change can't silently suppress the alarm), a first-boot tmp-file write race, and the APPLIANCE.md section its watchdog/drift siblings already had. 2 skipped with rationale (test-loader dedup at n=2; a pre-existing stale CLAUDE.md paragraph).

## Deliberately not done

The install-wizard completion screen (runs pre-firstboot, before the final ruleset exists) and role-port checks (legitimate closed states — the issue's scope question resolved to Web UI only).

## Verified

- 37 script/console test cases pin every reproduced review shape (multi-chain false-open, qualified drops, negation both directions, named sets, vmaps, jump-in-drop-policy, `meta l4proto` set form, v6-only scope, iif-lo trap, streak accounting, file-driven TTL); 138 tests pass across the affected files; ruff/black/mypy clean; the new cross-boundary read is declared in the #821 CI gate map.
- Honest caveat: unit-tested against verified-real `nft -j` shapes, not yet booted on a physical appliance — the next nightly ISO (or a `workflow_dispatch` with `force=true`) bakes it in for field validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)