### PR TITLE
fix(dns-agent): close the duplicate-`named` spawn race for real

### DIFF
--- a/agent/dns/spatium_dns_agent/drivers/_process.py
+++ b/agent/dns/spatium_dns_agent/drivers/_process.py
@@ -36,7 +36,12 @@ exactly the PowerDNS failure it exists to prevent.
 
 from __future__ import annotations
 
+import contextlib
+import errno
+import fcntl
 import os
+import time
+from collections.abc import Iterator
 
 
 def is_zombie(pid: str) -> bool:
@@ -87,3 +92,63 @@ def find_running_daemon(comm: str) -> int | None:
         except ValueError:
             continue
     return None
+
+
+@contextlib.contextmanager
+def spawn_guard(state_dir, name: str) -> Iterator[None]:
+    """Serialise check-then-spawn across every caller in this container.
+
+    ``find_running_daemon`` alone does not close the race it was written for,
+    and the reason is that it matches on ``/proc/<pid>/comm``: between
+    ``Popen(["named", ...])`` returning and the child completing ``execve``,
+    the new process is still named after the FORKING program, so a concurrent
+    caller looking for ``named`` sees nothing and spawns a second one. That is
+    precisely the 118 ms window this module's docstring describes as "not
+    fully established", and it still fires — observed live on a QA appliance
+    2026-08-06 with two ``named`` processes (pids 14 and 24), same parent,
+    same config, both holding :53 and :953 under SO_REUSEPORT, which made
+    every subsequent ``rndc`` a coin flip between one daemon holding the
+    current zones and one serving stale ones.
+
+    An exclusive flock held across check AND spawn removes the window
+    regardless of which caller wins. It is released on exit, so a crash
+    mid-spawn cannot wedge the next start.
+    """
+    lock_path = os.path.join(str(state_dir), f".{name}.spawn.lock")
+    fd = None
+    try:
+        fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+        fcntl.flock(fd, fcntl.LOCK_EX)
+    except OSError as exc:
+        # No writable state dir / no flock (some sandboxes). Fall back to the
+        # unguarded path, which is the pre-existing behaviour.
+        if exc.errno not in (errno.EACCES, errno.EPERM, errno.EROFS, errno.ENOSYS):
+            raise
+        if fd is not None:
+            os.close(fd)
+        fd = None
+    try:
+        yield
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                os.close(fd)
+
+
+def wait_for_daemon(comm: str, pid: int, timeout_s: float = 5.0) -> None:
+    """Block until ``pid`` is visible under ``comm``, or the timeout expires.
+
+    Held inside :func:`spawn_guard`, this is what makes the NEXT caller's
+    ``find_running_daemon`` see the daemon we just started: it does not return
+    while the child is still pre-``execve``.
+    """
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            with open(f"/proc/{pid}/comm", encoding="utf-8") as fh:
+                if fh.read().strip() == comm:
+                    return
+        except OSError:
+            return  # exited, or not Linux — nothing to wait for
+        time.sleep(0.02)

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -30,7 +30,12 @@ try:
 except ImportError:  # pragma: no cover - runtime-optional
     dns = None  # type: ignore[assignment]
 
-from ._process import find_running_daemon, is_zombie
+from ._process import (
+    find_running_daemon,
+    is_zombie,
+    spawn_guard,
+    wait_for_daemon,
+)
 from .base import RRSET_OP_KINDS, DriverBase
 
 log = structlog.get_logger(__name__)
@@ -1343,16 +1348,26 @@ class Bind9Driver(DriverBase):
         # ``rndc status`` land on either. Enabling query logging then
         # appears to do nothing, which silently breaks the Logs → DNS
         # Queries surface and anything built on it.
