### PR TITLE
fix(dns-agent): rendered PowerDNS config stops leaking its credentials (#869)

### DIFF
--- a/agent/dns/spatium_dns_agent/admin_pusher.py
+++ b/agent/dns/spatium_dns_agent/admin_pusher.py
@@ -22,6 +22,7 @@ them, and a transient 5xx just gets retried on the next tick.
 from __future__ import annotations
 
 import random
+import re
 import shutil
 import subprocess
 import threading
@@ -39,6 +40,48 @@ log = structlog.get_logger(__name__)
 # aren't meaningful for the operator (binary state, locks, etc).
 _SKIP_FILE_NAMES: frozenset[str] = frozenset()
 _RENDERED_DIR_NAME = "rendered"
+
+_REDACTED = "***REDACTED***"
+
+# Credentials that appear INSIDE rendered config, which this module uploads
+# to the control plane (#869). Making the files 0600 on disk protects them
+# from other uids on the appliance and does nothing about this path — the
+# snapshot is stored server-side and served back over the API, so an
+# unredacted push puts the pdns REST api-key and the TSIG secrets that
+# authorise dynamic updates into the database and onto any screen allowed to
+# read them. The PowerDNS driver's own comment asserts these "never leave the
+# appliance"; that is only true with this redaction in place.
+#
+# Regex rather than a JSON/config parse on purpose: this runs over whatever
+# a driver happens to have rendered, and a parse failure must not be the
+# thing standing between a secret and the wire. A pattern that over-matches
+# costs an operator some debugging context; one that under-matches leaks a
+# credential.
+_REDACTIONS: tuple[re.Pattern[str], ...] = (
+    # pdns.conf: ``api-key=<value>`` (also covers any ``*-key=`` setting).
+    re.compile(r"(?im)^([ \t]*[\w.-]*api-key[ \t]*=[ \t]*).+$"),
+    # zones.json: ``"secret": "<value>"`` anywhere in the tree.
+    re.compile(r'(?i)("secret"[ \t]*:[ \t]*")[^"]*(")'),
+    # BIND-style ``secret "<value>";`` — nothing renders this into the
+    # pushed tree today (named.conf includes the key file rather than
+    # inlining it), which is exactly why it is cheap to guard now.
+    re.compile(r'(?i)(\bsecret[ \t]+")[^"]*(")'),
+)
+
+
+def redact_secrets(content: str) -> str:
+    """Mask credential values in a rendered-config file before upload.
+
+    Values only — the surrounding key/setting name is preserved so the
+    operator can still see THAT an api-key or TSIG secret is configured,
+    which is usually the question they opened the snapshot to answer.
+    """
+    for pattern in _REDACTIONS:
+        if pattern.groups == 2:
+            content = pattern.sub(rf"\1{_REDACTED}\2", content)
+        else:
+            content = pattern.sub(rf"\1{_REDACTED}", content)
+    return content
 
 
 def _cp_client(cfg: AgentConfig) -> httpx.Client:
@@ -68,7 +111,10 @@ def _walk_rendered(rendered_dir: Path) -> Iterable[tuple[str, str]]:
         except UnicodeDecodeError:
             continue
         rel = path.relative_to(rendered_dir).as_posix()
-        yield rel, content
+        # Redact on the way OUT of the appliance, not at the call site — this
+        # generator is the single chokepoint every pushed file passes through,
+        # so a future caller can't accidentally bypass it (#869).
+        yield rel, redact_secrets(content)
 
 
 def push_rendered_config(cfg: AgentConfig, token: str) -> None:

--- a/agent/dns/spatium_dns_agent/drivers/powerdns.py
+++ b/agent/dns/spatium_dns_agent/drivers/powerdns.py
@@ -47,6 +47,7 @@ from ._process import (
     wait_for_daemon,
 )
 from .base import RRSET_OP_KINDS, DriverBase
+from ..secure_io import harden_mode, write_private
 
 log = structlog.get_logger(__name__)
 
@@ -195,6 +196,27 @@ def _dnsdist_cert_paths() -> tuple[str, str]:
     return f"{base}/{TLS_CERT_FILENAME}", f"{base}/{TLS_KEY_FILENAME}"
 
 
+# Files inside the rendered tree that embed a credential and therefore need
+# 0600 + redaction before the snapshot pusher ships them (#869). Keep this in
+# step with anything new that render() writes under ``rendered.new``.
+_SECRET_RENDERED_FILES: tuple[str, ...] = ("pdns.conf", "zones.json")
+
+
+def _harden_legacy_rendered_modes(state_dir: Path) -> None:
+    """Fix 0644 secret files left by a pre-#869 agent build.
+
+    Upgrading the agent does not re-mode what is already on disk: the live
+    ``rendered/`` tree survives until the next structural render replaces it,
+    and then lingers as ``rendered.prev/`` for one more cycle. Without this,
+    a still-valid API key and TSIG secrets stay world-readable for two
+    renders' worth of uptime after the fix ships — on a stable install, that
+    could be indefinitely.
+    """
+    for tree in ("rendered", "rendered.prev"):
+        for name in _SECRET_RENDERED_FILES:
+            harden_mode(state_dir / tree / name)
+
+
 def render_dnsdist_conf(opts: dict[str, Any], has_cert: bool = False) -> str:
     """Render the dnsdist RULES + encrypted listeners from bundle options.
 
@@ -279,6 +301,10 @@ class PowerDNSDriver(DriverBase):
         editing options through the UI (loglevel, listen address) see
         the change without restarting the container.
         """
+        # Re-mode anything a pre-#869 build left world-readable before we
+        # render over it — the old trees outlive the upgrade (see the helper).
+        _harden_legacy_rendered_modes(self.state_dir)
+
         new_dir = self.state_dir / "rendered.new"
         if new_dir.exists():
             shutil.rmtree(new_dir)
@@ -312,13 +338,25 @@ class PowerDNSDriver(DriverBase):
         if alias_resolver is None:
             alias_resolver = "1.1.1.1,8.8.8.8"
         conf_path = new_dir / "pdns.conf"
-        conf_path.write_text(
+        # 0600, not write_text: this file embeds ``api-key=`` in cleartext,
+        # and that key grants zone CRUD + DNSSEC over the pdns REST API
+        # (#869). ``pdns_server`` and the dnsdist front both run as uid 101,
+        # the same owner, so the owner bit is all either of them needs —
+        # what 0600 removes is group/other, i.e. any OTHER uid that can see
+        # this path (a differently-run sidecar, a host bind-mount, a future
+        # image that stops running everything as 101).
+        # ``atomic=False``: this lands in a freshly-created ``rendered.new``
+        # that no reader can see; the directory rename in swap_and_reload is
+        # the atomic step.
+        write_private(
+            conf_path,
             self._render_conf(
                 api_key=api_key,
                 log_level=log_level,
                 query_log_enabled=query_log_enabled,
                 alias_resolver=str(alias_resolver),
-            )
+            ),
+            atomic=False,
         )
 
         # dnsdist rate-limit RULES (issue #146 Phase 2). Written to a STABLE
@@ -470,7 +508,16 @@ class PowerDNSDriver(DriverBase):
                 ),
             )
 
