### PR TITLE
feat(requests): searchable, permission-filtered resource pickers on the portal form (#759)

### DIFF
--- a/backend/app/api/v1/requests/router.py
+++ b/backend/app/api/v1/requests/router.py
@@ -6,6 +6,11 @@ they cannot do themselves, an approver reviews it with the operation's own
 preview in front of them, and approving **executes the provisioning**.
 
 * ``GET  /catalog`` — what may be asked for (the allow-list + arg schemas).
+* ``GET  /resource-options`` — permission-filtered typeahead options for the
+  ``x-resource`` reference fields in those schemas (#759). No matching MCP
+  tool on purpose: the Copilot already has the full ``find_*`` read tools for
+  these resources — this endpoint exists only to narrow them to the caller's
+  read grants for the portal form (explicit NN #13 decision).
 * ``POST /`` — submit a request. Needs ``create,provisioning_request``; does
   **not** need the underlying operation's permission, which is the entire
   point (see ``services/requests/service.py``).
@@ -33,8 +38,11 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 from pydantic import BaseModel, Field
+from sqlalchemy import String, or_, select
+from sqlalchemy import cast as sa_cast
+from sqlalchemy.sql import Select
 
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import (
@@ -45,6 +53,9 @@ from app.core.permissions import (
 )
 from app.models.auth import User
 from app.models.change_request import ChangeRequest
+from app.models.dhcp import DHCPScope
+from app.models.dns import DNSZone
+from app.models.ipam import IPBlock, Subnet
 from app.services.approvals.service import (
     ChangeRequestStateError,
     DecisionError,
@@ -204,6 +215,157 @@ async def _load_visible(
     ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
     return cr
+
+
+# ── Resource picker (issue #759) ───────────────────────────────────────────
+#
+# Typeahead options for the resource-reference fields (``x-resource`` in the
+# catalog arg schemas). The submit path deliberately does not require the
+# underlying operation's permission, so a picker naively backed by the admin
+# list endpoints would hand a Requester the complete estate inventory —
+# resources they hold no read grant for, from the one screen designed for
+# people without grants. Every candidate row is therefore individually
+# filtered through ``user_has_permission(read, <type>, <id>)``; the
+# ``x-resource`` value IS the RBAC resource_type, so there is one vocabulary
+# and no mapping table to drift. This is the issue's primary acceptance
+# criterion, not an optimization.
+
+_PICKER_PAGE = 200  # rows fetched per scan page
+_PICKER_SCAN_CAP = 2000  # bound the per-request work for narrow grants
+_PICKER_MAX = 50
+
+
+class ResourceOption(BaseModel):
+    id: str
+    label: str
+    sublabel: str | None = None
+
+
+def _subnet_query(q: str) -> Select:
+    stmt = select(Subnet).order_by(Subnet.network)
+    if q:
+        like = f"%{q}%"
+        stmt = stmt.where(or_(Subnet.name.ilike(like), sa_cast(Subnet.network, String).ilike(like)))
+    return stmt
+
+
+def _subnet_option(row: object) -> ResourceOption:
+    sub = row[0]  # type: ignore[index]
+    return ResourceOption(id=str(sub.id), label=str(sub.network), sublabel=sub.name or None)
+
+
+def _block_query(q: str) -> Select:
+    stmt = select(IPBlock).order_by(IPBlock.network)
+    if q:
+        like = f"%{q}%"
+        stmt = stmt.where(
+            or_(IPBlock.name.ilike(like), sa_cast(IPBlock.network, String).ilike(like))
+        )
+    return stmt
+
+
+def _block_option(row: object) -> ResourceOption:
+    blk = row[0]  # type: ignore[index]
+    return ResourceOption(id=str(blk.id), label=str(blk.network), sublabel=blk.name or None)
+
+
+def _zone_query(q: str) -> Select:
+    # Primary zones only — records can only be created in zones the control
+    # plane authors; offering a secondary/forward zone would produce a request
+    # whose approval can only fail.
+    stmt = select(DNSZone).where(DNSZone.zone_type == "primary").order_by(DNSZone.name)
+    if q:
+        stmt = stmt.where(DNSZone.name.ilike(f"%{q}%"))
+    return stmt
+
+
+def _zone_option(row: object) -> ResourceOption:
+    zone = row[0]  # type: ignore[index]
+    return ResourceOption(
+        id=str(zone.id),
+        label=zone.name,
+        sublabel="reverse" if zone.kind == "reverse" else None,
+    )
+
+
+def _scope_query(q: str) -> Select:
+    # Active scopes only — a reservation in a deactivated scope would never
+    # serve. The subnet join supplies the range for the label.
+    stmt = (
+        select(DHCPScope, Subnet.network)
+        .join(Subnet, Subnet.id == DHCPScope.subnet_id)
+        .where(DHCPScope.is_active.is_(True))
+        .order_by(Subnet.network)
+    )
+    if q:
+        like = f"%{q}%"
+        stmt = stmt.where(
+            or_(DHCPScope.name.ilike(like), sa_cast(Subnet.network, String).ilike(like))
+        )
+    return stmt
+
+
+def _scope_option(row: Any) -> ResourceOption:
+    scope: DHCPScope = row[0]
+    network = row[1]
+    return ResourceOption(
+        id=str(scope.id),
+        label=scope.name or str(network),
+        sublabel=str(network) if scope.name else None,
+    )
+
+
+# resource → (query builder, RBAC resource_type, row → option). The key is the
+# exact ``x-resource`` value the arg schemas carry.
+_RESOURCE_PICKERS: dict[str, tuple] = {
+    "subnet": (_subnet_query, "subnet", _subnet_option),
+    "ip_block": (_block_query, "ip_block", _block_option),
+    "dns_zone": (_zone_query, "dns_zone", _zone_option),
+    "dhcp_scope": (_scope_query, "dhcp_scope", _scope_option),
+}
+
+
+@router.get("/resource-options", response_model=list[ResourceOption])
+async def resource_options(
+    db: DB,
+    current_user: CurrentUser,
+    resource: str,
+    q: str = "",
+    limit: int = Query(default=20, ge=1, le=_PICKER_MAX),
+) -> list[ResourceOption]:
+    """Permission-filtered typeahead options for one ``x-resource`` field.
+
+    Requires submit permission (like ``/catalog`` — the picker exists to fill
+    the request form), and returns only rows the caller holds a ``read`` grant
+    for. Scans candidates in pages so a caller with narrow per-resource grants
+    still fills their ``limit`` when the first page happens to contain none of
+    their rows; the scan is capped so a huge estate can't turn one keystroke
+    into a full-table permission sweep.
+    """
+    _require_submit(current_user)
+    picker = _RESOURCE_PICKERS.get(resource)
+    if picker is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unknown resource {resource!r} — expected one of "
+            f"{sorted(_RESOURCE_PICKERS)}",
+        )
+    query_fn, rtype, to_option = picker
+    out: list[ResourceOption] = []
+    offset = 0
+    while len(out) < limit and offset < _PICKER_SCAN_CAP:
+        rows = (await db.execute(query_fn(q).offset(offset).limit(_PICKER_PAGE))).all()
+        if not rows:
+            break
+        offset += len(rows)
+        for row in rows:
+            rid = row[0].id
+            if not user_has_permission(current_user, "read", rtype, rid):
+                continue
+            out.append(to_option(row))
+            if len(out) >= limit:
+                break
+    return out
 
 
 # ── Catalog ────────────────────────────────────────────────────────────────

--- a/backend/app/api/v1/requests/router.py
+++ b/backend/app/api/v1/requests/router.py
@@ -54,7 +54,7 @@ from app.core.permissions import (
 from app.models.auth import User
 from app.models.change_request import ChangeRequest
 from app.models.dhcp import DHCPScope
-from app.models.dns import DNSZone
+from app.models.dns import DNSView, DNSZone
 from app.models.ipam import IPBlock, Subnet
 from app.services.approvals.service import (
     ChangeRequestStateError,
@@ -241,10 +241,29 @@ class ResourceOption(BaseModel):
     sublabel: str | None = None
 
 
+class ResourceOptionsResponse(BaseModel):
+    options: list[ResourceOption]
+    # True when the permission scan hit its cap before filling ``limit`` —
+    # the caller's readable rows may exist beyond the scanned window, so the
+    # UI should say "keep typing to narrow" rather than "no matches".
+    truncated: bool
+
+
+def _like(q: str) -> str:
+    """``%<q>%`` with ILIKE metacharacters escaped so the user searches
+    literally — ``_``-led zone names are routine in AD estates."""
+    escaped = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return f"%{escaped}%"
+
+
 def _subnet_query(q: str) -> Select:
-    stmt = select(Subnet).order_by(Subnet.network)
+    # The id tiebreaker matters: none of these sort keys are unique (the same
+    # CIDR is legal in two IP spaces), and the scan re-executes the query per
+    # page — without a total order, a readable row straddling a page boundary
+    # can be skipped or duplicated between executions.
+    stmt = select(Subnet).order_by(Subnet.network, Subnet.id)
     if q:
-        like = f"%{q}%"
+        like = _like(q)
         stmt = stmt.where(or_(Subnet.name.ilike(like), sa_cast(Subnet.network, String).ilike(like)))
     return stmt
 
@@ -255,9 +274,9 @@ def _subnet_option(row: object) -> ResourceOption:
 
 
 def _block_query(q: str) -> Select:
-    stmt = select(IPBlock).order_by(IPBlock.network)
+    stmt = select(IPBlock).order_by(IPBlock.network, IPBlock.id)
     if q:
-        like = f"%{q}%"
+        like = _like(q)
         stmt = stmt.where(
             or_(IPBlock.name.ilike(like), sa_cast(IPBlock.network, String).ilike(like))
         )
@@ -273,18 +292,27 @@ def _zone_query(q: str) -> Select:
     # Primary zones only — records can only be created in zones the control
     # plane authors; offering a secondary/forward zone would produce a request
     # whose approval can only fail.
-    stmt = select(DNSZone).where(DNSZone.zone_type == "primary").order_by(DNSZone.name)
+    # The same zone name legitimately exists per view (split-horizon), so
+    # join the view for a disambiguating sublabel and tiebreak on id.
+    stmt = (
+        select(DNSZone, DNSView.name)
+        .outerjoin(DNSView, DNSView.id == DNSZone.view_id)
+        .where(DNSZone.zone_type == "primary")
+        .order_by(DNSZone.name, DNSZone.id)
+    )
     if q:
-        stmt = stmt.where(DNSZone.name.ilike(f"%{q}%"))
+        stmt = stmt.where(DNSZone.name.ilike(_like(q)))
     return stmt
 
 
 def _zone_option(row: object) -> ResourceOption:
     zone = row[0]  # type: ignore[index]
+    view_name = row[1]  # type: ignore[index]
+    parts = [p for p in (view_name, "reverse" if zone.kind == "reverse" else None) if p]
     return ResourceOption(
         id=str(zone.id),
         label=zone.name,
-        sublabel="reverse" if zone.kind == "reverse" else None,
+        sublabel=" · ".join(parts) or None,
     )
 
 
@@ -295,10 +323,10 @@ def _scope_query(q: str) -> Select:
         select(DHCPScope, Subnet.network)
         .join(Subnet, Subnet.id == DHCPScope.subnet_id)
         .where(DHCPScope.is_active.is_(True))
-        .order_by(Subnet.network)
+        .order_by(Subnet.network, DHCPScope.id)
     )
     if q:
-        like = f"%{q}%"
+        like = _like(q)
         stmt = stmt.where(
             or_(DHCPScope.name.ilike(like), sa_cast(Subnet.network, String).ilike(like))
         )
@@ -325,14 +353,14 @@ _RESOURCE_PICKERS: dict[str, tuple] = {
 }
 
 
-@router.get("/resource-options", response_model=list[ResourceOption])
+@router.get("/resource-options", response_model=ResourceOptionsResponse)
 async def resource_options(
     db: DB,
     current_user: CurrentUser,
     resource: str,
-    q: str = "",
+    q: str = Query(default="", max_length=200),
     limit: int = Query(default=20, ge=1, le=_PICKER_MAX),
-) -> list[ResourceOption]:
+) -> ResourceOptionsResponse:
     """Permission-filtered typeahead options for one ``x-resource`` field.
 
     Requires submit permission (like ``/catalog`` — the picker exists to fill
@@ -353,9 +381,11 @@ async def resource_options(
     query_fn, rtype, to_option = picker
     out: list[ResourceOption] = []
     offset = 0
+    exhausted = False
     while len(out) < limit and offset < _PICKER_SCAN_CAP:
         rows = (await db.execute(query_fn(q).offset(offset).limit(_PICKER_PAGE))).all()
         if not rows:
+            exhausted = True
             break
         offset += len(rows)
         for row in rows:
@@ -365,7 +395,13 @@ async def resource_options(
             out.append(to_option(row))
             if len(out) >= limit:
                 break
-    return out
+        if len(rows) < _PICKER_PAGE:
+            exhausted = True
+            break
+    # ``truncated`` = the caller's readable rows may exist beyond the scanned
+    # window (cap hit, or limit filled with candidates left) — the UI shows
+    # "keep typing to narrow" instead of a dead-end "no matches".
+    return ResourceOptionsResponse(options=out, truncated=not exhausted and len(out) < limit)
 
 
 # ── Catalog ────────────────────────────────────────────────────────────────

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -181,7 +181,14 @@ def expires_at_default() -> datetime:
 class CreateIPAddressArgs(BaseModel):
     """Args for the ``create_ip_address`` operation."""
 
-    subnet_id: str = Field(description="UUID of the subnet to create the address in")
+    subnet_id: str = Field(
+        description="UUID of the subnet to create the address in",
+        # #759 — marks this as a resource reference. The requests portal
+        # renders a permission-filtered picker off this annotation (the value
+        # is the RBAC resource_type), and MCP clients learn it's a reference,
+        # not an opaque string.
+        json_schema_extra={"x-resource": "subnet"},
+    )
     address: str = Field(description="The IP address as a string (e.g. 10.0.5.10)")
     status: str = Field(
         default="allocated",
@@ -1528,7 +1535,11 @@ register(
 class AllocateSubnetArgs(BaseModel):
     """Args for the ``allocate_subnet`` operation."""
 
-    block_id: str = Field(description="UUID of the parent IP block to carve the subnet from")
+    block_id: str = Field(
+        description="UUID of the parent IP block to carve the subnet from",
+        # #759 — resource reference; see CreateIPAddressArgs.subnet_id.
+        json_schema_extra={"x-resource": "ip_block"},
+    )
     prefix_len: int = Field(
         ge=1,
         le=128,
@@ -1904,7 +1915,11 @@ _DNS_RECORD_TYPES = {
 class CreateDNSRecordArgs(BaseModel):
     """Args for the ``create_dns_record`` operation."""
 
-    zone_id: str = Field(description="UUID of the parent DNS zone.")
+    zone_id: str = Field(
+        description="UUID of the parent DNS zone.",
+        # #759 — resource reference; see CreateIPAddressArgs.subnet_id.
+        json_schema_extra={"x-resource": "dns_zone"},
+    )
     name: str = Field(
         description=(
             "Relative record name. Use ``@`` for the zone apex. Do NOT "
@@ -2565,7 +2580,11 @@ register(
 class CreateDHCPStaticArgs(BaseModel):
     """Args for the ``create_dhcp_static`` operation."""
 
-    scope_id: str = Field(description="UUID of the parent DHCP scope.")
+    scope_id: str = Field(
+        description="UUID of the parent DHCP scope.",
+        # #759 — resource reference; see CreateIPAddressArgs.subnet_id.
+        json_schema_extra={"x-resource": "dhcp_scope"},
+    )
     ip_address: str = Field(description="IP to reserve (must fall inside the scope).")
     mac_address: str = Field(description="MAC address (any standard format).")
     hostname: str | None = Field(default=None, description="Optional hostname.")

--- a/backend/tests/test_request_resource_picker.py
+++ b/backend/tests/test_request_resource_picker.py
@@ -1,0 +1,283 @@
+"""#759 — portal resource-reference fields become permission-filtered pickers.
+
+The submit path deliberately does not require the underlying operation's
+permission, so the picker endpoint is the one surface that could hand a
+low-privilege Requester the whole estate inventory. These tests pin the
+acceptance criterion: the options list contains ONLY rows the caller holds a
+``read`` grant for — plus the schema annotation contract the form renders
+from.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+from app.models.dhcp import DHCPScope, DHCPServerGroup
+from app.models.dns import DNSServerGroup, DNSZone
+from app.models.feature_module import FeatureModule
+from app.models.ipam import IPBlock, IPSpace, Subnet
+from app.services import feature_modules
+
+MODULE = "governance.requests"
+
+REQUESTER_PERMS = [
+    {"action": "write", "resource_type": "provisioning_request"},
+    {"action": "read", "resource_type": "provisioning_request"},
+]
+
+
+async def _user(
+    db: AsyncSession, *, permissions: list[dict] | None = None, superadmin: bool = False
+) -> tuple[User, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"u-{uuid.uuid4().hex[:8]}@t.io",
+        display_name="u",
+        hashed_password=hash_password("password123"),
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    if permissions:
+        role = Role(name=f"role-{uuid.uuid4().hex[:8]}", permissions=permissions)
+        group = Group(name=f"grp-{uuid.uuid4().hex[:8]}")
+        group.roles = [role]
+        user.groups = [group]
+        db.add_all([role, group])
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _enable_module(db: AsyncSession) -> None:
+    existing = await db.get(FeatureModule, MODULE)
+    if existing is None:
+        db.add(FeatureModule(id=MODULE, enabled=True))
+    else:
+        existing.enabled = True
+    await db.flush()
+    feature_modules.invalidate_cache()
+
+
+async def _subnets(db: AsyncSession, cidrs: list[str]) -> list[Subnet]:
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name="b")
+    db.add(block)
+    await db.flush()
+    subs = []
+    for i, cidr in enumerate(cidrs):
+        sub = Subnet(space_id=space.id, block_id=block.id, network=cidr, name=f"net-{i}")
+        db.add(sub)
+        subs.append(sub)
+    await db.flush()
+    return subs
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── Schema annotation contract ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_catalog_carries_x_resource_annotations(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The form renders pickers off x-resource; each reference field must
+    carry it, valued as the RBAC resource_type."""
+    await _enable_module(db_session)
+    _, token = await _user(db_session, permissions=REQUESTER_PERMS)
+    await db_session.commit()
+
+    resp = await client.get("/api/v1/requests/catalog", headers=_auth(token))
+    assert resp.status_code == 200, resp.text
+    by_kind = {k["kind"]: k for k in resp.json()}
+    expected = {
+        "subnet": ("block_id", "ip_block"),
+        "ip_address": ("subnet_id", "subnet"),
+        "dns_record": ("zone_id", "dns_zone"),
+        "dhcp_reservation": ("scope_id", "dhcp_scope"),
+    }
+    for kind, (field, rtype) in expected.items():
+        props = by_kind[kind]["args_schema"]["properties"]
+        assert props[field].get("x-resource") == rtype, (kind, field, props[field])
+
+
+# ── Permission filtering (the acceptance criterion) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_picker_returns_only_rows_the_caller_can_read(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    subs = await _subnets(db_session, ["10.1.0.0/24", "10.2.0.0/24", "10.3.0.0/24"])
+    visible = subs[1]
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS
+        + [
+            {
+                "action": "read",
+                "resource_type": "subnet",
+                "resource_id": str(visible.id),
+            }
+        ],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "subnet"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert [o["id"] for o in resp.json()] == [str(visible.id)]
+    assert resp.json()[0]["label"] == "10.2.0.0/24"
+
+
+@pytest.mark.asyncio
+async def test_picker_type_level_read_sees_all(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    subs = await _subnets(db_session, ["10.1.0.0/24", "10.2.0.0/24"])
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS + [{"action": "read", "resource_type": "subnet"}],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "subnet"},
+    )
+    assert resp.status_code == 200
+    got = {o["id"] for o in resp.json()}
+    assert {str(s.id) for s in subs} <= got
+
+
+@pytest.mark.asyncio
+async def test_picker_requires_submit_permission(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """No write,provisioning_request → 403, even with resource read grants —
+    the endpoint exists for the portal form only."""
+    await _enable_module(db_session)
+    await _subnets(db_session, ["10.1.0.0/24"])
+    _, token = await _user(db_session, permissions=[{"action": "read", "resource_type": "subnet"}])
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "subnet"},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_picker_unknown_resource_is_422(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    _, token = await _user(db_session, permissions=REQUESTER_PERMS)
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "user"},  # never expose principals through this door
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_picker_search_narrows(client: AsyncClient, db_session: AsyncSession) -> None:
+    await _enable_module(db_session)
+    await _subnets(db_session, ["10.1.0.0/24", "192.168.7.0/24"])
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS + [{"action": "read", "resource_type": "subnet"}],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "subnet", "q": "192.168.7"},
+    )
+    assert resp.status_code == 200
+    labels = [o["label"] for o in resp.json()]
+    assert labels == ["192.168.7.0/24"]
+
+
+# ── Per-resource query shapes ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_zone_picker_offers_primary_zones_only(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A record request against a secondary zone can only fail at approval."""
+    await _enable_module(db_session)
+    g = DNSServerGroup(name=f"dg-{uuid.uuid4().hex[:6]}")
+    db_session.add(g)
+    await db_session.flush()
+    primary = DNSZone(group_id=g.id, name="corp.example.test.", zone_type="primary")
+    secondary = DNSZone(group_id=g.id, name="mirror.example.test.", zone_type="secondary")
+    db_session.add_all([primary, secondary])
+    await db_session.flush()
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS + [{"action": "read", "resource_type": "dns_zone"}],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "dns_zone", "q": "example.test"},
+    )
+    assert resp.status_code == 200
+    assert [o["id"] for o in resp.json()] == [str(primary.id)]
+
+
+@pytest.mark.asyncio
+async def test_scope_picker_active_only_and_labeled_with_range(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    await _enable_module(db_session)
+    subs = await _subnets(db_session, ["10.5.0.0/24", "10.6.0.0/24"])
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(grp)
+    await db_session.flush()
+    active = DHCPScope(subnet_id=subs[0].id, group_id=grp.id, name="office", is_active=True)
+    inactive = DHCPScope(subnet_id=subs[1].id, group_id=grp.id, name="old", is_active=False)
+    db_session.add_all([active, inactive])
+    await db_session.flush()
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS + [{"action": "read", "resource_type": "dhcp_scope"}],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "dhcp_scope"},
+    )
+    assert resp.status_code == 200
+    opts = {o["id"]: o for o in resp.json()}
+    assert str(active.id) in opts and str(inactive.id) not in opts
+    got = opts[str(active.id)]
+    assert got["label"] == "office" and got["sublabel"] == "10.5.0.0/24"

--- a/backend/tests/test_request_resource_picker.py
+++ b/backend/tests/test_request_resource_picker.py
@@ -140,8 +140,10 @@ async def test_picker_returns_only_rows_the_caller_can_read(
         params={"resource": "subnet"},
     )
     assert resp.status_code == 200, resp.text
-    assert [o["id"] for o in resp.json()] == [str(visible.id)]
-    assert resp.json()[0]["label"] == "10.2.0.0/24"
+    body = resp.json()
+    assert [o["id"] for o in body["options"]] == [str(visible.id)]
+    assert body["options"][0]["label"] == "10.2.0.0/24"
+    assert body["truncated"] is False
 
 
 @pytest.mark.asyncio
@@ -162,7 +164,7 @@ async def test_picker_type_level_read_sees_all(
         params={"resource": "subnet"},
     )
     assert resp.status_code == 200
-    got = {o["id"] for o in resp.json()}
+    got = {o["id"] for o in resp.json()["options"]}
     assert {str(s.id) for s in subs} <= got
 
 
@@ -217,7 +219,7 @@ async def test_picker_search_narrows(client: AsyncClient, db_session: AsyncSessi
         params={"resource": "subnet", "q": "192.168.7"},
     )
     assert resp.status_code == 200
-    labels = [o["label"] for o in resp.json()]
+    labels = [o["label"] for o in resp.json()["options"]]
     assert labels == ["192.168.7.0/24"]
 
 
@@ -249,7 +251,7 @@ async def test_zone_picker_offers_primary_zones_only(
         params={"resource": "dns_zone", "q": "example.test"},
     )
     assert resp.status_code == 200
-    assert [o["id"] for o in resp.json()] == [str(primary.id)]
+    assert [o["id"] for o in resp.json()["options"]] == [str(primary.id)]
 
 
 @pytest.mark.asyncio
@@ -277,7 +279,69 @@ async def test_scope_picker_active_only_and_labeled_with_range(
         params={"resource": "dhcp_scope"},
     )
     assert resp.status_code == 200
-    opts = {o["id"]: o for o in resp.json()}
+    opts = {o["id"]: o for o in resp.json()["options"]}
     assert str(active.id) in opts and str(inactive.id) not in opts
     got = opts[str(active.id)]
     assert got["label"] == "office" and got["sublabel"] == "10.5.0.0/24"
+
+
+@pytest.mark.asyncio
+async def test_picker_grants_on_other_types_reveal_nothing(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The acceptance criterion's other face: read on dns_zone does not open
+    the subnet picker."""
+    await _enable_module(db_session)
+    await _subnets(db_session, ["10.1.0.0/24"])
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS + [{"action": "read", "resource_type": "dns_zone"}],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "subnet"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"options": [], "truncated": False}
+
+
+@pytest.mark.asyncio
+async def test_picker_scan_reaches_past_the_first_page(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A scoped grant whose row sorts beyond page one (200 rows) must still be
+    found — this exercises the multi-page loop and the id tiebreaker."""
+    await _enable_module(db_session)
+    space = IPSpace(name=f"sp-{uuid.uuid4().hex[:6]}")
+    db_session.add(space)
+    await db_session.flush()
+    block = IPBlock(space_id=space.id, network="10.0.0.0/8", name="b")
+    db_session.add(block)
+    await db_session.flush()
+    subs = []
+    # 205 /24s — 10.0.0.0/24 … 10.0.204.0/24, sorted by network.
+    for i in range(205):
+        sub = Subnet(space_id=space.id, block_id=block.id, network=f"10.0.{i}.0/24", name=f"n{i}")
+        db_session.add(sub)
+        subs.append(sub)
+    await db_session.flush()
+    target = subs[204]  # sorts last → beyond the first 200-row page
+    _, token = await _user(
+        db_session,
+        permissions=REQUESTER_PERMS
+        + [{"action": "read", "resource_type": "subnet", "resource_id": str(target.id)}],
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/requests/resource-options",
+        headers=_auth(token),
+        params={"resource": "subnet"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert [o["id"] for o in body["options"]] == [str(target.id)]
+    assert body["truncated"] is False

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10018,9 +10018,22 @@ export interface SubmitRequestBody {
   justification?: string | null;
 }
 
+export interface ResourceOption {
+  id: string;
+  label: string;
+  sublabel: string | null;
+}
+
 export const requestsApi = {
   catalog: () =>
     api.get<RequestKind[]>("/requests/catalog").then((r) => r.data),
+  // #759 — permission-filtered typeahead options for x-resource fields.
+  resourceOptions: (resource: string, q: string) =>
+    api
+      .get<ResourceOption[]>("/requests/resource-options", {
+        params: { resource, q },
+      })
+      .then((r) => r.data),
   list: (params: ProvisioningRequestListParams = {}) =>
     api.get<ProvisioningRequest[]>("/requests", { params }).then((r) => r.data),
   get: (id: string) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10024,13 +10024,21 @@ export interface ResourceOption {
   sublabel: string | null;
 }
 
+export interface ResourceOptionsResponse {
+  options: ResourceOption[];
+  // True when the permission scan stopped before covering every candidate —
+  // the caller's readable rows may exist beyond the window, so show "keep
+  // typing to narrow" rather than "no matches".
+  truncated: boolean;
+}
+
 export const requestsApi = {
   catalog: () =>
     api.get<RequestKind[]>("/requests/catalog").then((r) => r.data),
   // #759 — permission-filtered typeahead options for x-resource fields.
   resourceOptions: (resource: string, q: string) =>
     api
-      .get<ResourceOption[]>("/requests/resource-options", {
+      .get<ResourceOptionsResponse>("/requests/resource-options", {
         params: { resource, q },
       })
       .then((r) => r.data),

--- a/frontend/src/pages/RequestsPage.tsx
+++ b/frontend/src/pages/RequestsPage.tsx
@@ -21,13 +21,14 @@
  * That means the form fields ARE the server's contract: adding a field to an
  * operation surfaces it here with no frontend change, and the two can't drift.
  */
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   authApi,
   requestsApi,
   type ChangeRequestState,
   type ProvisioningRequest,
+  type ResourceOption,
   type RequestKind,
   type RequestKindId,
 } from "@/lib/api";
@@ -139,6 +140,9 @@ type FieldSpec = {
   type: string;
   required: boolean;
   enum?: string[];
+  // #759 — RBAC resource_type of the resource this field references
+  // (server-annotated via x-resource); drives the searchable picker.
+  resource?: string;
 };
 
 /**
@@ -172,8 +176,116 @@ function fieldsFrom(kind: RequestKind): FieldSpec[] {
       type,
       required: required.has(name),
       enum: Array.isArray(spec.enum) ? (spec.enum as string[]) : undefined,
+      resource:
+        typeof spec["x-resource"] === "string"
+          ? (spec["x-resource"] as string)
+          : undefined,
     };
   });
+}
+
+/**
+ * Searchable, permission-filtered picker for an `x-resource` field (#759).
+ *
+ * Backed by `/requests/resource-options`, which returns only rows the caller
+ * holds a read grant for — the raw admin list endpoints would leak the whole
+ * estate to a Requester. Server-side search + capped results, so a mature
+ * install's hundreds of subnets/zones never render as one giant <select>.
+ * The submitted value is the UUID; the user only ever sees labels.
+ */
+function ResourcePicker({
+  resource,
+  value,
+  onChange,
+}: {
+  resource: string;
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  const [search, setSearch] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [open, setOpen] = useState(false);
+  const [selectedLabel, setSelectedLabel] = useState<string | null>(null);
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search), 250);
+    return () => clearTimeout(t);
+  }, [search]);
+
+  const { data: options = [], isFetching } = useQuery<ResourceOption[]>({
+    queryKey: ["resource-options", resource, debounced],
+    queryFn: () => requestsApi.resourceOptions(resource, debounced),
+    enabled: open,
+    staleTime: 30_000,
+  });
+
+  if (value && selectedLabel) {
+    return (
+      <div className="flex w-full min-w-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1.5 text-sm">
+        <span className="truncate">{selectedLabel}</span>
+        <button
+          type="button"
+          aria-label="Clear selection"
+          className="ml-auto shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={() => {
+            onChange("");
+            setSelectedLabel(null);
+            setSearch("");
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <input
+        className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm"
+        placeholder="Type to search…"
+        value={search}
+        onChange={(e) => {
+          setSearch(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 150)}
+      />
+      {open ? (
+        <div className="absolute z-50 mt-1 max-h-56 w-full overflow-y-auto rounded-md border border-border bg-background shadow-lg">
+          {options.length === 0 ? (
+            <div className="px-2 py-1.5 text-xs text-muted-foreground">
+              {isFetching ? "Searching…" : "No matches you can read"}
+            </div>
+          ) : (
+            options.map((o) => (
+              <button
+                type="button"
+                key={o.id}
+                className="block w-full px-2 py-1.5 text-left text-sm hover:bg-muted"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => {
+                  onChange(o.id);
+                  setSelectedLabel(
+                    o.sublabel ? `${o.label} — ${o.sublabel}` : o.label,
+                  );
+                  setOpen(false);
+                }}
+              >
+                <span>{o.label}</span>
+                {o.sublabel ? (
+                  <span className="ml-1.5 text-xs text-muted-foreground">
+                    {o.sublabel}
+                  </span>
+                ) : null}
+              </button>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function NewRequestModal({
@@ -265,7 +377,15 @@ function NewRequestModal({
                     <span className="ml-0.5 text-rose-500">*</span>
                   ) : null}
                 </label>
-                {f.enum ? (
+                {f.resource ? (
+                  <ResourcePicker
+                    resource={f.resource}
+                    value={values[f.name] ?? ""}
+                    onChange={(id) =>
+                      setValues((v) => ({ ...v, [f.name]: id }))
+                    }
+                  />
+                ) : f.enum ? (
                   <select
                     className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-sm"
                     value={values[f.name] ?? ""}

--- a/frontend/src/pages/RequestsPage.tsx
+++ b/frontend/src/pages/RequestsPage.tsx
@@ -28,7 +28,7 @@ import {
   requestsApi,
   type ChangeRequestState,
   type ProvisioningRequest,
-  type ResourceOption,
+  type ResourceOptionsResponse,
   type RequestKind,
   type RequestKindId,
 } from "@/lib/api";
@@ -212,12 +212,13 @@ function ResourcePicker({
     return () => clearTimeout(t);
   }, [search]);
 
-  const { data: options = [], isFetching } = useQuery<ResourceOption[]>({
+  const { data, isFetching } = useQuery<ResourceOptionsResponse>({
     queryKey: ["resource-options", resource, debounced],
     queryFn: () => requestsApi.resourceOptions(resource, debounced),
     enabled: open,
     staleTime: 30_000,
   });
+  const options = data?.options ?? [];
 
   if (value && selectedLabel) {
     return (
@@ -256,7 +257,11 @@ function ResourcePicker({
         <div className="absolute z-50 mt-1 max-h-56 w-full overflow-y-auto rounded-md border border-border bg-background shadow-lg">
           {options.length === 0 ? (
             <div className="px-2 py-1.5 text-xs text-muted-foreground">
-              {isFetching ? "Searching…" : "No matches you can read"}
+              {isFetching
+                ? "Searching…"
+                : data?.truncated
+                  ? "Large list — keep typing to narrow the search"
+                  : "No matches you can read"}
             </div>
           ) : (
             options.map((o) => (
@@ -282,6 +287,11 @@ function ResourcePicker({
               </button>
             ))
           )}
+          {options.length > 0 && data?.truncated ? (
+            <div className="border-t border-border px-2 py-1 text-[11px] text-muted-foreground">
+              More may exist — keep typing to narrow
+            </div>
+          ) : null}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
Fixes #759

The New Request form asked for raw UUIDs for the fields that reference an existing resource — parent block, subnet, DNS zone, DHCP scope. As the issue puts it, that defeats the portal's premise: a requester has no way to discover a UUID without access to the very screens the portal was built to avoid granting them.

This implements the issue's **Option B (server-annotated schema)**, keeping the "form fields ARE the server's contract" property intact.

## How it works

**Server-annotated schema.** The four reference fields on the catalog operations' args models (`backend/app/services/ai/operations.py`) carry `json_schema_extra={"x-resource": "<rbac resource_type>"}` — `ip_block`, `subnet`, `dns_zone`, `dhcp_scope`. The value IS the RBAC resource type, so there is one vocabulary and no mapping table to drift. A future kind (or a renamed field) gets a working picker with zero frontend changes; an unannotated field degrades to the existing text input. The annotation flows into the catalog `args_schema` and — because the registry is shared — into MCP tool schemas. That's the conscious side effect the issue called out: verified harmless (no strict schema validator in the AI path; `x-` keywords are legal JSON Schema annotations) and arguably useful, since it tells the Copilot these are resource references rather than opaque strings.

**Permission-filtered lookup — the issue's primary acceptance criterion.** New `GET /requests/resource-options?resource=&q=&limit=` in `backend/app/api/v1/requests/router.py`. Submit deliberately does not require the underlying operation's permission, so a picker naively backed by the admin list endpoints would hand a Requester the complete estate inventory. Instead:

- Gated on submit permission (like `/catalog`), and behind the `governance.requests` feature module like the rest of the router.
- **Every candidate row is individually filtered through `user_has_permission(read, <type>, <id>)`** — which includes superadmin bypass, wildcard/type-level grants, per-resource scoped grants, time-bound grants, and #374 token narrowing, because it *is* the standard check.
- Paged scan (200/page, 2000 cap, ≤50 options) so a caller with narrow grants still fills their limit without one keystroke becoming a full-table permission sweep; the response carries a `truncated` flag so the UI can say "keep typing to narrow" instead of a dead-end "no matches".
- Primary zones and active scopes only — anything else produces a request whose approval can only fail.
- **No matching MCP tool — an explicit NN #13 decision**, documented in the module docstring: the Copilot already has the full `find_*` read tools for these resources; this endpoint exists only to narrow them to the caller's read grants for the portal form.

**Generic picker.** `ResourcePicker` in `RequestsPage.tsx` renders for any field carrying `x-resource`: debounced (250 ms) server-side search, human labels — CIDR + name for subnets/blocks, zone name + view sublabel (split-horizon zones share names), scope name + range — with the UUID as the submitted value, never the displayed one. Enum fields keep their `<select>`, unannotated fields keep the text-input fallback.

## Review (adversarial, fresh-context reviewer over the full diff)

Verified safe: no permission bypass under any input (including ILIKE wildcards — rows are post-filtered), token narrowing applies, no lazy-load hazard in the sync permission walk (`groups`/`roles` are `selectin`-loaded for exactly this reason), route ordering can't be captured by `GET /{req_id}`, module-off hides the endpoint, soft-deleted rows excluded, kind-switch remounts the picker so no stale state.

Findings fixed in the second commit: **order-by id tiebreakers** in all four pickers (none of the sort keys are unique — same CIDR in two spaces, same zone name per view — and the offset scan re-executes per page, so a readable row straddling a page boundary could be intermittently skipped; regression-tested with a grant on the 205th-sorted subnet), the **`truncated` flag + hint** (a caller whose one readable row sorted beyond the cap previously hit a dead end with no way to submit), **literal search** (ILIKE metacharacters escaped — `_`-led zone names are routine in AD estates), and **view-name sublabels** on zone options.

## Tests

`backend/tests/test_request_resource_picker.py` — 10 tests: the schema-annotation contract for all four kinds; the acceptance criterion (a read grant scoped to one subnet sees exactly that row); type-level grants; **cross-type isolation** (read on `dns_zone` reveals no subnets); 403 without submit permission; 422 on unknown resource; search narrowing; primary-only zones; active-only scopes with range labels; and the multi-page scan past the first 200 rows. Plus the 20 existing portal tests, all green serially; frontend `npm run build` + eslint clean; `make ci` + host ruff/black/mypy clean. No migrations.

Acceptance, as stated in the issue: a user holding only the Requester role (plus their read grants) can submit all four request kinds without ever seeing or typing a UUID, choosing each referenced resource from a searchable list containing only resources they are permitted to read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
