### PR TITLE
fix(dns-agent): reload the zone files `rndc reconfig` ignores, so a record reaches the wire

### DIFF
--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -1063,23 +1063,99 @@ class Bind9Driver(DriverBase):
         # fall back to SIGHUP which named handles as a config + zone reload.
         rndc_ok = False
         if shutil.which("rndc"):
-            cmd = ["rndc"]
-            agent_conf = self.state_dir / "rndc.conf"
-            if agent_conf.exists():
-                cmd += ["-c", str(agent_conf)]
-            cmd.append("reconfig")
-            res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            base = self._rndc_base()
+            # ``reconfig`` picks up config changes and zones that were ADDED or
+            # REMOVED — but by BIND's documented definition it "does not reload
+            # existing zone files even if they have changed". That was fine
+            # while a record edit rode the RFC 2136 path. Under split-horizon
+            # (issue #24) it is not: the control plane deliberately stops
+            # dispatching record ops for a group with views — an nsupdate to
+            # loopback cannot target a view — and propagates record changes by
+            # RE-RENDERING the zone file instead
+            # (backend/app/services/dns/agent_config.py, has_views branch).
+            # ``reconfig`` never reads that file back, so on any group with a
+            # view every record created after the zone's first load was written
+            # to disk and never served: the API returned 201 and the wire
+            # answered NXDOMAIN forever. Proven live on a 3-node QA rig
+            # 2026-08-06 — the record was present in
+            # rendered/zones/<view>/<zone>.db while dig returned NXDOMAIN, and
+            # the zone's own ``rndc zonestatus`` still showed the serial and
+            # node count from the previous load.
+            res = subprocess.run(
+                [*base, "reconfig"], capture_output=True, text=True, check=False
+            )
             rndc_ok = res.returncode == 0
             if not rndc_ok:
                 log.warning(
                     "rndc_failed_falling_back_to_sighup", stderr=res.stderr.strip()
                 )
+            else:
+                self._reload_rendered_zones(base)
         if not rndc_ok and self.daemon_pid:
             try:
                 os.kill(self.daemon_pid, signal.SIGHUP)
                 log.info("named_sighup_sent", pid=self.daemon_pid)
             except OSError as e:
                 log.error("named_sighup_failed", error=str(e))
