### PR TITLE
fix(api): admit the string 422 detail the API has always returned

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.20.2
 

--- a/.github/workflows/build-appliance-builder.yml
+++ b/.github/workflows/build-appliance-builder.yml
@@ -30,18 +30,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build (PR) / Build + push (main)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: appliance/builder
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-appliance.yml
+++ b/.github/workflows/build-appliance.yml
@@ -85,7 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -119,7 +119,7 @@ jobs:
         # host: baltocdn.com" — Azure runner network policy).
         # bake-chart.sh shells out to ``helm package`` so helm must be
         # on PATH before the chart-bake step.
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.20.2
       - name: Fetch k3s binary + airgap tarball

--- a/.github/workflows/build-dhcp-images.yml
+++ b/.github/workflows/build-dhcp-images.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -51,7 +51,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/dhcp-${{ matrix.flavor }}
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dhcp/images/${{ matrix.flavor }}/Dockerfile
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dhcp/images/${{ matrix.flavor }}/Dockerfile

--- a/.github/workflows/build-dns-images.yml
+++ b/.github/workflows/build-dns-images.yml
@@ -42,10 +42,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -54,7 +54,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/dns-${{ matrix.flavor }}
           tags: |
@@ -64,7 +64,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dns/images/${{ matrix.flavor }}/Dockerfile
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/dns/images/${{ matrix.flavor }}/Dockerfile

--- a/.github/workflows/build-looking-glass-images.yml
+++ b/.github/workflows/build-looking-glass-images.yml
@@ -39,10 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -51,7 +51,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/looking-glass
           tags: |
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/looking-glass/images/${{ matrix.flavor }}/Dockerfile
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/looking-glass/images/${{ matrix.flavor }}/Dockerfile

--- a/.github/workflows/build-supervisor-image.yml
+++ b/.github/workflows/build-supervisor-image.yml
@@ -35,10 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io
@@ -47,7 +47,7 @@ jobs:
 
       - name: Image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/spatiumddi/spatium-supervisor
           tags: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: Build (PR — single-arch, load locally for Trivy)
         if: github.event_name == 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/supervisor/images/supervisor/Dockerfile
@@ -82,7 +82,7 @@ jobs:
 
       - name: Build and push (main / tag — multi-arch, push to ghcr)
         if: github.event_name != 'pull_request'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: agent/supervisor/images/supervisor/Dockerfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -177,9 +177,9 @@ jobs:
         include: ${{ fromJSON(needs.gate.outputs.images) }}
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         if: github.event.inputs.dry_run != 'true'
         with:
           registry: ${{ env.REGISTRY }}
@@ -194,7 +194,7 @@ jobs:
       # some-new / some-old images. Cost is one extra amd64 build, which
       # the shared buildx cache makes near-free.
       - name: Build amd64 for scanning
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
@@ -221,7 +221,7 @@ jobs:
       # The multi-arch build reuses the cache the scan build just warmed,
       # so the amd64 half is a cache hit.
       - name: Build + push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -82,14 +82,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: ./frontend
           file: ./frontend/Dockerfile
@@ -114,14 +114,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/bind9/Dockerfile
@@ -144,14 +144,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/powerdns/Dockerfile
@@ -174,14 +174,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/technitium/Dockerfile
@@ -204,14 +204,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dns/images/dnsdist/Dockerfile
@@ -234,14 +234,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/dhcp/images/kea/Dockerfile
@@ -269,14 +269,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/supervisor/images/supervisor/Dockerfile
@@ -304,14 +304,14 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v7
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: ./agent/looking-glass/images/gobgp/Dockerfile
@@ -348,7 +348,7 @@ jobs:
       chart_version: ${{ steps.pkg.outputs.chart_version }}
     steps:
       - uses: actions/checkout@v7
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
         with:
           version: v3.20.2
       - name: Log in to GHCR
@@ -544,7 +544,7 @@ jobs:
           name: appliance-artifacts
           path: dist/
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           name: "SpatiumDDI ${{ needs.meta.outputs.version }}"
           files: |

--- a/backend/app/api/pagination.py
+++ b/backend/app/api/pagination.py
@@ -22,6 +22,21 @@ DEFAULT_PAGE_SIZE = 100
 # Upper bound a client may request. Bounded so "fetch all" can't sneak back in
 # through an enormous page_size — bulk export has its own dedicated endpoint.
 MAX_PAGE_SIZE = 1000