-        (new_dir / "zones.json").write_text(json.dumps(zones_payload, indent=2))
+        # 0600 for the same reason as pdns.conf (#869), and this one is not
+        # obvious: ``update_tsig_keys`` carries whole key dicts including
+        # ``secret`` (see ``_ensure_tsigkey``), so zones.json holds the TSIG
+        # material that authorises dynamic updates. CodeQL flagged only
+        # pdns.conf; this file was the same defect one write call away.
+        write_private(
+            new_dir / "zones.json",
+            json.dumps(zones_payload, indent=2),
+            atomic=False,
+        )
 
     def _write_listener_cert(self, tls_cert: dict[str, Any] | None) -> None:
         """Write (or remove) the DoT/DoH listener cert for the dnsdist front.
@@ -501,16 +548,7 @@ class PowerDNSDriver(DriverBase):
             (TLS_CERT_FILENAME, str(tls_cert.get("cert_pem") or "")),
             (TLS_KEY_FILENAME, str(tls_cert.get("key_pem") or "")),
         ):
-            dest = tls_dir / filename
-            tmp = dest.with_suffix(dest.suffix + ".new")
-            fd = os.open(
-                str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600
-            )
-            try:
-                os.write(fd, material.encode())
-            finally:
-                os.close(fd)
-            tmp.replace(dest)
+            write_private(tls_dir / filename, material)
 
     def validate(self) -> None:
         """``pdns_server --config-check`` if the binary supports it.
@@ -1157,20 +1195,9 @@ class PowerDNSDriver(DriverBase):
                     "be running with the original value."
                 ) from exc
         key = secrets.token_urlsafe(32)
