### PR TITLE
fix(auth): SAML logins stop dying on the flow cookie's SameSite (#873)

### DIFF
--- a/backend/app/api/v1/auth/router.py
+++ b/backend/app/api/v1/auth/router.py
@@ -1218,6 +1218,41 @@ _OIDC_FLOW_COOKIE = "oidc_flow"
 _OIDC_FLOW_TTL = 300  # 5 minutes
 _SAML_FLOW_COOKIE = "saml_flow"
 _SAML_FLOW_TTL = 300
+
+
+def _saml_flow_cookie_kwargs(base: str) -> dict:
+    """Attributes shared by the set + delete of the SAML flow cookie.
+
+    SECURITY / CORRECTNESS (#873). Unlike OIDC — whose IdP hands the browser
+    back with a cross-site *GET* redirect, which SameSite=Lax permits — SAML's
+    Web Browser SSO profile returns the assertion as a cross-site **POST** to
+    our ACS, and Lax cookies are never sent on a cross-site POST. So a Lax
+    flow cookie is simply absent at the ACS for every IdP that does not share
+    our registrable domain — i.e. every hosted IdP (Okta / Entra / Google) —
+    and the login dies with ``saml_state_missing``. Only ``SameSite=None``
+    survives that POST, and browsers honour None only alongside ``Secure``.
+
+    Hence the policy is chosen from the deployment's own scheme rather than
+    fixed: over HTTPS we can (and must) set None + Secure; over plain HTTP
+    None would be dropped by the browser at *set* time, so Lax is strictly
+    better there — it is what a same-site IdP needs, and that is the only
+    kind of IdP that can work over HTTP at all. ``saml_callback`` turns the
+    remaining cross-site-IdP-on-HTTP case into an actionable
+    ``saml_requires_https`` instead of a bare state error.
+
+    ``base`` is the deployment's external URL (see ``_app_base_url``) — the
+    origin the SP metadata advertises as the ACS, i.e. the one the browser
+    actually posts to — not necessarily the origin of this request.
+    """
+    https = base.lower().startswith("https://")
+    return {
+        "httponly": True,
+        "samesite": "none" if https else "lax",
+        "secure": https,
+        "path": "/api/v1/auth/",
+    }
+
+
 _LOGIN_CALLBACK_PATH = "/login/callback"
 _LOGIN_ERROR_PATH = "/login"
 
@@ -1267,6 +1302,7 @@ _LOGIN_ERROR_REASONS = frozenset(
         "oidc_rejected",
         # SAML
         "saml_misconfigured",
+        "saml_requires_https",
         "saml_build_failed",
         "saml_state_missing",
         "saml_state_invalid",
@@ -1352,6 +1388,16 @@ async def _oidc_start(provider: AuthProvider, request: Request, db: DB) -> Redir
 
 async def _saml_start(provider: AuthProvider, request: Request, db: DB) -> RedirectResponse:
     base = await _app_base_url(db, request)
+    if not base.lower().startswith("https://"):
+        # Not fatal on its own — a same-site IdP still round-trips the Lax
+        # cookie this yields — but it is the precondition for the failure
+        # ``saml_callback`` reports as ``saml_requires_https`` (#873), so
+        # leave the operator a breadcrumb here rather than only at the ACS.
+        logger.warning(
+            "saml_authorize_insecure_base_url",
+            provider=provider.name,
+            base_url=base,
+        )
     try:
         cfg = SAMLConfig.from_provider(provider, base)
     except SAMLServiceError as exc:
@@ -1377,10 +1423,7 @@ async def _saml_start(provider: AuthProvider, request: Request, db: DB) -> Redir
         _SAML_FLOW_COOKIE,
         flow_token,
         max_age=_SAML_FLOW_TTL,
-        httponly=True,
-        samesite="lax",
-        secure=request.url.scheme == "https",
-        path="/api/v1/auth/",
+        **_saml_flow_cookie_kwargs(base),
     )
     return response
 