+# Upper bound on the page NUMBER. ``page_size`` was bounded from the start and
+# ``page`` was not, which left every list endpoint one query parameter away from
+# a 500: the offset is ``(page - 1) * page_size``, SQL ``OFFSET`` is a bigint,
+# and a large enough ``page`` overflows it before Postgres ever sees a row.
+# Measured on a live appliance at DEFAULT_PAGE_SIZE — page 92233720368547759
+# gives offset 9223372036854775800 and returns 200; page 92233720368547760
+# gives 9223372036854775900, past 2**63-1, and returns 500.
+#
+# A million pages is past any real client (a million pages of MAX_PAGE_SIZE is
+# a billion rows) while leaving the largest reachable offset — 10**9 — nine
+# orders of magnitude below the bigint ceiling, so no page_size can climb back
+# over it. Declared rather than clamped: the bound belongs in the OpenAPI
+# document next to page_size's, and an out-of-range page is a client error that
+# deserves the same 422 an out-of-range page_size already gets.
+MAX_PAGE = 1_000_000
 
 
 class Page[T](BaseModel):

--- a/backend/app/api/v1/dhcp/lease_history.py
+++ b/backend/app/api/v1/dhcp/lease_history.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import String, cast, func, select
 
 from app.api.deps import DB, CurrentUser
+from app.api.pagination import MAX_PAGE
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPLeaseHistory, DHCPServer
 