+
+    def rendered_zone_views(self) -> list[tuple[str, str | None]]:
+        """``(zone_name, view_name)`` for every zone file we just rendered.
+
+        Read back off the rendered tree rather than threaded down from
+        ``render()`` so it cannot drift from what is actually on disk — the
+        layout is ``rendered/zones/<view>/<zone>.db`` under split-horizon and
+        ``rendered/zones/<zone>.db`` without views, which is exactly the
+        ``file_prefix`` contract ``_zone_stanza`` writes.
+        """
+        root = self.state_dir / self.rendered_dir_name / "zones"
+        out: list[tuple[str, str | None]] = []
+        try:
+            entries = sorted(root.iterdir())
+        except OSError:
+            return out
+        for entry in entries:
+            if entry.is_dir():
+                for zf in sorted(entry.glob("*.db")):
+                    out.append((zf.name[: -len(".db")], entry.name))
+            elif entry.name.endswith(".db"):
+                out.append((entry.name[: -len(".db")], None))
+        return out
+
+    def _reload_rendered_zones(self, base: list[str]) -> None:
+        """Make named re-read the zone files ``reconfig`` just ignored.
+
+        Every primary zone we render carries an ``allow-update`` clause — the
+        group's loopback TSIG grant is ALWAYS included so control-plane record
+        ops can flow (see ``_render_allow_update``), which makes the zone
+        DYNAMIC as far as named is concerned. named will not re-read a dynamic
+        zone's file on a plain reload, because doing so would silently discard
+        journal contents; it has to be frozen first. So: freeze → reload →
+        thaw, per zone, per view. ``freeze``/``thaw`` fail harmlessly on a zone
+        that is not dynamic, and the plain ``reload`` covers that case, so one
+        sequence is correct for both.
+
+        Best-effort by design: a zone that will not reload must not stop the
+        rest from reloading, and it is already reported through the daemon's
+        own status channel.
+        """
+        for zname, view in self.rendered_zone_views():
+            scope = [zname] + (["in", view] if view else [])
+            for verb in ("freeze", "reload", "thaw"):
+                res = subprocess.run(
+                    [*base, verb, *scope],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                if res.returncode != 0 and verb == "reload":
+                    log.warning(
+                        "bind9_zone_reload_failed",
+                        zone=zname,
+                        view=view,
+                        stderr=res.stderr.strip()[:200],
+                    )
+        log.info("bind9_rendered_zones_reloaded",
+                 zones=len(self.rendered_zone_views()))
 
     # ── Record ops (RFC 2136 over loopback) ─────────────────────────────────
 

--- a/agent/dns/tests/test_zone_reload.py
+++ b/agent/dns/tests/test_zone_reload.py
@@ -1,0 +1,128 @@
+"""A rendered zone file is worthless if named never reads it back (#704).
+
+``rndc reconfig`` — what ``swap_and_reload`` used to issue on its own — is
+defined by BIND as "reload the configuration file and load new zones, but do
+not reload existing zone files even if they have changed". That is the right
+primitive only while a record edit reaches the daemon some OTHER way. Under
+split-horizon (issue #24) it does not: the control plane stops dispatching RFC
+2136 record ops for a group with views — an nsupdate to loopback cannot target
+a view — and propagates record changes by re-rendering the zone file instead.
+``reconfig`` never reads that file, so every record created after the zone's
+first load was written to disk and never served.
+
+And because every primary zone carries the group's loopback TSIG grant in
+``allow-update`` (``_render_allow_update``: "ALWAYS included"), the zones are
+DYNAMIC, and named will not re-read a dynamic zone's file on a plain reload
+either — it has to be frozen first. Hence freeze → reload → thaw.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from spatium_dns_agent.drivers.bind9 import Bind9Driver
+
+
+def _rendered(tmp_path, layout: dict[str | None, list[str]],
+              into: str = "rendered") -> Bind9Driver:
+    """A driver whose rendered tree carries `layout`.
+
+    `into="rendered.new"` stages it the way `render()` really does, so
+    `swap_and_reload` promotes it — reading the tree back after the swap is
+    the whole contract `rendered_zone_views` has to honour.
+    """
+    drv = Bind9Driver(state_dir=tmp_path)
+    zones = tmp_path / into / "zones"
+    for view, names in layout.items():
+        target = zones / view if view else zones
+        target.mkdir(parents=True, exist_ok=True)
+        for n in names:
+            (target / f"{n}.db").write_text("; rendered\n")
+    return drv
+
+
+def test_rendered_zone_views_reads_the_split_horizon_layout(tmp_path):
+    drv = _rendered(tmp_path, {
+        "meridian-internal": ["lab.ddipg.test", "50.10.10.in-addr.arpa"],
+        "meridian-external": ["lab.ddipg.test"],
+    })
+    assert sorted(drv.rendered_zone_views()) == [
+        ("50.10.10.in-addr.arpa", "meridian-internal"),
+        ("lab.ddipg.test", "meridian-external"),
+        ("lab.ddipg.test", "meridian-internal"),
+    ]
+
+
+def test_rendered_zone_views_reads_the_flat_layout(tmp_path):
+    drv = _rendered(tmp_path, {None: ["corp.ddipg.test"]})
+    assert drv.rendered_zone_views() == [("corp.ddipg.test", None)]
+
+
+def test_rendered_zone_views_is_empty_before_a_first_render(tmp_path):
+    assert Bind9Driver(state_dir=tmp_path).rendered_zone_views() == []
+
+
+@pytest.fixture
+def rndc_spy(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("shutil.which", lambda _n: "/usr/sbin/rndc")
+    return calls
+
+
+def test_swap_and_reload_reloads_each_rendered_zone_not_just_the_config(
+    tmp_path, monkeypatch, rndc_spy
+):
+    drv = _rendered(tmp_path, {"meridian-internal": ["lab.ddipg.test"]},
+                    into="rendered.new")
+    monkeypatch.setattr(drv, "daemon_running", lambda: True)
+
+    drv.swap_and_reload()
+
+    verbs = [c[1] for c in rndc_spy]
+    assert verbs[0] == "reconfig", "config changes still need reconfig"
+    # The whole point: the zone itself is reloaded, and frozen first because
+    # the loopback TSIG grant makes it dynamic.
+    assert verbs[1:] == ["freeze", "reload", "thaw"]
+    for call in rndc_spy[1:]:
+        assert call[2:] == ["lab.ddipg.test", "in", "meridian-internal"]
+
+
+def test_swap_and_reload_scopes_a_flat_zone_without_a_view(
+    tmp_path, monkeypatch, rndc_spy
+):
+    drv = _rendered(tmp_path, {None: ["corp.ddipg.test"]}, into="rendered.new")
+    monkeypatch.setattr(drv, "daemon_running", lambda: True)
+
+    drv.swap_and_reload()
+
+    assert [c[1] for c in rndc_spy] == ["reconfig", "freeze", "reload", "thaw"]
+    assert rndc_spy[-1][2:] == ["corp.ddipg.test"], "no `in <view>` without views"
+
+
+def test_a_zone_that_will_not_reload_does_not_block_the_others(
+    tmp_path, monkeypatch
+):
+    """Best-effort by design — one unreloadable zone must not strand the rest."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, *a, **kw):
+        calls.append(list(cmd))
+        rc = 1 if cmd[1:3] == ["reload", "a.test"] else 0
+        return subprocess.CompletedProcess(cmd, rc, "", "boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr("shutil.which", lambda _n: "/usr/sbin/rndc")
+    drv = _rendered(tmp_path, {None: ["a.test", "b.test"]}, into="rendered.new")
+    monkeypatch.setattr(drv, "daemon_running", lambda: True)
+
+    drv.swap_and_reload()
+
+    assert ["reload", "b.test"] in [c[1:3] for c in calls]


### PR DESCRIPTION
Fixes #838 — in views mode a record accepted by the API never reaches the wire.

## What the issue asked for, and what this does instead

#838's "Suggested fix" proposed one line: `reconfig` → `reload`. That is proven
to work for the views-mode path the issue is about, but it is not sufficient in
general, and this PR does the thing the issue files under *worth considering*
instead. The reason is in the issue's own primitive table:

```
rndc reload <zone>   ->  refused: 'reload' failed: dynamic zone
```

Every primary zone this product renders is dynamic in named's eyes, because
`_render_allow_update` emits the group's loopback TSIG grant unconditionally —
including on zones with `dynamic_update_enabled: false`. named will not re-read
a dynamic zone's master file on a plain `reload`, since that would discard
journal contents. Server-wide `rndc reload` gets away with it *only* in views
mode, where RFC 2136 is disabled so no journal has ever been written. On a group
without views, the same call would be a data-loss hazard.

So `swap_and_reload` now keeps `reconfig` for what `reconfig` is actually for —
config changes and zones added or removed — and then does **freeze → reload →
thaw per rendered zone, scoped `in <view>` under split-horizon**. That is the
journal-safe generalization, and it is the primitive #707's reporter originally
asked for.

## Change

- `Bind9Driver.swap_and_reload()` issues the per-zone reload after `reconfig`.
- New `rendered_zone_views()` reads the zone/view layout back off the rendered
  tree rather than off the bundle, so it cannot drift from what was actually
  written to disk.
- Per-zone best-effort: one zone that will not reload does not strand the rest.

## Why the failure was invisible

Nothing reported an error anywhere along the chain. The agent rendered, swapped
atomically, logged `structural_reload_applied` and moved on; the control plane
retired the queued op as `applied` on the way past, which it is right to do in
views mode (`agent_config.py:295-315`). Records present at first load kept
serving, so a fresh appliance looks healthy until someone adds a record.

The change is now visible doing the work — a new log line pairs with every
structural reload:

```json
{"zones": 5, "event": "bind9_rendered_zones_reloaded", "timestamp": "..."}
{"structural_etag": "sha256:557cc70e…", "event": "structural_reload_applied", "timestamp": "..."}
```

## Validation on real hardware

Nested 3-node appliance cluster on a QA rig, group `meridian-internal` with one
view, zone `lab.ddipg.test`. Before-fix numbers are from a rig at the same ref;
after-fix from a rig built from this branch.

| | before | after |
|---|---|---|
| create → served on the wire | never (0/24 polls over 120 s) | **5 s**, then 6/6 digs |
| delete → withdrawn from the wire | never | **5 s** |
| targeted `suites/api/test_deep_wire.py -m integration` | fail | **3 passed** in 49 s |
| `test_deep_wire_dns_record_serves` | fail | pass |
| `test_deep_wire_dns_delete_stops_serving` | fail (precondition) | pass |

Both of those checks had **never passed since they were written** — 0 flips
across 146 tags, no flake signature — so this is not a lucky flip.

## Tests

`agent/dns/tests/test_zone_reload.py` — 6 new cases: the rendered-tree layout in
both shapes (views and flat), that `swap_and_reload` issues freeze/reload/thaw
per zone rather than only `reconfig`, view scoping of the rndc calls, and that
one unreloadable zone does not strand the others.

`agent/dns`: **183 passed, 8 skipped**. `ruff check` introduces no new findings
(16 on this branch, 16 on `main` — the two that land on touched files are
pre-existing `RUF100` unused-`noqa` on `daemon_version`).

## Not in this PR

- The duplicate-`named` defect that shares this code path is **#704**, which is
  closed but still reproduces. It has its own PR; the two are independent and
  touch disjoint regions of `bind9.py`.
- `_render_allow_update` emitting the loopback grant unconditionally is what
  forces the freeze/thaw dance at all. Narrowing it to
  `dynamic_update_enabled` zones would be a cleaner fix but changes the
  security surface, so it is left as a note.