-        existing = find_running_daemon("named")
-        if existing is not None:
-            self.daemon_pid = existing
-            log.info(
-                "named_already_running_adopted",
-                pid=existing,
-                note="did not spawn a second daemon",
-            )
-            return
-        self.daemon_pid = subprocess.Popen(["named", "-f", "-c", str(conf_path)]).pid
+        # The system look-up alone does NOT close the race: it matches on
+        # ``/proc/<pid>/comm``, and a child that has been forked but has not
+        # yet ``execve``'d still carries the PARENT's name, so a concurrent
+        # caller sees no daemon and spawns a second one. Hold an exclusive
+        # lock across the check, the spawn, and the wait for the new process
+        # to become visible under its own name — then the window has no
+        # interior. (Observed live 2026-08-06: pids 14 and 24, same parent,
+        # same config, both bound to :53 and :953.)
+        with spawn_guard(self.state_dir, "named"):
+            existing = find_running_daemon("named")
+            if existing is not None:
+                self.daemon_pid = existing
+                log.info(
+                    "named_already_running_adopted",
+                    pid=existing,
+                    note="did not spawn a second daemon",
+                )
+                return
+            self.daemon_pid = subprocess.Popen(["named", "-f", "-c", str(conf_path)]).pid
+            wait_for_daemon("named", self.daemon_pid)
         log.info("named_started", pid=self.daemon_pid)
 
     def daemon_running(self) -> bool:

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -40,7 +40,12 @@ from typing import Any
 import httpx
 import structlog
 
-from ._process import find_running_daemon, is_zombie
+from ._process import (
+    find_running_daemon,
+    is_zombie,
+    spawn_guard,
+    wait_for_daemon,
+)
 from .base import RRSET_OP_KINDS, DriverBase
 
 log = structlog.get_logger(__name__)
@@ -999,46 +1004,53 @@ class PowerDNSDriver(DriverBase):
         # ``os.kill(zombie, 0)`` succeeds, the driver then reports a
         # healthy daemon while tracking a dead process, and any signal it
         # sends goes nowhere.
-        existing = find_running_daemon("pdns_server")
-        if existing is not None:
-            self.daemon_pid = existing
-            log.info(
-                "pdns_already_running_adopted",
-                pid=existing,
-                note="did not spawn a second daemon",
-            )
-            return
-        # ``--daemon=no`` + foreground; pdns logs to stderr.
-        # All flags use ``--name=value`` form — pdns_server rejects
-        # space-separated args with "perhaps a '--setting=123'
-        # statement missed the '='?".
-        #
-        # We redirect pdns_server stderr into a file the agent's
-        # ``QueryLogShipper`` thread can tail, gated on
-        # ``log-dns-queries=yes`` being set in pdns.conf. The file
-        # lives inside the agent's own state dir
-        # (``/var/lib/spatium-dns-agent/pdns.log``) — the ``spatium``
-        # user owns that path, which avoids the permission denied
-        # we'd hit trying to write to ``/var/log/pdns/`` (owned by
-        # root inside the container). The supervisor's
-        # ``QueryLogShipper`` is configured against the same path
-        # in ``supervisor.run``.
-        log_path = self.state_dir / "pdns.log"
-        # Open append-mode so log rotates are non-destructive and the
-        # tail can resume across daemon restarts (the shipper handles
-        # inode-change rotation separately).
-        log_fh = log_path.open("ab", buffering=0)
-        self.daemon_pid = subprocess.Popen(
-            [
-                "pdns_server",
-                "--daemon=no",
-                "--guardian=no",
-                f"--config-dir={current}",
-                "--config-name=",
-            ],
-            stdout=log_fh,
-            stderr=subprocess.STDOUT,
-        ).pid
+        # The system look-up is necessary but not sufficient: it matches on
+        # ``/proc/<pid>/comm``, and a forked-but-not-yet-``execve``'d child
+        # still carries the parent's name, so a concurrent caller sees no
+        # daemon and spawns a duplicate anyway. Serialise check-and-spawn on
+        # an exclusive lock instead (see ``_process.spawn_guard``).
+        with spawn_guard(self.state_dir, "pdns_server"):
+            existing = find_running_daemon("pdns_server")
+            if existing is not None:
+                self.daemon_pid = existing
+                log.info(
+                    "pdns_already_running_adopted",
+                    pid=existing,
+                    note="did not spawn a second daemon",
+                )
+                return
+            # ``--daemon=no`` + foreground; pdns logs to stderr.
+            # All flags use ``--name=value`` form — pdns_server rejects
+            # space-separated args with "perhaps a '--setting=123'
+            # statement missed the '='?".
+            #
+            # We redirect pdns_server stderr into a file the agent's
+            # ``QueryLogShipper`` thread can tail, gated on
+            # ``log-dns-queries=yes`` being set in pdns.conf. The file
+            # lives inside the agent's own state dir
+            # (``/var/lib/spatium-dns-agent/pdns.log``) — the ``spatium``
+            # user owns that path, which avoids the permission denied
+            # we'd hit trying to write to ``/var/log/pdns/`` (owned by
+            # root inside the container). The supervisor's
+            # ``QueryLogShipper`` is configured against the same path
+            # in ``supervisor.run``.
+            log_path = self.state_dir / "pdns.log"
+            # Open append-mode so log rotates are non-destructive and the
+            # tail can resume across daemon restarts (the shipper handles
+            # inode-change rotation separately).
+            log_fh = log_path.open("ab", buffering=0)
+            self.daemon_pid = subprocess.Popen(
+                [
+                    "pdns_server",
+                    "--daemon=no",
+                    "--guardian=no",
+                    f"--config-dir={current}",
+                    "--config-name=",
+                ],
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+            ).pid
+            wait_for_daemon("pdns_server", self.daemon_pid)
         # Track the path so a future health-check / observability
         # surface can find it without re-deriving.
         self._daemon_log_path = log_path