@@ -75,7 +76,7 @@ async def list_lease_history(
     ip: str | None = Query(None, description="IP or CIDR — exact / containment match"),
     hostname: str | None = Query(None, description="Hostname substring match"),
     lease_state: str | None = Query(None, description="Filter by lease_state"),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     per_page: int = Query(50, ge=1, le=500),
 ) -> LeaseHistoryPage:
     server = await db.get(DHCPServer, server_id)

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import String, cast, func, or_, select
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
-from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, paginate
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE, MAX_PAGE_SIZE, Page, paginate
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import (
     collect_wake,
@@ -1408,7 +1408,7 @@ async def list_leases(
     search: str | None = Query(None, description="substring over ip / mac / hostname"),
     state: str | None = Query(None, description="exact lease state filter"),
     device_class: str | None = None,
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ) -> Page[LeaseResponse]:
     """Leases for a server, server-side paginated (#455), enriched with OUI

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -19,7 +19,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
-from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page, paginate
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE, MAX_PAGE_SIZE, Page, paginate
 from app.config import settings
 from app.core.agent_wake import (
     appliance_channel,
@@ -5293,7 +5293,7 @@ async def list_group_records(
         None, description="substring over name / fqdn / value / type / zone"
     ),
     record_type: str | None = Query(None, description="exact record type filter (A, MX, …)"),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ) -> Page[GroupRecordResponse]:
     """Every record across every zone in the group, with zone + view context,
@@ -5378,7 +5378,7 @@ async def list_records(
     tag: list[str] = Query(default_factory=list),
     search: str | None = Query(None, description="substring over name / fqdn / value / type"),
     record_type: str | None = Query(None, description="exact record type filter (A, MX, …)"),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ) -> Page[RecordResponse]:
     """Records in a zone, server-side paginated (#455).

--- a/backend/app/api/v1/domains/router.py
+++ b/backend/app/api/v1/domains/router.py
@@ -26,6 +26,7 @@ from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, or_, select
 
 from app.api.deps import DB, CurrentUser
+from app.api.pagination import MAX_PAGE
 from app.core.permissions import require_permission, user_has_permission
 from app.models.audit import AuditLog
 from app.models.auth import User
@@ -244,7 +245,7 @@ async def list_domains(
     customer_id: uuid.UUID | None = Query(None),
     registrar_provider_id: uuid.UUID | None = Query(None),
     search: str | None = Query(None, min_length=1, max_length=255),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=500),
     tag: list[str] = Query(default_factory=list),
 ) -> DomainListResponse:

--- a/backend/app/api/v1/ipam/nat.py
+++ b/backend/app/api/v1/ipam/nat.py
@@ -34,6 +34,7 @@ from sqlalchemy import String, and_, cast, func, or_, select
 from sqlalchemy.dialects.postgresql import INET
 
 from app.api.deps import DB, CurrentUser
+from app.api.pagination import MAX_PAGE
 from app.api.v1.dhcp._audit import write_audit
 from app.core.permissions import require_resource_permission
 from app.models.ipam import IPAddress, NATMapping, Subnet
@@ -351,7 +352,7 @@ async def list_nat_mappings(
     internal_ip: str | None = Query(None),
     external_ip: str | None = Query(None),
     q: str | None = Query(None, description="Substring match on name / description"),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     per_page: int = Query(50, ge=1, le=500),
 ) -> NATMappingPage:
     base = select(NATMapping)

--- a/backend/app/api/v1/network/router.py
+++ b/backend/app/api/v1/network/router.py
@@ -25,6 +25,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
+from app.api.pagination import MAX_PAGE
 from app.core.crypto import encrypt_str
 from app.core.permissions import require_permission, user_has_permission
 from app.models.audit import AuditLog
@@ -176,7 +177,7 @@ async def list_devices(
     device_type: str | None = Query(None),
     last_poll_status: str | None = Query(None),
     site_id: uuid.UUID | None = Query(None),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=500),
     tag: list[str] = Query(default_factory=list),
 ) -> NetworkDeviceListResponse:
@@ -455,7 +456,7 @@ async def list_interfaces(
     device_id: uuid.UUID,
     db: DB,
     current_user: CurrentUser,
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=2000),
 ) -> NetworkInterfaceListResponse:
     if not user_has_permission(current_user, "read", PERMISSION):
@@ -490,7 +491,7 @@ async def list_arp(
     mac: str | None = Query(None),
     vrf: str | None = Query(None),
     state: str | None = Query(None),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=2000),
 ) -> NetworkArpListResponse:
     if not user_has_permission(current_user, "read", PERMISSION):
@@ -545,7 +546,7 @@ async def list_fdb(
     mac: str | None = Query(None),
     vlan_id: int | None = Query(None),
     interface_id: uuid.UUID | None = Query(None),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=2000),
 ) -> NetworkFdbListResponse:
     if not user_has_permission(current_user, "read", PERMISSION):
@@ -597,7 +598,7 @@ async def list_neighbours(
     sys_name: str | None = Query(None),
     chassis_id: str | None = Query(None),
     interface_id: uuid.UUID | None = Query(None),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=2000),
 ) -> NetworkNeighbourListResponse:
     """List LLDP neighbours discovered on this device.

--- a/backend/app/api/v1/new_devices/router.py
+++ b/backend/app/api/v1/new_devices/router.py
@@ -19,7 +19,7 @@ from sqlalchemy import String, and_, cast, func, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from app.api.deps import DB
-from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE, Page
+from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE, MAX_PAGE_SIZE, Page
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_permission
@@ -186,7 +186,7 @@ async def list_sightings(
     since_hours: int | None = Query(None, ge=1, le=24 * 365),
     include_randomized: bool = False,
     search: str | None = None,
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(DEFAULT_PAGE_SIZE, ge=1, le=MAX_PAGE_SIZE),
 ) -> Page[SightingOut]:
     """Paginated review queue. Defaults to unacknowledged new devices."""

--- a/backend/app/api/v1/nmap/router.py
+++ b/backend/app/api/v1/nmap/router.py
@@ -41,6 +41,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser
+from app.api.pagination import MAX_PAGE
 from app.api.v1.probe_guard import enforce_probe_target
 from app.core.permissions import require_permission, user_has_permission
 from app.core.security import decode_access_token
@@ -226,7 +227,7 @@ async def list_scans(
     ip_address_id: uuid.UUID | None = Query(None),
     target_ip: str | None = Query(None),
     status_filter: str | None = Query(None, alias="status"),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=500),
 ) -> NmapScanListResponse:
     base = select(NmapScan)

--- a/backend/app/api/v1/pcap/router.py
+++ b/backend/app/api/v1/pcap/router.py
@@ -37,6 +37,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser
+from app.api.pagination import MAX_PAGE
 from app.core.permissions import require_permission
 from app.models.appliance import APPLIANCE_STATE_APPROVED, Appliance
 from app.models.audit import AuditLog
@@ -315,7 +316,7 @@ async def list_captures(
     status_filter: str | None = Query(None, alias="status"),
     vantage: str | None = Query(None),
     appliance_id: uuid.UUID | None = Query(None),
-    page: int = Query(1, ge=1),
+    page: int = Query(1, ge=1, le=MAX_PAGE),
     page_size: int = Query(50, ge=1, le=500),
 ) -> PcapCaptureListResponse:
     base = select(PacketCapture)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -925,6 +925,59 @@ def create_app() -> FastAPI:
             content={"detail": "Internal Server Error"},
         )
 
