### PR TITLE
ci: bump the remaining third-party action majors to their Node 24 releases

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.20.2
 

--- a/.github/workflows/build-appliance-builder.yml
+++ b/.github/workflows/build-appliance-builder.yml
@@ -30,18 +30,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (PR) / Build + push (main)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: appliance/builder
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-appliance.yml
+++ b/.github/workflows/build-appliance.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -119,7 +119,7 @@ jobs:
         # host: baltocdn.com" — Azure runner network policy).
         # bake-chart.sh shells out to ``helm package`` so helm must be
         # on PATH before the chart-bake step.
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.20.2
       - name: Fetch k3s binary + airgap tarball

--- a/.github/workflows/build-dhcp-images.yml
+++ b/.github/workflows/build-dhcp-images.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -51,7 +51,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/dhcp-${{ matrix.flavor }}
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dhcp/images/${{ matrix.flavor }}/Dockerfile
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dhcp/images/${{ matrix.flavor }}/Dockerfile

--- a/.github/workflows/build-dns-images.yml
+++ b/.github/workflows/build-dns-images.yml
@@ -42,10 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -54,7 +54,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/dns-${{ matrix.flavor }}
           tags: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dns/images/${{ matrix.flavor }}/Dockerfile
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dns/images/${{ matrix.flavor }}/Dockerfile

--- a/.github/workflows/build-looking-glass-images.yml
+++ b/.github/workflows/build-looking-glass-images.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -51,7 +51,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/looking-glass
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/looking-glass/images/${{ matrix.flavor }}/Dockerfile
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/looking-glass/images/${{ matrix.flavor }}/Dockerfile

--- a/.github/workflows/build-supervisor-image.yml
+++ b/.github/workflows/build-supervisor-image.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -47,7 +47,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/spatium-supervisor
           tags: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/supervisor/images/supervisor/Dockerfile
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/supervisor/images/supervisor/Dockerfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -177,9 +177,9 @@ jobs:
         include: ${{ fromJSON(needs.gate.outputs.images) }}
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         if: github.event.inputs.dry_run != 'true'
         with:
           registry: ${{ env.REGISTRY }}
@@ -194,7 +194,7 @@ jobs:
       # some-new / some-old images. Cost is one extra amd64 build, which
       # the shared buildx cache makes near-free.
       - name: Build amd64 for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
@@ -221,7 +221,7 @@ jobs:
       # The multi-arch build reuses the cache the scan build just warmed,
       # so the amd64 half is a cache hit.
       - name: Build + push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -82,14 +82,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
@@ -114,14 +114,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/bind9/Dockerfile
@@ -144,14 +144,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/powerdns/Dockerfile
@@ -174,14 +174,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/technitium/Dockerfile
@@ -204,14 +204,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/dnsdist/Dockerfile
@@ -234,14 +234,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dhcp/images/kea/Dockerfile
@@ -269,14 +269,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/supervisor/images/supervisor/Dockerfile
@@ -304,14 +304,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/looking-glass/images/gobgp/Dockerfile
@@ -348,7 +348,7 @@ jobs:
       chart_version: ${{ steps.pkg.outputs.chart_version }}
     steps:
       - uses: actions/checkout@v7
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.20.2
       - name: Log in to GHCR
@@ -544,7 +544,7 @@ jobs:
           name: appliance-artifacts
           path: dist/
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           name: "SpatiumDDI ${{ needs.meta.outputs.version }}"
           files: |


### PR DESCRIPTION
Second half of [#764](https://github.com/spatiumddi/spatiumddi/issues/764) — #770 bumped the first-party `actions/*` set and deliberately left these seven behind as the materially riskier group (`build-push-action` spans every image-build workflow; `action-gh-release` is what publishes releases).

All **73 usages across 9 workflows**, each target major verified `node24` by reading `using:` out of that tag's own `action.yml`:

| action | | uses |
|---|---|---|
| `docker/build-push-action` | v5 + v6 → **v7** | 20 |
| `docker/login-action` | v3 → **v4** | 16 |
| `docker/setup-buildx-action` | v3 → **v4** | 15 |
| `docker/setup-qemu-action` | v3 → **v4** | 14 |
| `docker/metadata-action` | v5 → **v6** | 4 |
| `azure/setup-helm` | v4 → **v5** | 3 |
| `softprops/action-gh-release` | v2 → **v3** | 1 |

This also collapses the pre-existing `build-push-action` v5/v6 drift #770 called out.

## Nothing targets Node 20 after this

The two third-party actions *not* bumped were verified, not assumed: `aquasecurity/trivy-action` is `using: composite` (no Node runtime at all), and `helm/kind-action@v1` is already `node24`. So this PR completes #764's stated goal — no workflow in the repo breaks when the forced-Node-24 shim is removed.

## Validation: a full nightly run on this branch

`dry_run` would skip the appliance jobs — exactly the ones exercising `setup-helm` and the artifact hand-off — so validation is a **full** dispatch (`force=true`) of nightly.yml on this branch: [run 30964917264](https://github.com/spatiumddi/spatiumddi/actions/runs/30964917264). The branch's application code is byte-identical to main, so its pushed `:nightly` images and re-attached ISO are equivalent to a normal nightly.

That run exercises `setup-qemu@v4` / `setup-buildx@v4` / `login@v4` / `metadata@v6` / `build-push@v7` across all baked images (all green already), plus `azure/setup-helm@v5`, `upload-artifact@v7` and `download-artifact@v8` through the shared appliance reusable workflow.

**Residual risk, unchanged from the issue:** `softprops/action-gh-release@v3` only executes in `release.yml` on a tag push, so it stays unvalidated until the next release — worth someone watching it.

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)