### PR TITLE
ci(nightly): per-night CalVer pre-releases, 2am Eastern schedule, 7-day retention

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,27 +23,44 @@ name: Nightly
 #     reference them (see the prune job). Orphaned layers are GHCR's
 #     untagged-retention policy to collect, not this workflow's.
 #
-#   Appliance ISO + slot image — exactly ONE copy each (~1.5 GB), attached
-#     as assets on the reused pre-release below and replaced in place every
-#     build (#823). No dated ring: an older appliance build is reproducible
-#     from its dated image tags, and the asset budget must not grow by
-#     1.5 GB/night. The BUILD is the same `workflow_call` reusable workflow
-#     release.yml invokes (build-appliance.yml) — one copy of the most
-#     safety-critical assembly in the repo, exercised nightly so a
-#     regression in it surfaces the next morning instead of at the next
-#     release cut. (#805 deferred this exactly because a copied job would
-#     have been a second divergent copy, untestable short of a release.)
+#   Pre-releases — ONE per nightly, tagged `nightly-YYYY.MM.DD` (CalVer
+#     date, prefixed so it can never match release.yml's bare-CalVer tag
+#     trigger and fire a release build). The previous design reused a
+#     single `nightly` pre-release with assets replaced in place — which
+#     made GitHub show the release's original creation date forever, so
+#     every nightly looked a week stale. Per-night releases carry the
+#     appliance ISO + slot image (~1.5 GB/night) and are pruned to the
+#     trailing 7 DAYS by the prune-releases job below (release + git tag
+#     both), so the standing asset cost is bounded at ~10 GB and the
+#     Releases page shows at most a week of clearly-labelled nightlies.
+#     prune-release-assets.sh skips `nightly-*` so these never consume the
+#     real releases' keep-window slots.
+#
+#   Appliance ISO + slot image — attached to that night's pre-release
+#     under their dated names. The BUILD is the same `workflow_call`
+#     reusable workflow release.yml invokes (build-appliance.yml) — one
+#     copy of the most safety-critical assembly in the repo, exercised
+#     nightly so a regression in it surfaces the next morning instead of
+#     at the next release cut. (#805 deferred this exactly because a
+#     copied job would have been a second divergent copy, untestable
+#     short of a release.)
 #
 # NIGHTLY IS NEVER `:latest`. That tag means "latest release" and has to
-# keep meaning that. There is also no GitHub Release per nightly — one
-# reused pre-release — so the Releases page stays a list of real releases.
+# keep meaning that. Nightly pre-releases are marked `--prerelease`, so
+# they never become the /releases/latest target either.
 
 on:
   schedule:
-    # 02:23 UTC. Off-the-hour minute for the same reason
+    # Target: 02:23 America/New_York — Eric + Matt work Eastern evenings,
+    # so the nightly must run AFTER their late pushes, DST included. Cron
+    # is UTC-only, so schedule both candidate UTC hours (06:23 = 02:23
+    # EDT, 07:23 = 02:23 EST) and let the gate job keep exactly the one
+    # where the Eastern wall clock actually reads 02 — the other fires
+    # and immediately skips. Off-the-hour minute for the same reason
     # prune-release-assets.yml uses one: the top-of-hour cron stampede
     # delays runner scheduling on GitHub's shared infrastructure.
-    - cron: "23 2 * * *"
+    - cron: "23 6 * * *"
+    - cron: "23 7 * * *"
   workflow_dispatch:
     inputs:
       force:
@@ -60,10 +77,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
-  # A reused pre-release: the RECORD of which commit the last nightly was
-  # built from, and the home of the appliance ISO + slot-image assets
-  # (replaced in place each build — see the header).
-  NIGHTLY_TAG: nightly
 
 permissions:
   contents: read
@@ -88,6 +101,7 @@ jobs:
       should_build: ${{ steps.decide.outputs.should_build }}
       images: ${{ steps.decide.outputs.images }}
       date_tag: ${{ steps.decide.outputs.date_tag }}
+      release_tag: ${{ steps.decide.outputs.release_tag }}
       version: ${{ steps.decide.outputs.version }}
       last_sha: ${{ steps.decide.outputs.last_sha }}
     steps:
@@ -99,8 +113,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE: ${{ github.event.inputs.force || 'false' }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
+
+          # ── Eastern-wall-clock gate ──────────────────────────────────
+          # Two UTC crons cover 02:23 America/New_York across DST (see the
+          # trigger comment). Keep the firing where Eastern actually reads
+          # 02; the other is a no-op. Manual dispatch always proceeds.
+          ET_HOUR=$(TZ=America/New_York date +%H)
+          if [ "$EVENT_NAME" = "schedule" ] && [ "$ET_HOUR" != "02" ]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            echo "→ $(TZ=America/New_York date '+%H:%M %Z') is not the 02:xx Eastern slot; skipping (DST twin cron)"
+            exit 0
+          fi
 
           # ONE source of truth for which images exist. Both the build
           # matrix and the prune job read this, because a hardcoded second
@@ -122,16 +148,32 @@ jobs:
           IMAGES_EOF
           echo "images=$(jq -c . /tmp/images.json)" >> "$GITHUB_OUTPUT"
 
-          DATE_TAG="nightly-$(date -u +%Y%m%d)"
+          # Both stamps use the EASTERN calendar date — the run targets
+          # 02:23 America/New_York, so "tonight's build" carries the date
+          # the team just worked through, not whatever UTC rolled over to.
+          DATE_TAG="nightly-$(TZ=America/New_York date +%Y%m%d)"
           echo "date_tag=${DATE_TAG}" >> "$GITHUB_OUTPUT"
+          # Per-night pre-release tag: CalVer date so nightlies sort and
+          # read like the releases they sit next to, PREFIXED so it can
+          # never match release.yml's bare-CalVer tag trigger (a tag like
+          # 2026.08.08-nightly would fire a full release build).
+          echo "release_tag=nightly-$(TZ=America/New_York date +%Y.%m.%d)" >> "$GITHUB_OUTPUT"
           # Informational version string baked into the frontend build and
           # the appliance release stamp. Deliberately NOT CalVer-shaped, so
           # it can never be mistaken for a release by a human or a sort.
           echo "version=0.0.0-${DATE_TAG}+${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
-          # The last nightly's commit is recorded in the reused pre-release's
-          # body. One source of truth, and a human can read it.
-          LAST_SHA=$(gh release view "$NIGHTLY_TAG" --json body \
+          # The last nightly's commit is recorded in the newest dated
+          # pre-release's body. One source of truth, and a human can read
+          # it. (Falls back to the legacy reused `nightly` release so the
+          # first run after this rework still skips an unchanged main.)
+          NEWEST_NIGHTLY=$(gh release list --limit 100 \
+                             --json tagName,createdAt \
+                             --jq '[.[] | select(.tagName | startswith("nightly-"))]
+                                   | sort_by(.createdAt) | reverse | .[0].tagName // empty' \
+                           2>/dev/null || true)
+          NEWEST_NIGHTLY="${NEWEST_NIGHTLY:-nightly}"
+          LAST_SHA=$(gh release view "$NEWEST_NIGHTLY" --json body \
                        --jq '.body' 2>/dev/null \
                      | sed -n 's/^built-from: \([0-9a-f]\{40\}\).*/\1/p' | head -1 || true)
           LAST_SHA="${LAST_SHA:-}"
@@ -278,41 +320,37 @@ jobs:
         with:
           name: appliance-artifacts
           path: dist/
-      - name: Upload to the nightly pre-release (replace in place)
+      - name: Upload to tonight's pre-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}  # no checkout in this job
           DATE_TAG: ${{ needs.gate.outputs.date_tag }}
+          RELEASE_TAG: ${{ needs.gate.outputs.release_tag }}
         run: |
           set -euo pipefail
-          # Rename the dated build outputs to STABLE nightly asset names so
-          # --clobber replaces yesterday's copy instead of accumulating a
-          # 1.5 GB/night ring (see the retention note in the header). The
-          # dated identity isn't lost — it lives in the release body's
-          # date-tag line and in /etc/spatiumddi/appliance-release inside
-          # the image.
+          # One pre-release PER night (see the header) — the build's dated
+          # asset names ship as-is; no rename, no replace-in-place. The
+          # prune-releases job bounds the ring to the trailing 7 days.
           ISO="dist/spatiumddi-appliance-${DATE_TAG}.iso"
           XZ="dist/spatiumddi-appliance-slot-${DATE_TAG}-amd64.raw.xz"
+          SHA="dist/spatiumddi-appliance-slot-${DATE_TAG}-amd64.sha256"
           [ -f "$ISO" ] || { echo "✗ expected $ISO"; ls -l dist/; exit 1; }
           [ -f "$XZ" ]  || { echo "✗ expected $XZ";  ls -l dist/; exit 1; }
-          mv "$ISO" dist/spatiumddi-appliance-nightly-amd64.iso
-          mv "$XZ"  dist/spatiumddi-appliance-slot-nightly-amd64.raw.xz
-          # Regenerate the checksum so the filename inside it matches the
-          # renamed asset — important for `sha256sum -c`.
-          rm -f dist/spatiumddi-appliance-slot-*.sha256
-          ( cd dist && sha256sum spatiumddi-appliance-slot-nightly-amd64.raw.xz \
-              > spatiumddi-appliance-slot-nightly-amd64.sha256 )
+          [ -f "$SHA" ] || { echo "✗ expected $SHA"; ls -l dist/; exit 1; }
           ls -lh dist/
 
-          # First-ever run: finalize hasn't created the pre-release yet
-          # (it runs after this job). Same guard it uses.
-          if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
-            gh release create "$NIGHTLY_TAG" --title "Nightly build" --prerelease --notes "init"
+          # --target pins the tag to the exact commit this run built.
+          # `nightly-YYYY.MM.DD` cannot match release.yml's bare-CalVer
+          # trigger, so creating the tag fires nothing. Finalize fills in
+          # the real notes once every job has succeeded.
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" \
+              --target "$GITHUB_SHA" \
+              --title "Nightly ${RELEASE_TAG#nightly-}" \
+              --prerelease --notes "build in progress"
           fi
-          gh release upload "$NIGHTLY_TAG" --clobber \
-            dist/spatiumddi-appliance-nightly-amd64.iso \
-            dist/spatiumddi-appliance-slot-nightly-amd64.raw.xz \
-            dist/spatiumddi-appliance-slot-nightly-amd64.sha256
+          # --clobber keeps a same-day re-run (dispatch --force) idempotent.
+          gh release upload "$RELEASE_TAG" --clobber "$ISO" "$XZ" "$SHA"
 
   # ── Prune the dated tag ring ──────────────────────────────────────────
   prune:
@@ -406,11 +444,74 @@ jobs:
             exit 1
           fi
 
+  # ── Prune the nightly pre-release ring (releases + git tags) ──────────
+  prune-releases:
+    name: Prune old nightly pre-releases
+    runs-on: ubuntu-latest
+    needs: [gate, appliance-publish]
+    if: needs.gate.outputs.should_build == 'true' && github.event.inputs.dry_run != 'true'
+    permissions:
+      contents: write
+    steps:
+      - name: Delete nightly pre-releases older than 7 days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}  # no checkout in this job
+        run: |
+          set -euo pipefail
+          # The ring is keyed on the DATE IN THE TAG, not createdAt — a
+          # late manual re-run of an old day must not rejuvenate it. The
+          # cutoff is 7 Eastern calendar days, matching the tag's own
+          # calendar (see the gate job).
+          CUTOFF=$(TZ=America/New_York date -d '7 days ago' +%Y%m%d)
+          echo "cutoff: nightly dates < ${CUTOFF} are deleted"
+
+          # startswith("nightly"), no dash — the legacy reused release is
+          # tagged bare `nightly` and must enter the loop to be deleted;
+          # anything else oddly-named lands in the fail-safe skip below.
+          if ! tags=$(gh release list --limit 200 --json tagName \
+                        --jq '.[].tagName | select(startswith("nightly"))'); then
+            echo "::error::could not list releases — retention NOT applied"
+            exit 1
+          fi
+
+          failures=0
+          for tag in $tags; do
+            # Legacy single reused pre-release from the pre-rework design —
+            # superseded by the dated ring; delete on sight.
+            if [ "$tag" = "nightly" ]; then
+              echo "deleting legacy reused release: $tag"
+              gh release delete "$tag" --yes --cleanup-tag || failures=$((failures + 1))
+              continue
+            fi
+            # nightly-YYYY.MM.DD → YYYYMMDD. Anything not matching the
+            # dated shape is left alone (fail-safe: never delete what we
+            # can't positively date).
+            d=$(printf '%s' "$tag" | sed -n 's/^nightly-\([0-9]\{4\}\)\.\([0-9]\{2\}\)\.\([0-9]\{2\}\)$/\1\2\3/p')
+            [ -n "$d" ] || { echo "skipping unrecognized tag shape: $tag"; continue; }
+            if [ "$d" -lt "$CUTOFF" ]; then
+              echo "deleting ${tag} (older than 7 days)"
+              # --cleanup-tag removes the git tag too — without it the tag
+              # list grows one orphan per night forever.
+              gh release delete "$tag" --yes --cleanup-tag || failures=$((failures + 1))
+            else
+              echo "keeping  ${tag}"
+            fi
+          done
+
+          # Counted, not just logged — a retention sweep that 403s every
+          # night would otherwise report green while releases accumulated
+          # 1.5 GB/day (same silence-as-success rule as the tag prune).
+          if [ "$failures" -gt 0 ]; then
+            echo "::error::${failures} release deletion(s) failed — the nightly release ring is NOT bounded until this is fixed."
+            exit 1
+          fi
+
   # ── Record what was built, and make a failure impossible to miss ──────
   finalize:
     name: Finalize
     runs-on: ubuntu-latest
-    needs: [gate, images, appliance, appliance-publish, prune]
+    needs: [gate, images, appliance, appliance-publish, prune, prune-releases]
     # `always()`, and NOT gated on `should_build` alone: a gate job that
     # FAILS emits no outputs at all, so that condition would be false and
     # this job would be skipped — the nightly would die without opening the
@@ -440,12 +541,16 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          if ! gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
-            gh release create "$NIGHTLY_TAG" --title "Nightly build" --prerelease --notes "init"
+          RELEASE_TAG='${{ needs.gate.outputs.release_tag }}'
+          # appliance-publish created it; recreate defensively if a manual
+          # cleanup raced this run.
+          if ! gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            gh release create "$RELEASE_TAG" --target "$GITHUB_SHA" \
+              --title "Nightly ${RELEASE_TAG#nightly-}" --prerelease --notes "init"
           fi
           # `built-from:` is parsed by the gate job on the next run. Keep the
           # 40-hex shape; the sed there anchors on it.
-          gh release edit "$NIGHTLY_TAG" --notes "$(cat <<EOF
+          gh release edit "$RELEASE_TAG" --notes "$(cat <<EOF
           Automated nightly build of \`main\`. **Not a release** — no support, no upgrade path.
 
           built-from: ${GITHUB_SHA}
@@ -458,9 +563,9 @@ jobs:
           The dated tag \`${{ needs.gate.outputs.date_tag }}\` pins this exact build;
           the newest 7 are kept.
 
-          The appliance ISO (\`spatiumddi-appliance-nightly-amd64.iso\`) and slot
-          upgrade image (\`spatiumddi-appliance-slot-nightly-amd64.raw.xz\` +
-          \`.sha256\`) are attached below, replaced in place each build.
+          The appliance ISO and slot upgrade image (+ \`.sha256\`) for this exact
+          build are attached below. Nightly pre-releases older than 7 days are
+          deleted automatically.
           EOF
           )"
 
@@ -473,7 +578,8 @@ jobs:
           needs.images.result == 'failure' ||
           needs.appliance.result == 'failure' ||
           needs['appliance-publish'].result == 'failure' ||
-          needs.prune.result == 'failure'
+          needs.prune.result == 'failure' ||
+          needs['prune-releases'].result == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}  # no checkout in this job — see above
@@ -487,6 +593,7 @@ jobs:
           - appliance: ${{ needs.appliance.result }}
           - appliance-publish: ${{ needs['appliance-publish'].result }}
           - prune: ${{ needs.prune.result }}
+          - prune-releases: ${{ needs['prune-releases'].result }}
 
           Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -313,7 +313,10 @@ than it saves.
 ### Nightly builds
 
 [`.github/workflows/nightly.yml`](../.github/workflows/nightly.yml) builds
-and publishes every image from `main` at 02:23 UTC. It exists because
+and publishes every image from `main` at **02:23 America/New_York** (the
+team works Eastern evenings, so the nightly runs after the late pushes —
+two UTC crons plus a wall-clock gate keep that true across DST). It exists
+because
 nothing else builds the *release* image except a release — which is how
 [#732](https://github.com/spatiumddi/spatiumddi/issues/732) shipped an api
 image carrying pytest as root, undetected until the next release cut it.
@@ -338,11 +341,17 @@ pulling `:nightly` never sees the rest.
 
 A run is **skipped entirely when `main` has not moved** since the last
 nightly, so the seven tags cover seven *changed* days rather than seven
-calendar days. The last built commit is recorded as `built-from:` in the
-body of the reused `nightly` pre-release, which is also where the appliance
-ISO will be published once that lands (deferred — see the workflow header
-for why). A failing nightly opens or comments on a single reused tracking
-issue rather than one per night.
+calendar days.
+
+Each nightly also publishes a **pre-release tagged `nightly-YYYY.MM.DD`**
+(CalVer date, prefixed so it can never match `release.yml`'s bare-CalVer
+tag trigger), carrying that build's appliance ISO + slot-upgrade image and
+a `built-from:` line recording the exact commit. Pre-releases older than
+**7 days** are deleted automatically, git tag included, so the Releases
+page shows at most a week of dated nightlies alongside the real releases
+(`prune-release-assets.sh` skips `nightly-*` — the nightly owns its own
+retention). A failing nightly opens or comments on a single reused
+tracking issue rather than one per night.
 
 `workflow_dispatch` takes `force` (build anyway) and `dry_run` (build and
 scan, push and prune nothing).

--- a/scripts/prune-release-assets.sh
+++ b/scripts/prune-release-assets.sh
@@ -112,6 +112,19 @@ for line in "${RELEASES[@]}"; do
     tag="${line%%$'\t'*}"
     is_latest="${line##*$'\t'}"
 
+    # Nightly pre-releases are NOT this sweep's problem: nightly.yml's own
+    # prune-releases job deletes the whole release (assets, tag and all)
+    # after 7 days. They must also not consume keep-window index slots —
+    # up to 7 of them sit newest-first at any time, and counting them
+    # would silently shrink the real releases' asset window from
+    # KEEP_VERSIONED to KEEP_VERSIONED-7.
+    case "$tag" in
+        nightly | nightly-*)
+            echo "  [--] ${tag} — nightly pre-release: skipped (nightly.yml owns its retention)"
+            continue
+            ;;
+    esac
+
     # release-time race guard: the freshly-published tag IS (about to be)
     # latest; treat it as latest regardless of isLatest propagation lag so
     # its generic /latest/-backing assets are never Tier-1 pruned.


### PR DESCRIPTION
## Problem

The nightly reused ONE pre-release tagged `nightly`, replacing its assets in place every build. GitHub shows a release's original creation date, so the nightly permanently looked ~a week (and growing) stale, and there was no way to tell one night's build from another on the Releases page.

## Changes

**One pre-release per night, CalVer-tagged.** Each successful nightly now creates `nightly-YYYY.MM.DD` (`--prerelease`, `--target` pinned to the built commit), carrying that build's appliance ISO + slot-upgrade image under their dated names and a `built-from:` line. The prefix is load-bearing: a bare CalVer tag (`2026.08.08-nightly`) would match `release.yml`'s `[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-*` push trigger and fire a full release build — `nightly-…` can't.

**02:23 America/New_York, DST-followed.** The team works Eastern evenings, so the nightly must run after the late pushes year-round. GitHub cron is UTC-only, so two crons fire (06:23 + 07:23 UTC) and a wall-clock gate in the decide step keeps exactly the one where `TZ=America/New_York` reads 02:xx — verified once-per-day in both EDT and EST (including the transition days). The visible effect in Actions: one skipped run and one real run per day; that is the mechanism, not a flake. Date stamps (image date-tags + release tags) also switch to the Eastern calendar, so "tonight's build" carries the date the team worked through, not whatever UTC rolled over to.

**7-day retention, releases + git tags.** New `prune-releases` job deletes nightly pre-releases older than 7 Eastern calendar days — keyed on the tag's own date rather than `createdAt`, so a late manual re-run of an old day can't rejuvenate it — with `--cleanup-tag` so git tags don't accumulate one orphan per night. It also deletes the legacy reused `nightly` release on sight (one-time transition cleanup). Deletion failures are counted and fail the job, same silence-as-success rule as the image-tag ring prune. Standing asset cost bounds at ~10 GB (7 × ISO + slot image).

**Asset-sweep interaction fixed.** `prune-release-assets.sh` now skips `nightly*` releases before consuming a keep-window index slot: nightly.yml owns their retention, and up to 7 of them sitting newest-first would otherwise silently shrink the real releases' `KEEP_VERSIONED` asset window from 15 to 8.

**Unchanged:** the `:nightly` mutable pointer, the `:nightly-YYYYMMDD` 7-deep image tag ring and its prune (regex continuity preserved), the scan-before-push Trivy gate, the unchanged-`main` skip (now reading `built-from:` from the newest dated release, with a legacy fallback so the first post-merge run is still skip-aware), the reused failure-tracking issue (now also covering the new job), and `dry_run`/`force` dispatch semantics.

`docs/DEVELOPMENT.md` nightly section updated to match.

## Validation

- YAML parses; every `run:` block extracted and passed through `bash -n`.
- Logic exercised with real commands: the sed tag-parser (accepts only strict `nightly-YYYY.MM.DD`; fail-safe skip for anything it can't positively date), the jq newest-nightly selection, and the DST hour matrix (`2026-07-15`/`2026-12-15` at both UTC hours → exactly one 02:xx ET hit each).
- Self-review caught one real bug pre-commit: the retention loop's `startswith("nightly-")` filter would have made the legacy-`nightly` cleanup branch unreachable (the legacy tag has no dash).

First night after merge is the transition run: it builds under the new scheme, creates the first dated pre-release, and deletes the stale legacy `nightly` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