+    # The 422 the document declares is not the only 422 the API returns.
+    #
+    # FastAPI auto-declares ``HTTPValidationError`` (detail: array of
+    # ValidationError) on every operation that validates a parameter, and that
+    # is honest for the 422s its own request validation produces. But 270 call
+    # sites across ``backend/app/api/v1`` — 57 router files, led by
+    # ipam/router.py (24), dns/router.py (22), cutover/router.py (18) — raise
+    # ``HTTPException(status_code=422, detail="...")`` by hand for semantic
+    # validation a signature cannot express ("invalid classification"), and
+    # FastAPI serialises those as ``{"detail": "<string>"}``. The document said
+    # array, the wire said string, and nothing reconciled them: every one of
+    # those responses violated the API's own published contract.
+    #
+    # Found by the conformance fuzz, which validates live responses against
+    # this very document —
+    #   GET /api/v1/new-devices/sightings?classification=null
+    #   -> 422 {"detail":"invalid classification"}
+    # — where the declared schema demands an array. 29 of 39 red conformance
+    # rows on one build were this single defect.
+    #
+    # Widening the DOCUMENT rather than rewriting the BODIES is deliberate. The
+    # string form is the established contract: the frontend's ``formatApiError``
+    # normalises string, array and object shapes (issues #31 / #186), so both
+    # already render correctly. Rewriting 270 response bodies to chase the
+    # schema would break clients outside this repo in order to fix what is a
+    # documentation defect.
+    #
+    # Wraps FastAPI's own ``openapi()`` rather than re-deriving the document
+    # with ``get_openapi``, so every generation setting the app carries
+    # (webhooks, separate input/output schemas, servers) keeps applying. That
+    # call caches into ``app.openapi_schema`` and returns the cached object, so
+    # this patches in place — the ``anyOf`` guard keeps it idempotent.
+    _generate_openapi = app.openapi
+
+    def _openapi_with_string_validation_detail() -> dict:
+        schema = _generate_openapi()
+        props = (
+            schema.get("components", {})
+            .get("schemas", {})
+            .get("HTTPValidationError", {})
+            .get("properties", {})
+        )
+        detail = props.get("detail")
+        # Absent when no operation validates anything — nothing to widen.
+        if isinstance(detail, dict) and "anyOf" not in detail:
+            props["detail"] = {
+                "anyOf": [detail, {"type": "string"}],
+                "title": detail.get("title", "Detail"),
+            }
+        return schema
+
+    app.openapi = _openapi_with_string_validation_detail  # type: ignore[method-assign]
+
     return app
 
 

--- a/backend/tests/test_openapi_conformance.py
+++ b/backend/tests/test_openapi_conformance.py
@@ -70,8 +70,9 @@ def test_every_page_parameter_declares_an_upper_bound() -> None:
                     continue
                 if not any("maximum" in a for a in numeric):
                     unbounded.append(f"{method.upper()} {path}")
-    assert not unbounded, (
-        "page query parameters with no maximum — each one is an overflow 500:\n  "
-        + "\n  ".join(sorted(unbounded))
-    )
+    if unbounded:
+        listing = "\n  ".join(sorted(unbounded))
+        raise AssertionError(
+            f"page query parameters with no maximum — each one is an overflow 500:\n  {listing}"
+        )
     assert MAX_PAGE * 1000 < 2**63 - 1, "MAX_PAGE * MAX_PAGE_SIZE must stay inside a bigint"

--- a/backend/tests/test_openapi_conformance.py
+++ b/backend/tests/test_openapi_conformance.py
@@ -1,0 +1,37 @@
+"""The published OpenAPI document must describe the responses we actually send.
+
+The assertions here are regression guards for defects the per-commit
+conformance fuzz found on live appliances but nothing in CI could see: the fuzz
+validates real responses against this document, so a document that lies fails
+dozens of unrelated endpoints at once and reads as flake.
+
+No database, no client — the document is generated from the route table alone.
+"""
+
+from __future__ import annotations
+
+from app.main import app
+
+
+def _schema() -> dict:
+    return app.openapi()
+
+
+def test_validation_detail_allows_the_string_form_we_actually_return() -> None:
+    """422 bodies come in two shapes and the document has to admit both.
+
+    FastAPI auto-declares ``HTTPValidationError.detail`` as an array, which is
+    right for its own request validation. But 270 call sites across
+    ``app/api/v1`` raise ``HTTPException(status_code=422, detail="...")`` for
+    semantic checks a signature cannot express, and those serialise to
+    ``{"detail": "<string>"}``.
+
+    Live example that failed ``response_schema_conformance`` before this guard:
+    ``GET /api/v1/new-devices/sightings?classification=null`` returns
+    ``422 {"detail":"invalid classification"}``.
+    """
+    detail = _schema()["components"]["schemas"]["HTTPValidationError"]["properties"]["detail"]
+    arms = detail.get("anyOf")
+    assert arms, f"detail is not a union, so hand-raised 422s violate it: {detail}"
+    assert {"type": "string"} in arms, f"string 422 detail not admitted: {arms}"
+    assert any("array" in str(a) for a in arms), f"array 422 detail lost: {arms}"

