### PR TITLE
fix(dhcp): DHCP option 6 never reached the generated Kea config (#856)

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -97,10 +97,18 @@ _KEA_OPTION_NAMES_V4: dict[str, str] = {
     "time-offset": "time-offset",
 }
 
+# Keys that legitimately appear alongside options in an options mapping but
+# are NOT options — excluded from the "unsupported option dropped" warning.
+# ``lease_time`` rides in ``global_options``; ``option_data`` is the raw
+# pass-through list handled separately in ``_options_from_mapping``.
+_NON_OPTION_KEYS: frozenset[str] = frozenset({"lease_time", "option_data"})
+
 # Legacy input spellings accepted for backward compatibility with bundles
 # from an older control plane (and with hand-written test fixtures). Values
 # are canonical names in ``_KEA_OPTION_NAMES_V4``. Kea's own IANA spellings
 # are accepted too, so a bundle that already speaks Kea passes through.
+# Declaration order is load-bearing: two aliases of the same canonical name
+# resolve in this order, so the result never depends on input dict ordering.
 _LEGACY_OPTION_ALIASES_V4: dict[str, str] = {
     "dns_servers": "dns-servers",
     "domain-name-servers": "dns-servers",
@@ -125,6 +133,12 @@ _LEGACY_OPTION_ALIASES_V4: dict[str, str] = {
 # 'dhcp4.tftp-server-address' does not exist", which takes DHCP down rather
 # than dropping one option. Verified against Kea 3.0.3. So emitting it
 # requires shipping the definition alongside it.
+#
+# KEYED BY THE RENDERED KEA NAME, not the canonical SpatiumDDI one, because
+# that is what ``_collect_option_defs`` sees in the assembled ``option-data``.
+# The two happen to be spelled identically for option 150; they are NOT for
+# e.g. ``bootfile-name`` → ``boot-file-name``, and keying this table the other
+# way would emit that option with no definition and fail the whole config.
 _OPTION_DEFS_V4: dict[str, dict[str, Any]] = {
     "tftp-server-address": {
         "name": "tftp-server-address",
@@ -183,18 +197,16 @@ def _canonicalize_v4(options: dict[str, Any]) -> dict[str, Any]:
     """Resolve legacy / Kea-native input spellings onto canonical names.
 
     A canonical key already present always wins over an alias resolving onto
-    it, so a bundle carrying both never has the outcome depend on dict order.
+    it, and two aliases of the SAME canonical name (``dns_servers`` and
+    ``domain-name-servers``) resolve in ``_LEGACY_OPTION_ALIASES_V4``
+    declaration order — so the outcome never depends on the input dict's
+    ordering either way.
     """
-    out: dict[str, Any] = {}
-    for key, val in options.items():
-        canon = (
-            key if key in _KEA_OPTION_NAMES_V4 else _LEGACY_OPTION_ALIASES_V4.get(key)
-        )
-        if canon is None:
+    out: dict[str, Any] = {k: v for k, v in options.items() if k in _KEA_OPTION_NAMES_V4}
+    for alias, canon in _LEGACY_OPTION_ALIASES_V4.items():
+        if canon in out or alias not in options:
             continue
-        if canon in options and canon != key:
-            continue  # the canonical spelling is present; ignore the alias
-        out[canon] = val
+        out[canon] = options[alias]
     return out
 
 
@@ -218,6 +230,20 @@ def _options_from_mapping(options: dict[str, Any] | None) -> list[dict[str, Any]
         if val in (None, "", []):
             continue
         out.append(_opt(kea_name, val))
+
+    # Anything outside the table is still dropped — emitting an option Kea
+    # has no definition for fails the WHOLE config, which is worse than not
+    # serving it. But drop it LOUDLY: #856 was invisible precisely because a
+    # dropped key looks identical to an unset option. Custom / vendor options
+    # (the ``code:NN`` keys the Kea + ISC importers produce, and the ~80 codes
+    # the UI's custom-options accordion offers beyond the canonical set) land
+    # here, so the operator gets a log line instead of silence.
+    for key in options:
+        if key in _NON_OPTION_KEYS or key in _KEA_OPTION_NAMES_V4:
+            continue
+        if key in _LEGACY_OPTION_ALIASES_V4:
+            continue
+        _log.warning("kea_option_dropped_unsupported", option=key)
 
     # Pass through any raw Kea-style list already shaped correctly.
     raw = options.get("option_data")
@@ -255,8 +281,9 @@ def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
                 _walk(item)
 
     _walk(dhcp4)
-    # Stable order, keyed off the canonical table rather than set iteration.
-    return [_OPTION_DEFS_V4[n] for n in _KEA_OPTION_NAMES_V4 if n in seen]
+    # Stable order, keyed off ``_OPTION_DEFS_V4`` (Kea names, same namespace
+    # as ``seen``) rather than set iteration.
+    return [d for n, d in _OPTION_DEFS_V4.items() if n in seen]
 
 
 def _options_from_mapping_v6(options: dict[str, Any] | None) -> list[dict[str, Any]]:

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -68,6 +68,73 @@ _OPTION_CODES: dict[str, int] = {
     "domain-search": 119,
 }
 
+# Map of canonical SpatiumDDI option-name → Kea Dhcp4 ``option-data`` name.
+# This MUST stay in step with ``_KEA_OPTION_NAMES`` in
+# ``backend/app/drivers/dhcp/kea.py`` and with ``STANDARD_OPTION_NAMES`` in
+# ``backend/app/drivers/dhcp/base.py``, which is the vocabulary the bundle
+# actually carries.
+#
+# #856: this table replaces a hand-written list of per-option ``_put(...)``
+# lookups that had drifted from that vocabulary. Option 6 is stored
+# canonically as ``dns-servers``, but the old code looked only for
+# ``dns_servers`` / ``domain-name-servers`` and so dropped it from every
+# rendered config — silently, because a missing key is indistinguishable
+# from an unset option. ``routers`` survived purely because it happens to
+# be spelled the same on both sides. Driving both directions off one table
+# is what stops that class of bug recurring: a new option is added in one
+# place or it is not supported at all.
+_KEA_OPTION_NAMES_V4: dict[str, str] = {
+    "routers": "routers",
+    "dns-servers": "domain-name-servers",
+    "domain-name": "domain-name",
+    "broadcast-address": "broadcast-address",
+    "ntp-servers": "ntp-servers",
+    "tftp-server-name": "tftp-server-name",
+    "bootfile-name": "boot-file-name",
+    "tftp-server-address": "tftp-server-address",
+    "domain-search": "domain-search",
+    "mtu": "interface-mtu",
+    "time-offset": "time-offset",
+}
+
+# Legacy input spellings accepted for backward compatibility with bundles
+# from an older control plane (and with hand-written test fixtures). Values
+# are canonical names in ``_KEA_OPTION_NAMES_V4``. Kea's own IANA spellings
+# are accepted too, so a bundle that already speaks Kea passes through.
+_LEGACY_OPTION_ALIASES_V4: dict[str, str] = {
+    "dns_servers": "dns-servers",
+    "domain-name-servers": "dns-servers",
+    "ntp_servers": "ntp-servers",
+    "gateway": "routers",
+    "domain_name": "domain-name",
+    "domain_search": "domain-search",
+    "tftp_server": "tftp-server-name",
+    "boot_file": "bootfile-name",
+    "boot-file-name": "bootfile-name",
+    "broadcast_address": "broadcast-address",
+    "interface-mtu": "mtu",
+    "time_offset": "time-offset",
+    "tftp_server_address": "tftp-server-address",
+}
+
+# Options Kea has no built-in definition for, mapped to the ``option-def``
+# entry that makes them loadable.
+#
+# Option 150 (Cisco TFTP server address) is NOT a standard Kea option:
+# ``kea-dhcp4 -t`` fails the WHOLE config with "definition for the option
+# 'dhcp4.tftp-server-address' does not exist", which takes DHCP down rather
+# than dropping one option. Verified against Kea 3.0.3. So emitting it
+# requires shipping the definition alongside it.
+_OPTION_DEFS_V4: dict[str, dict[str, Any]] = {
+    "tftp-server-address": {
+        "name": "tftp-server-address",
+        "code": 150,
+        "space": "dhcp4",
+        "type": "ipv4-address",
+        "array": True,
+    },
+}
+
 # Map of SpatiumDDI / bundle-neutral option-name → Kea Dhcp6 ``option-data``
 # name. DHCPv6 uses a different option-code space + names from v4; only
 # options with a true v6 equivalent are forwarded. Mirrors
@@ -112,46 +179,84 @@ def _opt(name: str, value: Any) -> dict[str, Any]:
     return entry
 
 
-def _options_from_mapping(options: dict[str, Any] | None) -> list[dict[str, Any]]:
-    """Translate bundle-neutral keys to Kea option names.
+def _canonicalize_v4(options: dict[str, Any]) -> dict[str, Any]:
+    """Resolve legacy / Kea-native input spellings onto canonical names.
 
-    Supported keys (both snake_case and hyphenated are accepted):
-        dns_servers / domain-name-servers
-        ntp_servers / ntp-servers       (DHCP option 42)
-        routers
-        domain_name / domain-name
-        domain_search / domain-search
-        tftp_server / tftp-server-name
-        boot_file / boot-file-name
+    A canonical key already present always wins over an alias resolving onto
+    it, so a bundle carrying both never has the outcome depend on dict order.
+    """
+    out: dict[str, Any] = {}
+    for key, val in options.items():
+        canon = (
+            key if key in _KEA_OPTION_NAMES_V4 else _LEGACY_OPTION_ALIASES_V4.get(key)
+        )
+        if canon is None:
+            continue
+        if canon in options and canon != key:
+            continue  # the canonical spelling is present; ignore the alias
+        out[canon] = val
+    return out
+
+
+def _options_from_mapping(options: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Translate bundle-neutral keys to Kea Dhcp4 ``option-data`` entries.
+
+    Keys are the canonical SpatiumDDI option names in
+    ``_KEA_OPTION_NAMES_V4``; the legacy snake_case and Kea-native spellings
+    in ``_LEGACY_OPTION_ALIASES_V4`` are accepted for older bundles (#856).
+
+    Emission order follows ``_KEA_OPTION_NAMES_V4`` rather than the caller's
+    dict order, so the rendered file is byte-stable across restarts and an
+    unchanged bundle never triggers a spurious config rewrite + Kea reload.
     """
     if not options:
         return []
+    canon = _canonicalize_v4(options)
     out: list[dict[str, Any]] = []
-
-    def _put(name: str, val: Any) -> None:
+    for name, kea_name in _KEA_OPTION_NAMES_V4.items():
+        val = canon.get(name)
         if val in (None, "", []):
-            return
-        out.append(_opt(name, val))
-
-    _put(
-        "domain-name-servers",
-        options.get("dns_servers") or options.get("domain-name-servers"),
-    )
-    _put("ntp-servers", options.get("ntp_servers") or options.get("ntp-servers"))
-    _put("routers", options.get("routers") or options.get("gateway"))
-    _put("domain-name", options.get("domain_name") or options.get("domain-name"))
-    _put("domain-search", options.get("domain_search") or options.get("domain-search"))
-    _put(
-        "tftp-server-name",
-        options.get("tftp_server") or options.get("tftp-server-name"),
-    )
-    _put("boot-file-name", options.get("boot_file") or options.get("boot-file-name"))
+            continue
+        out.append(_opt(kea_name, val))
 
     # Pass through any raw Kea-style list already shaped correctly.
     raw = options.get("option_data")
     if isinstance(raw, list):
         out.extend(raw)
     return out
+
+
+def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
+    """``option-def`` entries required by whatever the render actually emitted.
+
+    Kea rejects the ENTIRE config for an option it has no definition for, so
+    a non-standard option must ship its definition or not be emitted at all.
+
+    This walks the assembled ``Dhcp4`` block rather than each options mapping
+    on the way in, so it cannot miss a source: subnet, pool, reservation,
+    client-class and global option-data are all covered by construction, as
+    is anything a future caller adds.
+    """
+    seen: set[str] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, val in node.items():
+                if key == "option-data" and isinstance(val, list):
+                    for entry in val:
+                        if isinstance(entry, dict):
+                            name = entry.get("name")
+                            if isinstance(name, str) and name in _OPTION_DEFS_V4:
+                                seen.add(name)
+                else:
+                    _walk(val)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(dhcp4)
+    # Stable order, keyed off the canonical table rather than set iteration.
+    return [_OPTION_DEFS_V4[n] for n in _KEA_OPTION_NAMES_V4 if n in seen]
 
 
 def _options_from_mapping_v6(options: dict[str, Any] | None) -> list[dict[str, Any]]:
@@ -792,6 +897,13 @@ def render(
 
     if rendered_classes:
         dhcp4["client-classes"] = rendered_classes
+
+    # #856 — ship definitions for any non-standard option we just emitted.
+    # Must run after every option-data producer above, and Kea requires
+    # ``option-def`` to precede nothing in particular, so placement is free.
+    option_defs = _collect_option_defs(dhcp4)
+    if option_defs:
+        dhcp4["option-def"] = option_defs
 
     out: dict[str, Any] = {"Dhcp4": dhcp4}
 

--- a/agent/dhcp/tests/test_render_kea_option_names.py
+++ b/agent/dhcp/tests/test_render_kea_option_names.py
@@ -142,9 +142,52 @@ def test_emission_order_is_independent_of_input_order() -> None:
     assert a == b
 
 
+def test_two_aliases_of_one_option_resolve_deterministically() -> None:
+    """Alias-vs-alias must not resolve by input dict ordering either.
+
+    ``dns_servers`` and ``domain-name-servers`` both collapse onto
+    ``dns-servers``; whichever wins, it must be the SAME one whatever order
+    the bundle happens to serialise them in, or two agents in a group render
+    different configs from the same bundle.
+    """
+    both = {"dns_servers": ["9.9.9.9"], "domain-name-servers": ["1.1.1.1"]}
+    assert _options_from_mapping(both) == _options_from_mapping(
+        dict(reversed(list(both.items())))
+    )
+
+
 def test_unknown_option_is_ignored_not_emitted() -> None:
     """An unrecognised key must not reach Kea, which would reject the config."""
     assert _options_from_mapping({"totally-made-up": "x"}) == []
+
+
+def test_dropped_option_is_logged_not_silent(capsys: pytest.CaptureFixture[str]) -> None:
+    """#856 was invisible because a dropped key looks like an unset option.
+
+    Custom / vendor options (``code:NN`` from the Kea + ISC importers, and the
+    codes the UI's custom-options accordion offers beyond the canonical set)
+    are still dropped — emitting a name Kea has no definition for would fail
+    the WHOLE config — but the operator must at least get a log line.
+    """
+    assert _options_from_mapping({"code:43": "0102", "time-servers": ["1.2.3.4"]}) == []
+    out = capsys.readouterr().out
+    assert out.count("kea_option_dropped_unsupported") == 2
+
+
+def test_supported_and_structural_keys_do_not_warn(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``lease_time`` rides in ``global_options`` and ``option_data`` is the
+    raw pass-through list — neither is a dropped option."""
+    _options_from_mapping(
+        {
+            "lease_time": 3600,
+            "dns-servers": ["1.1.1.1"],
+            "dns_servers": ["9.9.9.9"],
+            "option_data": [{"name": "domain-name", "data": "ex.com"}],
+        }
+    )
+    assert "kea_option_dropped_unsupported" not in capsys.readouterr().out
 
 
 # ── option-def for non-standard options ─────────────────────────────────────

--- a/agent/dhcp/tests/test_render_kea_option_names.py
+++ b/agent/dhcp/tests/test_render_kea_option_names.py
@@ -1,0 +1,233 @@
+"""#856 — the agent dropped DHCP options whose canonical name it didn't know.
+
+The control plane stores option 6 under the canonical name ``dns-servers``
+(``STANDARD_OPTION_NAMES`` in ``backend/app/drivers/dhcp/base.py``) and ships
+that key in the bundle. The agent's v4 renderer looked it up only as
+``dns_servers`` / ``domain-name-servers``, so the lookup missed and option 6
+never reached ``kea-dhcp4.conf`` — silently, because a missing key is
+indistinguishable from an unset option. ``routers`` survived only because it
+happens to be spelled identically on both sides.
+
+These tests pin the canonical vocabulary as the contract, so a future option
+cannot be added on one side alone and quietly go missing on the other.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from spatium_dhcp_agent.render_kea import (
+    _KEA_OPTION_NAMES_V4,
+    _collect_option_defs,
+    _options_from_mapping,
+    render,
+)
+
+
+def _by_name(entries: list[dict]) -> dict[str, str]:
+    return {e["name"]: e["data"] for e in entries}
+
+
+# ── The reported bug ────────────────────────────────────────────────────────
+
+
+def test_canonical_dns_servers_renders_option_6() -> None:
+    """The exact #856 report: option 6 stored canonically must reach Kea."""
+    out = _by_name(
+        _options_from_mapping(
+            {"routers": ["192.168.20.254"], "dns-servers": ["192.168.20.1"]}
+        )
+    )
+    assert out["domain-name-servers"] == "192.168.20.1"
+    assert out["routers"] == "192.168.20.254"
+
+
+def test_option_6_carries_code_and_space() -> None:
+    """The reporter's expected shape — Kea name plus explicit code 6."""
+    entry = next(
+        e
+        for e in _options_from_mapping({"dns-servers": ["192.168.20.1"]})
+        if e["name"] == "domain-name-servers"
+    )
+    assert entry["code"] == 6
+    assert entry["space"] == "dhcp4"
+
+
+def test_canonical_bootfile_name_renders() -> None:
+    """Option 67 had the identical defect — canonical ``bootfile-name`` vs the
+    agent's ``boot_file`` / ``boot-file-name``."""
+    out = _by_name(_options_from_mapping({"bootfile-name": "pxelinux.0"}))
+    assert out["boot-file-name"] == "pxelinux.0"
+
+
+@pytest.mark.parametrize(
+    ("canonical", "kea_name", "value"),
+    [
+        ("broadcast-address", "broadcast-address", "192.168.20.255"),
+        ("mtu", "interface-mtu", 1500),
+        ("time-offset", "time-offset", 0),
+        ("tftp-server-address", "tftp-server-address", ["192.168.20.5"]),
+    ],
+)
+def test_previously_unhandled_options_render(
+    canonical: str, kea_name: str, value: object
+) -> None:
+    """Four options the v4 renderer omitted entirely."""
+    assert kea_name in _by_name(_options_from_mapping({canonical: value}))
+
+
+def test_time_offset_zero_is_emitted() -> None:
+    """``0`` is a real time-offset (UTC), not an unset option — the falsy
+    filter must reject only None / "" / []."""
+    assert "time-offset" in _by_name(_options_from_mapping({"time-offset": 0}))
+
+
+# ── Contract between the two renderers ──────────────────────────────────────
+
+
+def test_every_canonical_backend_option_is_supported() -> None:
+    """The agent's v4 table must cover the control plane's whole vocabulary.
+
+    This is the assertion that would have caught #856 at author time.
+    ``STANDARD_OPTION_NAMES`` is duplicated here rather than imported because
+    the agent is a separate package that cannot import the backend.
+    """
+    backend_canonical = {
+        "routers",
+        "dns-servers",
+        "domain-name",
+        "broadcast-address",
+        "ntp-servers",
+        "tftp-server-name",
+        "bootfile-name",
+        "tftp-server-address",
+        "domain-search",
+        "mtu",
+        "time-offset",
+    }
+    assert backend_canonical == set(_KEA_OPTION_NAMES_V4)
+
+
+# ── Backward compatibility + determinism ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("legacy", "kea_name"),
+    [
+        ("dns_servers", "domain-name-servers"),
+        ("domain-name-servers", "domain-name-servers"),
+        ("gateway", "routers"),
+        ("boot_file", "boot-file-name"),
+        ("ntp_servers", "ntp-servers"),
+        ("domain_name", "domain-name"),
+    ],
+)
+def test_legacy_spellings_still_accepted(legacy: str, kea_name: str) -> None:
+    """Older bundles and hand-written fixtures must keep working."""
+    assert kea_name in _by_name(_options_from_mapping({legacy: "192.0.2.1"}))
+
+
+def test_canonical_key_wins_over_alias() -> None:
+    """Both spellings present must not resolve by dict ordering."""
+    out = _by_name(
+        _options_from_mapping({"dns-servers": ["1.1.1.1"], "dns_servers": ["9.9.9.9"]})
+    )
+    assert out["domain-name-servers"] == "1.1.1.1"
+
+
+def test_emission_order_is_independent_of_input_order() -> None:
+    """A stable file avoids a spurious rewrite + Kea reload on every poll."""
+    a = _options_from_mapping({"dns-servers": ["a"], "routers": ["b"]})
+    b = _options_from_mapping({"routers": ["b"], "dns-servers": ["a"]})
+    assert a == b
+
+
+def test_unknown_option_is_ignored_not_emitted() -> None:
+    """An unrecognised key must not reach Kea, which would reject the config."""
+    assert _options_from_mapping({"totally-made-up": "x"}) == []
+
+
+# ── option-def for non-standard options ─────────────────────────────────────
+
+
+def test_option_150_ships_its_definition() -> None:
+    """Kea has no built-in definition for option 150 and fails the WHOLE
+    config without one, so emitting it must ship the definition too."""
+    defs = _collect_option_defs(
+        {
+            "subnet4": [
+                {
+                    "option-data": _options_from_mapping(
+                        {"tftp-server-address": ["192.0.2.5"]}
+                    )
+                }
+            ]
+        }
+    )
+    assert defs == [
+        {
+            "name": "tftp-server-address",
+            "code": 150,
+            "space": "dhcp4",
+            "type": "ipv4-address",
+            "array": True,
+        }
+    ]
+
+
+def test_no_option_def_when_unused() -> None:
+    defs = _collect_option_defs(
+        {
+            "subnet4": [
+                {"option-data": _options_from_mapping({"dns-servers": ["1.1.1.1"]})}
+            ]
+        }
+    )
+    assert defs == []
+
+
+def test_option_def_found_in_nested_pool_and_reservation() -> None:
+    """The walk must reach every option-data producer, not just the subnet."""
+    entry = _options_from_mapping({"tftp-server-address": ["192.0.2.5"]})
+    for doc in (
+        {"subnet4": [{"pools": [{"option-data": entry}]}]},
+        {"subnet4": [{"reservations": [{"option-data": entry}]}]},
+        {"client-classes": [{"option-data": entry}]},
+        {"option-data": entry},
+    ):
+        assert len(_collect_option_defs(doc)) == 1
+
+
+def test_full_render_emits_option_6_and_option_def() -> None:
+    """End to end through ``render()``, mirroring the reported scope."""
+    doc = render(
+        {
+            "server": {"dhcp_socket_type": "raw"},
+            "global_options": {"lease_time": 3600},
+            "scopes": [
+                {
+                    "subnet_cidr": "192.168.20.0/24",
+                    "address_family": "ipv4",
+                    "is_active": True,
+                    "lease_time": 3600,
+                    "options": {
+                        "routers": ["192.168.20.254"],
+                        "dns-servers": ["192.168.20.1"],
+                        "tftp-server-address": ["192.168.20.5"],
+                    },
+                    "pools": [
+                        {
+                            "start_ip": "192.168.20.100",
+                            "end_ip": "192.168.20.200",
+                            "pool_type": "dynamic",
+                        }
+                    ],
+                    "statics": [],
+                }
+            ],
+        }
+    )["Dhcp4"]
+    opts = _by_name(doc["subnet4"][0]["option-data"])
+    assert opts["domain-name-servers"] == "192.168.20.1"
+    assert opts["routers"] == "192.168.20.254"
+    assert doc["option-def"][0]["code"] == 150

--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -122,9 +122,17 @@ def _normalize_options(raw: Any) -> dict[str, Any]:
             if not isinstance(entry, dict):
                 continue
             code = entry.get("code")
-            name = entry.get("name") or _CODE_TO_NAME.get(int(code)) if code else None
-            if not name:
-                name = f"option-{code}" if code else None
+            # #856 — the conditional binds looser than ``or``, so the previous
+            # ``entry.get("name") or _CODE_TO_NAME.get(int(code)) if code else None``
+            # evaluated as ``(name or lookup) if code else None``: an entry
+            # identified by NAME with no ``code`` was silently discarded rather
+            # than used as-is. Resolve the two independently.
+            name = entry.get("name")
+            if not name and code:
+                try:
+                    name = _CODE_TO_NAME.get(int(code)) or f"option-{code}"
+                except (TypeError, ValueError):
+                    name = None
             if not name:
                 continue
             name = _OPTION_NAME_ALIASES.get(name, name)

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -57,6 +57,12 @@ _KEA_OPTION_NAMES: dict[str, str] = {
 # ``definition for the option 'dhcp4.tftp-server-address' does not exist``
 # (verified against Kea 3.0.3) — which takes DHCP down rather than dropping
 # one option, so the definition has to ship with it.
+#
+# KEYED BY THE RENDERED KEA NAME, not the canonical SpatiumDDI one, because
+# that is what ``_collect_option_defs`` sees in the assembled ``option-data``.
+# The two happen to be spelled identically for option 150; they are NOT for
+# e.g. ``bootfile-name`` → ``boot-file-name``, and keying this table the other
+# way would emit that option with no definition and fail the whole config.
 _KEA_OPTION_DEFS: dict[str, dict[str, Any]] = {
     "tftp-server-address": {
         "name": "tftp-server-address",
@@ -91,7 +97,9 @@ def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
                 _walk(item)
 
     _walk(dhcp4)
-    return [_KEA_OPTION_DEFS[n] for n in _KEA_OPTION_NAMES if n in seen]
+    # Stable order, keyed off ``_KEA_OPTION_DEFS`` (Kea names, the same
+    # namespace as ``seen``) rather than set iteration.
+    return [d for n, d in _KEA_OPTION_DEFS.items() if n in seen]
 
 
 # Map of SpatiumDDI option-name → Kea Dhcp6 ``option-data`` name. DHCPv6

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -49,6 +49,51 @@ _KEA_OPTION_NAMES: dict[str, str] = {
     "time-offset": "time-offset",
 }
 
+# Options Kea has no built-in definition for, mapped to the ``option-def``
+# that makes them loadable.
+#
+# #856: option 150 (Cisco TFTP server address) is not a standard Kea option.
+# Emitting it by name alone fails the WHOLE config —
+# ``definition for the option 'dhcp4.tftp-server-address' does not exist``
+# (verified against Kea 3.0.3) — which takes DHCP down rather than dropping
+# one option, so the definition has to ship with it.
+_KEA_OPTION_DEFS: dict[str, dict[str, Any]] = {
+    "tftp-server-address": {
+        "name": "tftp-server-address",
+        "code": 150,
+        "space": "dhcp4",
+        "type": "ipv4-address",
+        "array": True,
+    },
+}
+
+
+def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
+    """``option-def`` entries required by whatever this render emitted.
+
+    Walks the assembled ``Dhcp4`` block rather than each options mapping on
+    the way in, so subnet, pool, reservation, client-class and global
+    option-data are all covered — including any future producer.
+    """
+    seen: set[str] = set()
+
+    def _walk(node: Any) -> None:
+        if isinstance(node, dict):
+            for key, val in node.items():
+                if key == "option-data" and isinstance(val, list):
+                    for entry in val:
+                        if isinstance(entry, dict) and entry.get("name") in _KEA_OPTION_DEFS:
+                            seen.add(str(entry["name"]))
+                else:
+                    _walk(val)
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(dhcp4)
+    return [_KEA_OPTION_DEFS[n] for n in _KEA_OPTION_NAMES if n in seen]
+
+
 # Map of SpatiumDDI option-name → Kea Dhcp6 ``option-data`` name. DHCPv6
 # uses a different option-code space + cmdlet names; only options that
 # have a true v6 equivalent are forwarded. Options with no v6 analogue
@@ -345,6 +390,10 @@ class KeaDriver(DHCPDriver):
                 + [_render_phone_class(p) for p in bundle.phone_classes],
                 "option-data": _render_option_data(bundle.options.options, address_family="ipv4"),
             }
+            # #856 — ship definitions for any non-standard option emitted above.
+            option_defs = _collect_option_defs(out["Dhcp4"])
+            if option_defs:
+                out["Dhcp4"]["option-def"] = option_defs
         if v6_scopes:
             # Kea names the subnet list "subnet6" in Dhcp6 mode. Options /
             # client-class options render through the Dhcp6 name map;

--- a/backend/tests/test_dhcp_option_name_render.py
+++ b/backend/tests/test_dhcp_option_name_render.py
@@ -1,0 +1,138 @@
+"""#856 — DHCP option-name handling: normalisation and the Kea ``option-def``.
+
+Two defects, both silent:
+
+* ``_normalize_options`` resolved an entry's name with
+  ``entry.get("name") or _CODE_TO_NAME.get(int(code)) if code else None``.
+  The conditional binds looser than ``or``, so it evaluated as
+  ``(name or lookup) if code else None`` — an option identified by NAME with
+  no ``code`` was discarded rather than used as-is.
+* Option 150 (``tftp-server-address``) has no built-in Kea definition. The
+  driver emitted it by name alone, which fails the WHOLE config with
+  "definition for the option 'dhcp4.tftp-server-address' does not exist"
+  (verified against Kea 3.0.3) — taking DHCP down rather than dropping one
+  option. The definition now ships with it.
+
+The matching agent-side renderer bug is covered in
+``agent/dhcp/tests/test_render_kea_option_names.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from app.api.v1.dhcp.scopes import _normalize_options
+from app.drivers.dhcp.base import ConfigBundle, ScopeDef, ServerOptionsDef
+from app.drivers.dhcp.kea import KeaDriver, _render_option_data
+
+
+def _bundle(options: dict) -> ConfigBundle:
+    return ConfigBundle(
+        server_id="00000000-0000-0000-0000-000000000000",
+        server_name="kea-856",
+        driver="kea",
+        roles=(),
+        options=ServerOptionsDef(options={}, lease_time=3600),
+        scopes=(
+            ScopeDef(
+                subnet_cidr="192.168.20.0/24",
+                lease_time=3600,
+                options=options,
+                pools=(),
+                statics=(),
+                is_active=True,
+            ),
+        ),
+        client_classes=(),
+        generated_at=datetime.now(UTC),
+    )
+
+
+def _dhcp4(options: dict) -> dict:
+    return json.loads(KeaDriver().render_config(_bundle(options)))["Dhcp4"]
+
+
+# ── _normalize_options: the operator-precedence bug ─────────────────────────
+
+
+def test_name_only_entry_is_kept() -> None:
+    """An option given by name with no ``code`` was silently dropped."""
+    assert _normalize_options([{"name": "routers", "value": ["192.168.20.254"]}]) == {
+        "routers": ["192.168.20.254"]
+    }
+
+
+def test_name_only_alias_still_normalises() -> None:
+    assert _normalize_options([{"name": "domain-name-servers", "value": ["192.168.20.1"]}]) == {
+        "dns-servers": ["192.168.20.1"]
+    }
+
+
+def test_code_only_entry_resolves_by_code() -> None:
+    assert _normalize_options([{"code": 6, "value": ["192.168.20.1"]}]) == {
+        "dns-servers": ["192.168.20.1"]
+    }
+
+
+def test_name_wins_over_code_when_both_present() -> None:
+    assert _normalize_options([{"code": 3, "name": "routers", "value": ["192.168.20.254"]}]) == {
+        "routers": ["192.168.20.254"]
+    }
+
+
+def test_unknown_code_falls_back_to_option_n() -> None:
+    assert _normalize_options([{"code": 252, "value": "x"}]) == {"option-252": "x"}
+
+
+def test_entry_with_neither_name_nor_code_is_skipped() -> None:
+    assert _normalize_options([{"value": "orphan"}]) == {}
+
+
+def test_non_integer_code_is_skipped_not_raised() -> None:
+    """A malformed code must not 500 the request."""
+    assert _normalize_options([{"code": "abc", "value": "x"}]) == {}
+
+
+# ── Kea render: option 6 and the option-def ─────────────────────────────────
+
+
+def test_option_6_renders_as_domain_name_servers() -> None:
+    rendered = _render_option_data({"dns-servers": ["192.168.20.1"]})
+    assert rendered == [{"name": "domain-name-servers", "data": "192.168.20.1"}]
+
+
+def test_option_150_ships_its_definition() -> None:
+    doc = _dhcp4({"tftp-server-address": ["192.168.20.5"]})
+    assert doc["option-def"] == [
+        {
+            "name": "tftp-server-address",
+            "code": 150,
+            "space": "dhcp4",
+            "type": "ipv4-address",
+            "array": True,
+        }
+    ]
+
+
+def test_no_option_def_key_when_unused() -> None:
+    """Installs that don't use option 150 keep a byte-identical config."""
+    assert "option-def" not in _dhcp4({"dns-servers": ["192.168.20.1"]})
+
+
+@pytest.mark.parametrize(
+    ("canonical", "kea_name"),
+    [
+        ("routers", "routers"),
+        ("dns-servers", "domain-name-servers"),
+        ("bootfile-name", "boot-file-name"),
+        ("mtu", "interface-mtu"),
+        ("broadcast-address", "broadcast-address"),
+        ("time-offset", "time-offset"),
+    ],
+)
+def test_canonical_names_map_to_kea_names(canonical: str, kea_name: str) -> None:
+    rendered = _render_option_data({canonical: "1"})
+    assert rendered[0]["name"] == kea_name


### PR DESCRIPTION
Fixes [#856](https://github.com/spatiumddi/spatiumddi/issues/856) — a DHCP scope's DNS Servers option was stored correctly, returned correctly by the API and shown correctly in the UI, then silently omitted from `kea-dhcp4.conf`, so clients got a lease with no resolver. Option 3 (routers) worked, which is what made it look arbitrary.

## Root cause

A vocabulary mismatch between the two Kea renderers.

The control plane stores option 6 under the canonical name `dns-servers` (`STANDARD_OPTION_NAMES`) and ships that key in the bundle. The agent's v4 renderer — which writes the file Kea actually loads — looked it up through a hand-written list of per-option `_put(...)` calls that checked only `dns_servers` and `domain-name-servers`. The lookup missed, and **a missing key is indistinguishable from an unset option**, so nothing complained anywhere in the chain.

`routers` survived purely because it happens to be spelled the same on both sides. That coincidence is the entire difference between the two options.

## The fix

Rather than add a third alias, the agent's v4 path is now driven by **one canonical name → Kea name table** mirroring the backend's, so an option is supported in one place or not at all. A contract test asserts the agent's table covers the backend's whole vocabulary — the assertion that would have caught this at author time.

That swept up three further defects the hand-written list had accumulated:

- **Option 67 (`bootfile-name`) was dropped identically** — the agent looked for `boot_file` / `boot-file-name`. Scope-level PXE boot files never reached clients.
- **Options 2, 26, 28 and 150** (`time-offset`, `mtu`, `broadcast-address`, `tftp-server-address`) were not handled at all.
- **Emission order followed the caller's dict**, so an unchanged bundle could rewrite the file and bounce Kea. It now follows the table.

Legacy snake_case and Kea-native spellings are still accepted for older bundles. Where both a canonical key and an alias are present the canonical one wins, so the result never depends on dict ordering.

## Option 150 needed more than a name

Kea has no built-in definition for option 150 and fails the **whole** config:

```
definition for the option 'dhcp4.tftp-server-address' does not exist
```

(verified against Kea 3.0.3). So passing it through naively would have converted a silently-dropped option into a DHCP outage. Both renderers now emit the matching `option-def` alongside it, collected by walking the assembled `Dhcp4` block so subnet, pool, reservation, client-class and global option-data are covered by construction rather than by remembering to thread it through each call site.

**The backend driver already had this bug** — it has always emitted option 150 by name with no definition, latent only because the agent was dropping it before Kea ever saw it.

## Also fixed

An operator-precedence bug found while verifying the workaround for the reporter:

```python
name = entry.get("name") or _CODE_TO_NAME.get(int(code)) if code else None
```

parses as `(name or lookup) if code else None`, so an option supplied by **name with no `code`** was discarded rather than used as-is. A non-integer `code` also raised where it should skip.

## Verification

- The rendered config for the reported scope now carries **both** option 3 and option 6 with their codes, matching the reporter's expected example.
- `kea-dhcp4 -t` **accepts** the full rendered config, including the `option-def`.
- 25 new agent tests + 16 new backend tests.
- 57 adjacent DHCP tests and the full 102-test agent suite pass unchanged.
- ruff / black / mypy clean; dev containers rebuilt and both renderers re-verified inside the fresh images.

## Release note

The agent half ships in the **`dhcp-kea` image**, so operators need a new agent image — a control-plane upgrade alone will not change the rendered file. Worth calling out in the next release's notes.

Blast radius was bounded throughout: the #477 config-test preflight means even a rejected render surfaces as a degraded daemon rather than taking DHCP down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