### PR DESCRIPTION
Reopens and fixes #704 — the BIND9 agent still starts `named` twice.

#704 was closed as complete, but the defect reproduces on current `main`. The
mitigation that landed at the time (`drivers/_process.find_running_daemon`) says
so itself:

> the trigger is not fully established

It is now established, and this PR closes it.

## The race

`find_running_daemon` matches on `/proc/<pid>/comm`. Between `Popen(["named",
…])` returning and the child completing `execve`, that child still carries the
**forking** program's name. A concurrent caller therefore sees no daemon and
spawns a second one. That is exactly the ~118 ms window the existing docstring
describes but could not name.

Checking harder cannot fix this — the check is racing the kernel, not another
check. So the guard has to span the whole operation: `spawn_guard` takes an
exclusive `flock` held across the check, the spawn, **and** `wait_for_daemon`
(the new process becoming visible under its own name). The window then has no
interior. Both the bind9 and powerdns drivers take it; where flock is
unavailable it degrades to the previous behaviour rather than failing.

## Observed live

Inside the DNS pod on a nested 3-node appliance cluster:

```
PID   PPID  ELAPSED COMMAND
    1     0  2h02   /sbin/tini -- /usr/local/bin/spatium-dns-entrypoint
    7     1  2h02   {spatium-dns-age} /usr/bin/python3 /usr/local/bin/spatium-dns-agent
   14     7  2h02   named -f -c /var/lib/spatium-dns-agent/rendered/named.conf
   24     7  2h02   named -f -c /var/lib/spatium-dns-agent/rendered/named.conf
```

Two daemons, same parent, same config. `/run/named/named.pid` tracks only 24.
`netstat` shows 8 duplicate LISTEN rows on `:53` and 2 on `:8053` — SO_REUSEPORT
hides the collision, which is why this survives boot looking healthy.

The operational consequence is that `rndc` becomes non-deterministic. Five
successive `zonestatus` calls for one zone alternate between two authoritative
answers:

```
[0] serial: 2026080624 | nodes: 7 | last loaded: 16:06:34 | frozen: yes
[1] serial: 2026080614 | nodes: 7 | last loaded: 15:09:38 | frozen: no
[2] serial: 2026080614 | nodes: 7 | last loaded: 15:09:38 | frozen: no
```

Any control-plane operation that reloads, freezes, signs or inspects a zone
lands on whichever daemon answers, and half of them silently address the wrong
one.

| | before | after |
|---|---|---|
| `named` processes in the pod | **2** (pids 14, 24) | **1** (pid 14) |
| `rndc zonestatus` ×3 | two alternating answers | identical ×3 |

## Tests

`agent/dns`: **177 passed, 8 skipped** with this commit applied to `main`
standalone. `ruff check` introduces no new findings.

## Relationship to #838

#838 is a different defect in the same file — `swap_and_reload` sending `rndc
reconfig`, which never re-reads a changed zone file. The two were found in the
same investigation and their symptoms compound (a reload aimed at the wrong
daemon is a reload that did not happen), but they are independent: disjoint
regions of `bind9.py`, and either commit applies to `main` without the other.
