### PR TITLE
Emit RFC 9110-valid weak ETags so nginx gzip stops stripping the agent long-poll validator (#862)

### DIFF
--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -28,6 +28,7 @@ from app.core.agent_wake import (
     wake_subscription,
 )
 from app.core.dns_names import sanitize_hostname
+from app.core.http_etag import etag_matches, format_etag
 from app.drivers.dhcp.kea import option_defs_for_option_maps
 from app.models.dhcp import (
     DHCPConfigOp,
@@ -516,18 +517,18 @@ async def agent_config_longpoll(
                     for o in ops_res.scalars().all()
                 ]
 
-            if etag != if_none_match or pending_ops:
+            if not etag_matches(if_none_match, etag) or pending_ops:
                 logger.info(
                     "dhcp_agent_config_200",
                     server_id=str(server.id),
                     etag=etag,
                     if_none_match=if_none_match,
-                    etag_match=(etag == if_none_match),
+                    etag_match=etag_matches(if_none_match, etag),
                     pending_ops=len(pending_ops),
                 )
                 server.config_etag = etag
                 await db.commit()
-                response.headers["ETag"] = etag
+                response.headers["ETag"] = format_etag(etag)
                 return {
                     "server_id": str(server.id),
                     "etag": etag,
@@ -763,7 +764,7 @@ async def agent_config_longpoll(
                 }
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
-                return Response(status_code=304, headers={"ETag": etag})
+                return Response(status_code=304, headers={"ETag": format_etag(etag)})
             await wake.wait(min(WAKE_TICK_SECONDS, remaining))
 
 

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -26,6 +26,7 @@ from app.core.agent_wake import (
     dns_wake_channels,
     wake_subscription,
 )
+from app.core.http_etag import etag_matches, format_etag
 from app.drivers.dns import get_driver as get_dns_driver
 from app.models.audit import AuditLog
 from app.models.dns import (
@@ -360,16 +361,16 @@ async def agent_config_longpoll(
             etag = bundle["etag"]
             # Early return if there are pending ops (fast-path per §3)
             has_pending_ops = bool(bundle.get("pending_record_ops"))
-            if etag != if_none_match or has_pending_ops:
+            if not etag_matches(if_none_match, etag) or has_pending_ops:
                 server.last_config_etag = etag
                 await db.commit()
-                response.headers["ETag"] = etag
+                response.headers["ETag"] = format_etag(etag)
                 return bundle
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
                 response.status_code = 304
-                response.headers["ETag"] = etag
-                return Response(status_code=304, headers={"ETag": etag})
+                response.headers["ETag"] = format_etag(etag)
+                return Response(status_code=304, headers={"ETag": format_etag(etag)})
             await wake.wait(min(WAKE_TICK_SECONDS, remaining))
 
 

--- a/backend/app/api/v1/looking_glass/agents.py
+++ b/backend/app/api/v1/looking_glass/agents.py
@@ -30,6 +30,7 @@ from app.core.agent_wake import (
     looking_glass_wake_channels,
     wake_subscription,
 )
+from app.core.http_etag import etag_matches, format_etag
 from app.models.bgp_looking_glass import BGPLGPeer, LookingGlassCollector
 from app.services.looking_glass.agent_token import (
     hash_token,
@@ -285,14 +286,14 @@ async def agent_config_longpoll(
         while True:
             bundle = await build_lg_config_bundle(db, collector)
             etag = bundle.etag
-            if etag != if_none_match:
+            if not etag_matches(if_none_match, etag):
                 logger.info(
                     "lg_agent_config_200",
                     collector_id=str(collector.id),
                     etag=etag,
                     if_none_match=if_none_match,
                 )
-                response.headers["ETag"] = etag
+                response.headers["ETag"] = format_etag(etag)
                 return {
                     "collector_id": str(collector.id),
                     "etag": etag,
@@ -320,7 +321,7 @@ async def agent_config_longpoll(
                 }
             remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
-                return Response(status_code=304, headers={"ETag": etag})
+                return Response(status_code=304, headers={"ETag": format_etag(etag)})
             await wake.wait(min(WAKE_TICK_SECONDS, remaining))
 
 

--- a/backend/app/core/http_etag.py
+++ b/backend/app/core/http_etag.py
@@ -1,0 +1,87 @@
+"""RFC 9110 entity-tag formatting for the agent long-poll (#862).
+
+The DNS / DHCP / looking-glass agent ``/config`` endpoints are conditional
+long-polls: the server hands back an ETag, the agent echoes it as
+``If-None-Match``, and the request parks on a held 304. That contract ran
+on a validator that was not a valid entity-tag at all.
+
+Two problems, one root cause.
+
+**The value was unquoted.** RFC 9110 §8.8.3 defines
+``entity-tag = [ weak ] opaque-tag`` where ``opaque-tag`` is a
+*quoted-string*, so a bare ``sha256:<hex>`` is malformed. Nothing in our own
+stack objected, which is exactly why it survived — the breakage only appears
+once a conformant intermediary handles it.
+
+**It was strong, so nginx deleted it.** A strong validator asserts
+byte-for-byte identity of the representation, so nginx's gzip filter drops
+it rather than lie about a body it just transformed; only weak validators
+survive the compression pass. The appliance and compose nginx both gzip
+``application/json``, so any client sending ``Accept-Encoding: gzip`` — the
+default for python-requests, and so for third-party agents — got a 200 with
+no ETag at all and nothing to condition the next poll on. Verified live:
+identity → ``sha256:…``, gzip → header absent, and the same request with a
+weak tag → header preserved through the compression.
+
+A weak tag is also the semantically correct answer: gzipped and identity are
+different representations of the same payload, and "semantically equivalent"
+is precisely what ``W/`` means.
+
+The bare ``sha256:<hex>`` stays the *internal* value — it is what the DB
+columns, the bundle body's own ``etag`` field, ``structural_etag`` and the
+agents' on-disk cache all hold. Only the wire representation changes, and
+:func:`etag_matches` accepts every spelling, so an agent still sending the
+old bare form matches on its very first poll after upgrade rather than
+re-downloading a full bundle.
+"""
+
+from __future__ import annotations
+
+__all__ = ["etag_matches", "format_etag"]
+
+
+def format_etag(value: str) -> str:
+    """Return ``value`` as a weak entity-tag suitable for the ETag header.
+
+    Idempotent: a value already carrying the ``W/`` prefix is returned
+    unchanged, so a caller that formats twice can't produce ``W/"W/"…""``.
+    """
+    if value.startswith(("W/", "w/")):
+        return value
+    return f'W/"{value}"'
+
+
+def _unwrap(tag: str) -> str:
+    """Strip the weak prefix and surrounding quotes from one entity-tag.
+
+    Tolerates the bare, unquoted form we used to emit — that is the whole
+    point, since agents cached it and will send it back after an upgrade.
+    """
+    tag = tag.strip()
+    if tag[:2] in ("W/", "w/"):
+        tag = tag[2:]
+    if len(tag) >= 2 and tag.startswith('"') and tag.endswith('"'):
+        tag = tag[1:-1]
+    return tag
+
+
+def etag_matches(if_none_match: str | None, current: str) -> bool:
+    """True when an ``If-None-Match`` header names ``current``.
+
+    ``current`` is the internal bare value. Comparison is weak (RFC 9110
+    §13.1.2 mandates the weak function for ``If-None-Match``), which is what
+    lets a gzipped and an identity response share one tag.
+
+    Handles the three shapes that reach us: the legacy bare value from an
+    agent that has not re-fetched since upgrading, the quoted and weak forms
+    from any conformant client, and a comma-separated list. ``*`` matches
+    anything, per spec — it means "if any representation exists".
+    """
+    if not if_none_match:
+        return False
+    raw = if_none_match.strip()
+    if raw == "*":
+        return True
+    # A comma inside an opaque-tag would be legal but we mint the value
+    # ourselves and it is always ``sha256:<hex>``, so a plain split is safe.
+    return any(_unwrap(part) == current for part in raw.split(",") if part.strip())

--- a/backend/tests/test_http_etag.py
+++ b/backend/tests/test_http_etag.py
@@ -1,0 +1,92 @@
+"""#862 — the agent long-poll's ETag was not a valid entity-tag.
+
+``GET /api/v1/{dns,dhcp,looking-glass}/agents/config`` is a conditional
+long-poll: the server hands back an ETag, the agent echoes it as
+``If-None-Match``, and the request parks on a held 304. That contract ran on
+a bare ``sha256:<hex>`` — unquoted, so malformed per RFC 9110 §8.8.3, and
+*strong*, so nginx's gzip filter deleted it outright rather than lie about a
+body it had just transformed.
+
+Both nginx configs gzip ``application/json``, so any client sending
+``Accept-Encoding: gzip`` (python-requests does by default) got a 200 with
+no ETag and nothing to condition the next poll on. Reproduced live on the
+compose stack before the fix — identity → header present, gzip → header
+absent — and re-run after it with a weak tag, which nginx preserves.
+
+The bare value stays internal; only the wire form changed. These tests pin
+the two halves that makes safe: a valid weak tag out, and every spelling
+accepted back in — so an agent still holding the old bare value matches on
+its first poll after upgrade instead of re-downloading a full bundle.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.http_etag import etag_matches, format_etag
+
+_V = "sha256:200dc207ac9b0d1e931172a7e7d62271425ed33e450606ef5aa73b5483ca817e"
+
+
+# ── Emission ────────────────────────────────────────────────────────────────
+
+
+def test_formats_as_a_weak_quoted_entity_tag() -> None:
+    """Quoted because RFC 9110 requires it; weak because nginx drops a strong
+    validator through gzip, and because gzipped and identity really are
+    different representations of the same payload."""
+    assert format_etag(_V) == f'W/"{_V}"'
+
+
+def test_format_is_idempotent() -> None:
+    """A double-format must not produce ``W/"W/"…""`` — the 304 path and the
+    200 path both format, and a future refactor could route one through the
+    other."""
+    assert format_etag(format_etag(_V)) == f'W/"{_V}"'
+
+
+# ── Matching ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("header", "why"),
+    [
+        (f'W/"{_V}"', "what a conformant client echoes back"),
+        (f'"{_V}"', "strong-quoted, e.g. an intermediary that re-tagged it"),
+        (_V, "THE upgrade case: an agent still holding the old bare value"),
+        (f'  W/"{_V}"  ', "surrounding whitespace is legal"),
+        (f'W/"other", W/"{_V}"', "comma-separated list, ours second"),
+        ("*", "means 'if any representation exists' per spec"),
+    ],
+)
+def test_every_spelling_of_the_current_tag_matches(header: str, why: str) -> None:
+    assert etag_matches(header, _V), why
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        None,
+        "",
+        "   ",
+        'W/"sha256:deadbeef"',
+        'W/"other", "another"',
+        # A prefix must not match: truncation is exactly how a broken
+        # intermediary would corrupt this, and answering 304 to a truncated
+        # tag would park an agent on a bundle it never received.
+        f'W/"{_V[:20]}"',
+    ],
+)
+def test_non_matching_headers_do_not_match(header: str | None) -> None:
+    assert not etag_matches(header, _V)
+
+
+def test_round_trip_through_the_wire_form() -> None:
+    """The property that actually matters: what we emit, we accept."""
+    assert etag_matches(format_etag(_V), _V)
+
+
+def test_bare_round_trip_still_works() -> None:
+    """The pre-#862 wire form must keep matching, or every agent in the fleet
+    re-downloads a full bundle on the first poll after an upgrade."""
+    assert etag_matches(_V, _V)

--- a/charts/spatiumddi/templates/frontend-tls-config.yaml
+++ b/charts/spatiumddi/templates/frontend-tls-config.yaml
@@ -214,5 +214,11 @@ data:
 
         gzip on;
         gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+        # Issue #862 — without this a shared cache between the appliance and a
+        # client can serve a gzipped body to a client that never asked for one,
+        # because nothing in the response says the entity varies by encoding.
+        # It also matters for the agent /config long-poll, whose ETag is now a
+        # weak validator deliberately shared by both encodings.
+        gzip_vary on;
     }
 {{- end }}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -224,6 +224,27 @@ See the loop in `backend/app/api/v1/dns/agents.py`
 (`agent_config_longpoll`). The ETag compare is the **sole source of
 truth** for whether the agent reloads.
 
+> **Wire form of the ETag (#862).** The internal value is a bare
+> `sha256:<hex>` — that is what the DB columns, the bundle body's own
+> `etag` field, `structural_etag` and the agents' on-disk cache all
+> hold. On the wire it is emitted as a **weak, quoted** entity-tag,
+> `W/"sha256:<hex>"`, via `format_etag` in
+> `backend/app/core/http_etag.py`. Two reasons, and both are load-bearing:
+> an unquoted tag is malformed per RFC 9110 §8.8.3, and a *strong* tag is
+> deleted outright by nginx's gzip filter — which cannot honestly assert
+> byte-identity for a body it just compressed. Both the appliance and
+> compose nginx gzip `application/json`, so before this the header simply
+> vanished for any client sending `Accept-Encoding: gzip`. A weak tag is
+> also the semantically correct one: gzipped and identity are different
+> representations of the same payload, which is exactly what `W/` means.
+>
+> Incoming `If-None-Match` is compared with `etag_matches`, which accepts
+> the weak, strong-quoted and legacy-bare spellings plus `*` and
+> comma-separated lists. That tolerance is what stops the whole fleet
+> re-downloading a bundle on the first poll after an upgrade. **Compare
+> with `etag_matches`, never with `==`** — a raw compare re-breaks the
+> conditional poll for every client that normalises the header.
+
 ### Redis wake (#358)
 
 The long-poll no longer blind-polls the DB on a fixed tick. It waits on

--- a/frontend/default.conf.template
+++ b/frontend/default.conf.template
@@ -313,4 +313,10 @@ server {
 
     gzip on;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    # Issue #862 — without this a shared cache between the appliance and a
+    # client can serve a gzipped body to a client that never asked for one,
+    # because nothing in the response says the entity varies by encoding.
+    # It also matters for the agent /config long-poll, whose ETag is now a
+    # weak validator deliberately shared by both encodings.
+    gzip_vary on;
 }


### PR DESCRIPTION
The agent `/config` endpoints are conditional long-polls: the server hands back an ETag, the agent echoes it as `If-None-Match`, and the request parks on a held 304. That contract ran on a bare `sha256:<hex>` — which is not a valid entity-tag at all.

## Two problems, one root cause

**Unquoted.** RFC 9110 §8.8.3 defines `entity-tag = [ weak ] opaque-tag` where `opaque-tag` is a *quoted-string*, so the bare form is malformed. Nothing in our own stack objected, which is exactly why it survived — it only breaks once a conformant intermediary handles it.

**Strong, so nginx deleted it.** A strong validator asserts byte-for-byte identity of the representation, so nginx's gzip filter drops it rather than lie about a body it just transformed. Only weak validators survive the compression pass.

Reproduced on the **compose stack**, not just the appliance the issue reported:

| Accept-Encoding | ETag | Content-Encoding | Vary |
|---|---|---|---|
| `identity` | `sha256:200dc207…` | — | — |
| `gzip` | **absent** | `gzip` | — |

## The fix

A shared `backend/app/core/http_etag.py`:

- **`format_etag`** wraps the value as `W/"sha256:<hex>"` **at the header boundary only**. The bare value stays internal, so the DB columns, the bundle body's own `etag` field, `structural_etag` and the agents' on-disk cache are all untouched. A weak tag is also the semantically correct answer — gzipped and identity genuinely are different representations of the same payload, which is precisely what `W/` means.
- **`etag_matches`** replaces the raw `==` compare and accepts the weak, strong-quoted and **legacy-bare** spellings, plus `*` and comma-separated lists. That tolerance is load-bearing: without it every agent in the fleet re-downloads a full bundle on its first poll after upgrading.

Also adds **`gzip_vary on`** to both nginx configs. That's a separate cache-correctness bug affecting *every* JSON response, not just agent config — without it a shared cache can serve a gzipped body to a client that never asked for one.

## Two corrections to the issue

**Our own agents do not degrade.** The issue states that gzip-accepting agents "silently degrade into an unconditional full-bundle download every poll interval." They don't: all three endpoints also carry the etag in the response body, and both shipped agents read `bundle.get("etag") or resp.headers.get("ETag")` — body first, header only as fallback. The real exposure is third-party agents and standard HTTP tooling, plus the spec violation and the missing `Vary`. Worth stating plainly so nobody goes hunting for a fleet-wide load regression that isn't there.

**There are three affected endpoints, not two.** The issue names DNS and DHCP; `looking_glass/agents.py` has identical code and is fixed here too.

I picked fix shape 1 (weak ETag) over shape 2 (`gzip off` for those locations) because a config bundle is the largest response an agent ever fetches, and turning off compression on exactly that payload is a bad trade for remote agents over a WAN. Shape 1 keeps compression *and* fixes the header.

## Verified live, not just unit-tested

Before building on the issue's premise I confirmed nginx actually preserves a weak validator through gzip. It does. After the fix, through nginx:

```
Accept-Encoding: identity  ->  200  Vary: Accept-Encoding  etag: W/"sha256:200dc207…"
Accept-Encoding: gzip      ->  200  Vary: Accept-Encoding  etag: W/"sha256:200dc207…"  Content-Encoding: gzip
```

And the conditional poll actually parks:

```
weak (what we now emit)                        -> HTTP 304  after 30s
strong-quoted (intermediary re-tag)            -> HTTP 304  after 30s
BARE (pre-upgrade agent, must not re-download) -> HTTP 304  after 30s
stale tag (must return 200, not 304)           -> HTTP 200  after 1s
```

Both real agents reconnect and sit on 304s. 16 new unit tests, 68 existing agent/long-poll/looking-glass tests still green, `make ci` clean.

## One thing I deliberately left alone

`dns/agents.py` has two pre-existing dead lines before its 304 return (`response.status_code` / `response.headers` are superseded by the explicit `Response(...)`). I edited one of them but didn't remove them — FastAPI's header-merge behaviour for an injected `Response` alongside a returned one isn't something I wanted to change blind inside a bug fix. Worth a separate tidy.

Closes #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)