-        tmp = path.with_suffix(path.suffix + ".new")
-        # Open with O_NOFOLLOW + mode 0600 so the file lands with
-        # the right permissions on creation (no race window between
-        # write + chmod where the file is world-readable).
-        fd = os.open(
-            str(tmp),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
-            0o600,
-        )
-        try:
-            os.write(fd, (key + "\n").encode())
-        finally:
-            os.close(fd)
-        tmp.replace(path)
+        # Shared primitive (#869): 0600 at creation via O_NOFOLLOW, complete
+        # write, atomic replace. Was open-coded here; the copies had drifted.
+        write_private(path, key + "\n")
         return key
 
     def _render_conf(

--- a/agent/dns/spatium_dns_agent/drivers/technitium.py
+++ b/agent/dns/spatium_dns_agent/drivers/technitium.py
@@ -70,6 +70,7 @@ import structlog
 
 from ._process import find_running_daemon, is_zombie
 from .base import RRSET_OP_KINDS, DriverBase
+from ..secure_io import write_private
 
 log = structlog.get_logger(__name__)
 
@@ -1846,15 +1847,12 @@ class TechnitiumDriver(DriverBase):
 
     @staticmethod
     def _write_secret(path: Path, value: str) -> None:
-        tmp = path.with_suffix(path.suffix + ".new")
-        fd = os.open(
-            str(tmp), os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600
-        )
-        try:
-            os.write(fd, (value + "\n").encode())
-        finally:
-            os.close(fd)
-        tmp.replace(path)
+        """0600 + atomic, via the shared primitive (#869).
+
+        The trailing newline is part of this store's format —
+        ``_read_or_create_secret`` strips it on the way back out.
+        """
+        write_private(path, value + "\n")
 
     def _read_or_create_secret(self, path: Path) -> str:
         if path.exists():

--- a/agent/dns/spatium_dns_agent/secure_io.py
+++ b/agent/dns/spatium_dns_agent/secure_io.py
@@ -1,0 +1,95 @@
+"""One correct way to put a secret on disk (issue #869).
+
+Four copies of the same ``os.open(O_NOFOLLOW, 0o600)`` incantation had grown
+across the drivers — the PowerDNS API-key store, the DoT/DoH listener key,
+Technitium's token store, and (briefly) the rendered-config writer. They
+agreed on the mode and disagreed on everything else: only three did the
+tmp+``replace`` dance, and none of them checked how many bytes ``os.write``
+actually wrote.
+
+Both properties are load-bearing:
+
+* **Mode at creation.** ``write_text`` + ``chmod`` leaves a window where the
+  file exists at the umask default (0644) with the secret already in it; a
+  crash in that window leaves it there permanently. ``O_NOFOLLOW`` additionally
+  refuses to follow a symlink planted at the destination.
+* **Atomic replace.** A reader (``pdns_server``, the dnsdist front, the agent
+  itself after a restart) must never observe a half-written secret file. The
+  content lands on a sibling tmp path and is renamed into place, which is
+  atomic within a filesystem.
+* **Complete write.** ``os.write`` is not obliged to write everything it is
+  given; on ENOSPC/EDQUOT it returns a short count rather than raising. The
+  loop below turns a partial write into an ``OSError``, because the callers'
+  error handling assumes a failed write raises — a silently truncated config
+  is worse than no config, since downstream code parses it and gives up.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+__all__ = ["write_private", "harden_mode"]
+
+_SECRET_MODE = 0o600
+
+
+def _write_all(fd: int, payload: bytes) -> None:
+    """``os.write`` until the buffer is drained, or raise.
+
+    A short write means the filesystem could not take the rest (out of space
+    or over quota). Raising here is deliberate: every caller's contract is
+    "this raises on failure", and the sync loops upstream rely on the
+    exception propagating so they do not advance their etag past a config
+    that was never fully written.
+    """
+    written = 0
+    while written < len(payload):
+        n = os.write(fd, payload[written:])
+        if n <= 0:
+            raise OSError(
+                f"short write: {written} of {len(payload)} bytes "
+                "(filesystem full or over quota?)"
+            )
+        written += n
+
+
+def write_private(path: Path, text: str, *, atomic: bool = True) -> None:
+    """Write ``text`` to ``path`` as 0600, atomically, or raise.
+
+    ``atomic=False`` writes in place — only for a destination inside a
+    freshly-created staging directory that no reader can see yet, where the
+    directory rename is already the atomic step.
+    """
+    payload = text.encode()
+    target = path.with_suffix(path.suffix + ".new") if atomic else path
+    fd = os.open(
+        str(target),
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+        _SECRET_MODE,
+    )
+    try:
+        _write_all(fd, payload)
+    finally:
+        os.close(fd)
+    if atomic:
+        target.replace(path)
+
+
+def harden_mode(path: Path) -> None:
+    """Force 0600 on a file that already exists, if it exists.
+
+    Remediation for files written by an OLDER agent build before the secret
+    ever went through :func:`write_private`. An upgrade alone does not fix
+    what is already on disk: the previous render survives as ``rendered/``
+    until the next structural change replaces it, and then as
+    ``rendered.prev/`` after that — so a still-live credential can sit at
+    0644 across two renders' worth of uptime unless something reaches back
+    and fixes it.
+
+    Missing file is not an error (the common case on a clean install).
+    """
+    try:
+        path.chmod(_SECRET_MODE)
+    except FileNotFoundError:
+        pass

--- a/agent/dns/spatium_dns_agent/secure_io.py
+++ b/agent/dns/spatium_dns_agent/secure_io.py
@@ -29,6 +29,10 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import structlog
+
+log = structlog.get_logger(__name__)
+
 __all__ = ["write_private", "harden_mode"]
 
 _SECRET_MODE = 0o600
@@ -87,9 +91,23 @@ def harden_mode(path: Path) -> None:
     0644 across two renders' worth of uptime unless something reaches back
     and fixes it.
 
-    Missing file is not an error (the common case on a clean install).
+    Best-effort by construction: this runs at the top of a render, and
+    failing to re-mode a file from a previous build must never be the thing
+    that stops the agent applying config. Both swallowed cases are logged
+    rather than silently dropped.
     """
     try:
         path.chmod(_SECRET_MODE)
     except FileNotFoundError:
-        pass
+        # Nothing to harden. The common case — a clean install has no
+        # previous render, and callers pass every candidate path
+        # unconditionally rather than pre-checking each one.
+        log.debug("harden_mode_absent", path=str(path))
+    except OSError as exc:
+        # Typically PermissionError: the file exists but belongs to another
+        # uid (the container entrypoint writes some state as root before
+        # chown'ing it). We cannot fix that from here, and raising would
+        # turn "couldn't tighten an old file" into "the agent stopped
+        # rendering config" — strictly worse than the exposure it guards.
+        # Surfaced at WARNING so the operator can fix ownership.
+        log.warning("harden_mode_failed", path=str(path), error=str(exc))

--- a/agent/dns/tests/test_powerdns_rendered_file_modes.py
+++ b/agent/dns/tests/test_powerdns_rendered_file_modes.py
@@ -1,0 +1,231 @@
+"""Rendered PowerDNS files that embed a credential are 0600 (issue #869).
+
+The driver already took care to write its *standalone* secret files at 0600
+via ``os.open`` + ``O_NOFOLLOW`` — the API key store (#249 / #253) and the
+DoT/DoH listener key (#50). What it then did was hand the same secrets back
+out at the umask default by rendering them into config with ``write_text``:
+
+* ``pdns.conf`` embeds ``api-key=``, which grants zone CRUD + DNSSEC over
+  the pdns REST API;
+* ``zones.json`` embeds ``update_tsig_keys``, whole TSIG key dicts including
+  ``secret`` — the material that authorises dynamic updates.
+
+CodeQL flagged only the first (alert 89). These tests pin both, plus the
+negative case, so the sweep can't quietly regress: ``dnsdist-rules.conf``
+carries cert *paths* rather than key material and is deliberately left at
+the default mode, which is only correct for as long as it stays secret-free.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from spatium_dns_agent.admin_pusher import redact_secrets
+from spatium_dns_agent.drivers.powerdns import PowerDNSDriver
+from spatium_dns_agent.secure_io import write_private
+
+_TSIG_SECRET = "c3VwZXItc2VjcmV0LXRzaWcta2V5LW1hdGVyaWFs"
+
+
+def _bundle() -> dict:
+    """A bundle whose zone carries a TSIG-keyed dynamic-update ACL, so the
+    rendered ``zones.json`` actually contains key material to protect."""
+    return {
+        "options": {},
+        "tsig_keys": [
+            {
+                "name": "ddns-key",
+                "algorithm": "hmac-sha256",
+                "secret": _TSIG_SECRET,
+            }
+        ],
+        "zones": [
+            {
+                "name": "example.com",
+                "type": "primary",
+                "dynamic_update_enabled": True,
+                "update_acl": [{"match_kind": "tsig_key", "tsig_key_name": "ddns-key"}],
+                "records": [],
+            }
+        ],
+    }
+
+
+def _mode(path: Path) -> str:
+    return oct(path.stat().st_mode & 0o777)
+
+
+def test_rendered_pdns_conf_is_private(tmp_path: Path) -> None:
+    drv = PowerDNSDriver(state_dir=tmp_path)
+    drv.render(_bundle())
+
+    conf = tmp_path / "rendered.new" / "pdns.conf"
+    # Guard the guard: if the key ever stops being inlined this test would
+    # otherwise keep passing while asserting nothing.
+    assert "api-key=" in conf.read_text()
+    assert _mode(conf) == "0o600"
+
+
+def test_rendered_zones_json_is_private(tmp_path: Path) -> None:
+    drv = PowerDNSDriver(state_dir=tmp_path)
+    drv.render(_bundle())
+
+    zones = tmp_path / "rendered.new" / "zones.json"
+    payload = json.loads(zones.read_text())
+    # The TSIG secret really does reach this file — that is the whole reason
+    # it needs the same treatment as pdns.conf.
+    assert _TSIG_SECRET in json.dumps(payload)
+    assert _mode(zones) == "0o600"
+
+
+def test_dnsdist_rules_carry_no_secret(tmp_path: Path) -> None:
+    """The one rendered file deliberately left at the default mode.
+
+    It is written with ``write_text`` because it holds cert *paths*, not key
+    material. If a future change puts a credential in here, this fails and
+    the file needs ``write_private`` too.
+    """
+    drv = PowerDNSDriver(state_dir=tmp_path)
+    bundle = _bundle()
+    bundle["options"] = {"dnsdist_enabled": True, "dnsdist_max_qps_per_client": 50}
+    drv.render(bundle)
+
+    rules = tmp_path / "dnsdist-rules.conf"
+    # Asserted, not `if rules.exists()`: guarding the body behind a condition
+    # the test itself sets up means the whole check silently disappears if
+    # rendering ever stops producing the file — the same vacuity the two
+    # tests above deliberately avoid.
+    assert rules.exists(), "dnsdist rules should render when dnsdist_enabled"
+    body = rules.read_text()
+    assert _TSIG_SECRET not in body
+    assert "api-key" not in body
+
+
+def test_render_hardens_files_left_by_a_pre_fix_build(tmp_path: Path) -> None:
+    """Upgrading the agent must re-mode what is already on disk (#869).
+
+    The live ``rendered/`` tree survives the upgrade until the next
+    structural render replaces it, and lingers as ``rendered.prev/`` for one
+    cycle after that — so without remediation a still-valid API key stays
+    world-readable for two renders' worth of uptime.
+    """
+    for tree in ("rendered", "rendered.prev"):
+        d = tmp_path / tree
+        d.mkdir(parents=True)
+        # Exactly what the old code produced: write_text at the umask default.
+        (d / "pdns.conf").write_text("api-key=stale-but-still-live\n")
+        (d / "zones.json").write_text("[]")
+        for name in ("pdns.conf", "zones.json"):
+            os.chmod(d / name, 0o644)
+
+    PowerDNSDriver(state_dir=tmp_path).render(_bundle())
+
+    for tree in ("rendered", "rendered.prev"):
+        for name in ("pdns.conf", "zones.json"):
+            assert _mode(tmp_path / tree / name) == "0o600", f"{tree}/{name}"
+
+
+def test_harden_is_a_noop_on_a_clean_install(tmp_path: Path) -> None:
+    """No pre-existing trees — remediation must not invent files or raise."""
+    PowerDNSDriver(state_dir=tmp_path).render(_bundle())
+    assert not (tmp_path / "rendered.prev").exists()
+
+
+# ── Redaction before the snapshot leaves the appliance ──────────────────
+
+
+def test_redaction_masks_api_key_and_tsig_secret() -> None:
+    """0600 on disk does nothing for the snapshot pusher, which uploads
+    these files to the control plane and serves them back over the API."""
+    conf = redact_secrets(f"api=yes\napi-key={_TSIG_SECRET}\nwebserver=yes\n")
+    assert _TSIG_SECRET not in conf
+    # The setting NAME survives — "is an api-key configured?" is usually the
+    # question the operator opened the snapshot to answer.
+    assert "api-key=" in conf
+    assert "api=yes" in conf and "webserver=yes" in conf
+
+    zones = redact_secrets(json.dumps({"update_tsig_keys": [{"secret": _TSIG_SECRET}]}))
+    assert _TSIG_SECRET not in zones
+    assert "update_tsig_keys" in zones
+
+    bind_style = redact_secrets(f'key "k" {{ secret "{_TSIG_SECRET}"; }};')
+    assert _TSIG_SECRET not in bind_style
+
+
+def test_redaction_leaves_ordinary_config_alone() -> None:
+    body = "local-port=53\nlog-dns-queries=yes\n"
+    assert redact_secrets(body) == body
+
+
+def test_pushed_snapshot_carries_no_secret(tmp_path: Path) -> None:
+    """End-to-end over the real render output, through the walk that feeds
+    the uploader — the property that actually matters."""
+    from spatium_dns_agent.admin_pusher import _walk_rendered
+
+    drv = PowerDNSDriver(state_dir=tmp_path)
+    drv.render(_bundle())
+    (tmp_path / "rendered.new").rename(tmp_path / "rendered")
+
+    files = dict(_walk_rendered(tmp_path / "rendered"))
+    assert files, "expected the render to produce pushable files"
+    blob = json.dumps(files)
+    assert _TSIG_SECRET not in blob
+    # The api-key is generated, so assert on the file rather than a literal.
+    live_key = (tmp_path / "pdns-api.key").read_text().strip()
+    assert live_key and live_key not in blob
+
+
+# ── write_private itself ────────────────────────────────────────────────
+
+
+def test_write_private_completes_a_short_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``os.write`` may write less than it was given; the file must still
+    end up complete.
+
+    The pre-fix code took the single return value on faith, so a short write
+    truncated the file silently — and a truncated ``zones.json`` doesn't
+    raise anywhere downstream, it just trips a log line in
+    ``swap_and_reload`` while the structural etag advances, so the zone
+    state is never applied and never retried.
+    """
+    real_write = os.write
+    payload = "x" * 4096
+
+    def _short(fd: int, data: bytes) -> int:
+        return real_write(fd, data[: max(1, len(data) // 2)])
+
+    monkeypatch.setattr(os, "write", _short)
+    write_private(tmp_path / "secret", payload)
+    monkeypatch.undo()
+
+    assert (tmp_path / "secret").read_text() == payload
+
+
+def test_write_private_raises_when_the_write_stalls(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A write making no progress raises rather than looping forever.
+
+    Callers' error handling assumes a failed write propagates — the sync
+    loop relies on the exception to avoid advancing its etag past a config
+    that never landed on disk.
+    """
+    monkeypatch.setattr(os, "write", lambda fd, data: 0)
+    with pytest.raises(OSError, match="short write"):
+        write_private(tmp_path / "secret", "payload")
+
+
+def test_write_private_is_atomic_and_private(tmp_path: Path) -> None:
+    dest = tmp_path / "secret"
+    write_private(dest, "first")
+    write_private(dest, "second")
+    assert dest.read_text() == "second"
+    assert _mode(dest) == "0o600"
+    # The tmp sibling must not survive a successful write.
+    assert not (tmp_path / "secret.new").exists()

--- a/agent/dns/tests/test_powerdns_rendered_file_modes.py
+++ b/agent/dns/tests/test_powerdns_rendered_file_modes.py
@@ -229,3 +229,33 @@ def test_write_private_is_atomic_and_private(tmp_path: Path) -> None:
     assert _mode(dest) == "0o600"
     # The tmp sibling must not survive a successful write.
     assert not (tmp_path / "secret.new").exists()
+
+
+def test_harden_survives_an_unchmodable_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file we cannot re-mode must not stop the render.
+
+    ``harden_mode`` runs at the top of ``render()``. The entrypoint writes
+    some state as root before chown'ing it, so an existing file can belong
+    to another uid; raising there would turn "couldn't tighten an old file"
+    into "the agent stopped applying config" — strictly worse than the
+    exposure the hardening guards against.
+    """
+    stale = tmp_path / "rendered"
+    stale.mkdir(parents=True)
+    (stale / "pdns.conf").write_text("api-key=x\n")
+
+    real_chmod = Path.chmod
+
+    def _refuse(self: Path, mode: int) -> None:
+        if self.name == "pdns.conf":
+            raise PermissionError(1, "Operation not permitted", str(self))
+        real_chmod(self, mode)
+
+    monkeypatch.setattr(Path, "chmod", _refuse)
+    # Must not raise, and must still produce a complete render.
+    PowerDNSDriver(state_dir=tmp_path).render(_bundle())
+    monkeypatch.undo()
+
+    assert _mode(tmp_path / "rendered.new" / "pdns.conf") == "0o600"

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -3920,7 +3920,7 @@ class RenderedConfigResponse(BaseModel):
     response_model=RenderedConfigResponse,
 )
 async def get_server_rendered_config(
-    server_id: uuid.UUID, db: DB, _: CurrentUser
+    server_id: uuid.UUID, db: DB, _: SuperAdmin
 ) -> RenderedConfigResponse:
     """Latest agent-pushed snapshot of the on-disk rendered config.
 
@@ -3928,6 +3928,15 @@ async def get_server_rendered_config(
     an empty file list with ``rendered_at=None`` when the agent hasn't
     pushed yet (fresh server, never reloaded). The UI shows a "no
     snapshot yet" placeholder in that case.
+
+    **Superadmin, not CurrentUser (#869).** This returns a server's whole
+    rendered configuration. The agent redacts known credential values before
+    pushing, but a full config dump is a reconnaissance surface in its own
+    right (ACLs, view match rules, forwarders, every zone name), and the
+    redaction is a denylist — it protects the secrets we know how to spot.
+    The router-level gate is satisfied by read on any dns_* resource, so
+    without this a Viewer could read it. No UI consumes this endpoint today,
+    so tightening it breaks no shipped workflow.
     """
     server = await db.get(DNSServer, server_id)
     if server is None:

--- a/backend/tests/test_dns_rendered_config_permission.py
+++ b/backend/tests/test_dns_rendered_config_permission.py
@@ -91,9 +91,7 @@ async def test_viewer_is_refused(client: AsyncClient, db_session: AsyncSession) 
     assert resp.status_code == 403, resp.text
 
 
-async def test_superadmin_is_allowed(
-    client: AsyncClient, db_session: AsyncSession
-) -> None:
+async def test_superadmin_is_allowed(client: AsyncClient, db_session: AsyncSession) -> None:
     """The gate must not have broken the endpoint for the role that needs it.
 
     No snapshot has been pushed, so this is the documented empty answer

--- a/backend/tests/test_dns_rendered_config_permission.py
+++ b/backend/tests/test_dns_rendered_config_permission.py
@@ -1,0 +1,112 @@
+"""``GET /dns/servers/{id}/rendered-config`` is superadmin-only (#869).
+
+The endpoint returns a DNS server's whole rendered configuration, pushed up
+by the agent. The DNS router's own gate is satisfied by *read on any* of
+``dns_group`` / ``dns_zone`` / ``dns_record``, so before this change the
+builtin Viewer role reached it — and the rendered PowerDNS config carries
+the REST ``api-key`` plus the TSIG secrets that authorise dynamic updates.
+
+The agent now redacts known credential values before pushing, but that is a
+denylist over whatever a driver happened to render; the gate is the part
+that doesn't depend on having anticipated the format.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+from app.models.dns import DNSServer, DNSServerGroup
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _viewer(db: AsyncSession) -> str:
+    """A non-superadmin with read on everything — the builtin Viewer shape."""
+    u = User(
+        username=f"viewer-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@example.com",
+        display_name="Viewer",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db.add(u)
+    await db.flush()
+    role = Role(
+        name=f"viewer-{uuid.uuid4().hex[:6]}",
+        description="",
+        permissions=[{"action": "read", "resource_type": "*"}],
+    )
+    db.add(role)
+    await db.flush()
+    group = Group(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    group.roles = [role]
+    group.users = [u]
+    db.add(group)
+    await db.flush()
+    return create_access_token(str(u.id))
+
+
+async def _superadmin(db: AsyncSession) -> str:
+    u = User(
+        username=f"admin-{uuid.uuid4().hex[:6]}",
+        email=f"{uuid.uuid4().hex[:6]}@example.com",
+        display_name="Admin",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(u)
+    await db.flush()
+    return create_access_token(str(u.id))
+
+
+async def _server(db: AsyncSession) -> DNSServer:
+    grp = DNSServerGroup(name=f"grp-{uuid.uuid4().hex[:6]}")
+    db.add(grp)
+    await db.flush()
+    srv = DNSServer(
+        group_id=grp.id,
+        name=f"srv-{uuid.uuid4().hex[:6]}",
+        driver="powerdns",
+        host="10.0.0.9",
+    )
+    db.add(srv)
+    await db.flush()
+    return srv
+
+
+async def test_viewer_is_refused(client: AsyncClient, db_session: AsyncSession) -> None:
+    srv = await _server(db_session)
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/api/v1/dns/servers/{srv.id}/rendered-config",
+        headers={"Authorization": f"Bearer {await _viewer(db_session)}"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+async def test_superadmin_is_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The gate must not have broken the endpoint for the role that needs it.
+
+    No snapshot has been pushed, so this is the documented empty answer
+    rather than a 404 — which is also what proves we got past the gate.
+    """
+    srv = await _server(db_session)
+    await db_session.commit()
+
+    resp = await client.get(
+        f"/api/v1/dns/servers/{srv.id}/rendered-config",
+        headers={"Authorization": f"Bearer {await _superadmin(db_session)}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["files"] == []
+    assert body["rendered_at"] is None


### PR DESCRIPTION
Fixes #869.

CodeQL [alert 89](https://github.com/spatiumddi/spatiumddi/security/code-scanning/89) flagged `pdns.conf` being written in cleartext with the PowerDNS REST api-key inlined. The mode was the visible half — chasing it turned up the same secrets going somewhere worse.

## 1. On disk (the reported defect, plus one the alert missed)

`pdns.conf` and `zones.json` were written with `write_text`, so they landed at the umask default — typically **0644**. `zones.json` wasn't in the alert and is the less obvious of the two: `update_tsig_keys` carries whole key dicts including `secret`, the material that authorises dynamic updates.

The driver already took real care with these secrets elsewhere — `_load_or_generate_api_key` writes the api-key store at 0600 via `O_NOFOLLOW` (#249/#253), `_write_listener_cert` does the same for the DoT/DoH key (#50). The render path then handed the same values back out world-readable. Both now use the shared writer.

`dnsdist-rules.conf` deliberately stays as-is — verified it carries cert *paths*, not key material, and there's a test that fails if that changes.

## 2. Off the appliance (the more serious one)

`admin_pusher._walk_rendered` uploads **every** text file under `rendered/` to the control plane (`_SKIP_FILE_NAMES` is an empty frozenset), and `GET /servers/{id}/rendered-config` served it to any authenticated user. The DNS router's gate is satisfied by read on any `dns_*` resource, so the builtin **Viewer role could read a live api-key and every TSIG secret**. File modes do nothing about this path.

The driver's own comment asserts these secrets "never leave the appliance". That was false. Two fixes so it's true:

- **Redaction at the source** — applied inside `_walk_rendered`, the single chokepoint every pushed file passes through, so a future caller can't route around it. Values are masked, setting names preserved ("is an api-key configured?" is usually why you opened the snapshot).
- **`SuperAdmin` on the endpoint** — redaction is a denylist over whatever a driver happened to render; the gate doesn't depend on having anticipated the format. A full config dump is also a recon surface in its own right (ACLs, view match rules, forwarders, zone names). No UI consumes this endpoint, so nothing shipped breaks.

## 3. Upgrade remediation

Shipping the fix doesn't re-mode what's already on disk. The old render survives as `rendered/` until the next structural change, then as `rendered.prev/` for one more cycle — so on a stable install a still-live credential could sit at 0644 more or less indefinitely. `render()` now hardens both trees before writing.

## 4. One writer, and a correctness bug in all four copies

Four copies of `os.open(O_NOFOLLOW, 0o600)` had drifted: only three did tmp+`replace`, and **none checked how many bytes `os.write` returned**. A short write truncated silently — and a truncated `zones.json` doesn't raise anywhere. `swap_and_reload` logs `powerdns_zones_payload_unreadable` and returns while the structural etag advances, so the zone state is never applied *and never retried*. `validate()` doesn't parse `zones.json` either (Technitium's does).

All four now route through `secure_io.write_private`: loops the write, raises if it stalls, 0600 at creation, atomic replace.

## Tests

`agent/dns/tests/test_powerdns_rendered_file_modes.py` (11) — modes on both files, each paired with a "the secret really is in this file" assertion so it can't pass vacuously; upgrade remediation across both stale trees; redaction unit + an end-to-end check through `_walk_rendered` over real render output; short-write completion and the stall case.

`backend/tests/test_dns_rendered_config_permission.py` (2) — Viewer gets 403, superadmin still gets the documented empty snapshot.

- Agent suite: **221 passed, 8 skipped**
- Backend: 33 passed across the new test + neighbouring DNS suites
- ruff clean; black clean on every line this PR touches (`admin_pusher.py` and `technitium.py` carry pre-existing drift on untouched lines — agent code isn't in CI's lint scope)
- Backend mypy unchanged vs baseline (120 pre-existing errors)

## Deployment note

No migration. The PowerDNS agent image needs a rebuild for the on-disk half to take effect; the endpoint gate and redaction-side behaviour land with the control plane. Existing 0644 files are remediated on the next render once the new agent is running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
