### PR TITLE
fix(dhcp): deliver pool options, PXE + phone classes to agent-managed Kea (#858)

### DIFF
--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -231,17 +231,32 @@ def _options_from_mapping(options: dict[str, Any] | None) -> list[dict[str, Any]
             continue
         out.append(_opt(kea_name, val))
 
-    # Anything outside the table is still dropped — emitting an option Kea
-    # has no definition for fails the WHOLE config, which is worse than not
-    # serving it. But drop it LOUDLY: #856 was invisible precisely because a
-    # dropped key looks identical to an unset option. Custom / vendor options
-    # (the ``code:NN`` keys the Kea + ISC importers produce, and the ~80 codes
-    # the UI's custom-options accordion offers beyond the canonical set) land
-    # here, so the operator gets a log line instead of silence.
+    # #858 — options addressed by raw code (``code:NN``), which is how phone
+    # profiles and the importers carry a vendor option with no canonical name.
+    # Emitted in Kea's ``{"code": NN}`` form, mirroring ``_render_option_data``
+    # in the backend driver. Kea types an unknown code as BINARY, so a string
+    # value only loads when the bundle also ships an ``option-def`` for it —
+    # the control plane resolves those (it owns the option catalogues) and
+    # ``render()`` emits them; see ``_option_defs_from_bundle``.
+    for key, val in options.items():
+        if not key.startswith("code:"):
+            continue
+        try:
+            code_int = int(key[5:])
+        except ValueError:
+            _log.warning("kea_option_bad_code_key", option=key)
+            continue
+        data = ", ".join(str(x) for x in val) if isinstance(val, list) else str(val)
+        out.append({"code": code_int, "data": data})
+
+    # Anything else outside the table is still dropped — emitting an option
+    # name Kea has no definition for fails the WHOLE config, which is worse
+    # than not serving it. But drop it LOUDLY: #856 was invisible precisely
+    # because a dropped key looks identical to an unset option.
     for key in options:
         if key in _NON_OPTION_KEYS or key in _KEA_OPTION_NAMES_V4:
             continue
-        if key in _LEGACY_OPTION_ALIASES_V4:
+        if key in _LEGACY_OPTION_ALIASES_V4 or key.startswith("code:"):
             continue
         _log.warning("kea_option_dropped_unsupported", option=key)
 
@@ -250,6 +265,37 @@ def _options_from_mapping(options: dict[str, Any] | None) -> list[dict[str, Any]
     if isinstance(raw, list):
         out.extend(raw)
     return out
+
+
+def _strip_undefined_code_options(node: Any, defined_codes: set[int]) -> None:
+    """Remove ``{"code": NN}`` option-data entries with no matching definition.
+
+    Mutates in place, walking the same structures ``_collect_option_defs``
+    does so subnet / pool / reservation / client-class / global option-data are
+    all covered. Emitting an undefined code fails the entire config, so this is
+    the guard that keeps a stray vendor option from taking DHCP down.
+    """
+    if isinstance(node, dict):
+        for key, val in node.items():
+            if key == "option-data" and isinstance(val, list):
+                kept = []
+                for entry in val:
+                    code = entry.get("code") if isinstance(entry, dict) else None
+                    # Entries carrying a name are Kea built-ins, already safe.
+                    if (
+                        isinstance(code, int)
+                        and not (isinstance(entry, dict) and entry.get("name"))
+                        and code not in defined_codes
+                    ):
+                        _log.warning("kea_option_dropped_no_definition", code=code)
+                        continue
+                    kept.append(entry)
+                node[key] = kept
+            else:
+                _strip_undefined_code_options(val, defined_codes)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_undefined_code_options(item, defined_codes)
 
 
 def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
@@ -323,6 +369,13 @@ def _options_from_mapping_v6(options: dict[str, Any] | None) -> list[dict[str, A
         normalized = k.replace("_", "-")
         if normalized in _DHCP4_ONLY_OPTION_NAMES:
             _log.warning("kea_option_skipped_v6_no_equivalent", option=k)
+        elif k.startswith("code:"):
+            # #858 — raw-code options are v4-only here. The definitions the
+            # control plane ships declare ``space: dhcp4``, so emitting the
+            # code under Dhcp6 would reference a definition that does not
+            # exist in that space and fail the whole config. Dropped, but
+            # loudly: the silent version of this is the bug #858 exists to fix.
+            _log.warning("kea_option_skipped_v6_raw_code", option=k)
 
     # Pass through any raw Kea-style list already shaped correctly.
     raw = options.get("option_data")
@@ -360,6 +413,79 @@ def _reservation_v6(res: dict[str, Any]) -> dict[str, Any]:
     if res.get("hostname"):
         out["hostname"] = res["hostname"]
     opts = _options_from_mapping_v6(res.get("options"))
+    if opts:
+        out["option-data"] = opts
+    return out
+
+
+def _pxe_class(p: dict[str, Any]) -> dict[str, Any]:
+    """Render a PXE / iPXE client class (#51) — Dhcp4 only.
+
+    Mirrors ``_render_pxe_class`` in ``backend/app/drivers/dhcp/kea.py``.
+    ``next-server`` + ``boot-file-name`` on the class win over scope-level
+    defaults when Kea matches the packet, which is what lets one scope serve
+    a different boot binary per architecture. An empty ``match_expression``
+    means "always match" — a low-priority fallthrough — so the key is omitted
+    rather than emitted empty, which Kea would reject.
+    """
+    out: dict[str, Any] = {
+        "name": p["name"],
+        "boot-file-name": p.get("boot_file_name") or "",
+    }
+    # ``next-server`` must be an IPv4 literal — Kea rejects the WHOLE config on
+    # a hostname or a typo, and the control plane only checks the field is a
+    # non-empty string. Omitting it falls back to the scope / global value,
+    # which is a served lease with a wrong boot server rather than no DHCP.
+    next_server = (p.get("next_server") or "").strip()
+    if next_server:
+        try:
+            ipaddress.IPv4Address(next_server)
+        except ValueError:
+            _log.warning(
+                "kea_pxe_next_server_invalid", pxe_class=p.get("name"), value=next_server
+            )
+        else:
+            out["next-server"] = next_server
+    if p.get("match_expression"):
+        out["test"] = p["match_expression"]
+    return out
+
+
+def _phone_class(c: dict[str, Any]) -> dict[str, Any]:
+    """Render a VoIP phone-profile client class.
+
+    Mirrors ``_render_phone_class`` in the backend driver. Vendor options Kea
+    does not know by name ride as ``code:NN`` keys, which
+    ``_options_from_mapping`` emits in ``{"code": NN}`` form.
+    """
+    out: dict[str, Any] = {"name": c["name"]}
+    if c.get("match_expression"):
+        out["test"] = c["match_expression"]
+    opts = _options_from_mapping(c.get("options"))
+    if opts:
+        out["option-data"] = opts
+    return out
+
+
+def _dynamic_pool(p: dict[str, Any], *, address_family: str) -> dict[str, Any]:
+    """Render one dynamic address pool, with its per-pool option overrides.
+
+    #858 — ``options_override`` is settable, ETag-hashed and rendered by the
+    control-plane driver, but the wire bundle never carried it and this
+    renderer never read it, so a per-pool option could not reach Kea at all.
+    Mirrors ``_render_pool`` in ``backend/app/drivers/dhcp/kea.py``.
+
+    ``class_restriction`` rides along for the same reason: the backend driver
+    emits it as Kea's ``client-class``, scoping the pool to one class.
+    """
+    out: dict[str, Any] = {"pool": f"{p['start_ip']} - {p['end_ip']}"}
+    if p.get("class_restriction"):
+        out["client-class"] = p["class_restriction"]
+    opts = (
+        _options_from_mapping_v6(p.get("options_override"))
+        if address_family == "ipv6"
+        else _options_from_mapping(p.get("options_override"))
+    )
     if opts:
         out["option-data"] = opts
     return out
@@ -463,7 +589,7 @@ def _scope_to_subnet6(scope: dict[str, Any]) -> dict[str, Any]:
             if (p.get("pool_type") or "dynamic") == "dynamic"
         ]
         if dyn:
-            out["pools"] = [{"pool": f"{p['start_ip']} - {p['end_ip']}"} for p in dyn]
+            out["pools"] = [_dynamic_pool(p, address_family="ipv6") for p in dyn]
         # Prefix-delegation pools (issue #368) — drop malformed rows.
         pd = [
             p
@@ -652,7 +778,7 @@ def _scope_to_subnet(scope: dict[str, Any]) -> dict[str, Any]:
         if (p.get("pool_type") or "dynamic") == "dynamic"
     ]
     if dyn:
-        out["pools"] = [{"pool": f"{p['start_ip']} - {p['end_ip']}"} for p in dyn]
+        out["pools"] = [_dynamic_pool(p, address_family="ipv4") for p in dyn]
     opts = _options_from_mapping(scope.get("options"))
     if opts:
         out["option-data"] = opts
@@ -912,6 +1038,15 @@ def render(
         for c in classes
     ]
 
+    # #858 — PXE + phone classes. Both were folded into the bundle ETag and
+    # rendered by the control-plane driver, but never serialized onto the wire
+    # and never read here, so neither could reach agent-managed Kea — which is
+    # how both the appliance and the Compose stack run DHCP. Order matches the
+    # backend driver: operator classes, then PXE, then phone. Kea evaluates
+    # client-classes in declaration order, so this is behaviour, not style.
+    rendered_classes += [_pxe_class(p) for p in (bundle.get("pxe_classes") or [])]
+    rendered_classes += [_phone_class(c) for c in (bundle.get("phone_classes") or [])]
+
     # MAC blocklist — render as Kea's reserved ``DROP`` class. Any packet
     # whose hardware address matches the OR-ed expression is silently
     # dropped before allocation. ``DROP`` is a Kea built-in name, not
@@ -928,7 +1063,32 @@ def render(
     # #856 — ship definitions for any non-standard option we just emitted.
     # Must run after every option-data producer above, and Kea requires
     # ``option-def`` to precede nothing in particular, so placement is free.
+    #
+    # #858 — plus the definitions the control plane resolved for raw-code
+    # vendor options. Those cannot be derived here: the type comes from the
+    # option catalogues, which live in the backend package. Deduplicated by
+    # code so a definition supplied both ways is emitted once — Kea rejects a
+    # duplicate definition for the same code.
     option_defs = _collect_option_defs(dhcp4)
+    seen_def_codes = {d.get("code") for d in option_defs}
+    for d in bundle.get("option_defs") or []:
+        if isinstance(d, dict) and d.get("code") not in seen_def_codes:
+            option_defs.append(d)
+            seen_def_codes.add(d.get("code"))
+
+    # A raw-code option is only safe to emit once a definition for it exists:
+    # Kea types an undefined code as BINARY and REJECTS THE WHOLE CONFIG when
+    # the value isn't hex. Dropping one option is survivable; a rejected config
+    # is not, and `sync.py` writes the file before `config-test`, so a bad
+    # render outlives the process that made it.
+    #
+    # This also covers the two cases where no definitions arrive at all: the
+    # on-disk last-known-good cache written before #858, and an older control
+    # plane that doesn't send them. Both then behave exactly as they did before
+    # #858 — the option is dropped, loudly — rather than wedging the daemon at
+    # the moment the cache matters most (non-negotiable #5).
+    _strip_undefined_code_options(dhcp4, {c for c in seen_def_codes if isinstance(c, int)})
+
     if option_defs:
         dhcp4["option-def"] = option_defs
 

--- a/agent/dhcp/tests/test_render_kea_option_names.py
+++ b/agent/dhcp/tests/test_render_kea_option_names.py
@@ -164,14 +164,17 @@ def test_unknown_option_is_ignored_not_emitted() -> None:
 def test_dropped_option_is_logged_not_silent(capsys: pytest.CaptureFixture[str]) -> None:
     """#856 was invisible because a dropped key looks like an unset option.
 
-    Custom / vendor options (``code:NN`` from the Kea + ISC importers, and the
-    codes the UI's custom-options accordion offers beyond the canonical set)
-    are still dropped — emitting a name Kea has no definition for would fail
-    the WHOLE config — but the operator must at least get a log line.
+    An unrecognised option NAME is still dropped — emitting a name Kea has no
+    definition for would fail the WHOLE config — but the operator gets a log
+    line rather than silence.
+
+    ``code:NN`` keys are no longer dropped: #858 renders them in Kea's
+    ``{"code": NN}`` form, with the control plane shipping the matching
+    ``option-def``.
     """
-    assert _options_from_mapping({"code:43": "0102", "time-servers": ["1.2.3.4"]}) == []
+    assert _options_from_mapping({"time-servers": ["1.2.3.4"]}) == []
     out = capsys.readouterr().out
-    assert out.count("kea_option_dropped_unsupported") == 2
+    assert out.count("kea_option_dropped_unsupported") == 1
 
 
 def test_supported_and_structural_keys_do_not_warn(

--- a/agent/dhcp/tests/test_render_kea_wire_coverage.py
+++ b/agent/dhcp/tests/test_render_kea_wire_coverage.py
@@ -1,0 +1,301 @@
+"""#858 — things the control plane models but the agent never rendered.
+
+Pool option overrides, pool class restrictions, PXE classes and phone-profile
+classes were all assembled into the ConfigBundle and rendered by the
+control-plane driver, but either never reached the wire payload or were never
+read here. Every one failed silently: the UI showed the value, the ETag moved
+when it changed so agents even re-synced, and the rendered config came out
+identical.
+
+Kea behaviour asserted below was measured against kea-dhcp4 3.0.3, not
+assumed — in particular that a raw ``code:NN`` option is typed BINARY, so a
+string value fails the WHOLE config without a matching ``option-def``.
+"""
+
+from __future__ import annotations
+
+from spatium_dhcp_agent.render_kea import (
+    _dynamic_pool,
+    _options_from_mapping,
+    _phone_class,
+    _pxe_class,
+    render,
+)
+
+
+def _bundle(**over: object) -> dict:
+    base: dict = {
+        "server": {"dhcp_socket_type": "raw"},
+        "global_options": {"lease_time": 3600},
+        "scopes": [
+            {
+                "subnet_cidr": "192.168.20.0/24",
+                "address_family": "ipv4",
+                "is_active": True,
+                "lease_time": 3600,
+                "options": {"routers": ["192.168.20.254"]},
+                "pools": [
+                    {
+                        "start_ip": "192.168.20.100",
+                        "end_ip": "192.168.20.200",
+                        "pool_type": "dynamic",
+                    }
+                ],
+                "statics": [],
+            }
+        ],
+    }
+    base.update(over)  # type: ignore[arg-type]
+    return base
+
+
+# ── Pool-level overrides ────────────────────────────────────────────────────
+
+
+def test_pool_options_override_renders() -> None:
+    p = _dynamic_pool(
+        {
+            "start_ip": "10.0.0.10",
+            "end_ip": "10.0.0.20",
+            "options_override": {"dns-servers": ["10.9.9.9"]},
+        },
+        address_family="ipv4",
+    )
+    assert p["option-data"] == [
+        {"name": "domain-name-servers", "data": "10.9.9.9", "code": 6, "space": "dhcp4"}
+    ]
+
+
+def test_pool_class_restriction_renders() -> None:
+    """Shipped on the wire since #368 but only honoured for v6 PD pools, so a
+    class-restricted address pool served EVERY client."""
+    p = _dynamic_pool(
+        {"start_ip": "10.0.0.10", "end_ip": "10.0.0.20", "class_restriction": "pxe-uefi"},
+        address_family="ipv4",
+    )
+    assert p["client-class"] == "pxe-uefi"
+
+
+def test_plain_pool_is_unchanged() -> None:
+    """A pool with neither override still renders exactly as before."""
+    assert _dynamic_pool(
+        {"start_ip": "10.0.0.10", "end_ip": "10.0.0.20"}, address_family="ipv4"
+    ) == {"pool": "10.0.0.10 - 10.0.0.20"}
+
+
+# ── PXE + phone classes ─────────────────────────────────────────────────────
+
+
+def test_pxe_class_renders_boot_fields() -> None:
+    c = _pxe_class(
+        {
+            "name": "pxe-uefi",
+            "match_expression": "option[93].hex == 0x0007",
+            "next_server": "10.0.0.5",
+            "boot_file_name": "ipxe.efi",
+        }
+    )
+    assert c == {
+        "name": "pxe-uefi",
+        "next-server": "10.0.0.5",
+        "boot-file-name": "ipxe.efi",
+        "test": "option[93].hex == 0x0007",
+    }
+
+
+def test_pxe_class_without_match_omits_test() -> None:
+    """An empty match means 'always match'; Kea rejects an empty ``test``."""
+    assert "test" not in _pxe_class(
+        {"name": "fallback", "match_expression": "", "next_server": "", "boot_file_name": "x"}
+    )
+
+
+def test_phone_class_renders_vendor_codes() -> None:
+    c = _phone_class(
+        {
+            "name": "voip-abc",
+            "match_expression": "substring(option[60].hex,0,5) == 'Cisco'",
+            "options": {"code:160": "http://prov/cfg"},
+        }
+    )
+    assert c["option-data"] == [{"code": 160, "data": "http://prov/cfg"}]
+
+
+def test_classes_render_in_driver_order() -> None:
+    """Kea evaluates client-classes in declaration order, so this is
+    behaviour: operator classes, then PXE, then phone."""
+    doc = render(
+        _bundle(
+            client_classes=[{"name": "op", "match_expression": "x"}],
+            pxe_classes=[
+                {"name": "pxe", "match_expression": "y", "next_server": "", "boot_file_name": "b"}
+            ],
+            phone_classes=[{"name": "voip", "match_expression": "z", "options": {}}],
+        )
+    )["Dhcp4"]
+    assert [c["name"] for c in doc["client-classes"]] == ["op", "pxe", "voip"]
+
+
+# ── Raw code options + the definitions they need ────────────────────────────
+
+
+def test_code_keyed_option_renders_by_code() -> None:
+    assert _options_from_mapping({"code:242": "MCIPADD=10.0.0.1"}) == [
+        {"code": 242, "data": "MCIPADD=10.0.0.1"}
+    ]
+
+
+def test_code_keyed_list_value_is_joined() -> None:
+    assert _options_from_mapping({"code:150": ["10.0.0.1", "10.0.0.2"]}) == [
+        {"code": 150, "data": "10.0.0.1, 10.0.0.2"}
+    ]
+
+
+def test_malformed_code_key_is_skipped() -> None:
+    assert _options_from_mapping({"code:abc": "x"}) == []
+
+
+def test_control_plane_option_defs_are_emitted() -> None:
+    """The agent cannot type a raw code itself — the catalogues live in the
+    backend — so it emits what the control plane resolved."""
+    doc = render(
+        _bundle(
+            option_defs=[
+                {"name": "spatium-opt-242", "code": 242, "space": "dhcp4", "type": "string"}
+            ],
+            phone_classes=[
+                {"name": "voip", "match_expression": "z", "options": {"code:242": "MCIPADD=1"}}
+            ],
+        )
+    )["Dhcp4"]
+    assert doc["option-def"] == [
+        {"name": "spatium-opt-242", "code": 242, "space": "dhcp4", "type": "string"}
+    ]
+
+
+def test_option_defs_are_deduplicated_by_code() -> None:
+    """Kea rejects two definitions for one code, so a def supplied both by the
+    agent's own table and by the control plane must be emitted once."""
+    doc = render(
+        _bundle(
+            option_defs=[
+                {
+                    "name": "tftp-server-address",
+                    "code": 150,
+                    "space": "dhcp4",
+                    "type": "ipv4-address",
+                    "array": True,
+                }
+            ],
+            scopes=[
+                {
+                    "subnet_cidr": "192.168.20.0/24",
+                    "address_family": "ipv4",
+                    "is_active": True,
+                    "lease_time": 3600,
+                    "options": {"tftp-server-address": ["10.0.0.5"]},
+                    "pools": [],
+                    "statics": [],
+                }
+            ],
+        )
+    )["Dhcp4"]
+    assert [d["code"] for d in doc["option-def"]] == [150]
+
+
+def test_no_option_def_key_when_none_needed() -> None:
+    assert "option-def" not in render(_bundle())["Dhcp4"]
+
+
+# ── Review fixes: an undefined raw code must never reach Kea ────────────────
+
+
+def test_undefined_code_is_stripped_not_emitted() -> None:
+    """Emitting a code with no definition fails the WHOLE config — Kea types it
+    BINARY and rejects a non-hex value. Dropping one option is survivable; a
+    rejected config is not, and sync.py writes the file before config-test, so
+    a bad render outlives the process that made it."""
+    doc = render(
+        _bundle(
+            phone_classes=[
+                {"name": "voip", "match_expression": "z", "options": {"code:242": "MCIPADD=1"}}
+            ]
+        )
+    )["Dhcp4"]
+    assert doc["client-classes"][0]["option-data"] == []
+    assert "option-def" not in doc
+
+
+def test_defined_code_survives_the_strip() -> None:
+    doc = render(
+        _bundle(
+            option_defs=[
+                {"name": "spatium-opt-242", "code": 242, "space": "dhcp4", "type": "string"}
+            ],
+            phone_classes=[
+                {"name": "voip", "match_expression": "z", "options": {"code:242": "MCIPADD=1"}}
+            ],
+        )
+    )["Dhcp4"]
+    assert doc["client-classes"][0]["option-data"] == [{"code": 242, "data": "MCIPADD=1"}]
+
+
+def test_named_options_are_never_stripped() -> None:
+    """Named entries reference Kea built-ins and carry a code for resilience;
+    the strip must not mistake them for undefined raw codes."""
+    doc = render(
+        _bundle(
+            scopes=[
+                {
+                    "subnet_cidr": "192.168.20.0/24",
+                    "address_family": "ipv4",
+                    "is_active": True,
+                    "lease_time": 3600,
+                    "options": {"dns-servers": ["1.1.1.1"], "routers": ["1.1.1.254"]},
+                    "pools": [],
+                    "statics": [],
+                }
+            ]
+        )
+    )["Dhcp4"]
+    names = {e["name"] for e in doc["subnet4"][0]["option-data"]}
+    assert names == {"domain-name-servers", "routers"}
+
+
+def test_cached_bundle_without_defs_degrades_safely() -> None:
+    """A last-known-good bundle written before #858 carries no option_defs.
+    The agent must keep serving (non-negotiable #5), not render a config Kea
+    refuses."""
+    doc = render(
+        _bundle(
+            phone_classes=[
+                {"name": "voip", "match_expression": "z", "options": {"code:160": "http://x"}}
+            ]
+        )
+    )["Dhcp4"]
+    assert doc["client-classes"][0]["option-data"] == []
+
+
+# ── Review fixes: PXE next-server validation ────────────────────────────────
+
+
+def test_pxe_next_server_hostname_is_omitted() -> None:
+    """Kea rejects the whole config on a non-IP next-server; falling back to
+    the scope value serves a lease with a wrong boot server rather than no
+    DHCP at all."""
+    c = _pxe_class(
+        {
+            "name": "pxe",
+            "match_expression": "",
+            "next_server": "tftp.example.com",
+            "boot_file_name": "b",
+        }
+    )
+    assert "next-server" not in c
+
+
+def test_pxe_next_server_ip_is_kept() -> None:
+    c = _pxe_class(
+        {"name": "pxe", "match_expression": "", "next_server": "10.0.0.5", "boot_file_name": "b"}
+    )
+    assert c["next-server"] == "10.0.0.5"

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -28,6 +28,7 @@ from app.core.agent_wake import (
     wake_subscription,
 )
 from app.core.dns_names import sanitize_hostname
+from app.drivers.dhcp.kea import option_defs_for_option_maps
 from app.models.dhcp import (
     DHCPConfigOp,
     DHCPLease,
@@ -592,6 +593,13 @@ async def agent_config_longpoll(
                                         "delegated_length": p.delegated_length,
                                         "excluded_prefix": p.excluded_prefix,
                                         "class_restriction": p.class_restriction,
+                                        # #858 — per-pool option overrides are
+                                        # settable and ETag-hashed, and the
+                                        # control-plane driver renders them, but
+                                        # were omitted here: the same silent drop
+                                        # #430 hit for statics' options_override
+                                        # (serialized on the very next block).
+                                        "options_override": p.options_override,
                                     }
                                     for p in s.pools
                                 ],
@@ -626,6 +634,51 @@ async def agent_config_longpoll(
                             }
                             for c in bundle.client_classes
                         ],
+                        # #858 — PXE + phone classes were folded into the bundle
+                        # ETag and rendered by the control-plane driver, but
+                        # never serialized here. The consequence was worse than a
+                        # plain omission: editing a PXE profile DID move the
+                        # ETag, so it broke every agent's /config long-poll and
+                        # they all re-fetched — a payload with no PXE classes in
+                        # it, which re-rendered byte-identical config. A
+                        # guaranteed no-op resync of the whole group, and a
+                        # feature (README-advertised PXE provisioning profiles)
+                        # that could never reach agent-managed Kea at all.
+                        "pxe_classes": [
+                            {
+                                "name": p.name,
+                                "match_expression": p.match_expression,
+                                "next_server": p.next_server,
+                                "boot_file_name": p.boot_file_name,
+                                "is_ipxe_chain": p.is_ipxe_chain,
+                            }
+                            for p in bundle.pxe_classes
+                        ],
+                        "phone_classes": [
+                            {
+                                "name": c.name,
+                                "match_expression": c.match_expression,
+                                "options": c.options,
+                            }
+                            for c in bundle.phone_classes
+                        ],
+                        # #858 — Kea types a raw ``code:NN`` option as BINARY,
+                        # so an operator's string value ("not a valid string of
+                        # hexadecimal digits") fails the WHOLE config. The real
+                        # type comes from the VoIP / option-code catalogues,
+                        # which live in this package and not the agent's, so the
+                        # control plane resolves the definitions once and the
+                        # agent emits them verbatim — rather than keeping a
+                        # second copy of the table, which is the drift that
+                        # caused #856.
+                        "option_defs": option_defs_for_option_maps(
+                            [bundle.options.options]
+                            + [s.options for s in bundle.scopes]
+                            + [p.options_override for s in bundle.scopes for p in s.pools]
+                            + [st.options_override for s in bundle.scopes for st in s.statics]
+                            + [c.options for c in bundle.client_classes]
+                            + [c.options for c in bundle.phone_classes]
+                        ),
                         "mac_blocks": [
                             {
                                 "mac_address": m.mac_address,

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 import json
+from collections.abc import Iterable
 from typing import Any
 
 import structlog
@@ -63,6 +64,39 @@ _KEA_OPTION_NAMES: dict[str, str] = {
 # The two happen to be spelled identically for option 150; they are NOT for
 # e.g. ``bootfile-name`` → ``boot-file-name``, and keying this table the other
 # way would emit that option with no definition and fail the whole config.
+# Vendor / phone-profile options addressed by RAW CODE (``code:NN`` keys,
+# which is how ``_assemble_phone_classes`` emits an option the operator picked
+# from the VoIP vendor catalogue rather than by name).
+#
+# #858: Kea does not reject these as undefined — it types them as BINARY, so
+# an operator's string value fails with "not a valid string of hexadecimal
+# digits" and takes the whole config down. Declaring the real type fixes it.
+#
+# The membership of this table is MEASURED against Kea 3.0.3, not assumed,
+# because the rule is not derivable: Kea REFUSES to redefine an option it
+# already types correctly ("unable to override definition of option '66' in
+# standard option space"), so a blanket definition for every code is just as
+# fatal as none. Every code below was confirmed to (a) fail bare with a
+# type-appropriate value and (b) accept the definition given here. Types come
+# from ``app/data/dhcp_voip_options.json``'s ``kind``.
+#
+# Re-measure with `kea-dhcp4 -t` before adding a code here.
+_KEA_VENDOR_OPTION_DEFS: dict[int, dict[str, Any]] = {
+    43: {"name": "spatium-opt-43", "code": 43, "space": "dhcp4", "type": "binary"},
+    132: {"name": "spatium-opt-132", "code": 132, "space": "dhcp4", "type": "string"},
+    150: {
+        "name": "spatium-opt-150",
+        "code": 150,
+        "space": "dhcp4",
+        "type": "ipv4-address",
+        "array": True,
+    },
+    160: {"name": "spatium-opt-160", "code": 160, "space": "dhcp4", "type": "string"},
+    161: {"name": "spatium-opt-161", "code": 161, "space": "dhcp4", "type": "string"},
+    176: {"name": "spatium-opt-176", "code": 176, "space": "dhcp4", "type": "string"},
+    242: {"name": "spatium-opt-242", "code": 242, "space": "dhcp4", "type": "string"},
+}
+
 _KEA_OPTION_DEFS: dict[str, dict[str, Any]] = {
     "tftp-server-address": {
         "name": "tftp-server-address",
@@ -74,6 +108,59 @@ _KEA_OPTION_DEFS: dict[str, dict[str, Any]] = {
 }
 
 
+def _dedupe_defs_by_code(
+    named: list[dict[str, Any]], vendor: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """One definition per code — Kea rejects a config that declares two.
+
+    #858: option 150 is reachable both ways, as the canonical
+    ``tftp-server-address`` name and as a raw ``code:150`` from a Cisco phone
+    profile. A scope using one and a profile using the other produced two
+    definitions for code 150 and a config Kea refuses. The NAMED definition
+    wins: it is the one the rendered ``option-data`` references by name, and a
+    name with no matching definition is itself fatal.
+    """
+    out = list(named)
+    seen = {d.get("code") for d in out}
+    for d in vendor:
+        if d.get("code") not in seen:
+            out.append(d)
+            seen.add(d.get("code"))
+    return out
+
+
+def option_defs_for_option_maps(maps: Iterable[dict[str, Any] | None]) -> list[dict[str, Any]]:
+    """``option-def`` entries needed by the given SpatiumDDI option mappings.
+
+    The agent renders its own Kea config but cannot compute these: the type
+    for a raw ``code:NN`` comes from the VoIP / option-code catalogues, which
+    live in the backend package. So the control plane resolves them once and
+    ships the result on the wire (#858) — the agent emits it verbatim rather
+    than keeping a second copy of a table that would drift, which is the
+    mistake #856 was.
+
+    Takes the neutral ``{name: value}`` mappings, not a rendered document, so
+    it can run at bundle-assembly time before any driver is involved.
+    """
+    codes: set[int] = set()
+    names: set[str] = set()
+    for m in maps:
+        for key in m or {}:
+            if key.startswith("code:"):
+                try:
+                    codes.add(int(key[5:]))
+                except ValueError:
+                    continue
+            else:
+                kea_name = _KEA_OPTION_NAMES.get(key)
+                if kea_name in _KEA_OPTION_DEFS:
+                    names.add(str(kea_name))
+    return _dedupe_defs_by_code(
+        [d for n, d in _KEA_OPTION_DEFS.items() if n in names],
+        [d for c, d in _KEA_VENDOR_OPTION_DEFS.items() if c in codes],
+    )
+
+
 def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
     """``option-def`` entries required by whatever this render emitted.
 
@@ -81,15 +168,24 @@ def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
     the way in, so subnet, pool, reservation, client-class and global
     option-data are all covered — including any future producer.
     """
-    seen: set[str] = set()
+    seen_names: set[str] = set()
+    seen_codes: set[int] = set()
 
     def _walk(node: Any) -> None:
         if isinstance(node, dict):
             for key, val in node.items():
                 if key == "option-data" and isinstance(val, list):
                     for entry in val:
-                        if isinstance(entry, dict) and entry.get("name") in _KEA_OPTION_DEFS:
-                            seen.add(str(entry["name"]))
+                        if not isinstance(entry, dict):
+                            continue
+                        if entry.get("name") in _KEA_OPTION_DEFS:
+                            seen_names.add(str(entry["name"]))
+                        # #858 — code-addressed vendor options need the same
+                        # treatment; they are emitted by ``code:NN`` keys and
+                        # carry no ``name`` to match on.
+                        code = entry.get("code")
+                        if isinstance(code, int) and code in _KEA_VENDOR_OPTION_DEFS:
+                            seen_codes.add(code)
                 else:
                     _walk(val)
         elif isinstance(node, list):
@@ -97,9 +193,12 @@ def _collect_option_defs(dhcp4: dict[str, Any]) -> list[dict[str, Any]]:
                 _walk(item)
 
     _walk(dhcp4)
-    # Stable order, keyed off ``_KEA_OPTION_DEFS`` (Kea names, the same
-    # namespace as ``seen``) rather than set iteration.
-    return [d for n, d in _KEA_OPTION_DEFS.items() if n in seen]
+    # Stable order, keyed off the definition tables (whose keys share a
+    # namespace with what was collected) rather than set iteration.
+    return _dedupe_defs_by_code(
+        [d for n, d in _KEA_OPTION_DEFS.items() if n in seen_names],
+        [d for c, d in _KEA_VENDOR_OPTION_DEFS.items() if c in seen_codes],
+    )
 
 
 # Map of SpatiumDDI option-name → Kea Dhcp6 ``option-data`` name. DHCPv6

--- a/backend/tests/test_dhcp_wire_bundle_coverage.py
+++ b/backend/tests/test_dhcp_wire_bundle_coverage.py
@@ -1,0 +1,89 @@
+"""#858 — guard against a field being modelled but never shipped to the agent.
+
+This boundary has now produced the same bug four times:
+
+* #430 — scope ``min_lease_time`` / ``max_lease_time`` and static
+  ``client_id`` / ``options_override``: settable, ETag-hashed, read by the
+  agent renderer, omitted from the wire payload.
+* #856 — the option-name half, on the agent's side of the same boundary.
+* #858 — pool ``options_override``, ``pxe_classes`` and ``phone_classes``.
+* #858 — pool ``class_restriction``, shipped but never read by the agent.
+
+Every occurrence is silent: the UI shows the value, the API returns it, the
+ETag moves when it changes so the agent even re-syncs — and the rendered
+config is identical, because the payload never carried it.
+
+So this test asserts that every field on ``ConfigBundle`` is *consciously*
+classified as either shipped to agents or deliberately withheld. Adding a
+field to the dataclass fails here until someone makes that call, which is the
+step all four bugs skipped.
+
+It deliberately does NOT assert *how* a field is serialized — the wire shape
+and the dataclass shape differ on purpose (the wire synthesizes a ``server``
+block, scopes carry a key subset). It asserts only that the decision was made.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+
+from app.drivers.dhcp.base import ConfigBundle
+
+# Fields serialized into the agent wire bundle in
+# ``app/api/v1/dhcp/agents.py``. Adding one here is a claim that the agent
+# receives it; the claim is checked below for the collections that carry
+# per-item state.
+SHIPPED: frozenset[str] = frozenset(
+    {
+        "options",  # → "global_options"
+        "scopes",
+        "client_classes",
+        "pxe_classes",
+        "phone_classes",
+        "mac_blocks",
+        "failover",
+        "dhcp_socket_type",  # → inside the synthesized "server" block
+        "lease_cache_threshold",  # → "server" block (group-wide default)
+        "lease_cache_max_age",  # → "server" block
+        "radvd_conf",
+        "ra_configs",
+    }
+)
+
+# Fields the agent deliberately never receives, each with the reason it is
+# withheld rather than forgotten.
+WITHHELD: dict[str, str] = {
+    "server_id": "the agent knows its own identity from its JWT",
+    "server_name": "display-only; the agent has no use for it",
+    "driver": "the agent IS the driver — it renders Kea by construction",
+    "roles": "control-plane scheduling concern, not daemon config",
+    "generated_at": "debug metadata; excluded from the ETag for the same reason",
+    "etag": "transport-level, carried in the HTTP header not the body",
+}
+
+
+def test_every_config_bundle_field_is_classified() -> None:
+    """A new ConfigBundle field must be shipped or explicitly withheld."""
+    declared = {f.name for f in fields(ConfigBundle)}
+    classified = SHIPPED | set(WITHHELD)
+    unclassified = declared - classified
+    assert not unclassified, (
+        f"ConfigBundle fields {sorted(unclassified)} are neither in SHIPPED nor "
+        "WITHHELD. If the agent needs the field, serialize it in "
+        "app/api/v1/dhcp/agents.py AND read it in the agent's render_kea.py, "
+        "then add it to SHIPPED. If it is control-plane-only, add it to "
+        "WITHHELD with the reason. Skipping this decision is what caused "
+        "#430, #856 and #858."
+    )
+
+
+def test_no_stale_entries_in_the_classification() -> None:
+    """A removed field must not linger here claiming to be shipped."""
+    declared = {f.name for f in fields(ConfigBundle)}
+    stale = (set(SHIPPED) | set(WITHHELD)) - declared
+    assert not stale, f"{sorted(stale)} no longer exist on ConfigBundle"
+
+
+def test_withheld_reasons_are_non_empty() -> None:
+    """A reason is the whole point — an empty one is an unmade decision."""
+    assert all(r.strip() for r in WITHHELD.values())


### PR DESCRIPTION
Fixes [#858](https://github.com/spatiumddi/spatiumddi/issues/858).

Four things the control plane modelled, stored, ETag-hashed and rendered correctly never reached **agent-managed Kea** — which is how both the OS appliance and the Compose stack run DHCP.

Each failed silently, and in the worst way: the UI showed the value, the API returned it, and because the ETag moved when it changed, **agents even re-synced** — then re-rendered byte-identical config.

| | What was wrong |
|---|---|
| Pool `options_override` | Rendered by the control-plane driver, absent from the wire payload, and the agent never read pool options either — unreachable from both ends. |
| `pxe_classes` / `phone_classes` | In the ConfigBundle and in the ETag, but `agents.py` hand-builds its payload and emitted neither; the agent renderer had **zero** references to them. Editing a PXE profile bumped the hash, broke every agent's long-poll, and delivered a payload with no PXE classes — a guaranteed no-op resync of the whole group. |
| Pool `class_restriction` | **Not in the issue.** Shipped on the wire, honoured only for v6 prefix-delegation pools — so a class-restricted *address* pool served every client instead of the class it named. |

## Raw-code options needed more than serialization

Kea does not reject an unknown `code:NN` as undefined — it types it **BINARY**, so an operator's string value fails with `not a valid string of hexadecimal digits` and takes the **whole config** down. But defining every code is equally fatal:

```
unable to override definition of option '66' in standard option space
```

So the definition table is **measured against Kea 3.0.3, not derived**. Each of 43 / 132 / 150 / 160 / 161 / 176 / 242 was confirmed to (a) fail bare with a type-appropriate value and (b) accept the definition given, with types taken from the VoIP catalogue's `kind`.

**The control plane resolves those definitions and ships them on the wire**, because the option catalogues live in the backend package. Giving the agent its own copy of that table is precisely the drift that caused #856.

A raw code is emitted **only** when a matching definition is present, and dropped with a warning otherwise. That bounds the blast radius of a code outside the measured set, and makes the two no-definitions cases — a last-known-good cache written before this change, and an older control plane — degrade to pre-#858 behaviour rather than wedging the daemon at the moment the cache matters most (non-negotiable #5).

## Also fixed on the way

- **Code 150 collision** — the named `tftp-server-address` definition and a raw `code:150` from a Cisco profile both claim code 150, which Kea refuses as a duplicate. Deduped; the named definition wins.
- **PXE `next_server`** is validated as an IPv4 literal. The control plane only checks it is a non-empty string, and Kea rejects the whole config on a hostname; omitting it falls back to the scope value, which is a lease with a wrong boot server rather than no DHCP.
- **v6 raw codes** warn instead of vanishing silently — the shipped definitions declare `space: dhcp4`.

## The part meant to stop the next one

This boundary has now produced the same bug four times (#430, #856, and both halves of #858). `test_dhcp_wire_bundle_coverage.py` asserts every `ConfigBundle` field is consciously classified as **shipped to agents** or **withheld with a reason** — so adding a field fails the suite until someone makes that call. That is the step every previous occurrence skipped.

It deliberately does not assert *how* a field is serialized: the wire and dataclass shapes differ on purpose. It asserts only that the decision was made.

## Verification

One render carrying pool options, a class-restricted pool, a PXE class, phone vendor codes, **an undefined code 999 and a hostname next-server** — both unsafe inputs dropped with warnings, everything else served, and `kea-dhcp4 -t` accepts the config.

124 agent tests + 19 backend tests, plus a 64-test backend DHCP regression run. ruff / black / mypy clean.

## Known limit

Raw codes work for the seven measured codes only; anything else is dropped loudly. Extending that set means **re-measuring with `kea-dhcp4 -t`**, not reasoning about it — the table comment says so.

## Release note

The agent half ships in the **`dhcp-kea` image**, so this needs a new agent image — a control-plane upgrade alone will not change the rendered config. Same caveat as #857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
