### PR TITLE
fix(appliance): make the slot-upgrade endpoints honest about which node they act on

### DIFF
--- a/backend/app/api/v1/appliance/slot.py
+++ b/backend/app/api/v1/appliance/slot.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from app.api.deps import DB, CurrentUser
+from app.config import settings
 from app.core.permissions import require_permission
 from app.models.audit import AuditLog
 from app.services.appliance.slot import (
@@ -34,6 +35,17 @@ router = APIRouter()
 
 
 class SlotStatusResponse(BaseModel):
+    # WHICH NODE THIS ANSWER IS ABOUT. Every other field here is read from
+    # the responding pod's own host mounts, and the api Deployment runs one
+    # replica per control-plane node behind a Service with no session
+    # affinity — so on a cluster consecutive polls of this endpoint are
+    # answered by different nodes, even when the caller addressed one node's
+    # own IP. Without this field that is invisible: each response is a
+    # well-formed 200 describing a machine the caller never named.
+    #
+    # Empty string on non-appliance deploys (no downward API, and only one
+    # place the answer could have come from).
+    node: str
     appliance_mode: bool
     current_slot: str | None
     durable_default: str | None
@@ -69,6 +81,7 @@ class ApplyResponse(BaseModel):
 
 def _serialise(s: SlotStatus) -> SlotStatusResponse:
     return SlotStatusResponse(
+        node=settings.node_name,
         appliance_mode=s.appliance_mode,
         current_slot=s.current_slot,
         durable_default=s.durable_default,

--- a/backend/app/api/v1/appliance/slot.py
+++ b/backend/app/api/v1/appliance/slot.py
@@ -15,10 +15,12 @@ from typing import Literal
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
+from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
 from app.config import settings
 from app.core.permissions import require_permission
+from app.models.appliance import CLUSTER_ROLES, Appliance
 from app.models.audit import AuditLog
 from app.services.appliance.slot import (
     SlotStatus,
@@ -79,6 +81,55 @@ class ApplyResponse(BaseModel):
     scheduled: str
 
 
+async def _reject_if_clustered(db: DB, action: str) -> None:
+    """Refuse a node-local WRITE when this deployment has more than one
+    appliance node.
+
+    ``schedule_apply``/``schedule_rollback`` write trigger files into
+    ``/var/lib/spatiumddi-host/release-state``, which is a hostPath on the
+    node the responding pod happens to occupy. That is correct on a
+    single-node appliance — there is exactly one node, and it is this one.
+    On a cluster it is not: the api Deployment runs one replica per
+    control-plane node behind a Service with no session affinity, so the
+    node that receives this POST is chosen by the load balancer. The
+    operator asks to upgrade an appliance and an arbitrary machine writes
+    its inactive slot; addressing a node's own IP does not change that,
+    because the IP selects an ingress, not a pod.
+
+    A wrong-node upgrade is silent — 202 Accepted, a real upgrade, on a
+    host nobody named — so this refuses rather than guesses. The
+    per-appliance endpoints
+    (``POST /appliance/appliances/{id}/upgrade``, ``/set-next-boot``,
+    ``/set-default-slot``) are the node-addressed path: they stamp desired
+    state on that appliance's row and the target node's own supervisor
+    writes the trigger on its own disk.
+
+    Counts CONTROL-PLANE nodes, not approved appliances: ``cluster_role`` is
+    NULL for a data-plane appliance and for a single node that has not been
+    promoted, and becomes primary/member only on promotion. That is the same
+    quantity the api Deployment's replica count tracks, so it is exactly the
+    condition that makes "which node answered?" ambiguous — a single-node
+    control plane with paired data-plane appliances stays unambiguous and
+    keeps working.
+    """
+    nodes = (
+        await db.execute(
+            select(func.count())
+            .select_from(Appliance)
+            .where(Appliance.cluster_role.in_(CLUSTER_ROLES))
+        )
+    ).scalar_one()
+    if nodes > 1:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"{action} is unavailable on a clustered deployment: this endpoint "
+            f"acts on whichever node serves the request ({settings.node_name or 'unknown'}), "
+            f"not on one you can choose, and this cluster has {nodes} control-plane nodes. "
+            "Use POST /api/v1/appliance/appliances/{appliance_id}/upgrade, which "
+            "targets a node by id and lets that node's own supervisor apply it.",
+        )
+
+
 def _serialise(s: SlotStatus) -> SlotStatusResponse:
     return SlotStatusResponse(
         node=settings.node_name,
@@ -116,6 +167,7 @@ async def apply(
     db: DB,
     user: CurrentUser,
 ) -> ApplyResponse:
+    await _reject_if_clustered(db, "slot-upgrade apply")
     if is_apply_in_flight():
         raise HTTPException(
             status.HTTP_409_CONFLICT,
@@ -185,6 +237,7 @@ async def rollback(
     choice, no health gate. Calls ``grub-set-default`` durably; the
     swap doesn't take effect until the operator reboots.
     """
+    await _reject_if_clustered(db, "slot-upgrade rollback")
     if is_apply_in_flight():
         raise HTTPException(
             status.HTTP_409_CONFLICT,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -186,6 +186,14 @@ class Settings(BaseSettings):
     appliance_mode: bool = False
     appliance_version: str = ""
     appliance_hostname: str = ""
+    # The k8s node this api pod runs on, from the downward API
+    # (spec.nodeName) in the api Deployment. The api runs one replica per
+    # control-plane node under hard anti-affinity, and several endpoints
+    # read the HOST filesystem through node-local hostPath mounts — so on
+    # a cluster their answer is about whichever node served the request.
+    # Empty on docker-compose / non-appliance deploys, where there is only
+    # one place the answer could have come from.
+    node_name: str = ""
     # Comma-separated list of the host's real IPv4/IPv6 addresses,
     # detected by spatiumddi-firstboot via `ip -o addr show scope global`
     # and threaded through .env. Used by the self-signed cert bootstrap

--- a/backend/tests/test_slot_node_affinity.py
+++ b/backend/tests/test_slot_node_affinity.py
@@ -1,0 +1,224 @@
+"""The singleton slot endpoints are node-local; on a cluster they must say so.
+
+``/api/v1/appliance/slot-upgrade`` reads and writes the responding pod's OWN
+host mounts. The api Deployment scales to the control-plane node count under
+hard anti-affinity and its Service sets no session affinity, so on a cluster
+consecutive calls are served by different nodes even when the caller addressed
+one node's IP.
+
+Found live on a 3-node cluster: eight consecutive GETs against ONE member's own
+IP alternated between that node's real upgrade (``done``, a timestamp, 6.6 KB of
+log_tail) and other nodes' idle state (``ready``, null, empty). The reads were
+merely unreadable; the WRITES were worse — an apply lands on whichever node the
+load balancer picked, so a rolling upgrade can upgrade one node repeatedly and
+never touch the others, silently, with a 202 every time.
+
+Two guards here: the response names the node it describes, and the writes refuse
+to guess.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.appliance import slot as slot_api
+from app.config import settings
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import (
+    APPLIANCE_STATE_APPROVED,
+    CLUSTER_ROLE_MEMBER,
+    CLUSTER_ROLE_PRIMARY,
+    Appliance,
+)
+from app.models.auth import User
+
+
+async def _superadmin(db: AsyncSession) -> dict[str, str]:
+    user = User(
+        username=f"admin-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test Admin",
+        hashed_password=hash_password("test-pw-slot"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _approve(db: AsyncSession, hostname: str,
+                   cluster_role: str | None = None) -> Appliance:
+    """An approved appliance. `cluster_role` None models a data-plane
+    appliance or an unpromoted single node — approved, but NOT part of the
+    control plane, and therefore not a source of node ambiguity."""
+    row = Appliance(
+        id=uuid.uuid4(),
+        hostname=hostname,
+        state=APPLIANCE_STATE_APPROVED,
+        cluster_role=cluster_role,
+        public_key_der=b"fake-key",
+        public_key_fingerprint=uuid.uuid4().hex * 2,
+        cert_serial="0000",
+        deployment_kind="appliance",
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+# ── the response names the node it is about ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_status_reports_the_responding_node(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    headers = await _superadmin(db_session)
+    monkeypatch.setattr(settings, "node_name", "ddipg-member-1")
+    r = await client.get("/api/v1/appliance/slot-upgrade", headers=headers)
+    assert r.status_code == 200
+    # Without this an operator cannot tell whose slot state they just read,
+    # and every response looks equally authoritative.
+    assert r.json()["node"] == "ddipg-member-1"
+
+
+@pytest.mark.asyncio
+async def test_status_node_is_empty_off_cluster(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # docker-compose / non-appliance: no downward API, and only one place the
+    # answer could have come from. Empty is honest; a fabricated name is not.
+    headers = await _superadmin(db_session)
+    monkeypatch.setattr(settings, "node_name", "")
+    r = await client.get("/api/v1/appliance/slot-upgrade", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["node"] == ""
+
+
+# ── the writes refuse to act on a node nobody chose ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_apply_refuses_on_a_cluster(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    headers = await _superadmin(db_session)
+    monkeypatch.setattr(settings, "node_name", "ddipg-member-1")
+    for host, role in (("ddipg-seed", CLUSTER_ROLE_PRIMARY),
+                       ("ddipg-member-1", CLUSTER_ROLE_MEMBER),
+                       ("ddipg-member-2", CLUSTER_ROLE_MEMBER)):
+        await _approve(db_session, host, role)
+    await db_session.commit()
+
+    fired: list[str] = []
+    monkeypatch.setattr(slot_api, "schedule_apply", lambda *a, **k: fired.append("apply"))
+
+    r = await client.post(
+        "/api/v1/appliance/slot-upgrade/apply",
+        headers=headers,
+        json={"image_url": "http://example/slot.raw.xz"},
+    )
+    assert r.status_code == 409
+    detail = r.json()["detail"]
+    # The refusal has to be actionable: which node would have been hit, how
+    # many there are, and where to go instead.
+    assert "clustered" in detail
+    assert "ddipg-member-1" in detail
+    assert "3 control-plane nodes" in detail
+    assert "appliances/{appliance_id}/upgrade" in detail
+    # and nothing was written to any node's disk
+    assert fired == []
+
+
+@pytest.mark.asyncio
+async def test_rollback_refuses_on_a_cluster(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    headers = await _superadmin(db_session)
+    for host, role in (("ddipg-seed", CLUSTER_ROLE_PRIMARY),
+                       ("ddipg-member-1", CLUSTER_ROLE_MEMBER)):
+        await _approve(db_session, host, role)
+    await db_session.commit()
+    fired: list[str] = []
+    monkeypatch.setattr(
+        slot_api, "schedule_rollback", lambda *a, **k: fired.append("rollback")
+    )
+
+    r = await client.post(
+        "/api/v1/appliance/slot-upgrade/rollback", headers=headers, json={}
+    )
+    assert r.status_code == 409
+    assert fired == []
+
+
+@pytest.mark.asyncio
+async def test_single_node_appliance_still_applies(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One approved node is the deployment this endpoint was written for:
+    there is exactly one machine it could mean, and it is this one."""
+    headers = await _superadmin(db_session)
+    await _approve(db_session, "ddipg-seed", CLUSTER_ROLE_PRIMARY)
+    await db_session.commit()
+    fired: list[str] = []
+    monkeypatch.setattr(slot_api, "schedule_apply", lambda *a, **k: fired.append("apply"))
+    monkeypatch.setattr(slot_api, "is_apply_in_flight", lambda: False)
+
+    r = await client.post(
+        "/api/v1/appliance/slot-upgrade/apply",
+        headers=headers,
+        json={"image_url": "http://example/slot.raw.xz"},
+    )
+    assert r.status_code == 202
+    assert fired == ["apply"]
+
+
+@pytest.mark.asyncio
+async def test_no_approved_appliances_still_applies(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh install that has not registered itself yet must not be locked
+    out of its own upgrade path — the guard is about ambiguity, and zero rows
+    are not ambiguous."""
+    headers = await _superadmin(db_session)
+    await db_session.commit()
+    fired: list[str] = []
+    monkeypatch.setattr(slot_api, "schedule_apply", lambda *a, **k: fired.append("apply"))
+    monkeypatch.setattr(slot_api, "is_apply_in_flight", lambda: False)
+
+    r = await client.post(
+        "/api/v1/appliance/slot-upgrade/apply",
+        headers=headers,
+        json={"image_url": "http://example/slot.raw.xz"},
+    )
+    assert r.status_code == 202
+    assert fired == ["apply"]
+
+
+@pytest.mark.asyncio
+async def test_data_plane_appliances_do_not_count_as_a_cluster(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Approved != control-plane. A single unclustered node with paired
+    data-plane appliances has exactly one machine this endpoint could mean,
+    so it must keep working — counting approved rows would have 409'd it."""
+    headers = await _superadmin(db_session)
+    await _approve(db_session, "ddipg-seed", None)
+    await _approve(db_session, "ddipg-dns-1", None)
+    await _approve(db_session, "ddipg-dhcp-1", None)
+    await db_session.commit()
+    fired: list[str] = []
+    monkeypatch.setattr(slot_api, "schedule_apply", lambda *a, **k: fired.append("apply"))
+    monkeypatch.setattr(slot_api, "is_apply_in_flight", lambda: False)
+
+    r = await client.post(
+        "/api/v1/appliance/slot-upgrade/apply",
+        headers=headers,
+        json={"image_url": "http://example/slot.raw.xz"},
+    )
+    assert r.status_code == 202
+    assert fired == ["apply"]

--- a/backend/tests/test_slot_node_affinity.py
+++ b/backend/tests/test_slot_node_affinity.py
@@ -50,8 +50,7 @@ async def _superadmin(db: AsyncSession) -> dict[str, str]:
     return {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
 
 
-async def _approve(db: AsyncSession, hostname: str,
-                   cluster_role: str | None = None) -> Appliance:
+async def _approve(db: AsyncSession, hostname: str, cluster_role: str | None = None) -> Appliance:
     """An approved appliance. `cluster_role` None models a data-plane
     appliance or an unpromoted single node — approved, but NOT part of the
     control plane, and therefore not a source of node ambiguity."""
@@ -108,9 +107,11 @@ async def test_apply_refuses_on_a_cluster(
 ) -> None:
     headers = await _superadmin(db_session)
     monkeypatch.setattr(settings, "node_name", "ddipg-member-1")
-    for host, role in (("ddipg-seed", CLUSTER_ROLE_PRIMARY),
-                       ("ddipg-member-1", CLUSTER_ROLE_MEMBER),
-                       ("ddipg-member-2", CLUSTER_ROLE_MEMBER)):
+    for host, role in (
+        ("ddipg-seed", CLUSTER_ROLE_PRIMARY),
+        ("ddipg-member-1", CLUSTER_ROLE_MEMBER),
+        ("ddipg-member-2", CLUSTER_ROLE_MEMBER),
+    ):
         await _approve(db_session, host, role)
     await db_session.commit()
 
@@ -139,18 +140,16 @@ async def test_rollback_refuses_on_a_cluster(
     client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     headers = await _superadmin(db_session)
-    for host, role in (("ddipg-seed", CLUSTER_ROLE_PRIMARY),
-                       ("ddipg-member-1", CLUSTER_ROLE_MEMBER)):
+    for host, role in (
+        ("ddipg-seed", CLUSTER_ROLE_PRIMARY),
+        ("ddipg-member-1", CLUSTER_ROLE_MEMBER),
+    ):
         await _approve(db_session, host, role)
     await db_session.commit()
     fired: list[str] = []
-    monkeypatch.setattr(
-        slot_api, "schedule_rollback", lambda *a, **k: fired.append("rollback")
-    )
+    monkeypatch.setattr(slot_api, "schedule_rollback", lambda *a, **k: fired.append("rollback"))
 
-    r = await client.post(
-        "/api/v1/appliance/slot-upgrade/rollback", headers=headers, json={}
-    )
+    r = await client.post("/api/v1/appliance/slot-upgrade/rollback", headers=headers, json={})
     assert r.status_code == 409
     assert fired == []
 

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -55,6 +55,16 @@ spec:
               containerPort: 8000
           env:
             {{- include "spatiumddi.commonEnv" . | nindent 12 }}
+            # The node this replica runs on. The api Deployment scales to
+            # the control-plane node count under hard anti-affinity, so on a
+            # cluster there is one api pod per node — and several appliance
+            # endpoints read node-local hostPath mounts. Without this the
+            # pod cannot say which host its answer describes, and the caller
+            # cannot either. Same downward-API shape the supervisor uses.
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             {{- if .Values.frontend.controlPlaneVIP }}
             # #272 Phase 6 — the self-signed cert bootstrap adds the
             # control-plane VIP to the cert SANs (and regenerates an


### PR DESCRIPTION
Fixes #839 — the slot-upgrade endpoints act on an arbitrary node on a cluster.

Root-caused live on a nested 3-node QA cluster, where a rolling upgrade driven
through these endpoints produced three-for-three "upgrade_state regressed"
failures on applies that had all succeeded, and one member that never flipped
slots despite a 202.

## 1. The response never said which node it described

`GET /appliance/slot-upgrade` reads the responding pod's own host mounts. The
api Deployment is scaled to the control-plane node count with hard pod
anti-affinity (`k8s_api.apply_control_plane_overrides`) and its Service sets no
`sessionAffinity`, so on a cluster consecutive polls are answered by different
nodes — including when the caller addressed one node's own IP, because an IP
selects an ingress, not a pod.

Eight consecutive GETs against **one member's own IP**, moments after a slot
upgrade completed on that node:

```
#  upgrade_state   upgrade_state_at                  log_tail
0  ready           None                              0 bytes
1  done            2026-08-05T20:56:28+00:00         6676 bytes
2  ready           None                              0 bytes
3  done            2026-08-05T20:56:28+00:00         6676 bytes
4  done            2026-08-05T20:56:28+00:00         6676 bytes
5  done            2026-08-05T20:56:28+00:00         6676 bytes
6  done            2026-08-05T20:56:28+00:00         6676 bytes
7  ready           None                              0 bytes
```

The `ready` rows are pods on nodes that never ran an upgrade. Same URL, same
second, different machines — and every response a well-formed 200.

`SlotStatusResponse` now carries `node`, sourced from a `NODE_NAME` the api
Deployment takes off the downward API (`spec.nodeName`), the same shape the
supervisor DaemonSet already uses. Empty on non-appliance deploys, where there
is only one place the answer could have come from and a fabricated name would be
worse than none.

This does not make the endpoint node-addressable. It makes its existing
behaviour legible, which is what was missing: there was no failure to see, only
a different node's truth.

## 2. The writes act on a node nobody chose

`schedule_apply` / `schedule_rollback` write trigger files into
`/var/lib/spatiumddi-host/release-state` — a hostPath on whichever node the
responding pod occupies. On a single-node appliance that is correct. On a
cluster the node is chosen by the load balancer, so an operator asks to upgrade
an appliance and an arbitrary machine writes its inactive slot and arms
next-boot. It returns 202 either way.

A rolling upgrade driven this way hits the intended node with probability about
1/n on an n-node cluster. On the run that surfaced this, one member never
flipped slots at all.

Both endpoints now return **409** when the deployment has more than one
control-plane node, naming the responding node, the count, and the endpoint that
does target a node:

```
slot-upgrade apply is unavailable on a clustered deployment: this endpoint acts
on whichever node serves the request (ddipg-member-1), not on one you can
choose, and this cluster has 3 control-plane nodes. Use POST
/api/v1/appliance/appliances/{appliance_id}/upgrade, which targets a node by id
and lets that node's own supervisor apply it.
```

Refusing rather than guessing is deliberate: a wrong-node upgrade is silent and
the caller cannot detect or correct it, while a 409 is loud and actionable.

The count is over `cluster_role IN (primary, member)`, not over approved rows.
`cluster_role` is NULL for a data-plane appliance and for a node that has not
been promoted, so a single unclustered node with paired data-plane appliances
keeps working — counting approved rows would have 409'd it. It is also the same
quantity the api Deployment's replica count tracks, which is exactly the
condition that makes "which node answered?" ambiguous. The guard is about
ambiguity, not about clusters as such.

### Why this is a small change

The node-affine path already exists end to end and this PR does not rebuild it:
`POST /appliance/appliances/{id}/upgrade` stamps desired state on an appliance
row, the heartbeat hands it to that node's supervisor, and the supervisor writes
the trigger on its own disk. Per-node slot telemetry returns the same way onto
the row, which is what the Fleet UI reads. These singleton endpoints simply
predate clustering.

## Validation on real hardware

Nested 3-node cluster on a QA rig (Proxmox, seed + 2 members), running this
branch's build.

**12 consecutive `GET /appliance/slot-upgrade` against member-1's own IP:**

```
 0 ddipg-member-1    4 ddipg-member-1    8 ddipg-member-2
 1 ddipg-member-1    5 ddipg-seed        9 ddipg-seed
 2 ddipg-member-1    6 ddipg-member-1   10 ddipg-member-1
 3 ddipg-member-1    7 ddipg-member-2   11 ddipg-member-1
```

Three distinct nodes from one address. That is the defect — now readable
rather than silent.

| | before | after |
|---|---|---|
| GETs at one member's IP | no `node` field; state alternates with no way to tell why | `node` in every response, visibly 3 distinct nodes |
| `POST /apply` on a cluster | 202, upgrades an arbitrary node | 409 naming the node (`ddipg-member-1`) and the count (3) |
| `POST /rollback` on a cluster | 202, flips grubenv on an arbitrary node | 409, same message shape |
| `POST /apply` single-node | 202 | 202 (unchanged) |
| single node + data-plane appliances | n/a | 202 (unchanged) |

**Reproducing this requires a settled cluster.** The first attempt saw one
node only: the api Deployment was still at `1/3`, because the supervisor
scales `replicas` to the control-plane count *after* the cluster forms. Wait
for `kubectl -n spatium get deploy …-api` to read `3/3` or you will wrongly
conclude the endpoint is node-affine.

Cluster rows the guard counts, read off the live cluster:

```
ddipg-seed       state=approved  cluster_role='primary'  cluster_join_state=None
ddipg-member-1   state=approved  cluster_role='member'   cluster_join_state='ready'
ddipg-member-2   state=approved  cluster_role='member'   cluster_join_state='ready'
```

Note the seed's `cluster_join_state` is NULL — counting `join_state == 'ready'`
would have reported 2 control-plane nodes instead of 3.

## Tests

`backend/tests/test_slot_node_affinity.py` — 7 new cases: node reported, node
empty off-cluster, apply 409s on a cluster **and writes nothing**, rollback
409s, single-node still 202s, zero-approved-rows still 202s, and a single
unclustered node with paired data-plane appliances still 202s.

Neighbourhood run (`pytest -k 'slot or appliance_info or upgrade or cluster'`):
**289 passed, 2 skipped, 0 failed**. `ruff check` clean on the touched files. `helm template`
renders the new downward-API block.

## Tradeoffs and remaining work

- **Breaking for automation** that drives the singleton endpoint against a
  cluster. That is the intent — such a caller was already upgrading whichever
  node it happened to reach — but it is a behaviour change and worth a release
  note. Nothing in `frontend/` calls it (`applianceSlotApi` is defined but
  unreferenced; `FleetTab` uses the per-appliance surface).
- The Fleet UI's OS Image card polls the singleton endpoint and will now receive
  a `node` field it does not render. Displaying it, or moving the card to the
  per-appliance surface, is left out of scope.
- `GET` is left working rather than also 409'd: it is genuinely useful for the
  node you reached, and now says which node that is. Breaking reads would break
  existing pollers for no safety gain.
- Not addressed here: the separate defect where the api pod does not mount
  `/run/udev` or `/boot/efi-host`, so `current_slot` / `durable_default` are
  null and `/rollback` 409s on every appliance. Different cause, same endpoint;
  fixing it would still leave every answer coming from an arbitrary node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
