### PR TITLE
fix(dhcp,dns): keep overlapping IP spaces from breaking shared DHCP/DNS groups (#844)

### DIFF
--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -833,6 +833,7 @@ async def agent_lease_events(
     from app.models.ipam import IPAddress
     from app.services.dhcp.pull_leases import (
         _find_containing_subnet,
+        _load_scope_cache,
         _load_subnet_cache,
     )
     from app.services.feature_modules import is_module_enabled
@@ -854,6 +855,25 @@ async def agent_lease_events(
     # ingestion path, up to 100 events/POST). Three queries total instead
     # of ~3 per event. ──────────────────────────────────────────────────
     ips = list({ev.ip_address for ev in events})
+
+    # Resolve subnets once (Python longest-prefix match, no per-IP SQL),
+    # BEFORE the lease upsert so new rows get their scope FK stamped. #844:
+    # prefer subnets actually scoped to this server's group — IPAM allows the
+    # same CIDR in different IP spaces, and an unranked longest-prefix match
+    # would mirror every customer's leases into one arbitrary space's subnet
+    # (and fire DDNS into the wrong customer's zone). The IPAM mirror is
+    # keyed by (subnet_id, address) below, which only disambiguates once the
+    # subnet itself is resolved correctly.
+    subnets = await _load_subnet_cache(db)
+    scope_cache = await _load_scope_cache(db, server.server_group_id)
+    subnet_for_ip = {
+        ip: _find_containing_subnet(ip, subnets, preferred_subnet_ids=set(scope_cache))
+        for ip in ips
+    }
+
+    def _scope_for_ip(ip: str) -> Any:
+        subnet = subnet_for_ip.get(ip)
+        return scope_cache.get(subnet.id) if subnet is not None else None
 
     existing_leases = (
         (
@@ -895,6 +915,10 @@ async def agent_lease_events(
                 ends_at=ev.ends_at,
                 expires_at=expires_at,
                 last_seen_at=now,
+                # #844 — wire the scope FK at ingestion so downstream
+                # consumers (lease cleanup, mirror scoping) never have to
+                # fall back to the space-ambiguous CIDR match.
+                scope_id=_scope_for_ip(ev.ip_address),
             )
             db.add(lease)
             lease_by_key[key] = lease
@@ -907,14 +931,15 @@ async def agent_lease_events(
             lease.ends_at = ev.ends_at
             lease.expires_at = expires_at
             lease.last_seen_at = now
+            if lease.scope_id is None:
+                # Backfill legacy rows created before scope stamping (#844).
+                lease.scope_id = _scope_for_ip(ev.ip_address)
         upserted += 1
     await db.flush()
 
-    # Resolve subnets once (Python longest-prefix match, no per-IP SQL) and
-    # bulk-load the existing IPAM mirror rows. Keyed by (subnet_id, address)
-    # so overlapping ranges across spaces stay disambiguated.
-    subnets = await _load_subnet_cache(db)
-    subnet_for_ip = {ip: _find_containing_subnet(ip, subnets) for ip in ips}
+    # Bulk-load the existing IPAM mirror rows. Keyed by (subnet_id, address)
+    # so overlapping ranges across spaces stay disambiguated (subnets were
+    # resolved space-aware above).
     ipam_existing = (
         (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
     )
@@ -1110,7 +1135,11 @@ async def agent_mac_sightings(
     server-side until the operator arms the feature.
     """
     from app.models.ipam import IPAddress
-    from app.services.dhcp.pull_leases import _find_containing_subnet, _load_subnet_cache
+    from app.services.dhcp.pull_leases import (
+        _find_containing_subnet,
+        _load_scope_cache,
+        _load_subnet_cache,
+    )
     from app.services.feature_modules import is_module_enabled
 
     server, _ = auth
@@ -1124,6 +1153,9 @@ async def agent_mac_sightings(
 
     now = datetime.now(UTC)
     subnets = await _load_subnet_cache(db)
+    # #844 — prefer this server's own scoped subnets over an equal prefix
+    # from an unrelated IP space (same ambiguity as the lease-event path).
+    sighting_preferred = set(await _load_scope_cache(db, server.server_group_id))
     ips = list({s.ip_address for s in body.sightings})
     existing = (
         (await db.execute(select(IPAddress).where(IPAddress.address.in_(ips)))).scalars().all()
@@ -1133,7 +1165,9 @@ async def agent_mac_sightings(
     # (ipam_row, mac) pairs to classify after the flush assigns new-row ids.
     to_observe: list[tuple[IPAddress, str]] = []
     for s in body.sightings:
-        subnet = _find_containing_subnet(s.ip_address, subnets)
+        subnet = _find_containing_subnet(
+            s.ip_address, subnets, preferred_subnet_ids=sighting_preferred
+        )
         if subnet is None:
             continue
         row = by_key.get((subnet.id, s.ip_address))

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import select
+from sqlalchemy import text as sa_text
 from sqlalchemy.exc import IntegrityError
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
@@ -559,6 +560,64 @@ async def list_scopes_for_group(
     return [_scope_to_response(s) for s in res.unique().scalars().all()]
 
 
+async def _assert_no_overlapping_group_cidr(
+    db: DB,
+    group_id: uuid.UUID,
+    subnet: Subnet,
+    *,
+    exclude_scope_id: uuid.UUID | None = None,
+) -> None:
+    """Refuse a scope whose subnet CIDR overlaps another ACTIVE scope's subnet
+    in the same group (#844).
+
+    IPAM deliberately allows the same CIDR in different IP spaces (VRF
+    semantics), but a Kea server renders one ``subnet4``/``subnet6`` entry per
+    scope and rejects the entire config at load on a duplicate prefix — so two
+    overlapping-space subnets converging on one group takes DHCP down for
+    every scope on that group. Same failure class as the out-of-CIDR
+    reservation guard (#619): refuse at the API instead of shipping a config
+    the daemon will refuse. Overlap within one space is already impossible
+    (IPAM validates), so a hit here means two IP spaces — the fix is a
+    separate DHCP server group per overlapping space.
+
+    Raw SQL for the ``&&`` cidr operator (mirrors the IPAM overlap checks);
+    that bypasses the ORM soft-delete filter, hence the explicit
+    ``deleted_at IS NULL``.
+    """
+    res = await db.execute(
+        sa_text("""
+            SELECT s.network FROM subnet s
+            JOIN dhcp_scope sc ON sc.subnet_id = s.id
+            WHERE sc.group_id = CAST(:gid AS uuid)
+              AND sc.subnet_id != CAST(:sid AS uuid)
+              AND sc.is_active
+              AND sc.deleted_at IS NULL
+              AND s.network && CAST(:net AS cidr)
+              AND (CAST(:excl AS uuid) IS NULL OR sc.id != CAST(:excl AS uuid))
+            LIMIT 1
+            """),
+        {
+            "gid": str(group_id),
+            "sid": str(subnet.id),
+            "net": str(subnet.network),
+            "excl": str(exclude_scope_id) if exclude_scope_id else None,
+        },
+    )
+    row = res.first()
+    if row:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"An active scope in this DHCP server group already covers "
+                f"{row[0]}, which overlaps {subnet.network} (another IP "
+                f"space). Duplicate or overlapping prefixes on one Kea "
+                f"server reject the whole config at load, taking down DHCP "
+                f"for every scope in the group — use a separate DHCP server "
+                f"group per overlapping IP space (#844)."
+            ),
+        )
+
+
 @router.post(
     "/subnets/{subnet_id}/dhcp-scopes",
     response_model=ScopeResponse,
@@ -597,6 +656,11 @@ async def create_scope(
         )
 
     sync_mode = _normalize_sync_mode(body.hostname_sync_mode or body.hostname_to_ipam_sync)
+    # #844 — only an ACTIVE scope reaches the rendered config, so an inactive
+    # create is allowed and the guard re-fires on activation (update_scope).
+    _will_be_active = body.enabled if body.enabled is not None else body.is_active
+    if _will_be_active:
+        await _assert_no_overlapping_group_cidr(db, group_id, subnet)
     if sync_mode not in VALID_SYNC_MODES - {"ipam", "learned"}:
         raise HTTPException(status_code=422, detail=f"invalid hostname sync mode: {sync_mode}")
     # Same alias resolution as update: ``enabled`` wins when supplied, and
@@ -743,6 +807,15 @@ async def update_scope(
         # Family must match the scope's (subnet-derived) address_family;
         # address_family itself is immutable on update (#337).
         _validate_relay_family(changes["relay_addresses"], scope.address_family or "ipv4")
+    # #844 — activation is the other door into the rendered config: a scope
+    # created inactive (or deactivated to dodge the create-time guard) must
+    # pass the same overlapping-CIDR check before it starts rendering.
+    if changes.get("is_active") is True and not scope.is_active:
+        subnet = await db.get(Subnet, scope.subnet_id)
+        if subnet is not None:
+            await _assert_no_overlapping_group_cidr(
+                db, scope.group_id, subnet, exclude_scope_id=scope.id
+            )
     for k, v in changes.items():
         setattr(scope, k, v)
     await db.flush()

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -61,6 +61,7 @@ from app.services.approvals.gate import gate_or_execute
 from app.services.dhcp.windows_writethrough import (
     push_statics_bulk_delete,
 )
+from app.services.dns.reverse_zone import cidrs_overlap
 from app.services.ipam.address_set_gate import (
     WritableSetRanges,
     load_writable_set_ranges,
@@ -73,6 +74,11 @@ from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normaliz
 from app.services.tags import apply_tag_filter
 
 logger = structlog.get_logger(__name__)
+
+# #844 — log-dedupe for _resolve_reverse_zone's cross-space skip (it runs per
+# IP inside _sync_dns_record). Log suppression only — never consulted for
+# logic.
+_cross_space_skip_warned: set[tuple[str, str]] = set()
 
 
 def _validate_opt_ddns_domain(v: Any) -> Any:
@@ -489,12 +495,13 @@ async def _check_ip_collisions(
       common virtual MAC, so the MAC-collision warning is suppressed.
       The FQDN check still runs (a duplicate hostname on a VIP isn't a
       shared-by-design pattern, just an operator typo).
-    - PTR check (#844) runs when ``subnet`` + ``address`` are supplied and a
-      hostname will publish DNS: if the reverse zone this IP would land in
-      already holds a PTR at the same name from a *different* IP row (a
-      manual PTR, or pre-existing cross-space data from before the #844
-      space guards), warn rather than silently stacking a second value onto
-      the RRset.
+    - PTR check (#844) runs when ``subnet`` + ``address`` are supplied AND
+      the pending row would actually publish DNS (hostname + forward zone —
+      ``_sync_dns_record`` only writes a PTR alongside a forward record): if
+      the reverse zone this IP would land in already holds a PTR at the same
+      name from a *different* IP row (a manual PTR, or pre-existing
+      cross-space data from before the #844 space guards), warn rather than
+      silently stacking a second value onto the RRset.
     """
     warnings: list[dict[str, Any]] = []
 
@@ -542,7 +549,7 @@ async def _check_ip_collisions(
                 }
             )
 
-    if subnet is not None and address and hostname:
+    if subnet is not None and address and hostname and forward_zone_id:
         try:
             ip_obj = ipaddress.ip_address(address)
         except ValueError:
@@ -1003,16 +1010,20 @@ async def _resolve_reverse_zone(
     effective_group_ids, _, _ = await _resolve_effective_dns(db, subnet)
     if not effective_group_ids:
         return None
-    # #844 — carry the linked subnet's space so a zone another IP space's
-    # subnet auto-created is never adopted here. IPAM allows the same CIDR in
-    # different spaces, and both compute the identical reverse zone name; a
-    # bare name-suffix match would fold two customers' PTRs into one zone
-    # (cross-tenant hostname disclosure). Zones with no linked subnet
-    # (operator-created shared reverse zones) stay matchable — a space can't
-    # be attributed to them, and refusing would break legit single-tenant
-    # setups.
+    # #844 — carry the linked subnet's space + network so a zone that an
+    # OVERLAPPING subnet in another IP space auto-created is never adopted
+    # here: both compute the identical reverse zone name, and a bare
+    # name-suffix match would fold two customers' PTRs onto the same names
+    # (cross-tenant hostname disclosure). The overlap test matters — IPv4
+    # reverse zones aggregate to /24, so two NON-overlapping subnets (in any
+    # spaces) legitimately share one zone with disjoint PTR names and must
+    # keep working. Zones with no linked subnet (operator-created shared
+    # reverse zones, or a link left dangling by a subnet delete) stay
+    # matchable — a space can't be attributed to them, and refusing would
+    # break legit single-tenant setups; ``ensure_reverse_zone_for_subnet``
+    # re-links dangling zones on the next allocation.
     res = await db.execute(
-        select(DNSZone, Subnet.space_id)
+        select(DNSZone, Subnet.space_id, Subnet.network)
         .outerjoin(Subnet, Subnet.id == DNSZone.linked_subnet_id)
         .where(
             DNSZone.group_id.in_(effective_group_ids),
@@ -1021,17 +1032,27 @@ async def _resolve_reverse_zone(
     )
     # Choose the longest matching suffix (most specific)
     best: DNSZone | None = None
-    for z, linked_space_id in res.all():
+    for z, linked_space_id, linked_network in res.all():
         zname = z.name.rstrip(".") + "."
         if rev_pointer.endswith("." + zname) or rev_pointer == zname:
-            if linked_space_id is not None and linked_space_id != subnet.space_id:
-                logger.warning(
+            if (
+                linked_space_id is not None
+                and linked_space_id != subnet.space_id
+                and cidrs_overlap(linked_network, subnet.network)
+            ):
+                key = (str(subnet.id), str(z.id))
+                # Per-IP call site: warn once per (subnet, zone) pair per
+                # process, debug after — bulk syncs would otherwise emit one
+                # warning per IP per run, forever.
+                log_fn = logger.debug if key in _cross_space_skip_warned else logger.warning
+                _cross_space_skip_warned.add(key)
+                log_fn(
                     "reverse_zone_cross_space_skipped",
                     subnet_id=str(subnet.id),
                     zone_id=str(z.id),
                     zone=z.name,
-                    note="zone is linked to a subnet in another IP space; "
-                    "PTR would leak across tenants (#844)",
+                    note="zone is linked to an overlapping subnet in another "
+                    "IP space; PTR would leak across tenants (#844)",
                 )
                 continue
             if best is None or len(z.name) > len(best.name):

--- a/backend/app/api/v1/ipam/router.py
+++ b/backend/app/api/v1/ipam/router.py
@@ -470,8 +470,10 @@ async def _check_ip_collisions(
     mac_address: str | None,
     exclude_ip_id: uuid.UUID | None = None,
     role: str | None = None,
+    subnet: Subnet | None = None,
+    address: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Return FQDN + MAC collision warnings for a pending IP assignment.
+    """Return FQDN + MAC + PTR collision warnings for a pending IP assignment.
 
     - FQDN check runs only when both ``hostname`` and ``forward_zone_id``
       resolve — nothing to collide on otherwise.
@@ -487,6 +489,12 @@ async def _check_ip_collisions(
       common virtual MAC, so the MAC-collision warning is suppressed.
       The FQDN check still runs (a duplicate hostname on a VIP isn't a
       shared-by-design pattern, just an operator typo).
+    - PTR check (#844) runs when ``subnet`` + ``address`` are supplied and a
+      hostname will publish DNS: if the reverse zone this IP would land in
+      already holds a PTR at the same name from a *different* IP row (a
+      manual PTR, or pre-existing cross-space data from before the #844
+      space guards), warn rather than silently stacking a second value onto
+      the RRset.
     """
     warnings: list[dict[str, Any]] = []
 
@@ -533,6 +541,43 @@ async def _check_ip_collisions(
                     "existing_ip_id": str(ip.id),
                 }
             )
+
+    if subnet is not None and address and hostname:
+        try:
+            ip_obj = ipaddress.ip_address(address)
+        except ValueError:
+            ip_obj = None
+        if ip_obj is not None:
+            rev_zone = await _resolve_reverse_zone(db, subnet, ip_obj)
+            if rev_zone is not None:
+                rev_pointer_full = ip_obj.reverse_pointer + "."
+                rev_zone_name = rev_zone.name.rstrip(".") + "."
+                if rev_pointer_full == rev_zone_name:
+                    ptr_name = "@"
+                else:
+                    ptr_name = rev_pointer_full[: -(len(rev_zone_name) + 1)]
+                q = select(DNSRecord).where(
+                    DNSRecord.zone_id == rev_zone.id,
+                    DNSRecord.record_type == "PTR",
+                    DNSRecord.name == ptr_name,
+                )
+                if exclude_ip_id is not None:
+                    q = q.where(
+                        or_(
+                            DNSRecord.ip_address_id.is_(None),
+                            DNSRecord.ip_address_id != exclude_ip_id,
+                        )
+                    )
+                for rec in (await db.execute(q)).scalars().all():
+                    warnings.append(
+                        {
+                            "kind": "ptr_collision",
+                            "zone": rev_zone.name,
+                            "ptr_name": ptr_name,
+                            "existing_value": rec.value,
+                            "existing_record_id": str(rec.id),
+                        }
+                    )
 
     return warnings
 
@@ -958,18 +1003,37 @@ async def _resolve_reverse_zone(
     effective_group_ids, _, _ = await _resolve_effective_dns(db, subnet)
     if not effective_group_ids:
         return None
+    # #844 — carry the linked subnet's space so a zone another IP space's
+    # subnet auto-created is never adopted here. IPAM allows the same CIDR in
+    # different spaces, and both compute the identical reverse zone name; a
+    # bare name-suffix match would fold two customers' PTRs into one zone
+    # (cross-tenant hostname disclosure). Zones with no linked subnet
+    # (operator-created shared reverse zones) stay matchable — a space can't
+    # be attributed to them, and refusing would break legit single-tenant
+    # setups.
     res = await db.execute(
-        select(DNSZone).where(
+        select(DNSZone, Subnet.space_id)
+        .outerjoin(Subnet, Subnet.id == DNSZone.linked_subnet_id)
+        .where(
             DNSZone.group_id.in_(effective_group_ids),
             DNSZone.kind == "reverse",
         )
     )
-    candidates = list(res.scalars().all())
     # Choose the longest matching suffix (most specific)
     best: DNSZone | None = None
-    for z in candidates:
+    for z, linked_space_id in res.all():
         zname = z.name.rstrip(".") + "."
         if rev_pointer.endswith("." + zname) or rev_pointer == zname:
+            if linked_space_id is not None and linked_space_id != subnet.space_id:
+                logger.warning(
+                    "reverse_zone_cross_space_skipped",
+                    subnet_id=str(subnet.id),
+                    zone_id=str(z.id),
+                    zone=z.name,
+                    note="zone is linked to a subnet in another IP space; "
+                    "PTR would leak across tenants (#844)",
+                )
+                continue
             if best is None or len(z.name) > len(best.name):
                 best = z
     return best
@@ -6717,6 +6781,8 @@ async def create_address(
             forward_zone_id=effective_zone,
             mac_address=body.mac_address,
             role=body.role,
+            subnet=subnet,
+            address=body.address,
         )
         # Public-facing safety guard (issue #25). Append to the same
         # warnings list so the operator sees both surfaces in one
@@ -7071,6 +7137,8 @@ async def update_address(
             mac_address=body.mac_address if mac_touched else None,
             exclude_ip_id=ip.id,
             role=effective_role,
+            subnet=subnet_for_check if hostname_or_zone_touched else None,
+            address=str(ip.address),
         )
         # Public-facing safety guard (issue #25). Run on every update
         # that touches the zone bindings — adding an extra zone can

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -13,6 +13,7 @@ Mirrors ``app.services.dns.config_bundle``.
 
 from __future__ import annotations
 
+import ipaddress
 from datetime import UTC, datetime
 
 import structlog
@@ -48,6 +49,10 @@ from app.services.dhcp.radvd import build_ra_config, render_radvd_conf
 from app.services.feature_modules import is_module_enabled
 
 log = structlog.get_logger(__name__)
+
+# #844 — log-dedupe for the duplicate-prefix drop below (see comment at the
+# call site). Log suppression only — never consulted for logic.
+_dup_prefix_logged: set[tuple[str, str]] = set()
 
 
 async def _resolve_failover(
@@ -203,43 +208,55 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
     # and if two such subnets both carry an active scope in this group the
     # rendered config holds two identical subnet4/subnet6 entries — Kea
     # rejects the WHOLE config at load, taking down every scope on the
-    # server. The API refuses new collisions (create/activate 409 in
-    # scopes.py); this guard keeps a pre-existing or raced-in collision from
-    # reaching agents: ship the oldest scope per prefix, drop the rest, and
-    # log loudly so the operator sees which customer isn't being served.
-    seen_prefix: dict[str, DHCPScope] = {}
-    for sc in scope_rows:
+    # server. Overlapping-but-unequal prefixes (a subnet resize can produce
+    # them — resize has no scope-aware guard) are dropped too, so the last
+    # line of defense is at least as wide as the API guard. The API refuses
+    # new collisions (create/activate 409 in scopes.py); this keeps a
+    # pre-existing or raced-in collision from reaching agents: ship the
+    # oldest scope per overlap cluster, drop the rest, and log so the
+    # operator sees which subnet isn't being served.
+    kept_nets: list[tuple[DHCPScope, ipaddress.IPv4Network | ipaddress.IPv6Network]] = []
+    dropped: list[tuple[DHCPScope, DHCPScope]] = []
+    # Oldest row wins — deterministic across rebuilds, and the newer scope
+    # is the one that slipped in against the API guard.
+    for sc in sorted(
+        scope_rows,
+        key=lambda s: (s.created_at or datetime.max.replace(tzinfo=UTC), str(s.id)),
+    ):
         subnet = subnet_map.get(sc.subnet_id)
         if subnet is None or not subnet.network:
             continue
-        prefix = str(subnet.network)
-        cur = seen_prefix.get(prefix)
-        # Oldest row wins — deterministic across rebuilds, and the newer
-        # scope is the one that slipped in against the API guard.
-        if cur is None or (
-            (sc.created_at or datetime.max.replace(tzinfo=UTC), str(sc.id))
-            < (cur.created_at or datetime.max.replace(tzinfo=UTC), str(cur.id))
-        ):
-            seen_prefix[prefix] = sc
-    dropped = [
-        sc
-        for sc in scope_rows
-        if (subnet := subnet_map.get(sc.subnet_id)) is not None
-        and subnet.network
-        and seen_prefix.get(str(subnet.network)) is not sc
-    ]
+        try:
+            net = ipaddress.ip_network(str(subnet.network), strict=False)
+        except ValueError:
+            continue
+        winner = next(
+            (k for k, knet in kept_nets if knet.version == net.version and knet.overlaps(net)),
+            None,
+        )
+        if winner is None:
+            kept_nets.append((sc, net))
+        else:
+            dropped.append((sc, winner))
     if dropped:
-        for sc in dropped:
-            log.error(
+        for sc, winner in dropped:
+            # This runs inside the agent /config long-poll loop, so an
+            # unfixed pre-existing collision would emit ERROR every wake /
+            # safety tick forever. Error once per pair per process, then
+            # demote to debug. Log suppression only — never drives logic.
+            key = (str(sc.id), str(winner.id))
+            log_fn = log.debug if key in _dup_prefix_logged else log.error
+            _dup_prefix_logged.add(key)
+            log_fn(
                 "dhcp_bundle_duplicate_prefix_dropped",
                 group_id=str(group.id) if group else None,
                 scope_id=str(sc.id),
                 subnet_id=str(sc.subnet_id),
                 prefix=str(subnet_map[sc.subnet_id].network),
-                kept_scope_id=str(seen_prefix[str(subnet_map[sc.subnet_id].network)].id),
-                note="duplicate prefix would make Kea reject the whole config",
+                kept_scope_id=str(winner.id),
+                note="duplicate/overlapping prefix would make Kea reject " "the whole config",
             )
-        dropped_ids = {sc.id for sc in dropped}
+        dropped_ids = {sc.id for sc, _ in dropped}
         scope_rows = [sc for sc in scope_rows if sc.id not in dropped_ids]
 
     scopes: list[ScopeDef] = []

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import structlog
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -45,6 +46,8 @@ from app.models.dhcp import (
 from app.models.ipam import Subnet
 from app.services.dhcp.radvd import build_ra_config, render_radvd_conf
 from app.services.feature_modules import is_module_enabled
+
+log = structlog.get_logger(__name__)
 
 
 async def _resolve_failover(
@@ -195,6 +198,49 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
         res = await db.execute(select(Subnet).where(Subnet.id.in_(subnet_ids)))
         for s in res.scalars().all():
             subnet_map[s.id] = s
+
+    # #844 belt-and-braces: IPAM allows the same CIDR in different IP spaces,
+    # and if two such subnets both carry an active scope in this group the
+    # rendered config holds two identical subnet4/subnet6 entries — Kea
+    # rejects the WHOLE config at load, taking down every scope on the
+    # server. The API refuses new collisions (create/activate 409 in
+    # scopes.py); this guard keeps a pre-existing or raced-in collision from
+    # reaching agents: ship the oldest scope per prefix, drop the rest, and
+    # log loudly so the operator sees which customer isn't being served.
+    seen_prefix: dict[str, DHCPScope] = {}
+    for sc in scope_rows:
+        subnet = subnet_map.get(sc.subnet_id)
+        if subnet is None or not subnet.network:
+            continue
+        prefix = str(subnet.network)
+        cur = seen_prefix.get(prefix)
+        # Oldest row wins — deterministic across rebuilds, and the newer
+        # scope is the one that slipped in against the API guard.
+        if cur is None or (
+            (sc.created_at or datetime.max.replace(tzinfo=UTC), str(sc.id))
+            < (cur.created_at or datetime.max.replace(tzinfo=UTC), str(cur.id))
+        ):
+            seen_prefix[prefix] = sc
+    dropped = [
+        sc
+        for sc in scope_rows
+        if (subnet := subnet_map.get(sc.subnet_id)) is not None
+        and subnet.network
+        and seen_prefix.get(str(subnet.network)) is not sc
+    ]
+    if dropped:
+        for sc in dropped:
+            log.error(
+                "dhcp_bundle_duplicate_prefix_dropped",
+                group_id=str(group.id) if group else None,
+                scope_id=str(sc.id),
+                subnet_id=str(sc.subnet_id),
+                prefix=str(subnet_map[sc.subnet_id].network),
+                kept_scope_id=str(seen_prefix[str(subnet_map[sc.subnet_id].network)].id),
+                note="duplicate prefix would make Kea reject the whole config",
+            )
+        dropped_ids = {sc.id for sc in dropped}
+        scope_rows = [sc for sc in scope_rows if sc.id not in dropped_ids]
 
     scopes: list[ScopeDef] = []
     for sc in scope_rows:

--- a/backend/app/services/dhcp/lease_cleanup.py
+++ b/backend/app/services/dhcp/lease_cleanup.py
@@ -81,8 +81,11 @@ async def _resolve_lease_subnet_id(
     own subnet so expiring one subnet's lease can't drop another's
     mirror. Prefer the lease's scope FK (DHCPScope.subnet_id); fall back
     to longest-prefix match over ``subnet_cache`` when the lease has no
-    scope backlink. The sweep passes a cache loaded ONCE per run; the
-    single-lease delete path leaves it None and we load it on demand.
+    scope backlink. Both ingestion paths now stamp ``scope_id`` (Windows
+    pull always did; Kea lease-events since #844), so the space-ambiguous
+    CIDR fallback only covers legacy rows and shrinks as they refresh.
+    The sweep passes a cache loaded ONCE per run; the single-lease delete
+    path leaves it None and we load it on demand.
     """
     if lease.scope_id is not None:
         subnet_id = (

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -215,6 +215,9 @@ async def pull_leases_from_server(
     # resolve a stale lease's owning subnet straight from its scope FK,
     # without an extra query per stale row.
     scope_subnet_ids = {scope_id: subnet_id for subnet_id, scope_id in scope_cache.items()}
+    # #844 — subnet ids this server's group actually serves; hoisted out of
+    # the per-lease loops (rebuilding the set per lease is O(scopes) each).
+    preferred_subnet_ids = set(scope_cache)
 
     now = datetime.now(UTC)
 
@@ -224,7 +227,7 @@ async def pull_leases_from_server(
         if not ip or not mac:
             continue
 
-        containing = _find_containing_subnet(ip, subnets, preferred_subnet_ids=set(scope_cache))
+        containing = _find_containing_subnet(ip, subnets, preferred_subnet_ids=preferred_subnet_ids)
         scope_id = scope_cache.get(containing.id) if containing else None
 
         existing = (
@@ -459,7 +462,7 @@ async def pull_leases_from_server(
         stale_subnet_id = scope_subnet_ids.get(stale.scope_id) if stale.scope_id else None
         if stale_subnet_id is None:
             stale_containing = _find_containing_subnet(
-                stale.ip_address, subnets, preferred_subnet_ids=set(scope_cache)
+                stale.ip_address, subnets, preferred_subnet_ids=preferred_subnet_ids
             )
             stale_subnet_id = stale_containing.id if stale_containing else None
         if apply:

--- a/backend/app/services/dhcp/pull_leases.py
+++ b/backend/app/services/dhcp/pull_leases.py
@@ -224,7 +224,7 @@ async def pull_leases_from_server(
         if not ip or not mac:
             continue
 
-        containing = _find_containing_subnet(ip, subnets)
+        containing = _find_containing_subnet(ip, subnets, preferred_subnet_ids=set(scope_cache))
         scope_id = scope_cache.get(containing.id) if containing else None
 
         existing = (
@@ -458,7 +458,9 @@ async def pull_leases_from_server(
         # lease's scope FK when present, else longest-prefix match.
         stale_subnet_id = scope_subnet_ids.get(stale.scope_id) if stale.scope_id else None
         if stale_subnet_id is None:
-            stale_containing = _find_containing_subnet(stale.ip_address, subnets)
+            stale_containing = _find_containing_subnet(
+                stale.ip_address, subnets, preferred_subnet_ids=set(scope_cache)
+            )
             stale_subnet_id = stale_containing.id if stale_containing else None
         if apply:
             # Shared teardown: revoke DDNS (best-effort) → delete the
@@ -533,20 +535,34 @@ async def _load_scope_cache(db: AsyncSession, group_id: Any) -> dict[Any, Any]:
 
 
 def _find_containing_subnet(
-    ip: str, subnets: list[tuple[Subnet, ipaddress._BaseNetwork]]
+    ip: str,
+    subnets: list[tuple[Subnet, ipaddress._BaseNetwork]],
+    preferred_subnet_ids: set[Any] | None = None,
 ) -> Subnet | None:
+    """Longest-prefix match of ``ip`` over ``subnets``.
+
+    ``preferred_subnet_ids`` (#844) carries the subnet ids actually scoped to
+    the requesting server's group. IPAM allows the same CIDR in different IP
+    spaces (VRF semantics), so a bare longest-prefix over ALL subnets is
+    ambiguous on an MSP install — whichever space's row came back first would
+    swallow every customer's leases. A subnet the server actually serves
+    outranks any equal-or-longer prefix from an unrelated space; the global
+    match stays as the fallback for leases in ranges the group has no scope
+    for. Remaining ties break on subnet id so resolution is at least
+    deterministic across runs.
+    """
     try:
         addr = ipaddress.ip_address(ip)
     except (ValueError, TypeError):
         return None
-    # Longest-prefix wins if multiple subnets nest (shouldn't in IPAM,
-    # but defensively).
-    best: tuple[int, Subnet] | None = None
+    best: tuple[int, int, str, Subnet] | None = None
     for subnet, net in subnets:
         if addr in net:
-            if best is None or net.prefixlen > best[0]:
-                best = (net.prefixlen, subnet)
-    return best[1] if best else None
+            rank = 1 if preferred_subnet_ids and subnet.id in preferred_subnet_ids else 0
+            key = (rank, net.prefixlen, str(subnet.id))
+            if best is None or key > (best[0], best[1], best[2]):
+                best = (rank, net.prefixlen, str(subnet.id), subnet)
+    return best[3] if best else None
 
 
 async def _upsert_scope(

--- a/backend/app/services/dns/reverse_zone.py
+++ b/backend/app/services/dns/reverse_zone.py
@@ -32,6 +32,29 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+# #844 — log-dedupe for the cross-space refusal below. The ensure path runs
+# per IP allocation, so an unfixed misconfig would otherwise emit one warning
+# per allocation forever; warn once per (subnet, zone) pair per process, and
+# demote repeats to debug. Log suppression only — never consulted for logic.
+_cross_space_warned: set[tuple[str, str]] = set()
+
+
+def cidrs_overlap(a: object, b: object) -> bool:
+    """True when two CIDR strings are the same address family and overlap.
+
+    #844 uses this instead of a bare space-id comparison: IPv4 reverse zones
+    aggregate to /24 (``compute_reverse_zone_name``), so two NON-overlapping
+    subnets in different spaces legitimately share one reverse zone — their
+    PTR names are disjoint and nothing leaks. Only an actual CIDR overlap
+    can fold two tenants' PTRs onto the same names.
+    """
+    try:
+        na = ipaddress.ip_network(str(a), strict=False)
+        nb = ipaddress.ip_network(str(b), strict=False)
+    except (ValueError, TypeError):
+        return False
+    return na.version == nb.version and na.overlaps(nb)
+
 
 def compute_reverse_zone_name(network: str) -> str:
     """Return the canonical reverse-zone FQDN (with trailing dot) for ``network``.
@@ -156,29 +179,51 @@ async def ensure_reverse_zone_for_subnet(
     )
     existing = existing_q.scalar_one_or_none()
     if existing is not None:
-        # #844 — same CIDR in two IP spaces computes the same reverse zone
-        # name, and the (group_id, view_id, name) unique constraint means a
-        # second zone can't exist. Silently reusing the other space's zone
-        # would merge two tenants' PTRs into one zone (cross-tenant hostname
-        # disclosure), so refuse: this subnet's IPs simply get no PTR until
-        # the operator gives the overlapping space its own DNS group.
+        # #844 — an OVERLAPPING CIDR in another IP space computes the same
+        # reverse zone name, and the (group_id, view_id, name) unique
+        # constraint means a second zone can't exist. Silently reusing the
+        # other space's zone would merge two tenants' PTRs onto the same
+        # names (cross-tenant hostname disclosure), so refuse: this subnet's
+        # IPs simply get no PTR until the operator gives the overlapping
+        # space its own DNS group. Non-overlapping subnets sharing an
+        # aggregated /24 zone (even across spaces) keep working — their PTR
+        # names are disjoint, so there is nothing to leak.
         if existing.linked_subnet_id is not None and existing.linked_subnet_id != subnet.id:
-            linked_space_id = (
+            linked = (
                 await db.execute(
-                    select(Subnet.space_id).where(Subnet.id == existing.linked_subnet_id)
+                    select(Subnet.space_id, Subnet.network).where(
+                        Subnet.id == existing.linked_subnet_id
+                    )
                 )
-            ).scalar_one_or_none()
-            if linked_space_id is not None and linked_space_id != subnet.space_id:
-                logger.warning(
+            ).first()
+            if linked is None:
+                # Dangling link — the owning subnet was deleted but its zone
+                # survived (linked_subnet_id is ondelete=SET NULL on hard
+                # delete, but a stale id can linger). Re-link to the live
+                # subnet so the zone is attributable again instead of
+                # becoming permanently "shared with everyone".
+                existing.linked_subnet_id = subnet.id
+                await db.flush()
+                logger.info(
+                    "reverse_zone_relinked",
+                    zone_id=str(existing.id),
+                    subnet_id=str(subnet.id),
+                    name=reverse_name,
+                )
+            elif linked[0] != subnet.space_id and cidrs_overlap(linked[1], subnet.network):
+                key = (str(subnet.id), str(existing.id))
+                log_fn = logger.debug if key in _cross_space_warned else logger.warning
+                _cross_space_warned.add(key)
+                log_fn(
                     "reverse_zone_cross_space_conflict",
                     subnet_id=str(subnet.id),
                     space_id=str(subnet.space_id),
                     zone_id=str(existing.id),
                     name=reverse_name,
                     linked_subnet_id=str(existing.linked_subnet_id),
-                    note="reverse zone already owned by a subnet in another "
-                    "IP space; refusing to share it — use a separate DNS "
-                    "server group per overlapping IP space (#844)",
+                    note="reverse zone owned by an overlapping subnet in "
+                    "another IP space; refusing to share it — use a separate "
+                    "DNS server group per overlapping IP space (#844)",
                 )
                 return None
         logger.debug(

--- a/backend/app/services/dns/reverse_zone.py
+++ b/backend/app/services/dns/reverse_zone.py
@@ -23,12 +23,12 @@ from sqlalchemy import select
 
 from app.models.audit import AuditLog
 from app.models.dns import DNSServerGroup, DNSZone
+from app.models.ipam import Subnet
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
     from app.models.auth import User
-    from app.models.ipam import Subnet
 
 logger = structlog.get_logger(__name__)
 
@@ -156,6 +156,31 @@ async def ensure_reverse_zone_for_subnet(
     )
     existing = existing_q.scalar_one_or_none()
     if existing is not None:
+        # #844 — same CIDR in two IP spaces computes the same reverse zone
+        # name, and the (group_id, view_id, name) unique constraint means a
+        # second zone can't exist. Silently reusing the other space's zone
+        # would merge two tenants' PTRs into one zone (cross-tenant hostname
+        # disclosure), so refuse: this subnet's IPs simply get no PTR until
+        # the operator gives the overlapping space its own DNS group.
+        if existing.linked_subnet_id is not None and existing.linked_subnet_id != subnet.id:
+            linked_space_id = (
+                await db.execute(
+                    select(Subnet.space_id).where(Subnet.id == existing.linked_subnet_id)
+                )
+            ).scalar_one_or_none()
+            if linked_space_id is not None and linked_space_id != subnet.space_id:
+                logger.warning(
+                    "reverse_zone_cross_space_conflict",
+                    subnet_id=str(subnet.id),
+                    space_id=str(subnet.space_id),
+                    zone_id=str(existing.id),
+                    name=reverse_name,
+                    linked_subnet_id=str(existing.linked_subnet_id),
+                    note="reverse zone already owned by a subnet in another "
+                    "IP space; refusing to share it — use a separate DNS "
+                    "server group per overlapping IP space (#844)",
+                )
+                return None
         logger.debug(
             "reverse_zone_already_exists",
             subnet_id=str(subnet.id),

--- a/backend/tests/test_overlap_guards.py
+++ b/backend/tests/test_overlap_guards.py
@@ -22,7 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.security import create_access_token, hash_password
 from app.models.auth import User
 from app.models.dhcp import DHCPScope, DHCPServer, DHCPServerGroup
-from app.models.dns import DNSRecord, DNSServerGroup
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
 from app.models.ipam import IPBlock, IPSpace, Subnet
 from app.services.dhcp.config_bundle import build_config_bundle
 from app.services.dhcp.pull_leases import _find_containing_subnet
@@ -173,6 +173,7 @@ async def test_bundle_ships_one_scope_per_prefix_oldest_wins(
         group_id=grp.id,
         name="older",
         is_active=True,
+        lease_time=1111,
         created_at=datetime(2026, 1, 1, tzinfo=UTC),
     )
     newer = DHCPScope(
@@ -180,16 +181,56 @@ async def test_bundle_ships_one_scope_per_prefix_oldest_wins(
         group_id=grp.id,
         name="newer",
         is_active=True,
+        lease_time=2222,
         created_at=datetime(2026, 6, 1, tzinfo=UTC),
     )
     db_session.add_all([srv, older, newer])
     await db_session.flush()
 
     bundle = await build_config_bundle(db_session, srv)
-    cidrs = [s.subnet_cidr for s in bundle.scopes]
-    assert cidrs.count(CIDR) == 1, cidrs
-    # Oldest scope's subnet is the one shipped.
     assert len(bundle.scopes) == 1
+    # The OLDEST scope survives — the newer one is the interloper.
+    assert bundle.scopes[0].lease_time == 1111
+
+
+@pytest.mark.asyncio
+async def test_bundle_also_drops_overlapping_unequal_prefix(
+    db_session: AsyncSession,
+) -> None:
+    """A resize can produce a partial overlap the API guard never saw; the
+    bundle must not ship both (Kea overlap behavior is not worth gambling
+    the whole config on)."""
+    sub_a = await _space_subnet(db_session)  # /24
+    sub_b = await _space_subnet(db_session, cidr="192.168.1.0/25")
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    srv = DHCPServer(
+        name=f"kea-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    a = DHCPScope(
+        subnet_id=sub_a.id,
+        group_id=grp.id,
+        name="a",
+        is_active=True,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    b = DHCPScope(
+        subnet_id=sub_b.id,
+        group_id=grp.id,
+        name="b",
+        is_active=True,
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    db_session.add_all([srv, a, b])
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, srv)
+    assert [s.subnet_cidr for s in bundle.scopes] == [CIDR]
 
 
 # ── Guard 3: lease→subnet resolution prefers the server's own subnets ───────
@@ -269,12 +310,14 @@ async def test_resolve_reverse_zone_skips_other_space_zone(
 
     # Subnet B resolves DNS through the same group (the MSP misconfig).
     sub_b.dns_group_ids = [str(g.id)]
+    sub_b.dns_inherit_settings = False  # make the subnet-level groups effective
     await db_session.flush()
 
     ip = ipaddress.ip_address("192.168.1.10")
     assert await _resolve_reverse_zone(db_session, sub_b, ip) is None
     # The owning space still resolves its own zone.
     sub_a.dns_group_ids = [str(g.id)]
+    sub_a.dns_inherit_settings = False
     await db_session.flush()
     got = await _resolve_reverse_zone(db_session, sub_a, ip)
     assert got is not None and got.id == zone_a.id
@@ -293,7 +336,10 @@ async def test_ptr_collision_warning_on_manual_record(
     await db_session.flush()
     zone = await ensure_reverse_zone_for_subnet(db_session, sub_a, None, dns_group_id=g.id)
     assert zone is not None
+    fwd = DNSZone(group_id=g.id, name="corp.example.test.", zone_type="primary")
+    db_session.add(fwd)
     sub_a.dns_group_ids = [str(g.id)]
+    sub_a.dns_inherit_settings = False
     db_session.add(
         DNSRecord(
             zone_id=zone.id,
@@ -308,10 +354,52 @@ async def test_ptr_collision_warning_on_manual_record(
     warnings = await _check_ip_collisions(
         db_session,
         hostname="mine",
-        forward_zone_id=None,
+        forward_zone_id=fwd.id,
         mac_address=None,
         subnet=sub_a,
         address="192.168.1.10",
     )
     kinds = [w["kind"] for w in warnings]
     assert "ptr_collision" in kinds, warnings
+
+    # No forward zone → no DNS would publish → the PTR check must not fire.
+    warnings = await _check_ip_collisions(
+        db_session,
+        hostname="mine",
+        forward_zone_id=None,
+        mac_address=None,
+        subnet=sub_a,
+        address="192.168.1.10",
+    )
+    assert warnings == []
+
+
+# ── F1 regression: NON-overlapping subnets may share an aggregated zone ─────
+
+
+@pytest.mark.asyncio
+async def test_non_overlapping_subnets_share_aggregated_zone_across_spaces(
+    db_session: AsyncSession,
+) -> None:
+    """IPv4 reverse zones aggregate to /24, so two disjoint /26es — even in
+    different IP spaces — legitimately share one zone: their PTR names are
+    disjoint and nothing can leak. The cross-space guard must key on CIDR
+    overlap, not on a bare space-id mismatch."""
+    from app.api.v1.ipam.router import _resolve_reverse_zone
+
+    sub_a = await _space_subnet(db_session, cidr="10.1.2.0/26")
+    sub_b = await _space_subnet(db_session, cidr="10.1.2.64/26")
+    g = DNSServerGroup(name=f"dg-{uuid.uuid4().hex[:6]}")
+    db_session.add(g)
+    await db_session.flush()
+
+    zone_a = await ensure_reverse_zone_for_subnet(db_session, sub_a, None, dns_group_id=g.id)
+    assert zone_a is not None
+    zone_b = await ensure_reverse_zone_for_subnet(db_session, sub_b, None, dns_group_id=g.id)
+    assert zone_b is not None and zone_b.id == zone_a.id
+
+    sub_b.dns_group_ids = [str(g.id)]
+    sub_b.dns_inherit_settings = False  # make the subnet-level groups effective
+    await db_session.flush()
+    got = await _resolve_reverse_zone(db_session, sub_b, ipaddress.ip_address("10.1.2.70"))
+    assert got is not None and got.id == zone_a.id

--- a/backend/tests/test_overlap_guards.py
+++ b/backend/tests/test_overlap_guards.py
@@ -1,0 +1,317 @@
+"""#844 — overlapping IP spaces must not converge on shared DHCP/DNS infra.
+
+IPAM deliberately allows the same CIDR in different IP spaces (VRF
+semantics). What it must NOT allow is two same-prefix subnets reaching the
+same DHCP server group (Kea rejects the whole config at load on a duplicate
+prefix — an outage for every scope on the group) or the same DNS reverse
+zone (two tenants' PTRs fold into one RRset — cross-tenant hostname
+disclosure). These tests pin the guards at each convergence point.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import uuid
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPScope, DHCPServer, DHCPServerGroup
+from app.models.dns import DNSRecord, DNSServerGroup
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services.dhcp.config_bundle import build_config_bundle
+from app.services.dhcp.pull_leases import _find_containing_subnet
+from app.services.dns.reverse_zone import ensure_reverse_zone_for_subnet
+
+CIDR = "192.168.1.0/24"
+
+
+async def _make_token(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="T",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _space_subnet(db: AsyncSession, cidr: str = CIDR) -> Subnet:
+    """One space holding one subnet — call twice for the overlap scenario."""
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=cidr, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=cidr, name="s")
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+# ── Guard 1: scope create / activate refuses overlapping CIDR ───────────────
+
+
+@pytest.mark.asyncio
+async def test_second_space_same_cidr_same_group_is_409(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _make_token(db_session)
+    sub_a = await _space_subnet(db_session)
+    sub_b = await _space_subnet(db_session)
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{sub_a.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "a"},
+    )
+    assert r.status_code == 201, r.text
+
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{sub_b.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "b"},
+    )
+    assert r.status_code == 409, r.text
+    assert "IP" in r.text and "space" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_second_space_same_cidr_separate_group_is_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The documented safe deployment: one group per overlapping space."""
+    token = await _make_token(db_session)
+    sub_a = await _space_subnet(db_session)
+    sub_b = await _space_subnet(db_session)
+    grp_a = DHCPServerGroup(name=f"ga-{uuid.uuid4().hex[:6]}")
+    grp_b = DHCPServerGroup(name=f"gb-{uuid.uuid4().hex[:6]}")
+    db_session.add_all([grp_a, grp_b])
+    await db_session.flush()
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    for sub, grp in ((sub_a, grp_a), (sub_b, grp_b)):
+        r = await client.post(
+            f"/api/v1/dhcp/subnets/{sub.id}/dhcp-scopes",
+            headers=h,
+            json={"group_id": str(grp.id), "name": "s"},
+        )
+        assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_inactive_create_allowed_but_activation_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Activation is the other door into the rendered config."""
+    token = await _make_token(db_session)
+    sub_a = await _space_subnet(db_session)
+    sub_b = await _space_subnet(db_session)
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    await db_session.commit()
+    h = {"Authorization": f"Bearer {token}"}
+
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{sub_a.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "a"},
+    )
+    assert r.status_code == 201, r.text
+
+    # Inactive: never reaches the rendered config, so allowed…
+    r = await client.post(
+        f"/api/v1/dhcp/subnets/{sub_b.id}/dhcp-scopes",
+        headers=h,
+        json={"group_id": str(grp.id), "name": "b", "enabled": False},
+    )
+    assert r.status_code == 201, r.text
+    scope_b = r.json()
+
+    # …but flipping it on re-runs the guard.
+    r = await client.put(f"/api/v1/dhcp/scopes/{scope_b['id']}", headers=h, json={"enabled": True})
+    assert r.status_code == 409, r.text
+
+
+# ── Guard 2: bundle build drops a raced-in duplicate prefix ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_bundle_ships_one_scope_per_prefix_oldest_wins(
+    db_session: AsyncSession,
+) -> None:
+    sub_a = await _space_subnet(db_session)
+    sub_b = await _space_subnet(db_session)
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    srv = DHCPServer(
+        name=f"kea-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    older = DHCPScope(
+        subnet_id=sub_a.id,
+        group_id=grp.id,
+        name="older",
+        is_active=True,
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    newer = DHCPScope(
+        subnet_id=sub_b.id,
+        group_id=grp.id,
+        name="newer",
+        is_active=True,
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+    db_session.add_all([srv, older, newer])
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, srv)
+    cidrs = [s.subnet_cidr for s in bundle.scopes]
+    assert cidrs.count(CIDR) == 1, cidrs
+    # Oldest scope's subnet is the one shipped.
+    assert len(bundle.scopes) == 1
+
+
+# ── Guard 3: lease→subnet resolution prefers the server's own subnets ───────
+
+
+def _fake_subnet(cidr: str) -> tuple[SimpleNamespace, ipaddress.IPv4Network]:
+    return (SimpleNamespace(id=uuid.uuid4()), ipaddress.ip_network(cidr))
+
+
+def test_find_containing_subnet_prefers_scoped_subnet() -> None:
+    a = _fake_subnet(CIDR)
+    b = _fake_subnet(CIDR)
+    subnets = [a, b]
+    # Preferring either side wins over an equal prefix from the other space.
+    assert _find_containing_subnet("192.168.1.10", subnets, preferred_subnet_ids={b[0].id}) is b[0]
+    assert _find_containing_subnet("192.168.1.10", subnets, preferred_subnet_ids={a[0].id}) is a[0]
+
+
+def test_find_containing_subnet_unpreferred_tie_is_deterministic() -> None:
+    a = _fake_subnet(CIDR)
+    b = _fake_subnet(CIDR)
+    first = _find_containing_subnet("192.168.1.10", [a, b])
+    # Same winner regardless of input order.
+    assert _find_containing_subnet("192.168.1.10", [b, a]) is first
+
+
+def test_find_containing_subnet_longest_prefix_still_wins_within_preferred() -> None:
+    wide = _fake_subnet("192.168.0.0/16")
+    narrow = _fake_subnet(CIDR)
+    got = _find_containing_subnet(
+        "192.168.1.10",
+        [wide, narrow],
+        preferred_subnet_ids={wide[0].id, narrow[0].id},
+    )
+    assert got is narrow[0]
+
+
+# ── Guard 4: reverse zone is never shared across spaces ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reverse_zone_not_shared_across_spaces(
+    db_session: AsyncSession,
+) -> None:
+    sub_a = await _space_subnet(db_session)
+    sub_b = await _space_subnet(db_session)
+    g = DNSServerGroup(name=f"dg-{uuid.uuid4().hex[:6]}")
+    db_session.add(g)
+    await db_session.flush()
+
+    zone_a = await ensure_reverse_zone_for_subnet(db_session, sub_a, None, dns_group_id=g.id)
+    assert zone_a is not None
+    assert zone_a.linked_subnet_id == sub_a.id
+
+    # Same CIDR, different space, same group → refused, not silently shared.
+    zone_b = await ensure_reverse_zone_for_subnet(db_session, sub_b, None, dns_group_id=g.id)
+    assert zone_b is None
+
+    # Idempotent for the owning subnet itself.
+    again = await ensure_reverse_zone_for_subnet(db_session, sub_a, None, dns_group_id=g.id)
+    assert again is not None and again.id == zone_a.id
+
+
+@pytest.mark.asyncio
+async def test_resolve_reverse_zone_skips_other_space_zone(
+    db_session: AsyncSession,
+) -> None:
+    from app.api.v1.ipam.router import _resolve_reverse_zone
+
+    sub_a = await _space_subnet(db_session)
+    sub_b = await _space_subnet(db_session)
+    g = DNSServerGroup(name=f"dg-{uuid.uuid4().hex[:6]}")
+    db_session.add(g)
+    await db_session.flush()
+    zone_a = await ensure_reverse_zone_for_subnet(db_session, sub_a, None, dns_group_id=g.id)
+    assert zone_a is not None
+
+    # Subnet B resolves DNS through the same group (the MSP misconfig).
+    sub_b.dns_group_ids = [str(g.id)]
+    await db_session.flush()
+
+    ip = ipaddress.ip_address("192.168.1.10")
+    assert await _resolve_reverse_zone(db_session, sub_b, ip) is None
+    # The owning space still resolves its own zone.
+    sub_a.dns_group_ids = [str(g.id)]
+    await db_session.flush()
+    got = await _resolve_reverse_zone(db_session, sub_a, ip)
+    assert got is not None and got.id == zone_a.id
+
+
+@pytest.mark.asyncio
+async def test_ptr_collision_warning_on_manual_record(
+    db_session: AsyncSession,
+) -> None:
+    """A manual PTR at the same name surfaces as a warning, not a silent stack."""
+    from app.api.v1.ipam.router import _check_ip_collisions
+
+    sub_a = await _space_subnet(db_session)
+    g = DNSServerGroup(name=f"dg-{uuid.uuid4().hex[:6]}")
+    db_session.add(g)
+    await db_session.flush()
+    zone = await ensure_reverse_zone_for_subnet(db_session, sub_a, None, dns_group_id=g.id)
+    assert zone is not None
+    sub_a.dns_group_ids = [str(g.id)]
+    db_session.add(
+        DNSRecord(
+            zone_id=zone.id,
+            name="10",
+            fqdn="10.1.168.192.in-addr.arpa.",
+            record_type="PTR",
+            value="host.other.example.com.",
+        )
+    )
+    await db_session.flush()
+
+    warnings = await _check_ip_collisions(
+        db_session,
+        hostname="mine",
+        forward_zone_id=None,
+        mac_address=None,
+        subnet=sub_a,
+        address="192.168.1.10",
+    )
+    kinds = [w["kind"] for w in warnings]
+    assert "ptr_collision" in kinds, warnings

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -948,6 +948,17 @@ rule here has been surfaced to an operator, not just silently logged.
 - **Scope already exists for this group + subnet.** A subnet may host
   at most one scope per server group. `409` at
   `backend/app/api/v1/dhcp/scopes.py`.
+- **Overlapping CIDR from another IP space (#844).** IPAM allows the
+  same CIDR in different IP spaces (VRF semantics), but one Kea server
+  renders one `subnet4`/`subnet6` entry per scope and rejects the whole
+  config at load on a duplicate prefix — an outage for every scope on
+  the group. Creating or *activating* a scope whose subnet overlaps
+  another active scope's subnet in the same group is refused. `409` at
+  `backend/app/api/v1/dhcp/scopes.py`; the bundle build additionally
+  drops any raced-in duplicate (oldest scope wins, logged as
+  `dhcp_bundle_duplicate_prefix_dropped`) so a bad combination can never
+  reach an agent. **Overlapping IP spaces need a separate DHCP server
+  group per space.**
 - **`group_id` required when multiple groups are registered.** If
   more than one DHCP server group is defined, scope-create must name
   one explicitly; single-group deployments can omit the field.

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -454,6 +454,8 @@ Every subnet can be assigned:
 
 When a subnet is created or edited, the UI prompts: *"Auto-create reverse zone for 10.1.2.0/24?"* — which generates `2.1.10.in-addr.arpa.` on the designated server group.
 
+> **Overlapping IP spaces (#844).** The same CIDR in two IP spaces computes the same reverse zone name, and a DNS group can hold only one zone by that name — sharing it would merge two tenants' PTRs into one RRset (cross-tenant hostname disclosure). SpatiumDDI therefore refuses to attach a second space's subnet to a reverse zone another space's subnet created (the IPs get no PTR, logged as `reverse_zone_cross_space_conflict`), and PTR sync skips reverse zones linked to a different space's subnet. **Overlapping IP spaces need a separate DNS server group per space.** Operator-created reverse zones with no linked subnet stay shared — no space can be attributed to them.
+
 ---
 
 ## 5. DNS Records

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -29,6 +29,7 @@ The IPAM module is the core of SpatiumDDI. It manages the hierarchy of IP space 
 - The primary unit of management — a routable network with a gateway
 - IPs are allocated, tracked, and assigned at the subnet level
 - Subnets cannot overlap within the same IP Space
+- Subnets in *different* IP Spaces **may** overlap (VRF semantics) — but overlapping spaces must use **disjoint DHCP and DNS server groups**: one Kea server cannot serve two same-prefix subnets, and one DNS group cannot hold two same-name reverse zones. Enforced per #844 (scope create/activate `409`; reverse-zone attach refused)
 
 ---
 


### PR DESCRIPTION
Fixes #844

IPAM deliberately allows the same CIDR in different IP spaces (VRF semantics — `models/ipam.py`: *"IPs in different spaces may overlap"*), but nothing stopped two same-CIDR subnets from converging on the same DHCP server group (Kea rejects the whole config at load on a duplicate `subnet4` prefix — an outage for every scope on the group) or the same DNS reverse zone (two tenants' PTRs fold into one RRset — cross-tenant hostname disclosure). This PR adds a guard at each convergence point.

## Guards

1. **Scope create/activate 409** (`api/v1/dhcp/scopes.py`) — creating or *activating* a scope whose subnet CIDR overlaps another active scope's subnet in the same group is refused, mirroring the #619 out-of-CIDR-reservation shape. Raw SQL with the `&&` cidr operator (same pattern as the IPAM overlap validators) + explicit `deleted_at IS NULL` since raw SQL bypasses the ORM soft-delete filter. Inactive creates stay allowed (they never render); the guard re-fires on activation. Cross-family (v4+v6 dual-stack) can't false-positive — `&&` returns false across families — and same-space overlap is already impossible, so a hit always means two IP spaces.
2. **Bundle belt-and-braces** (`services/dhcp/config_bundle.py`) — the DHCP bundle build drops overlapping prefixes that reach it anyway (pre-existing data, races, or a subnet resize — which has no scope-aware guard, see follow-ups). Oldest scope wins, deterministically, order-preserving (no ETag flapping); the drop error-logs once per pair per process (the build runs inside the agent `/config` long-poll, so unconditional ERROR would flood ~7k lines/day/agent). Placed in the neutral bundle layer rather than wiring up `KeaDriver.validate_config` — importing a concrete driver into services would violate non-negotiable #10, and dropping-before-ship beats validating-after-render.
3. **Space-aware lease→subnet resolution** (`services/dhcp/pull_leases.py`, `api/v1/dhcp/agents.py`) — `_find_containing_subnet` now prefers subnets actually scoped to the requesting server's group over an equal-or-longer prefix from an unrelated space, with a deterministic tie-break; applied to the Windows pull path, absence-delete, Kea `/lease-events`, and L2-sniff sightings. Kea lease-events additionally stamp `scope_id` at ingestion (and backfill it on refresh), so `lease_cleanup`'s space-ambiguous CIDR fallback shrinks to legacy rows and disappears as they refresh.
4. **Reverse zones are never shared across overlapping spaces** (`services/dns/reverse_zone.py`, `api/v1/ipam/router.py`) — `ensure_reverse_zone_for_subnet` refuses to attach a subnet to a zone owned by an **overlapping** subnet in another space (the IPs get no PTR, warned once, until the operator gives the space its own DNS group), and `_resolve_reverse_zone` skips such zones at PTR-sync time. The overlap test matters: IPv4 reverse zones aggregate to /24, so two *non-overlapping* /26es in different spaces legitimately share one zone with disjoint PTR names — that keeps working (regression-tested). A zone whose linked subnet was deleted is re-linked to the next subnet that computes its name instead of becoming permanently unattributable. `_check_ip_collisions` gains a `ptr_collision` warning (force-confirmable, same pattern as FQDN/MAC) when the target reverse zone already holds a PTR at the same name — gated on hostname + forward zone, since `_sync_dns_record` only publishes a PTR alongside a forward record.

**The safe MSP deployment — disjoint DHCP and DNS server groups per overlapping space — is now documented** in `DHCP.md` (scope rules), `DNS.md` (reverse-zone note), and `IPAM.md` (subnet rules). Previously it was stated nowhere and the single-group auto-bind in scope-create actively worked against it.

## Review

Adversarially reviewed (fresh-context reviewer over the full diff); all findings fixed in the second commit, most notably: the cross-space refusal originally keyed on a bare space-id mismatch, which would have silently broken PTR sync for non-overlapping subnets sharing an aggregated /24 zone — it now requires an actual CIDR overlap. Also: overlap-wide (not just equal-prefix) bundle dedupe, once-per-pair log dedupe on all three new warning sites, dangling-zone re-link, the forward-zone gate on the PTR check, and a winner assertion (not just a count) in the bundle test.

## Tests

`backend/tests/test_overlap_guards.py` — 12 tests: the 409 (create + activation doors, and the separate-groups allow), bundle dedupe (exact + overlapping prefix, oldest-wins asserted via lease_time), preferred-subnet lease resolution (rank beats equal prefix, deterministic ties, longest-prefix within rank), reverse-zone refusal + resolver skip + PTR-collision warning + the non-overlapping-/26 sharing regression. All run serially in the dev container; plus a 233-test regression sweep over every touched surface (scope CRUD, lease events, bundle/ETag, reverse DNS, IPAM↔DNS sync) — all green. `make ci` + host ruff/black/mypy clean. No migrations (no schema changes).

## Follow-ups (recorded on #844)

- One-shot backfill for pre-existing wrong-space `auto_from_lease` mirror rows (orphaned now that resolution is space-aware).
- Scope-aware guard on subnet resize (the bundle dedupe contains the blast radius; the resize preview should surface the conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