--- a/backend/tests/test_openapi_conformance.py
+++ b/backend/tests/test_openapi_conformance.py
@@ -10,6 +10,7 @@ No database, no client — the document is generated from the route table alone.
 
 from __future__ import annotations
 
+from app.api.pagination import MAX_PAGE
 from app.main import app
 
 
@@ -35,3 +36,42 @@ def test_validation_detail_allows_the_string_form_we_actually_return() -> None:
     assert arms, f"detail is not a union, so hand-raised 422s violate it: {detail}"
     assert {"type": "string"} in arms, f"string 422 detail not admitted: {arms}"
     assert any("array" in str(a) for a in arms), f"array 422 detail lost: {arms}"
+
+
+def test_every_page_parameter_declares_an_upper_bound() -> None:
+    """``page`` bounded like ``page_size``, or the offset overflows the bigint.
+
+    The offset is ``(page - 1) * page_size`` and SQL ``OFFSET`` is a bigint, so
+    an unbounded ``page`` is a 500 one query parameter away. Measured live at
+    the default page size: page 92233720368547759 -> 200, page
+    92233720368547760 -> 500, which is exactly ``2**63-1``.
+
+    Asserted over the document rather than the source so it also covers list
+    endpoints that build their own offset instead of calling ``paginate()`` —
+    which is most of them.
+    """
+    unbounded = []
+    for path, item in _schema()["paths"].items():
+        for method, op in item.items():
+            if not isinstance(op, dict):
+                continue
+            for param in op.get("parameters") or []:
+                if param.get("name") != "page" or param.get("in") != "query":
+                    continue
+                schema = param.get("schema") or {}
+                arms = schema.get("anyOf") or [schema]
+                numeric = [a for a in arms if a.get("type") == "integer"]
+                # Not every `page` is a page NUMBER: GET /api/v1/saved-views
+                # takes `page: str`, the UI page a preset belongs to. Only an
+                # integer page reaches an SQL OFFSET, so only that one needs a
+                # ceiling — skip the rest rather than demanding `maximum` on a
+                # string.
+                if not numeric:
+                    continue
+                if not any("maximum" in a for a in numeric):
+                    unbounded.append(f"{method.upper()} {path}")
+    assert not unbounded, (
+        "page query parameters with no maximum — each one is an overflow 500:\n  "
+        + "\n  ".join(sorted(unbounded))
+    )
+    assert MAX_PAGE * 1000 < 2**63 - 1, "MAX_PAGE * MAX_PAGE_SIZE must stay inside a bigint"


### PR DESCRIPTION
Fixes #834

Root-caused and validated live on nested single-node QA appliances, across two releases and two rigs.

## 1. The document declared one 422 shape; the API returns two

FastAPI auto-declares `HTTPValidationError` (`detail`: array of `ValidationError`) on every operation that validates a parameter — honest for the 422s its own request validation produces. But **270 call sites** across `backend/app/api/v1` (57 router files, led by `ipam/router.py` 24, `dns/router.py` 22, `cutover/router.py` 18) raise `HTTPException(status_code=422, detail="…")` by hand for semantic validation a signature cannot express, and FastAPI serialises those as `{"detail": "<string>"}`.

The document said array, the wire said string, and nothing reconciled them — so every hand-raised 422 violated the API's own published contract.

Found by the per-commit conformance fuzz, which validates live responses against this very document:

```
GET /api/v1/ipam/addresses/search?limit=128&sort=null
-> 422 {"detail":"sort must be one of: address, description, hostname, last_seen, mac, status"}

  "sort must be one of: …" is not of type "array"
  Validated against the response schema for status code 422.
  Schema at /components/schemas/HTTPValidationError/properties/detail
```

Grouping every violation instance in a full pass over the affected set:

```
54  Validated against the response schema for status code 422
54  Schema at /components/schemas/HTTPValidationError
```

Unanimous — one cause, no exceptions. **29 of 39 red conformance rows on one build were this single defect.**

