### PR TITLE
fix(dhcp): adopt-existing retry in the scope modal — end the FortiGate create dead end (#865)

### DIFF
--- a/backend/app/api/v1/dhcp/scopes.py
+++ b/backend/app/api/v1/dhcp/scopes.py
@@ -632,8 +632,19 @@ async def _assert_no_overlapping_group_cidr(
     status_code=status.HTTP_201_CREATED,
 )
 async def create_scope(
-    subnet_id: uuid.UUID, body: ScopeCreate, db: DB, user: SuperAdmin
+    subnet_id: uuid.UUID,
+    body: ScopeCreate,
+    db: DB,
+    user: SuperAdmin,
+    adopt_existing: bool = False,
 ) -> ScopeResponse:
+    """Create a scope.
+
+    ``adopt_existing`` (cloud/FortiGate members only, #865) opts in to
+    overwriting a pre-existing provider DHCP object SpatiumDDI never created;
+    without it the pre-commit push 409s (``X-Adoption-Required``) and the
+    create rolls back, so the UI can offer an adopt-and-retry.
+    """
     subnet = await db.get(Subnet, subnet_id)
     if subnet is None:
         raise HTTPException(status_code=404, detail="Subnet not found")
@@ -731,7 +742,7 @@ async def create_scope(
         ) from exc
     # Push to every Windows DHCP member of the group BEFORE commit so a
     # WinRM failure rolls the DB row back.
-    await push_scope_upsert(db, scope)
+    await push_scope_upsert(db, scope, adopt_existing=adopt_existing)
     collect_wake(dhcp_group_channel(group_id))
     write_audit(
         db,
@@ -757,8 +768,15 @@ async def get_scope(scope_id: uuid.UUID, db: DB, _: CurrentUser) -> ScopeRespons
 
 @router.put("/scopes/{scope_id}", response_model=ScopeResponse)
 async def update_scope(
-    scope_id: uuid.UUID, body: ScopeUpdate, db: DB, user: SuperAdmin
+    scope_id: uuid.UUID,
+    body: ScopeUpdate,
+    db: DB,
+    user: SuperAdmin,
+    adopt_existing: bool = False,
 ) -> ScopeResponse:
+    # ``adopt_existing``: same opt-in as create (#865) — an edit of a scope
+    # whose interface carries a foreign provider object hits the same
+    # adoption guard on the pre-commit push.
     scope = await db.get(DHCPScope, scope_id)
     if scope is None:
         raise HTTPException(status_code=404, detail="Scope not found")
@@ -827,7 +845,7 @@ async def update_scope(
     for k, v in changes.items():
         setattr(scope, k, v)
     await db.flush()
-    await push_scope_upsert(db, scope)
+    await push_scope_upsert(db, scope, adopt_existing=adopt_existing)
     collect_wake(dhcp_group_channel(scope.group_id))
     write_audit(
         db,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -780,10 +780,14 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
         # Custom response headers the browser must be allowed to read via
         # fetch(). ``X-Total-Count`` backs server-side pagination on the IPAM
-        # address list + cross-subnet search (issues #517 / #520). Without
-        # this the header is present on the wire but the JS layer can't read
-        # it under CORS.
-        expose_headers=["X-Total-Count"],
+        # address list + cross-subnet search (issues #517 / #520);
+        # ``X-Adoption-Required`` marks the cloud-driver adoption 409 so the
+        # scope modal can offer an adopt-and-retry instead of the generic
+        # error (#865). Without this the header is present on the wire but
+        # the JS layer can't read it under CORS — for a cross-origin
+        # frontend the feature would silently degrade to the dead end it
+        # fixes.
+        expose_headers=["X-Total-Count", "X-Adoption-Required"],
     )
 
     # SECURITY (#400 / L3): Host-header allow-list. Added LAST so — given

--- a/backend/app/services/dhcp/cloud_writethrough.py
+++ b/backend/app/services/dhcp/cloud_writethrough.py
@@ -44,10 +44,14 @@ class CloudAdoptionRequired(HTTPException):
     The operator must opt in (``adopt_existing``) to take it over. Distinct
     from :class:`CloudPushError` so the UI can offer an adopt-and-retry action
     instead of treating it as a transient provider failure.
+
+    Carries ``X-Adoption-Required: true`` so clients can tell this 409 apart
+    from other conflicts on the same endpoint (scope create also 409s on a
+    duplicate group+subnet, where an adopt-retry would be wrong) — #865.
     """
 
     def __init__(self, detail: str) -> None:
-        super().__init__(status_code=409, detail=detail)
+        super().__init__(status_code=409, detail=detail, headers={"X-Adoption-Required": "true"})
 
 
 async def cloud_servers_for_group(db: AsyncSession, group_id: Any) -> list[DHCPServer]:

--- a/backend/app/services/dhcp/windows_writethrough.py
+++ b/backend/app/services/dhcp/windows_writethrough.py
@@ -121,17 +121,24 @@ async def _scope_range(
     return str(hosts[0]), str(hosts[-1])
 
 
-async def push_scope_upsert(db: AsyncSession, scope: DHCPScope) -> None:
+async def push_scope_upsert(
+    db: AsyncSession, scope: DHCPScope, *, adopt_existing: bool = False
+) -> None:
     """Push a scope create/update to every agentless member of the scope's group.
 
     Windows members take a per-object ``apply_scope``; agentless cloud/REST
     members (FortiGate) take the whole ``system.dhcp.server`` object rebuilt
     from DB (see ``cloud_writethrough``). Both run before commit so a push
     failure surfaces as a 502 and rolls back.
+
+    ``adopt_existing`` (cloud members only, #865) opts in to overwriting a
+    provider DHCP object SpatiumDDI never created; without it such a push
+    raises ``CloudAdoptionRequired`` (409) and the caller's transaction rolls
+    back. Windows members have no equivalent guard, so the flag stops here.
     """
     # Cloud/REST members first — independent of, and not gated by, the Windows
     # early-return below (a cloud-only group has no Windows members).
-    await push_cloud_scope_upsert(db, scope)
+    await push_cloud_scope_upsert(db, scope, adopt_existing=adopt_existing)
 
     win_servers = await _windows_servers_for_group(db, scope.group_id)
     if not win_servers:

--- a/backend/tests/test_dhcp_fortigate_agentless_member.py
+++ b/backend/tests/test_dhcp_fortigate_agentless_member.py
@@ -260,3 +260,105 @@ async def test_real_upsert_persists_provider_ref(
     assert post["json"]["reserved-address"][0]["ip"] == "10.88.0.10"
     # …and the FortiOS mkey is recorded as this scope+server's ownership marker.
     assert scope.provider_refs == {str(server.id): {"mkey": 9, "interface": "port2"}}
+
+
+async def test_scope_create_adoption_409_then_adopt_retry(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#865 — the scope-create dead end. A create whose pre-commit push hits
+    the adoption guard must 409 with the ``X-Adoption-Required`` marker (so the
+    modal can tell it apart from the duplicate-scope 409) and roll the scope
+    back; retrying with ``?adopt_existing=true`` threads the flag through
+    ``push_scope_upsert`` to the cloud push and persists the scope."""
+    from app.services.dhcp.cloud_writethrough import CloudAdoptionRequired
+
+    user, scope = await _setup(db_session)
+    subnet1 = await db_session.get(Subnet, scope.subnet_id)
+    assert subnet1 is not None
+    group_id = scope.group_id
+    # A second subnet with no scope yet — the create target.
+    subnet2 = Subnet(
+        space_id=subnet1.space_id,
+        block_id=subnet1.block_id,
+        name="s2",
+        network="10.89.0.0/24",
+    )
+    db_session.add(subnet2)
+    await db_session.flush()
+    subnet2_id = subnet2.id
+    await db_session.commit()
+
+    adopt_flags: list[bool] = []
+
+    async def _stub(db: AsyncSession, sc: DHCPScope, **kw: object) -> None:
+        adopt = bool(kw.get("adopt_existing"))
+        adopt_flags.append(adopt)
+        if not adopt:
+            raise CloudAdoptionRequired(
+                "A DHCP server already exists on FortiGate interface 'port2' "
+                "that SpatiumDDI did not create."
+            )
+
+    monkeypatch.setattr("app.services.dhcp.windows_writethrough.push_cloud_scope_upsert", _stub)
+
+    hdrs = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    body = {"group_id": str(group_id), "name": "vlan30"}
+
+    resp = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet2_id}/dhcp-scopes", json=body, headers=hdrs
+    )
+    assert resp.status_code == 409, resp.text
+    assert resp.headers.get("x-adoption-required") == "true"
+    # The create rolled back — no half-persisted scope for Force Sync to find.
+    # (The test client shares this session and skips the per-request
+    # ``session.close()`` the real ``get_db`` does, so discard the pending
+    # flush the same way close would before checking what was persisted.)
+    await db_session.rollback()
+    orphan = (
+        (await db_session.execute(select(DHCPScope).where(DHCPScope.subnet_id == subnet2_id)))
+        .unique()
+        .scalar_one_or_none()
+    )
+    assert orphan is None
+
+    resp = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet2_id}/dhcp-scopes?adopt_existing=true",
+        json=body,
+        headers=hdrs,
+    )
+    assert resp.status_code == 201, resp.text
+    assert adopt_flags == [False, True]
+
+    # The duplicate-scope 409 must NOT carry the adoption marker — an
+    # adopt-retry there would be wrong, and the modal keys on the header.
+    resp = await client.post(
+        f"/api/v1/dhcp/subnets/{subnet2_id}/dhcp-scopes", json=body, headers=hdrs
+    )
+    assert resp.status_code == 409
+    assert resp.headers.get("x-adoption-required") is None
+
+
+async def test_scope_update_threads_adopt_existing(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#865 — the edit/activation path hits the same guard, so update accepts
+    the same opt-in and forwards it to the cloud push."""
+    user, scope = await _setup(db_session)
+    scope_id = scope.id
+    await db_session.commit()
+
+    adopt_flags: list[bool] = []
+
+    async def _stub(db: AsyncSession, sc: DHCPScope, **kw: object) -> None:
+        adopt_flags.append(bool(kw.get("adopt_existing")))
+
+    monkeypatch.setattr("app.services.dhcp.windows_writethrough.push_cloud_scope_upsert", _stub)
+
+    hdrs = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    resp = await client.put(
+        f"/api/v1/dhcp/scopes/{scope_id}?adopt_existing=true",
+        json={"description": "adopted"},
+        headers=hdrs,
+    )
+    assert resp.status_code == 200, resp.text
+    assert adopt_flags == [True]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -7897,12 +7897,28 @@ export const dhcpApi = {
       .then((r) => r.data),
   getScope: (id: string) =>
     api.get<DHCPScope>(`/dhcp/scopes/${id}`).then((r) => r.data),
-  createScope: (subnetId: string, data: Partial<DHCPScope>) =>
+  // `adoptExisting` (cloud/FortiGate groups only, #865) opts in to
+  // overwriting a provider DHCP object SpatiumDDI never created; without it
+  // such a save 409s with an X-Adoption-Required header (see
+  // isAdoptionRequired) so the modal can offer an adopt-and-retry.
+  createScope: (
+    subnetId: string,
+    data: Partial<DHCPScope>,
+    adoptExisting = false,
+  ) =>
     api
-      .post<DHCPScope>(`/dhcp/subnets/${subnetId}/dhcp-scopes`, data)
+      .post<DHCPScope>(
+        `/dhcp/subnets/${subnetId}/dhcp-scopes${adoptExisting ? "?adopt_existing=true" : ""}`,
+        data,
+      )
       .then((r) => r.data),
-  updateScope: (id: string, data: Partial<DHCPScope>) =>
-    api.put<DHCPScope>(`/dhcp/scopes/${id}`, data).then((r) => r.data),
+  updateScope: (id: string, data: Partial<DHCPScope>, adoptExisting = false) =>
+    api
+      .put<DHCPScope>(
+        `/dhcp/scopes/${id}${adoptExisting ? "?adopt_existing=true" : ""}`,
+        data,
+      )
+      .then((r) => r.data),
   // #62: returns the full axios response (may be 202 queued-for-approval —
   // see ipamApi.deleteSpace). Do NOT add ``.then((r) => r.data)``.
   deleteScope: (id: string) => api.delete(`/dhcp/scopes/${id}`),

--- a/frontend/src/pages/dhcp/CreateScopeModal.tsx
+++ b/frontend/src/pages/dhcp/CreateScopeModal.tsx
@@ -7,7 +7,14 @@ import {
   type DHCPScope,
   type DHCPOption,
 } from "@/lib/api";
-import { Modal, Field, Btns, inputCls, errMsg } from "./_shared";
+import {
+  Modal,
+  Field,
+  Btns,
+  inputCls,
+  errMsg,
+  isAdoptionRequired,
+} from "./_shared";
 import { DHCPOptionsEditor } from "./DHCPOptionsEditor";
 
 // Suggest a dynamic pool range for a v4 subnet: skip the first 10 hosts
@@ -135,6 +142,11 @@ export function CreateScopeModal({
   const [poolStart, setPoolStart] = useState("");
   const [poolEnd, setPoolEnd] = useState("");
   const [error, setError] = useState("");
+  // 409 + X-Adoption-Required from a cloud (FortiGate) group member: a DHCP
+  // server already exists on the interface that SpatiumDDI didn't create
+  // (#865). Holds the provider detail so we can offer an adopt-and-retry —
+  // the save is always attempted WITHOUT the flag first.
+  const [adoptConflict, setAdoptConflict] = useState<string | null>(null);
 
   const { data: subnets = [] } = useQuery({
     queryKey: ["subnets"],
@@ -242,7 +254,7 @@ export function CreateScopeModal({
   }, [editing, prefilled, settings, subnetDetail]);
 
   const mut = useMutation({
-    mutationFn: () => {
+    mutationFn: (adoptExisting: boolean) => {
       const parsedLeaseTime = parseInt(leaseTime, 10) || 86400;
       const parsedMinLease = minLease ? parseInt(minLease, 10) : null;
       const parsedMaxLease = maxLease ? parseInt(maxLease, 10) : null;
@@ -346,18 +358,20 @@ export function CreateScopeModal({
       } else if (editing && scope?.pxe_profile_id) {
         data.clear_pxe_profile = true;
       }
-      if (editing) return dhcpApi.updateScope(scope!.id, data);
-      return dhcpApi.createScope(subnetId, data).then(async (created) => {
-        if (poolStart && poolEnd) {
-          await dhcpApi.createPool(created.id, {
-            name: "default",
-            start_ip: poolStart,
-            end_ip: poolEnd,
-            pool_type: "dynamic",
-          });
-        }
-        return created;
-      });
+      if (editing) return dhcpApi.updateScope(scope!.id, data, adoptExisting);
+      return dhcpApi
+        .createScope(subnetId, data, adoptExisting)
+        .then(async (created) => {
+          if (poolStart && poolEnd) {
+            await dhcpApi.createPool(created.id, {
+              name: "default",
+              start_ip: poolStart,
+              end_ip: poolEnd,
+              pool_type: "dynamic",
+            });
+          }
+          return created;
+        });
     },
     onSuccess: () => {
       // Invalidate every shape of the scope query so the DHCP page
@@ -378,7 +392,19 @@ export function CreateScopeModal({
       }
       onClose();
     },
-    onError: (e) => setError(errMsg(e, "Failed to save scope")),
+    onError: (e) => {
+      if (isAdoptionRequired(e)) {
+        // Don't show the generic error too — the banner carries the detail
+        // plus the retry action.
+        setAdoptConflict(
+          errMsg(e, "A DHCP server already exists on the interface."),
+        );
+        setError("");
+      } else {
+        setAdoptConflict(null);
+        setError(errMsg(e, "Failed to save scope"));
+      }
+    },
   });
 
   return (
@@ -390,7 +416,9 @@ export function CreateScopeModal({
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          mut.mutate();
+          // Always try without adopting first; the 409 banner below offers
+          // the explicit adopt-and-retry (#865).
+          mut.mutate(false);
         }}
         className="space-y-3"
       >
@@ -851,6 +879,28 @@ export function CreateScopeModal({
         />
 
         {error && <p className="text-xs text-destructive">{error}</p>}
+        {adoptConflict && (
+          <div className="flex items-center justify-between gap-2 rounded border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+            <span>{adoptConflict}</span>
+            <div className="flex flex-shrink-0 gap-1.5">
+              <button
+                type="button"
+                onClick={() => mut.mutate(true)}
+                disabled={mut.isPending}
+                className="rounded-md border border-amber-500/50 bg-amber-500/10 px-2.5 py-1 font-medium hover:bg-amber-500/20 disabled:opacity-50"
+              >
+                Adopt existing &amp; save
+              </button>
+              <button
+                type="button"
+                onClick={() => setAdoptConflict(null)}
+                className="rounded border px-1.5 py-0.5 text-[10px] hover:bg-accent"
+              >
+                dismiss
+              </button>
+            </div>
+          </div>
+        )}
         <Btns onClose={onClose} pending={mut.isPending} />
       </form>
     </Modal>

--- a/frontend/src/pages/dhcp/_shared.tsx
+++ b/frontend/src/pages/dhcp/_shared.tsx
@@ -79,6 +79,22 @@ export function errMsg(e: unknown, fallback = "Request failed"): string {
   return fallback;
 }
 
+// True when the error is the cloud-driver adoption conflict (#865): a push
+// would overwrite a provider DHCP object SpatiumDDI never created. The
+// backend marks these 409s with X-Adoption-Required so they're
+// distinguishable from other conflicts (e.g. duplicate group+subnet) where
+// an adopt-retry would be wrong. Axios lower-cases response header names.
+// eslint-disable-next-line react-refresh/only-export-components
+export function isAdoptionRequired(e: unknown): boolean {
+  const ae = e as {
+    response?: { status?: number; headers?: Record<string, unknown> };
+  };
+  return (
+    ae?.response?.status === 409 &&
+    String(ae.response.headers?.["x-adoption-required"] ?? "") === "true"
+  );
+}
+
 /** Shared destructive-confirm modal (single-step with optional references block). */
 export function DeleteConfirmModal({
   title,


### PR DESCRIPTION
Fixes #865.

### Problem

Creating a scope in a group with a FortiGate member pushes to the device **before commit**; when the matching interface already carries a DHCP-server object SpatiumDDI didn't create, the #630 adoption guard raises `CloudAdoptionRequired` (409) and the create **rolls back**. The only adopt affordance — *Adopt existing & sync* on the server detail page — needs a persisted scope to push, so the conflict could never be resolved from the UI (workaround: detach the server from the group, create the scope, re-attach, Force Sync + adopt).

A second problem hid underneath: the adoption 409 was indistinguishable from the duplicate group+subnet 409 (both plain string `detail`s), so a client couldn't safely decide when an adopt-retry is appropriate.

### Change

**Backend**
- `POST /dhcp/subnets/{id}/dhcp-scopes` and `PUT /dhcp/scopes/{id}` accept `?adopt_existing=true`, threaded through `push_scope_upsert` → `push_cloud_scope_upsert` (cloud members only — Windows has no adoption guard, so the flag stops at the seam).
- `CloudAdoptionRequired` responses now carry `X-Adoption-Required: true`, keeping `detail` a plain string (the existing Force Sync banner keeps working unchanged) while giving clients a stable marker.

**Frontend**
- The scope modal always tries the save **without** the flag first. On an adoption 409 (detected via the header — `isAdoptionRequired` in `pages/dhcp/_shared.tsx`) it shows the provider detail in an amber banner with an **"Adopt existing & save"** retry that re-submits with `adopt_existing=true`, mirroring the server page's Force Sync banner. Every other error renders exactly as before.

Adoption semantics are unchanged from #630: the existing FortiOS object is taken over in place (same mkey, child-table ids reconciled — no delete/recreate, leases untouched) and ownership lands in `scope.provider_refs`, so later edits never re-adopt.

### Tests

`backend/tests/test_dhcp_fortigate_agentless_member.py`:
- create → 409 with the header, and the scope row rolled back (no half-persisted state);
- retry with `?adopt_existing=true` → 201, flag observed at the cloud push (`[False, True]`);
- duplicate-scope 409 does **not** carry the header (adopt-retry would be wrong there);
- update path threads the flag too.

Ran serially in the dev container per project guidance: 7/7 in the file, 68 passed across the neighbouring scope/write-through suites, ruff + black + mypy clean, frontend tsc + eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GtVkdCbknnwHaRJTfhCpHU
