### PR TITLE
docs(looking-glass): the Go pin comment stops naming a version that moves

### DIFF
--- a/agent/looking-glass/images/gobgp/Dockerfile
+++ b/agent/looking-glass/images/gobgp/Dockerfile
@@ -41,8 +41,12 @@ RUN python3 -m pip install --prefix=/install --no-cache-dir --break-system-packa
 # no separate package to patch and no ``apk upgrade`` that can fix it. The only
 # remedy is to rebuild with a fixed toolchain.
 #
-# ``1.26.5`` clears CVE-2026-39822 (HIGH — ``os.Root`` symlink following allows
-# directory traversal), which 1.26.4 carries. Keep this at the latest 1.26.x.
+# The 1.26.4 → 1.26.5 bump cleared CVE-2026-39822 (HIGH — ``os.Root`` symlink
+# following allows directory traversal). Keep this at the latest 1.26.x.
+#
+# Stated in the PAST tense on purpose: Dependabot bumps the ``FROM`` line but
+# cannot touch this comment, so any wording that names the CURRENT pin goes
+# stale on the very next bump — which is exactly what happened at 1.26.6.
 FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS gobgp-build
 ARG GOBGP_VERSION
 ARG TARGETOS


### PR DESCRIPTION
Follow-up to #871.

That PR bumped the Go pin to `1.26.6-alpine`, which was correct — the Dockerfile's own comment instructs "Keep this at the latest 1.26.x", and the toolchain version is a security pin because Go static-links its stdlib into `gobgpd`. But it left the comment three lines above claiming:

> ``1.26.5`` clears CVE-2026-39822 (HIGH — ``os.Root`` symlink following allows directory traversal), which 1.26.4 carries.

Not false, but it now cites a version the file no longer uses.

Rewritten in the past tense so it stays true as the pin advances, with a line recording *why* it drifted: Dependabot updates the `FROM` line and cannot touch the comment above it, so any wording anchored to the current pin is guaranteed to go stale at the next bump. That is the actual failure mode worth documenting — otherwise the same fix gets made again at 1.26.7.

**Comment-only.** Zero non-comment lines changed, so the built image is byte-identical to what #871 produced and CI already scanned clean. The `agent/looking-glass/**` path filter means `build (gobgp)` will rebuild and re-run the Trivy gate (HIGH/CRITICAL, `ignore-unfixed`) anyway — that re-scan is the only thing in this PR that could plausibly fail, and only if a new CVE landed since this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