@@ -1480,8 +1523,23 @@ async def saml_callback(
     if provider is None or provider.type != "saml":
         raise HTTPException(status_code=404, detail="Provider not found")
 
+    base = await _app_base_url(db, request)
+
     flow_cookie = request.cookies.get(_SAML_FLOW_COOKIE)
     if not flow_cookie:
+        # Classify the absence (#873). Over plain HTTP the flow cookie can
+        # only be Lax (see ``_saml_flow_cookie_kwargs``), which the browser
+        # withholds from a *cross-site* POST — so on an HTTP deployment a
+        # missing cookie here is the signature of a hosted IdP, and the fix
+        # is TLS, not "try again". Over HTTPS the cookie is SameSite=None and
+        # should have arrived, so absence means an expired or dropped flow.
+        if not base.lower().startswith("https://"):
+            logger.warning(
+                "saml_callback_requires_https",
+                provider=provider.name,
+                base_url=base,
+            )
+            return _login_error_redirect("saml_requires_https")
         return _login_error_redirect("saml_state_missing")
     try:
         flow = _verify_flow_token(flow_cookie)
@@ -1492,7 +1550,6 @@ async def saml_callback(
     if RelayState != flow.get("relay_state"):
         return _login_error_redirect("saml_state_mismatch")
 
-    base = await _app_base_url(db, request)
     try:
         cfg = SAMLConfig.from_provider(provider, base)
         consumed = saml_consume_assertion(
@@ -1540,7 +1597,11 @@ async def saml_callback(
     )
     response = RedirectResponse(f"{_LOGIN_CALLBACK_PATH}#{frag}", status_code=302)
     _set_refresh_cookie(response, request, tokens.refresh_token)
-    response.delete_cookie(_SAML_FLOW_COOKIE, path="/api/v1/auth/")
+    # Clear with the attributes it was set with. Not strictly required —
+    # a cookie is identified by (name, domain, path), so the attributes
+    # play no part in matching — but keeping set and clear in one helper
+    # stops the pair drifting apart (#873).
+    response.delete_cookie(_SAML_FLOW_COOKIE, **_saml_flow_cookie_kwargs(base))
     return response
 
 

--- a/backend/tests/test_saml_flow_cookie.py
+++ b/backend/tests/test_saml_flow_cookie.py
@@ -1,0 +1,134 @@
+"""SAML flow-cookie SameSite semantics (issue #873).
+
+The IdP returns the assertion as a cross-site POST to our ACS. A
+``SameSite=Lax`` cookie is never sent on a cross-site POST, so the flow
+cookie has to be ``SameSite=None`` — which browsers only honour when the
+cookie is also ``Secure``. These tests pin both halves: the attributes on
+the cookie, and the HTTPS pre-flight that refuses the flow when the
+deployment could not set such a cookie in the first place.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.auth import router as auth_router
+from app.models.auth_provider import AuthProvider
+from app.models.settings import PlatformSettings
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _saml_provider(db_session: AsyncSession) -> AuthProvider:
+    provider = AuthProvider(
+        name="test-idp",
+        type="saml",
+        is_enabled=True,
+        config={
+            "idp_entity_id": "https://idp.example.com/entity",
+            "idp_sso_url": "https://idp.example.com/sso",
+            "idp_x509_cert": "MIIBogus",
+        },
+    )
+    db_session.add(provider)
+    await db_session.commit()
+    return provider
+
+
+async def _set_base_url(db_session: AsyncSession, url: str) -> None:
+    row = await db_session.get(PlatformSettings, 1)
+    if row is None:
+        row = PlatformSettings(id=1)
+        db_session.add(row)
+    row.app_base_url = url
+    await db_session.commit()
+
+
+async def test_saml_flow_cookie_is_samesite_none_and_secure(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cookie must survive the IdP's cross-site POST back to the ACS."""
+    provider = await _saml_provider(db_session)
+    await _set_base_url(db_session, "https://ddi.example.com")
+    monkeypatch.setattr(
+        auth_router,
+        "saml_authorize_url",
+        lambda cfg, base, relay: "https://idp.example.com/sso?x=1",
+    )
+
+    resp = await client.get(f"/api/v1/auth/{provider.id}/authorize")
+
+    assert resp.status_code == 302
+    assert resp.headers["location"].startswith("https://idp.example.com/sso")
+    set_cookie = next(
+        v for k, v in resp.headers.multi_items() if k.lower() == "set-cookie" and "saml_flow=" in v
+    )
+    lowered = set_cookie.lower()
+    assert "samesite=none" in lowered
+    assert "secure" in lowered
+    assert "httponly" in lowered
+    assert "path=/api/v1/auth/" in lowered
+
+
+async def test_saml_flow_cookie_stays_lax_over_plain_http(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SameSite=None is only honoured with Secure, which we cannot set over
+    HTTP — so an HTTP deployment keeps the Lax cookie, which is exactly what
+    the one IdP topology that can work there (same-site) needs. The flow is
+    not refused up front: that would break those installs."""
+    provider = await _saml_provider(db_session)
+    await _set_base_url(db_session, "http://ddi.example.com")
+    monkeypatch.setattr(
+        auth_router,
+        "saml_authorize_url",
+        lambda cfg, base, relay: "https://idp.example.com/sso?x=1",
+    )
+
+    resp = await client.get(f"/api/v1/auth/{provider.id}/authorize")
+
+    assert resp.status_code == 302
+    assert resp.headers["location"].startswith("https://idp.example.com/sso")
+    set_cookie = next(
+        v for k, v in resp.headers.multi_items() if k.lower() == "set-cookie" and "saml_flow=" in v
+    )
+    lowered = set_cookie.lower()
+    assert "samesite=lax" in lowered
+    assert "secure" not in lowered
+
+
+async def test_acs_without_cookie_over_http_reports_requires_https(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """On an HTTP deployment a missing flow cookie means the IdP's POST was
+    cross-site and the Lax cookie was withheld — an actionable TLS problem,
+    not a "try again" state error."""
+    provider = await _saml_provider(db_session)
+    await _set_base_url(db_session, "http://ddi.example.com")
+
+    resp = await client.post(
+        f"/api/v1/auth/{provider.id}/callback",
+        data={"SAMLResponse": "bogus", "RelayState": "whatever"},
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/login?error=saml_requires_https"
+
+
+async def test_acs_without_cookie_over_https_is_a_state_error(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Over HTTPS the cookie is SameSite=None and should have ridden the POST,
+    so absence is a genuinely expired / dropped flow."""
+    provider = await _saml_provider(db_session)
+    await _set_base_url(db_session, "https://ddi.example.com")
+
+    resp = await client.post(
+        f"/api/v1/auth/{provider.id}/callback",
+        data={"SAMLResponse": "bogus", "RelayState": "whatever"},
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/login?error=saml_state_missing"

--- a/docs/features/AUTH.md
+++ b/docs/features/AUTH.md
@@ -191,6 +191,50 @@ Key config fields:
 
 Secrets: `sp_private_key` (PEM, optional — only needed for signed requests).
 
+**SAML needs HTTPS with any hosted IdP.** Step 2 above is a *cross-site
+POST*: the browser is on the IdP's origin and submits the assertion to
+SpatiumDDI. The short-lived `saml_flow` cookie set in step 1 — which
+binds the assertion to the browser that started the flow — only rides
+that POST when it is marked `SameSite=None`, and browsers honour
+`SameSite=None` only when the cookie is also `Secure`. A `Lax` cookie is
+withheld from every cross-site POST, which is what made all logins
+against a hosted IdP fail with `error=saml_state_missing`
+([#873](https://github.com/spatiumddi/spatiumddi/issues/873)). Note the
+contrast with OIDC, whose flow cookie is legitimately `SameSite=Lax`:
+the OIDC provider returns the browser with a cross-site **GET**
+redirect, which Lax permits.
+
+The cookie policy is therefore picked per deployment, from the external
+URL's scheme:
+
+| External URL | Flow cookie | Works with |
+|---|---|---|
+| `https://…` | `SameSite=None; Secure` | any IdP |
+| `http://…` | `SameSite=Lax` | only an IdP sharing SpatiumDDI's registrable domain (its POST is same-site) |
+
+`SameSite=None` cannot be used over plain HTTP at all — the browser
+drops such a cookie at *set* time — so HTTP keeps Lax rather than
+losing the same-site case too. When that Lax cookie does not come back,
+the ACS reports `/login?error=saml_requires_https` instead of
+`saml_state_missing`, because on an HTTP deployment a missing cookie is
+the signature of a cross-site IdP and the fix is TLS, not a retry.
+
+The URL whose scheme decides all this is the admin-set **External URL**
+(Settings → General, `platform_settings.app_base_url`) when configured,
+otherwise the incoming request URL — the same value the SP metadata
+advertises as the ACS, i.e. the origin the IdP actually posts to.
+**Behind a TLS-terminating proxy, set the External URL to the public
+`https://` address.** Relying on `X-Forwarded-Proto` alone is not enough
+with the shipped Docker Compose stack: the frontend container's nginx
+listens on `:80` and hard-sets `X-Forwarded-Proto $scheme`, so it
+overwrites the `https` an outer terminator sent (the TLS recipes in
+[DOCKER.md §5](../deployment/DOCKER.md) Options A and B both put the
+terminator *in front of* that container). The request then looks like
+plain HTTP to the API, and the SP metadata would advertise an `http://`
+ACS URL anyway. The forwarded header does carry the real scheme where
+nginx itself terminates TLS: DOCKER.md Option C, and the Helm chart's
+TLS-enabled frontend.
+
 ### RADIUS
 
 Driver: `backend/app/core/auth/radius.py` (`pyrad`).

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -6,6 +6,11 @@ import { KeyRound, ShieldCheck } from "lucide-react";
 
 function humanizeError(code: string | null): string {
   if (!code) return "";
+  if (code === "oidc_rejected")
+    return "OIDC login rejected: your account could not be provisioned (group mapping, username collision, or auto-create disabled).";
+  // Defensive: the backend allowlist (`_LOGIN_ERROR_REASONS`) only emits the
+  // bare `oidc_rejected` above, but keep the per-reason rendering in case a
+  // suffixed code is ever added to that set.
   if (code.startsWith("oidc_rejected_")) {
     const reason = code.slice("oidc_rejected_".length);
     if (reason === "no_group_mapping_match") {
@@ -35,6 +40,22 @@ function humanizeError(code: string | null): string {
     return "OIDC provider is misconfigured. Contact an administrator.";
   if (code.startsWith("oidc_idp_"))
     return `Identity provider returned: ${code.slice(9)}`;
+  if (code === "saml_requires_https")
+    return "SAML login requires HTTPS. The identity provider posts the assertion back cross-site, and browsers only carry the flow cookie across that POST over a secure connection — serve SpatiumDDI over TLS and set the external URL in Settings to its https:// address.";
+  if (
+    code === "saml_state_missing" ||
+    code === "saml_state_invalid" ||
+    code === "saml_state_mismatch"
+  )
+    return "SAML flow state was invalid or expired. Please try again.";
+  if (code === "saml_assertion_rejected")
+    return "The SAML assertion was rejected. Check the SP/IdP certificate and entity ID configuration.";
+  if (code === "saml_rejected")
+    return "SAML login rejected: your account could not be provisioned (group mapping, username collision, or auto-create disabled).";
+  if (code === "saml_build_failed")
+    return "Could not build the SAML authentication request. Check provider configuration.";
+  if (code === "saml_misconfigured")
+    return "SAML provider is misconfigured. Contact an administrator.";
   return "Login failed.";
 }
 


### PR DESCRIPTION
Closes #873

## The bug

Every SAML login against a hosted IdP failed with `error=saml_state_missing`, exactly as reported. The `saml_flow` cookie — which binds the assertion to the browser that started the flow — was set `SameSite=Lax`, and SAML's Web Browser SSO profile returns the assertion as a **cross-site POST** to our ACS. Browsers never send a Lax cookie on a cross-site POST, so the cookie was absent at the ACS every time, for every IdP not sharing our registrable domain.

Worth noting the contrast with OIDC, whose flow cookie is legitimately `SameSite=Lax` and stays that way: its provider returns the browser with a cross-site **GET** redirect, which Lax does permit.

## The fix

`SameSite=None` is the only policy that survives that POST — and browsers honour `None` only alongside `Secure`, which cannot be set over plain HTTP. So rather than a blanket swap, the policy is picked per deployment from the external URL's scheme, in one helper shared by the cookie's set and its clear:

| External URL | Flow cookie | Works with |
|---|---|---|
| `https://…` | `SameSite=None; Secure` | any IdP — **this is the fix** |
| `http://…` | `SameSite=Lax` (unchanged) | only an IdP sharing SpatiumDDI's registrable domain |

The scheme is read from `_app_base_url` (the admin-set **External URL**, else the request URL) rather than `request.url.scheme`, because that is the value SP metadata advertises as the ACS — the origin the browser actually posts to.

### Why there is no HTTPS pre-flight

The first cut refused SAML outright at `/authorize` when the external URL wasn't `https://`. Code review caught that this breaks deployments that work today: an IdP on the same registrable domain (`sso.corp.example.com` → `ddi.corp.example.com`) POSTs *same-site*, so the Lax cookie was delivered and those plain-HTTP installs were fine.

So the refusal is gone. Instead `saml_callback` classifies a **missing** cookie: over HTTP that absence is the signature of a cross-site IdP, so it returns a new `saml_requires_https` reason instead of the misleading `saml_state_missing`. Same actionable error for the operator who needs it, no regression for anyone.

## Two adjacent problems found while documenting this

- **`X-Forwarded-Proto` is not trustworthy on the shipped Compose stack.** `frontend/default.conf.template` listens on `:80` and hard-sets `X-Forwarded-Proto $scheme`, overwriting the `https` an outer terminator sent — so DOCKER.md §5 Options A and B look like plain HTTP to the API. `docs/features/AUTH.md` now tells operators to set the External URL rather than rely on the header, and names the topologies where it does carry through (Option C, the Helm TLS frontend).
- **The login page had no SAML branch at all** — every SAML failure rendered a bare "Login failed." Six messages added, plus the `oidc_rejected` twin, which was equally unhandled (the existing `startsWith("oidc_rejected_")` branch is dead, since the backend allowlist only emits the bare code).

## Testing

- 4 new tests in `backend/tests/test_saml_flow_cookie.py` pinning both cookie policies and both ACS classifications.
- 24 passed across the auth suite (`test_auth_refresh_cookie`, `test_fix_m3_m4_auth_session`, `test_reveal_mfa_reauth`) — no regressions.
- `make ci` green; host ruff / black / mypy clean.

No migration, no new dependency, no API-surface change beyond one added `?error=` reason code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