Widening the **document** rather than rewriting the **bodies** is deliberate. The string form is the established contract: the frontend's `formatApiError` already normalises string, array and object shapes (#31 / #186), so both render correctly today. Rewriting 270 response bodies to chase the schema would break clients outside this repo in order to fix what is a documentation defect.

The wrapper goes around FastAPI's own `openapi()` rather than re-deriving the document with `get_openapi`, so every generation setting the app carries (webhooks, separate input/output schemas, servers) keeps applying. That call caches into `app.openapi_schema` and returns the cached object, so this patches in place — the `anyOf` guard keeps it idempotent.

## 2. `page` was unbounded, so a deep offset overflowed the bigint

`page_size` has been bounded since #455 so "fetch all" could not sneak back in through an enormous page. `page` never was — and the offset is `(page - 1) * page_size`, while SQL `OFFSET` is a bigint. Every list endpoint was one query parameter away from a 500.

Measured on a live appliance at `DEFAULT_PAGE_SIZE = 100`:

| `page` | offset | status |
|---|---|---|
| 92233720368547758 | 9223372036854775700 | 200 |
| 92233720368547759 | 9223372036854775800 | 200 |
| 92233720368547760 | 9223372036854775900 | **500** |
| 92233720368547761 | 9223372036854776000 | **500** |

The boundary is exactly `2**63-1`, so the mechanism is the OFFSET overflow and nothing else.

## Validation on real hardware

Rig vmid 108 on `optiplex3`, `role=patch`, `suites=api`, against `dev-eab2547` as the baseline.

| | before (`dev-eab2547`) | after (`dev-7e75843`) |
|---|---|---|
| api rows | 827 | 1116 |
| fail | 40 | **12** |
| pass | 787 | 986 |
| `JsonSchemaError` rows | **29** | **0** |
| `DELETE /api/v1/dns-threat/mutes/{client_ip}` | **fail** | **pass** |

33 checks went from fail to pass.

**The lane budget alone would not have proven this.** These operations fail only ~50% of runs at `api_fuzz_examples: 3` and 100% at 25, so the previously-failing set was re-run on the fixed rig at 25 — the budget where the unfixed code fails every time:

```
12 failed, 82 passed, 1016 deselected in 601.09s

Validated against the response schema for status code …   0
Schema at /components/schemas/…                           0
```

Zero schema-conformance violations. All 12 residuals are the `502` gateway wave under fuzz load (one surfacing as a `hypothesis FlakyFailure` on a transient 502), unrelated to this change.

**No regression.** Four checks flipped pass→fail, all `500`s — `DELETE /settings/audit-forward-targets/{target_id}`, `POST /new-devices/allowlist`, `POST /new-devices/block`, `POST /overlays`. Re-running them on an **unfixed** rig (vmid 102, `2026.07.30-1`) reproduces the same 500s (`5 failed, 18 passed`), so they are pre-existing defects surfaced by different random sampling. Commit 1 changes only the generated document and cannot produce a runtime 500; commit 2 only *adds* an upper bound.

Six checks still fail from before and are untouched here: `schema-health` 500, two `export.pdf` `UndefinedContentType`, three import-preview 502s.

## Tests

`backend/tests/test_openapi_conformance.py` (new) — generated from the route table alone, no DB, no client:

- `test_validation_detail_allows_the_string_form_we_actually_return`
- `test_every_page_parameter_declares_an_upper_bound` — asserted over the document rather than the source, so it also covers list endpoints that build their own offset instead of calling `paginate()`, which is most of them.

These are regression guards for defects the conformance fuzz found on live appliances but nothing in CI could see: the fuzz validates real responses against this document, so a document that lies fails dozens of unrelated endpoints at once and reads as flake.

## Tradeoffs and known remaining work

- Widening `HTTPValidationError.detail` to a union makes a well-known FastAPI model loosely typed. The alternative — keeping it intact and making each 422 response `anyOf: [HTTPValidationError, ErrorDetail]` — generates better clients but rewrites the 422 of ~1086 operations. Happy to switch if you prefer that shape.
- **One uncovered edge:** exactly one 422 raises a dict detail (`dns/router.py:4403`, `DYNAMIC_UPDATE_UNSUPPORTED`), which the `anyOf` does not admit. It is not fuzz-reachable — both path params on that route are `format: uuid`, so generated UUIDs 404 at `_require_zone` first — so it is a latent gap rather than a live failure.
- The two `export.pdf` `UndefinedContentType` failures are a separate defect and are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
