### PR TITLE
feat(branding): login banner, custom logo, environment strip, real app title

### DIFF
--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -481,6 +481,16 @@ backend/alembic/versions/d3f1ab7c8e02_windows_dns_credentials.py:drop_column:36
 backend/alembic/versions/d3f2a51c8e76_bgp_peering.py:drop_column:98
 backend/alembic/versions/d3f2a51c8e76_bgp_peering.py:drop_constraint_fk:96
 backend/alembic/versions/d3f2a51c8e76_bgp_peering.py:drop_table:94
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:151
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:152
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:153
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:154
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:155
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:156
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:157
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:158
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_column:159
+backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py:drop_table:150
 backend/alembic/versions/d4a18b20e3c7_dhcp_mac_blocks.py:drop_table:83
 backend/alembic/versions/d4a8b2e6f193_dns_group_tsig_key.py:drop_column:40
 backend/alembic/versions/d4a8b2e6f193_dns_group_tsig_key.py:drop_column:41

--- a/backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py
+++ b/backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py
@@ -1,0 +1,159 @@
+"""Branding — login banner, environment banner, and operator logo storage.
+
+Revision ID: d3f8b6c02a41
+Revises: f4c81a37e0b2
+Create Date: 2026-08-21 00:00:00
+
+Issues #885 (login acceptable-use banner), #886 (custom logo), #887
+(environment banner). All new ``platform_settings`` columns are NOT NULL
+with a server_default so the existing singleton row backfills in place,
+and every default reproduces today's behaviour — an install that upgrades
+into this migration renders exactly as it did before, with both banners
+off and no custom logo.
+
+The logo lives in its own table rather than as a column on
+``platform_settings``: that row is read on many request paths, and none of
+them should pay for a blob. Storing the bytes in Postgres (rather than on
+a volume) is what makes a custom logo appear on every API pod without a
+shared filesystem — the same problem the slot-image mirror sidecar (#296)
+had to solve the hard way.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "d3f8b6c02a41"
+down_revision: str | None = "f4c81a37e0b2"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    # ── Login-screen acceptable-use banner (#885) ──────────────────────
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "login_banner_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "login_banner_title",
+            sa.String(length=120),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "login_banner_text",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "login_banner_require_ack",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    # ── Environment banner (#887) ──────────────────────────────────────
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "env_banner_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "env_banner_text",
+            sa.String(length=200),
+            nullable=False,
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "env_banner_bg",
+            sa.String(length=7),
+            nullable=False,
+            server_default=sa.text("'#b91c1c'"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "env_banner_fg",
+            sa.String(length=7),
+            nullable=False,
+            server_default=sa.text("'#ffffff'"),
+        ),
+    )
+    op.add_column(
+        "platform_settings",
+        sa.Column(
+            "env_banner_position",
+            sa.String(length=10),
+            nullable=False,
+            server_default=sa.text("'top'"),
+        ),
+    )
+
+    # ── Operator-uploaded branding assets (#886) ───────────────────────
+    op.create_table(
+        "branding_asset",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("kind", sa.String(length=32), nullable=False),
+        sa.Column("content", sa.LargeBinary(), nullable=False),
+        sa.Column("media_type", sa.String(length=100), nullable=False),
+        sa.Column("sha256", sa.String(length=64), nullable=False),
+        sa.Column("byte_size", sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("kind", name="uq_branding_asset_kind"),
+    )
+    op.create_index("ix_branding_asset_kind", "branding_asset", ["kind"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_branding_asset_kind", table_name="branding_asset")
+    op.drop_table("branding_asset")
+    op.drop_column("platform_settings", "env_banner_position")
+    op.drop_column("platform_settings", "env_banner_fg")
+    op.drop_column("platform_settings", "env_banner_bg")
+    op.drop_column("platform_settings", "env_banner_text")
+    op.drop_column("platform_settings", "env_banner_enabled")
+    op.drop_column("platform_settings", "login_banner_require_ack")
+    op.drop_column("platform_settings", "login_banner_text")
+    op.drop_column("platform_settings", "login_banner_title")
+    op.drop_column("platform_settings", "login_banner_enabled")

--- a/backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py
+++ b/backend/alembic/versions/d3f8b6c02a41_branding_banners_and_logo.py
@@ -140,13 +140,14 @@ def upgrade() -> None:
         sa.Column("sha256", sa.String(length=64), nullable=False),
         sa.Column("byte_size", sa.Integer(), nullable=False),
         sa.PrimaryKeyConstraint("id"),
+        # Named to match the model's __table_args__ exactly, so a schema
+        # built by create_all (tests) and one built by migrations agree.
+        # The constraint is itself index-backed — no separate index here.
         sa.UniqueConstraint("kind", name="uq_branding_asset_kind"),
     )
-    op.create_index("ix_branding_asset_kind", "branding_asset", ["kind"])
 
 
 def downgrade() -> None:
-    op.drop_index("ix_branding_asset_kind", table_name="branding_asset")
     op.drop_table("branding_asset")
     op.drop_column("platform_settings", "env_banner_position")
     op.drop_column("platform_settings", "env_banner_fg")

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 import uuid
 from datetime import UTC, datetime
@@ -9,18 +10,26 @@ from ipaddress import ip_network
 from typing import Any, Literal
 
 import structlog
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, File, Header, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, field_validator, model_validator
 from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser
 from app.core.agent_wake import HOSTCONFIG_ALL, publish_wake
 from app.core.demo_mode import forbid_in_demo_mode
+from app.core.http_etag import etag_matches, format_etag
 from app.core.permissions import is_effective_superadmin, user_has_permission
 from app.models.audit import AuditLog
 from app.models.audit_forward import AuditForwardTarget
 from app.models.oui import OUIVendor
-from app.models.settings import PlatformSettings
+from app.models.settings import (
+    BRANDING_ASSET_KIND_LOGO,
+    BRANDING_ASSET_MAX_BYTES,
+    BRANDING_ASSET_MEDIA_TYPE,
+    PNG_MAGIC,
+    BrandingAsset,
+    PlatformSettings,
+)
 from app.services import audit_forward as audit_forward_svc
 from app.services.appliance.apt import render_sources_list
 from app.services.appliance.ssh import is_valid_public_key, validate_lockout_safe
@@ -72,6 +81,18 @@ _SINGLETON_ID = 1
 class SettingsResponse(BaseModel):
     app_title: str
     app_base_url: str
+    # ── Login banner (issue #885) / environment banner (issue #887) ──
+    # No secrets — every field here is also served unauthenticated from
+    # ``GET /settings/public`` so the login page can render it.
+    login_banner_enabled: bool = False
+    login_banner_title: str = ""
+    login_banner_text: str = ""
+    login_banner_require_ack: bool = False
+    env_banner_enabled: bool = False
+    env_banner_text: str = ""
+    env_banner_bg: str = "#b91c1c"
+    env_banner_fg: str = "#ffffff"
+    env_banner_position: str = "top"
     ip_allocation_strategy: str
     session_timeout_minutes: int
     auto_logout_minutes: int
@@ -785,6 +806,16 @@ def _merge_apt_auth(
 class SettingsUpdate(BaseModel):
     app_title: str | None = None
     app_base_url: str | None = None
+    # Login banner (#885) + environment banner (#887).
+    login_banner_enabled: bool | None = None
+    login_banner_title: str | None = None
+    login_banner_text: str | None = None
+    login_banner_require_ack: bool | None = None
+    env_banner_enabled: bool | None = None
+    env_banner_text: str | None = None
+    env_banner_bg: str | None = None
+    env_banner_fg: str | None = None
+    env_banner_position: Literal["top", "bottom", "both"] | None = None
     ip_allocation_strategy: str | None = None
     session_timeout_minutes: int | None = None
     auto_logout_minutes: int | None = None
@@ -1214,6 +1245,47 @@ class SettingsUpdate(BaseModel):
             ZoneInfo(v)
         except Exception as exc:  # noqa: BLE001 — surface the parse failure
             raise ValueError(f"timezone {v!r} is not a valid IANA tz name: {exc}") from exc
+        return v
+
+    @field_validator("env_banner_bg", "env_banner_fg")
+    @classmethod
+    def _valid_banner_colour(cls, v: str | None) -> str | None:
+        # The colour is written straight into an inline ``style`` on every
+        # page, so it has to be a literal we control the shape of — a
+        # 6-digit hex triple and nothing else. Anything looser (named
+        # colours, ``rgb()``, CSS functions) would be operator-supplied
+        # text landing in a style attribute.
+        if v is None:
+            return None
+        s = v.strip().lower()
+        if not re.fullmatch(r"#[0-9a-f]{6}", s):
+            raise ValueError("colour must be a 6-digit hex value such as #b91c1c")
+        return s
+
+    @field_validator("env_banner_text")
+    @classmethod
+    def _valid_env_banner_text(cls, v: str | None) -> str | None:
+        # Mirrors the column width (VARCHAR(200)).
+        if v is not None and len(v) > 200:
+            raise ValueError("env_banner_text must be 200 characters or fewer")
+        return v
+
+    @field_validator("login_banner_title")
+    @classmethod
+    def _valid_login_banner_title(cls, v: str | None) -> str | None:
+        # Mirrors the column width (VARCHAR(120)).
+        if v is not None and len(v) > 120:
+            raise ValueError("login_banner_title must be 120 characters or fewer")
+        return v
+
+    @field_validator("login_banner_text")
+    @classmethod
+    def _valid_login_banner_text(cls, v: str | None) -> str | None:
+        # The column is unbounded TEXT, but this renders in a fixed-width
+        # box above the sign-in form — cap it so a paste accident can't
+        # push the form off-screen for every user at once.
+        if v is not None and len(v) > 8000:
+            raise ValueError("login_banner_text must be 8000 characters or fewer")
         return v
 
     @field_validator("maintenance_message")
@@ -1681,6 +1753,21 @@ async def update_settings(
                 detail="resolver override mode requires at least one DNS server",
             )
 
+    # Branding is SUPERADMIN-ONLY (issues #885 / #887). These fields render
+    # on the unauthenticated login page, so a delegated ``write:settings``
+    # editor could otherwise put arbitrary text in front of every visitor —
+    # a phishing surface, not a preference. The Settings UI already gates
+    # the branding block on superadmin; this is the server-side half of
+    # that (non-negotiable #3).
+    _branding_fields = {
+        f for f in changes if f.startswith(("login_banner_", "env_banner_")) or f == "app_title"
+    }
+    if _branding_fields and not is_effective_superadmin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Branding can only be changed by a superadmin",
+        )
+
     # Maintenance mode is SUPERADMIN-ONLY (issue #57). Flipping it turns the
     # WHOLE platform read-only for everyone except superadmins — a delegated
     # ``write:settings`` editor must not be able to inflict a platform-wide
@@ -2132,6 +2219,34 @@ async def update_settings(
                 resource_display="Appliance registration",
                 result="success",
                 new_value={"enabled": _reg_now},
+            )
+        )
+
+    # Branding (#885 / #887 / #888) — what an anonymous visitor sees before
+    # they authenticate, so every change is on the record.
+    if _branding_fields:
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                user_display_name=current_user.display_name,
+                auth_source=current_user.auth_source,
+                action="update",
+                resource_type="platform_settings",
+                resource_id="branding",
+                resource_display="Branding",
+                result="success",
+                new_value={
+                    "app_title": str(settings.app_title or ""),
+                    "login_banner_enabled": bool(settings.login_banner_enabled),
+                    "login_banner_title": str(settings.login_banner_title or ""),
+                    "login_banner_text": str(settings.login_banner_text or ""),
+                    "login_banner_require_ack": bool(settings.login_banner_require_ack),
+                    "env_banner_enabled": bool(settings.env_banner_enabled),
+                    "env_banner_text": str(settings.env_banner_text or ""),
+                    "env_banner_bg": str(settings.env_banner_bg or ""),
+                    "env_banner_fg": str(settings.env_banner_fg or ""),
+                    "env_banner_position": str(settings.env_banner_position or "top"),
+                },
             )
         )
 
@@ -2956,3 +3071,222 @@ async def test_audit_target(
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"delivery failed: {exc}") from exc
     return {"status": "ok", "target": row.name}
+
+
+# ── Public branding surface (issues #885 / #886 / #887 / #888) ──────────────────
+#
+# These two routes are the only ones in this router with no ``CurrentUser``
+# dependency, and that is deliberate: the login page renders the banner,
+# the logo and the app title before anyone has a session. Nothing here may
+# ever carry a value an anonymous visitor shouldn't see, which is why the
+# response is an explicit whitelist rather than a filtered dump of the
+# settings row — a field added to PlatformSettings tomorrow cannot leak
+# through by default.
+
+
+class PublicLoginBanner(BaseModel):
+    enabled: bool
+    title: str
+    text: str
+    require_ack: bool
+
+
+class PublicEnvBanner(BaseModel):
+    enabled: bool
+    text: str
+    bg: str
+    fg: str
+    position: str
+
+
+class PublicSettingsResponse(BaseModel):
+    app_title: str
+    login_banner: PublicLoginBanner
+    env_banner: PublicEnvBanner
+    logo_sha256: str | None
+
+
+@router.get("/public", response_model=PublicSettingsResponse)
+async def get_public_settings(db: DB) -> PublicSettingsResponse:
+    """Branding for pre-authentication rendering.
+
+    Unauthenticated on purpose — the login screen needs the operator's
+    title, acceptable-use banner, environment strip and logo before a
+    session exists. Everything returned is operator-authored text intended
+    for exactly that audience.
+    """
+    # Both lookups tolerate absence: on a fresh install the singleton
+    # settings row is only created by the first write, and the logo is
+    # independent of it — a logo uploaded before anyone saves settings must
+    # still be served, so these two are queried separately.
+    settings = await db.get(PlatformSettings, _SINGLETON_ID)
+    logo_sha: str | None = (
+        await db.execute(
+            select(BrandingAsset.sha256).where(BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO)
+        )
+    ).scalar_one_or_none()
+
+    return PublicSettingsResponse(
+        app_title=(getattr(settings, "app_title", "") or "SpatiumDDI"),
+        login_banner=PublicLoginBanner(
+            enabled=bool(getattr(settings, "login_banner_enabled", False)),
+            title=str(getattr(settings, "login_banner_title", "") or ""),
+            text=str(getattr(settings, "login_banner_text", "") or ""),
+            require_ack=bool(getattr(settings, "login_banner_require_ack", False)),
+        ),
+        env_banner=PublicEnvBanner(
+            enabled=bool(getattr(settings, "env_banner_enabled", False)),
+            text=str(getattr(settings, "env_banner_text", "") or ""),
+            bg=str(getattr(settings, "env_banner_bg", "") or "#b91c1c"),
+            fg=str(getattr(settings, "env_banner_fg", "") or "#ffffff"),
+            position=str(getattr(settings, "env_banner_position", "") or "top"),
+        ),
+        logo_sha256=logo_sha,
+    )
+
+
+@router.get("/public/logo", response_model=None)
+async def get_public_logo(db: DB, if_none_match: str | None = Header(default=None)) -> Response:
+    """Serve the operator-uploaded logo, or 404 so the frontend falls back
+    to the bundled asset.
+
+    Unauthenticated for the same reason as ``/public`` — the browser
+    fetches this straight from an ``img`` tag on the login page, where no
+    Authorization header is available.
+    """
+    row = (
+        await db.execute(
+            select(BrandingAsset).where(BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "No custom logo is configured")
+
+    if if_none_match and etag_matches(if_none_match, row.sha256):
+        return Response(status_code=304, headers={"ETag": format_etag(row.sha256)})
+
+    return Response(
+        content=row.content,
+        media_type=row.media_type,
+        headers={
+            "ETag": format_etag(row.sha256),
+            # The URL the frontend builds carries the sha as a query
+            # param, so a cached copy is only ever reused for identical
+            # bytes; a re-upload changes the URL and misses the cache.
+            "Cache-Control": "public, max-age=300",
+        },
+    )
+
+
+class BrandingLogoInfo(BaseModel):
+    sha256: str
+    byte_size: int
+    media_type: str
+
+
+@router.put("/branding/logo", response_model=BrandingLogoInfo)
+async def upload_branding_logo(
+    current_user: CurrentUser,
+    db: DB,
+    file: UploadFile = File(..., description="PNG image, 512 KB maximum."),
+) -> BrandingLogoInfo:
+    """Replace the branding logo (issue #886).
+
+    PNG only. SVG is deliberately refused: this is served same-origin, and
+    an SVG can carry script — accepting one would turn a branding upload
+    into stored XSS against every visitor, including unauthenticated ones.
+    """
+    forbid_in_demo_mode("Branding changes are disabled")
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Branding can only be changed by a superadmin",
+        )
+
+    # Read with one byte of headroom so an oversized upload is detected
+    # rather than silently truncated to the limit.
+    content = await file.read(BRANDING_ASSET_MAX_BYTES + 1)
+    if len(content) > BRANDING_ASSET_MAX_BYTES:
+        raise HTTPException(
+            status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            f"Logo must be {BRANDING_ASSET_MAX_BYTES // 1024} KB or smaller",
+        )
+    if not content:
+        raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, "Uploaded file is empty")
+    # Trust the magic bytes, not the client-declared content type.
+    if not content.startswith(PNG_MAGIC):
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_ENTITY,
+            "Logo must be a PNG image (SVG and other formats are not accepted)",
+        )
+
+    digest = hashlib.sha256(content).hexdigest()
+    row = (
+        await db.execute(
+            select(BrandingAsset).where(BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO)
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        row = BrandingAsset(kind=BRANDING_ASSET_KIND_LOGO)
+        db.add(row)
+    row.content = content
+    row.media_type = BRANDING_ASSET_MEDIA_TYPE
+    row.sha256 = digest
+    row.byte_size = len(content)
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="update",
+            resource_type="platform_settings",
+            resource_id="branding_logo",
+            resource_display="Branding logo",
+            result="success",
+            new_value={"sha256": digest, "byte_size": len(content)},
+        )
+    )
+    await db.commit()
+
+    logger.info("branding_logo_updated", user=current_user.username, sha256=digest)
+    return BrandingLogoInfo(
+        sha256=digest,
+        byte_size=len(content),
+        media_type=BRANDING_ASSET_MEDIA_TYPE,
+    )
+
+
+@router.delete("/branding/logo", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_branding_logo(current_user: CurrentUser, db: DB) -> Response:
+    """Drop the custom logo; the UI falls back to the bundled asset."""
+    forbid_in_demo_mode("Branding changes are disabled")
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Branding can only be changed by a superadmin",
+        )
+
+    row = (
+        await db.execute(
+            select(BrandingAsset).where(BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO)
+        )
+    ).scalar_one_or_none()
+    if row is not None:
+        await db.delete(row)
+        db.add(
+            AuditLog(
+                user_id=current_user.id,
+                user_display_name=current_user.display_name,
+                auth_source=current_user.auth_source,
+                action="delete",
+                resource_type="platform_settings",
+                resource_id="branding_logo",
+                resource_display="Branding logo",
+                result="success",
+            )
+        )
+        await db.commit()
+        logger.info("branding_logo_deleted", user=current_user.username)
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -13,6 +13,7 @@ import structlog
 from fastapi import APIRouter, File, Header, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, field_validator, model_validator
 from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from app.api.deps import DB, CurrentUser
 from app.core.agent_wake import HOSTCONFIG_ALL, publish_wake
@@ -3119,7 +3120,14 @@ async def get_public_settings(db: DB) -> PublicSettingsResponse:
     # settings row is only created by the first write, and the logo is
     # independent of it — a logo uploaded before anyone saves settings must
     # still be served, so these two are queried separately.
-    settings = await db.get(PlatformSettings, _SINGLETON_ID)
+    # A transient instance stands in for the missing row so the no-row case
+    # answers with the same shape as a configured one. Note its columns read
+    # as None, NOT the ORM ``default=`` values — SQLAlchemy applies those at
+    # flush, not at construction — so the ``or`` fallbacks below are
+    # load-bearing, not belt-and-braces. Real attribute access (rather than
+    # ``getattr`` by string) keeps mypy and rename refactors honest: a
+    # renamed column errors here instead of silently serving defaults.
+    settings = await db.get(PlatformSettings, _SINGLETON_ID) or PlatformSettings()
     logo_sha: str | None = (
         await db.execute(
             select(BrandingAsset.sha256).where(BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO)
@@ -3127,19 +3135,19 @@ async def get_public_settings(db: DB) -> PublicSettingsResponse:
     ).scalar_one_or_none()
 
     return PublicSettingsResponse(
-        app_title=(getattr(settings, "app_title", "") or "SpatiumDDI"),
+        app_title=settings.app_title or "SpatiumDDI",
         login_banner=PublicLoginBanner(
-            enabled=bool(getattr(settings, "login_banner_enabled", False)),
-            title=str(getattr(settings, "login_banner_title", "") or ""),
-            text=str(getattr(settings, "login_banner_text", "") or ""),
-            require_ack=bool(getattr(settings, "login_banner_require_ack", False)),
+            enabled=bool(settings.login_banner_enabled),
+            title=settings.login_banner_title or "",
+            text=settings.login_banner_text or "",
+            require_ack=bool(settings.login_banner_require_ack),
         ),
         env_banner=PublicEnvBanner(
-            enabled=bool(getattr(settings, "env_banner_enabled", False)),
-            text=str(getattr(settings, "env_banner_text", "") or ""),
-            bg=str(getattr(settings, "env_banner_bg", "") or "#b91c1c"),
-            fg=str(getattr(settings, "env_banner_fg", "") or "#ffffff"),
-            position=str(getattr(settings, "env_banner_position", "") or "top"),
+            enabled=bool(settings.env_banner_enabled),
+            text=settings.env_banner_text or "",
+            bg=settings.env_banner_bg or "#b91c1c",
+            fg=settings.env_banner_fg or "#ffffff",
+            position=settings.env_banner_position or "top",
         ),
         logo_sha256=logo_sha,
     )
@@ -3221,18 +3229,31 @@ async def upload_branding_logo(
         )
 
     digest = hashlib.sha256(content).hexdigest()
-    row = (
-        await db.execute(
-            select(BrandingAsset).where(BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO)
+    # Upsert rather than read-then-insert: ``kind`` is UNIQUE, so two
+    # concurrent uploads would both see no row, both INSERT, and the loser
+    # would 500 on uq_branding_asset_kind. ON CONFLICT makes last-write-wins
+    # explicit instead.
+    await db.execute(
+        pg_insert(BrandingAsset)
+        .values(
+            id=uuid.uuid4(),
+            kind=BRANDING_ASSET_KIND_LOGO,
+            content=content,
+            media_type=BRANDING_ASSET_MEDIA_TYPE,
+            sha256=digest,
+            byte_size=len(content),
         )
-    ).scalar_one_or_none()
-    if row is None:
-        row = BrandingAsset(kind=BRANDING_ASSET_KIND_LOGO)
-        db.add(row)
-    row.content = content
-    row.media_type = BRANDING_ASSET_MEDIA_TYPE
-    row.sha256 = digest
-    row.byte_size = len(content)
+        .on_conflict_do_update(
+            constraint="uq_branding_asset_kind",
+            set_={
+                "content": content,
+                "media_type": BRANDING_ASSET_MEDIA_TYPE,
+                "sha256": digest,
+                "byte_size": len(content),
+                "modified_at": func.now(),
+            },
+        )
+    )
 
     db.add(
         AuditLog(

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -3244,7 +3244,11 @@ async def upload_branding_logo(
             byte_size=len(content),
         )
         .on_conflict_do_update(
-            constraint="uq_branding_asset_kind",
+            # Infer the target from the column rather than naming the
+            # constraint, so this cannot break if the constraint is ever
+            # renamed — and so it behaves identically on a schema built by
+            # create_all versus one built by migrations.
+            index_elements=["kind"],
             set_={
                 "content": content,
                 "media_type": BRANDING_ASSET_MEDIA_TYPE,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -129,7 +129,7 @@ from app.models.panos import FirewallObject, PANOSFirewall
 from app.models.pcap import PacketCapture
 from app.models.proxmox import ProxmoxNode
 from app.models.saved_view import SavedView
-from app.models.settings import PlatformSettings
+from app.models.settings import BrandingAsset, PlatformSettings
 from app.models.system_upgrade import SystemUpgradeRun
 from app.models.tailscale import TailscaleTenant
 from app.models.time_bound_grant import TimeBoundGrant
@@ -206,6 +206,7 @@ __all__ = [
     "VLANMapping",
     "OUIVendor",
     "PlatformSettings",
+    "BrandingAsset",
     "DNSServerGroup",
     "DNSServer",
     "DNSServerZoneState",

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -1062,7 +1062,6 @@ class PlatformSettings(Base):
 # Deliberately NOT columns on PlatformSettings: that row is read on many
 # request paths, and no one should pay for a blob on every settings load.
 BRANDING_ASSET_KIND_LOGO = "logo"
-BRANDING_ASSET_KINDS = (BRANDING_ASSET_KIND_LOGO,)
 
 # PNG only, and small. SVG is deliberately excluded: it is served
 # same-origin, and an SVG is a script-execution vector unless sanitised.

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -16,7 +16,7 @@ from sqlalchemy import text as sa_text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.models.base import Base
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
 
 # Default managed APT repos (issue #155) — mirror the Debian 13 (trixie)
 # set baked into the appliance ISO so enabling APT management starts from
@@ -72,6 +72,45 @@ class PlatformSettings(Base):
     # External-facing URL (used for OIDC / SAML redirect + callback URLs). Empty
     # means "derive from the incoming request" at runtime.
     app_base_url: Mapped[str] = mapped_column(String(500), nullable=False, default="")
+
+    # Login-screen acceptable-use banner (issue #885). Rendered above the
+    # sign-in form, so every field here is served UNAUTHENTICATED via
+    # ``GET /api/v1/settings/public`` — never put anything secret in them.
+    # ``require_ack`` gates the submit button on an "I acknowledge"
+    # checkbox; that is a display-and-consent affordance, not an
+    # enforcement boundary (the API never sees the acknowledgement).
+    login_banner_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    login_banner_title: Mapped[str] = mapped_column(
+        String(120), nullable=False, default="", server_default=sa_text("''")
+    )
+    login_banner_text: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=sa_text("''")
+    )
+    login_banner_require_ack: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+
+    # Environment banner (issue #887) — the "you are on the DEV box" strip
+    # rendered on every screen including the login page. Colours are
+    # operator-picked hex, so they land in an inline style rather than a
+    # Tailwind class. ``position`` is one of top / bottom / both.
+    env_banner_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa_text("false")
+    )
+    env_banner_text: Mapped[str] = mapped_column(
+        String(200), nullable=False, default="", server_default=sa_text("''")
+    )
+    env_banner_bg: Mapped[str] = mapped_column(
+        String(7), nullable=False, default="#b91c1c", server_default=sa_text("'#b91c1c'")
+    )
+    env_banner_fg: Mapped[str] = mapped_column(
+        String(7), nullable=False, default="#ffffff", server_default=sa_text("'#ffffff'")
+    )
+    env_banner_position: Mapped[str] = mapped_column(
+        String(10), nullable=False, default="top", server_default=sa_text("'top'")
+    )
 
     # IP allocation
     ip_allocation_strategy: Mapped[str] = mapped_column(
@@ -1008,3 +1047,40 @@ class PlatformSettings(Base):
     approvals_protect_controls: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=sa_text("false")
     )
+
+
+# Operator-uploaded branding assets (issue #886). One row per ``kind``.
+#
+# The bytes live in Postgres rather than on a volume because the control
+# plane is multi-node: a file written to one API pod's filesystem is
+# invisible to the others, which is exactly the problem that forced the
+# slot-image mirror sidecar (#296) into existence. The database is already
+# the shared store, so a DB blob propagates everywhere for free and rides
+# along in backups. A logo is tens of KB — this is not a place where blob
+# storage costs anything.
+#
+# Deliberately NOT columns on PlatformSettings: that row is read on many
+# request paths, and no one should pay for a blob on every settings load.
+BRANDING_ASSET_KIND_LOGO = "logo"
+BRANDING_ASSET_KINDS = (BRANDING_ASSET_KIND_LOGO,)
+
+# PNG only, and small. SVG is deliberately excluded: it is served
+# same-origin, and an SVG is a script-execution vector unless sanitised.
+BRANDING_ASSET_MAX_BYTES = 512 * 1024
+BRANDING_ASSET_MEDIA_TYPE = "image/png"
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class BrandingAsset(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """A single operator-uploaded branding file, keyed by ``kind``."""
+
+    __tablename__ = "branding_asset"
+
+    kind: Mapped[str] = mapped_column(String(32), nullable=False, unique=True, index=True)
+    content: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    media_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    # Hex sha256 of ``content`` — doubles as the ETag and as the cache-buster
+    # in the URL the frontend builds, so a re-upload is picked up immediately
+    # instead of sitting behind a stale browser cache.
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    byte_size: Mapped[int] = mapped_column(Integer, nullable=False)

--- a/backend/app/models/settings.py
+++ b/backend/app/models/settings.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     Numeric,
     String,
     Text,
+    UniqueConstraint,
 )
 from sqlalchemy import text as sa_text
 from sqlalchemy.dialects.postgresql import JSONB
@@ -1075,7 +1076,19 @@ class BrandingAsset(UUIDPrimaryKeyMixin, TimestampMixin, Base):
 
     __tablename__ = "branding_asset"
 
-    kind: Mapped[str] = mapped_column(String(32), nullable=False, unique=True, index=True)
+    # The uniqueness of ``kind`` is declared as a NAMED constraint rather
+    # than ``unique=True`` on the column: an inline unique= lets Postgres
+    # auto-name it (``branding_asset_kind_key``) under
+    # ``Base.metadata.create_all``, which would not match the name the
+    # migration creates. The upload path's ON CONFLICT then resolves
+    # differently depending on whether the schema came from migrations or
+    # create_all. Naming it here keeps both paths identical.
+    #
+    # No separate index= on the column either — a unique constraint is
+    # already backed by an index, so one would just be a duplicate.
+    __table_args__ = (UniqueConstraint("kind", name="uq_branding_asset_kind"),)
+
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
     content: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     media_type: Mapped[str] = mapped_column(String(100), nullable=False)
     # Hex sha256 of ``content`` — doubles as the ETag and as the cache-buster

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -20,6 +20,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     bgp_lg,
     bgp_monitor,
     block_sync,
+    branding,
     certificates,
     changes,
     conformity,

--- a/backend/app/services/ai/tools/branding.py
+++ b/backend/app/services/ai/tools/branding.py
@@ -1,0 +1,107 @@
+"""Operator Copilot read tool for the branding surface (issues #885-#888).
+
+Surfaces the singleton ``platform_settings`` branding slice plus whether a
+custom logo is stored, so an operator can ask "is the login banner on?",
+"what does the login notice say?", "which environment is this box labelled
+as?", or "are we using a custom logo?".
+
+Read-only, and there is deliberately no ``propose_update_branding``: every
+field here renders to *anonymous* visitors on the login page, which is why
+the REST write path is superadmin-only rather than the ``write:settings``
+the rest of the settings PUT takes. That is not a gate to hand to a chat
+tool — the friendly path is Settings -> Branding, which also carries the
+colour-contrast warning and the live preview.
+
+``module=None`` (always available) — branding is not behind a feature
+module; the write half is gated at the handler level (superadmin), like the
+other host-config settings tools.
+
+``default_enabled=True`` (NN #13) — read-only, and nothing it returns is a
+secret: the identical payload is served unauthenticated from
+``GET /api/v1/settings/public``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.auth import User
+from app.models.settings import (
+    BRANDING_ASSET_KIND_LOGO,
+    BrandingAsset,
+    PlatformSettings,
+)
+from app.services.ai.tools.base import register_tool
+
+
+class FindBrandingSettingsArgs(BaseModel):
+    """No arguments — there is exactly one branding config row."""
+
+    pass
+
+
+@register_tool(
+    name="find_branding_settings",
+    description=(
+        "Return the platform branding configuration — the product title "
+        "shown in the browser tab / sign-in heading / sidebar wordmark, "
+        "the login acceptable-use banner (enabled, heading, text, and "
+        "whether an acknowledgement checkbox gates sign-in), the "
+        "environment banner (enabled, text, hex colours, and whether it "
+        "renders top / bottom / both), and whether a custom logo is "
+        "uploaded. Use to answer 'is the login banner on?', 'what does "
+        "our login notice say?', 'which environment is this labelled as?' "
+        "or 'are we using a custom logo?'. Everything here is also served "
+        "unauthenticated to the login page, so none of it is secret."
+    ),
+    args_model=FindBrandingSettingsArgs,
+    category="admin",
+    default_enabled=True,
+)
+async def find_branding_settings(
+    db: AsyncSession, user: User, args: FindBrandingSettingsArgs
+) -> dict[str, Any]:
+    # Same transient-instance stand-in the public endpoint uses: on a fresh
+    # install the settings row does not exist until the first write, and the
+    # answer should be the defaults rather than an error. Its columns read as
+    # None (ORM ``default=`` applies at flush, not construction), so the
+    # ``or`` fallbacks below supply the actual defaults.
+    settings = await db.get(PlatformSettings, 1) or PlatformSettings()
+    logo = (
+        await db.execute(
+            select(BrandingAsset.sha256, BrandingAsset.byte_size).where(
+                BrandingAsset.kind == BRANDING_ASSET_KIND_LOGO
+            )
+        )
+    ).one_or_none()
+
+    return {
+        "app_title": settings.app_title or "SpatiumDDI",
+        "login_banner": {
+            "enabled": bool(settings.login_banner_enabled),
+            "title": settings.login_banner_title or "",
+            "text": settings.login_banner_text or "",
+            "require_ack": bool(settings.login_banner_require_ack),
+        },
+        "env_banner": {
+            "enabled": bool(settings.env_banner_enabled),
+            "text": settings.env_banner_text or "",
+            "background_colour": settings.env_banner_bg or "#b91c1c",
+            "text_colour": settings.env_banner_fg or "#ffffff",
+            "position": settings.env_banner_position or "top",
+        },
+        "custom_logo": {
+            "configured": logo is not None,
+            "sha256": logo.sha256 if logo else None,
+            "byte_size": logo.byte_size if logo else None,
+        },
+        "note": (
+            "Branding writes are superadmin-only because these fields render "
+            "to anonymous visitors on the login page. Change them in "
+            "Settings -> Branding."
+        ),
+    }

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -101,13 +101,18 @@ SECTIONS: tuple[Section, ...] = (
         key="settings",
         label="Platform settings & RBAC scaffolding",
         description=(
-            "Platform-wide settings, custom field definitions, "
-            "IPAM templates, feature-module toggles, alert rules + "
-            "events, conformity policies + results, platform-wide "
+            "Platform-wide settings, branding assets, custom field "
+            "definitions, IPAM templates, feature-module toggles, alert "
+            "rules + events, conformity policies + results, platform-wide "
             "tags, event subscriptions + outbox."
         ),
         tables=(
             "platform_settings",
+            # The operator-uploaded logo (#886). Belongs with settings
+            # rather than in its own section: it is branding config that
+            # happens to be bytes, and restoring the banner text without
+            # the logo it sits beside would be a half-restore.
+            "branding_asset",
             "custom_field_definition",
             "feature_module",
             "ipam_template",

--- a/backend/tests/test_settings_branding.py
+++ b/backend/tests/test_settings_branding.py
@@ -1,0 +1,296 @@
+"""Settings-router tests for branding (issues #885 / #886 / #887 / #888).
+
+Covers:
+
+* ``GET /settings/public`` answers UNAUTHENTICATED and returns only the
+  whitelisted branding fields — the login page depends on both halves.
+* Banner fields round-trip through PUT /settings and are audited.
+* Branding writes are superadmin-only: a delegated ``write:settings``
+  editor is refused, because these fields render to anonymous visitors.
+* Colour + length validation rejects anything that is not a hex triple.
+* Logo upload accepts a PNG, rejects a non-PNG (an SVG in particular) and
+  rejects an oversized file; the bytes come back from the public route
+  with a matching ETag, and DELETE restores the bundled-asset fallback.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import struct
+import uuid
+import zlib
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import Group, Role, User
+from app.models.settings import BRANDING_ASSET_MAX_BYTES
+
+
+async def _make_superadmin(db: AsyncSession, username: str = "brsuper") -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_settings_editor(db: AsyncSession, username: str = "brsettings") -> tuple[User, str]:
+    """Holds ``write`` on ``settings`` but is not a superadmin — passes the
+    generic settings gate, must still fail the branding gate."""
+    role = Role(
+        name=f"settings-editor-{uuid.uuid4().hex[:6]}",
+        description="",
+        permissions=[{"action": "write", "resource_type": "settings"}],
+    )
+    group = Group(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    group.roles = [role]
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=False,
+    )
+    user.groups = [group]
+    db.add_all([role, group, user])
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+def _tiny_png() -> bytes:
+    """A real 1x1 PNG, built here so the test needs no fixture file."""
+
+    def chunk(tag: bytes, payload: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(payload))
+            + tag
+            + payload
+            + struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+        )
+
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0)
+    idat = zlib.compress(b"\x00\xff\xff\xff")
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+@pytest.mark.asyncio
+async def test_public_settings_needs_no_auth(client: AsyncClient) -> None:
+    # No Authorization header at all — this is the whole point of the route.
+    resp = await client.get("/api/v1/settings/public")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body) == {"app_title", "login_banner", "env_banner", "logo_sha256"}
+    assert body["login_banner"]["enabled"] is False
+    assert body["env_banner"]["enabled"] is False
+    assert body["logo_sha256"] is None
+
+
+@pytest.mark.asyncio
+async def test_banner_round_trip_and_audit(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={
+            "app_title": "Acme DDI",
+            "login_banner_enabled": True,
+            "login_banner_title": "NOTICE",
+            "login_banner_text": "Authorised users only.",
+            "login_banner_require_ack": True,
+            "env_banner_enabled": True,
+            "env_banner_text": "DEVELOPMENT",
+            "env_banner_bg": "#B91C1C",
+            "env_banner_fg": "#FFFFFF",
+            "env_banner_position": "both",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["login_banner_require_ack"] is True
+    # Colours are normalised to lowercase on the way in.
+    assert body["env_banner_bg"] == "#b91c1c"
+    assert body["env_banner_position"] == "both"
+
+    # The same values must now reach an anonymous visitor.
+    pub = (await client.get("/api/v1/settings/public")).json()
+    assert pub["app_title"] == "Acme DDI"
+    assert pub["login_banner"] == {
+        "enabled": True,
+        "title": "NOTICE",
+        "text": "Authorised users only.",
+        "require_ack": True,
+    }
+    assert pub["env_banner"]["text"] == "DEVELOPMENT"
+
+    audit = (
+        (await db_session.execute(select(AuditLog).where(AuditLog.resource_id == "branding")))
+        .scalars()
+        .all()
+    )
+    assert len(audit) == 1
+    assert audit[0].resource_type == "platform_settings"
+    assert audit[0].new_value["login_banner_text"] == "Authorised users only."
+
+
+@pytest.mark.asyncio
+async def test_branding_write_requires_superadmin(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_settings_editor(db_session)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    resp = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"login_banner_text": "hello"},
+    )
+    assert resp.status_code == 403, resp.text
+
+    # A non-branding field still goes through for the same user, proving
+    # the refusal is the branding gate and not the generic settings gate.
+    ok = await client.put(
+        "/api/v1/settings",
+        headers=headers,
+        json={"dns_default_ttl": 7200},
+    )
+    assert ok.status_code == 200, ok.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad", ["red", "#fff", "b91c1c", "#gggggg", "rgb(1,2,3)"])
+async def test_rejects_non_hex_colour(
+    db_session: AsyncSession, client: AsyncClient, bad: str
+) -> None:
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"env_banner_bg": bad},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_rejects_overlong_banner_text(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings",
+        headers={"Authorization": f"Bearer {token}"},
+        json={"env_banner_text": "x" * 201},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_logo_upload_serve_and_delete(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+    png = _tiny_png()
+
+    resp = await client.put(
+        "/api/v1/settings/branding/logo",
+        headers=headers,
+        files={"file": ("logo.png", png, "image/png")},
+    )
+    assert resp.status_code == 200, resp.text
+    digest = hashlib.sha256(png).hexdigest()
+    assert resp.json()["sha256"] == digest
+
+    # Advertised on the public payload so the frontend knows to use it.
+    pub = (await client.get("/api/v1/settings/public")).json()
+    assert pub["logo_sha256"] == digest
+
+    # Bytes come back unauthenticated, with a matching ETag.
+    got = await client.get("/api/v1/settings/public/logo")
+    assert got.status_code == 200
+    assert got.content == png
+    assert got.headers["content-type"] == "image/png"
+    etag = got.headers["etag"]
+    assert digest in etag
+
+    # A conditional re-fetch is a 304, so browsers don't re-pull the blob.
+    again = await client.get("/api/v1/settings/public/logo", headers={"If-None-Match": etag})
+    assert again.status_code == 304
+
+    # Uploading a second time replaces rather than accumulating.
+    resp2 = await client.put(
+        "/api/v1/settings/branding/logo",
+        headers=headers,
+        files={"file": ("logo.png", png, "image/png")},
+    )
+    assert resp2.status_code == 200
+
+    delete = await client.delete("/api/v1/settings/branding/logo", headers=headers)
+    assert delete.status_code == 204
+    assert (await client.get("/api/v1/settings/public/logo")).status_code == 404
+    assert (await client.get("/api/v1/settings/public")).json()["logo_sha256"] is None
+
+
+@pytest.mark.asyncio
+async def test_logo_rejects_svg_and_other_non_png(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """SVG is the one that matters: it is served same-origin and can carry
+    script, so accepting it would be stored XSS against anonymous visitors."""
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    svg = b'<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+    resp = await client.put(
+        "/api/v1/settings/branding/logo",
+        # Even with an image content-type claimed by the client.
+        headers=headers,
+        files={"file": ("logo.svg", svg, "image/png")},
+    )
+    assert resp.status_code == 422, resp.text
+    assert (await client.get("/api/v1/settings/public/logo")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_logo_rejects_oversized_upload(db_session: AsyncSession, client: AsyncClient) -> None:
+    _, token = await _make_superadmin(db_session)
+    await db_session.commit()
+    # Valid PNG magic, but past the cap — the size check must fire even
+    # for a well-formed image.
+    payload = b"\x89PNG\r\n\x1a\n" + b"\x00" * (BRANDING_ASSET_MAX_BYTES + 1)
+    resp = await client.put(
+        "/api/v1/settings/branding/logo",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"file": ("big.png", payload, "image/png")},
+    )
+    assert resp.status_code == 413, resp.text
+
+
+@pytest.mark.asyncio
+async def test_logo_write_requires_superadmin(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _make_settings_editor(db_session, "brlogoeditor")
+    await db_session.commit()
+    resp = await client.put(
+        "/api/v1/settings/branding/logo",
+        headers={"Authorization": f"Bearer {token}"},
+        files={"file": ("logo.png", _tiny_png(), "image/png")},
+    )
+    assert resp.status_code == 403, resp.text

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -540,9 +540,76 @@ Performance: the middleware reads the flag from a short-TTL process-local cache.
 **Branding**
 
 ```
-app_title: str (default "SpatiumDDI")
+app_title: str (default "SpatiumDDI")   -- browser tab, login heading, sidebar wordmark
 app_base_url: str (default "") -- used to build OIDC/SAML redirect URLs; empty = derive from request
+
+-- Login-screen acceptable-use banner (issue #885)
+login_banner_enabled: bool (default false)
+login_banner_title: str (default "")        -- short heading, e.g. "NOTICE"
+login_banner_text: str (default "")         -- plain text; newlines preserved
+login_banner_require_ack: bool (default false)
+
+-- Environment banner (issue #887)
+env_banner_enabled: bool (default false)
+env_banner_text: str (default "")
+env_banner_bg: str (default "#b91c1c")      -- 6-digit hex, validated
+env_banner_fg: str (default "#ffffff")      -- 6-digit hex, validated
+env_banner_position: str (default "top")    -- top | bottom | both
 ```
+
+Branding writes (`app_title`, either banner) are **superadmin-only**, a
+stronger gate than the `write:settings` the rest of the PUT takes: these
+fields render to anonymous visitors on the login page, so a delegated
+settings editor must not be able to put arbitrary text in front of
+everyone. Every branding change writes an audit row
+(`resource_type="platform_settings"`, `resource_id="branding"`).
+
+### 6.1 Public branding endpoint
+
+`GET /api/v1/settings/public` is **unauthenticated** — the login page has
+to render the title, banners and logo before a session exists, the same
+reason `/auth/password-policy` and `/auth/providers` are public. It
+returns an explicit whitelist (`app_title`, `login_banner`, `env_banner`,
+`logo_sha256`), never a filtered dump of the settings row, so a column
+added to `PlatformSettings` later cannot leak through by default. Anything
+placed in these fields is world-readable to anyone who can reach the login
+page; the Settings UI says so.
+
+The acknowledgement checkbox (`login_banner_require_ack`) gates the
+sign-in button and the SSO buttons client-side. It is a consent
+affordance, not an access control — the API never receives the
+acknowledgement, and nothing server-side depends on it.
+
+### 6.2 Branding logo (issue #886)
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `PUT /api/v1/settings/branding/logo` | superadmin, audited | Upload (multipart, PNG, ≤512 KB) |
+| `DELETE /api/v1/settings/branding/logo` | superadmin, audited | Remove; UI falls back to the bundled asset |
+| `GET /api/v1/settings/public/logo` | **none** | Serve the bytes to the login page |
+
+The bytes live in Postgres, in a dedicated `branding_asset` table keyed by
+`kind` — not on a volume, and not as a column on `PlatformSettings`.
+
+*Why the database:* the control plane is multi-node. A file written to one
+API pod's filesystem is invisible to the others, which is the problem that
+forced the slot-image mirror sidecar (#296) into existence — a whole extra
+Deployment and PVC to fan one file out. A logo is tens of KB, Postgres is
+already the shared store, and DB storage means it propagates everywhere for
+free and rides along in backups.
+
+*Why its own table:* the `platform_settings` row is read on many request
+paths, and none of them should pay to load a blob.
+
+*Why PNG only:* the logo is served same-origin, and an SVG can carry
+script — accepting one would turn a branding upload into stored XSS
+against every visitor, including unauthenticated ones. The upload
+validates PNG magic bytes rather than trusting the client's declared
+content type.
+
+The response carries a weak `ETag` built from the content sha256, and the
+frontend requests the logo with that sha as a query parameter, so a
+re-upload busts the cache immediately while an unchanged logo answers 304.
 
 **IP allocation**
 

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -611,6 +611,17 @@ The response carries a weak `ETag` built from the content sha256, and the
 frontend requests the logo with that sha as a query parameter, so a
 re-upload busts the cache immediately while an unchanged logo answers 304.
 
+The upload is an `ON CONFLICT` upsert keyed on `uq_branding_asset_kind`, so
+two superadmins uploading at the same moment resolve as last-write-wins
+rather than one of them hitting a unique-constraint error.
+
+Operator Copilot coverage is one read tool, `find_branding_settings`
+(default enabled) — it returns the same payload `GET /settings/public`
+serves, so nothing it exposes is secret. There is deliberately **no**
+`propose_update_branding`: these fields render to anonymous visitors, which
+is why the write path is superadmin-only, and that is not a gate to hand to
+a chat tool.
+
 **IP allocation**
 
 ```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate } from "react-router-dom";
 
 import { AppLayout } from "@/components/layout/AppLayout";
+import { useBrandDocumentTitle } from "@/hooks/usePublicSettings";
 import { LoginPage } from "@/pages/LoginPage";
 import { LoginCallbackPage } from "@/pages/LoginCallbackPage";
 import { ChangePasswordPage } from "@/pages/ChangePasswordPage";
@@ -107,6 +108,9 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  // Issue #888 — keep the browser tab on the operator's configured title.
+  useBrandDocumentTitle();
+
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/components/BrandLogo.tsx
+++ b/frontend/src/components/BrandLogo.tsx
@@ -1,0 +1,30 @@
+import logoIcon from "@/assets/logo-icon.svg";
+import {
+  usePublicSettings,
+  DEFAULT_APP_TITLE,
+} from "@/hooks/usePublicSettings";
+import { publicSettingsApi } from "@/lib/api";
+
+/**
+ * The product mark — an operator-uploaded logo when one exists (issue
+ * #886), the bundled asset otherwise. Shared by the sidebar and the login
+ * page so a custom logo can never appear in one and not the other.
+ *
+ * The custom logo is served from our own API rather than a CDN or a data
+ * URI, which keeps it inside the ``img-src 'self'`` CSP without widening
+ * the policy.
+ */
+export function BrandLogo({ className }: { className?: string }) {
+  const { settings } = usePublicSettings();
+  const src = settings.logo_sha256
+    ? publicSettingsApi.logoUrl(settings.logo_sha256)
+    : logoIcon;
+
+  return (
+    <img
+      src={src}
+      alt={settings.app_title.trim() || DEFAULT_APP_TITLE}
+      className={className}
+    />
+  );
+}

--- a/frontend/src/components/BrandLogo.tsx
+++ b/frontend/src/components/BrandLogo.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 import logoIcon from "@/assets/logo-icon.svg";
 import {
   usePublicSettings,
@@ -16,13 +18,22 @@ import { publicSettingsApi } from "@/lib/api";
  */
 export function BrandLogo({ className }: { className?: string }) {
   const { settings } = usePublicSettings();
-  const src = settings.logo_sha256
+  const custom = settings.logo_sha256
     ? publicSettingsApi.logoUrl(settings.logo_sha256)
-    : logoIcon;
+    : null;
+
+  // Fall back to the bundled mark if the custom logo fails to load. This
+  // is not hypothetical: another operator deleting or replacing the logo
+  // leaves every other open tab requesting the old sha until its cached
+  // ``public-settings`` query goes stale (5 min), and without this the
+  // sidebar shows a broken-image glyph for that whole window.
+  const [failed, setFailed] = useState(false);
+  useEffect(() => setFailed(false), [custom]);
 
   return (
     <img
-      src={src}
+      src={custom && !failed ? custom : logoIcon}
+      onError={() => setFailed(true)}
       alt={settings.app_title.trim() || DEFAULT_APP_TITLE}
       className={className}
     />

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { DemoBanner } from "./DemoBanner";
+import { EnvironmentBanner } from "./EnvironmentBanner";
 import { MaintenanceBanner } from "./MaintenanceBanner";
 import { MaintenanceModeBanner } from "./MaintenanceModeBanner";
 import { SetupBanner } from "./SetupBanner";
@@ -36,6 +37,9 @@ export function AppLayout() {
         onMobileClose={() => setMobileOpen(false)}
       />
       <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Which box am I on (#887) comes before what state it's in — the
+            other banners describe the platform, this one identifies it. */}
+        <EnvironmentBanner edge="top" />
         <DemoBanner />
         <SetupBanner />
         <MaintenanceBanner />
@@ -65,6 +69,7 @@ export function AppLayout() {
             <Outlet />
           </ErrorBoundary>
         </main>
+        <EnvironmentBanner edge="bottom" />
       </div>
       {/* Issue #90 — Operator Copilot floating button. Hidden when no
           AI provider is enabled, opens the chat drawer otherwise. */}

--- a/frontend/src/components/layout/EnvironmentBanner.tsx
+++ b/frontend/src/components/layout/EnvironmentBanner.tsx
@@ -1,0 +1,43 @@
+import { usePublicSettings } from "@/hooks/usePublicSettings";
+
+/**
+ * Operator-defined environment strip — "you are on the DEV box" (issue
+ * #887). Palo Alto and F5 both ship this, and for the same reason: the
+ * expensive mistake is making a real change on a box you thought was a
+ * lab.
+ *
+ * Colours are operator-picked hex, so they land in an inline ``style``
+ * rather than Tailwind classes — the palette isn't known at build time.
+ *
+ * Rendered above the maintenance banners (identity first, then state) and
+ * on the login page, where "which box is this" matters most.
+ */
+export function EnvironmentBanner({ edge }: { edge: "top" | "bottom" }) {
+  const { settings } = usePublicSettings();
+  const banner = settings.env_banner;
+
+  if (!banner.enabled) return null;
+  const text = banner.text.trim();
+  if (!text) return null;
+  if (banner.position !== "both" && banner.position !== edge) return null;
+
+  return (
+    <div
+      // Not aria-live: the text never changes while the page is open, and
+      // announcing it on every render would be noise. It reads in normal
+      // document order instead.
+      className={
+        edge === "top"
+          ? "flex-shrink-0 border-b px-4 py-1 text-center text-xs font-semibold tracking-wide"
+          : "flex-shrink-0 border-t px-4 py-1 text-center text-xs font-semibold tracking-wide"
+      }
+      style={{
+        backgroundColor: banner.bg,
+        color: banner.fg,
+        borderColor: banner.bg,
+      }}
+    >
+      {text}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -77,7 +77,11 @@ import { cn } from "@/lib/utils";
 import { changeRequestsApi, versionApi } from "@/lib/api";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { useSessionState } from "@/lib/useSessionState";
-import logoIcon from "@/assets/logo-icon.svg";
+import { BrandLogo } from "@/components/BrandLogo";
+import {
+  usePublicSettings,
+  DEFAULT_APP_TITLE,
+} from "@/hooks/usePublicSettings";
 
 // Core section. The flat list had grown to 11 rows — the four canonical
 // anchors (Dashboard / IPAM / DHCP / DNS) plus seven grown-in sub-features
@@ -597,6 +601,11 @@ export function Sidebar({
   );
   const location = useLocation();
 
+  // Operator-configured product name (#888) — the wordmark used to be a
+  // hard-coded literal here, which is why setting a title changed nothing.
+  const { settings } = usePublicSettings();
+  const appTitle = settings.app_title.trim() || DEFAULT_APP_TITLE;
+
   // Close the mobile drawer whenever the user navigates.
   useEffect(() => {
     if (mobileOpen) onMobileClose?.();
@@ -739,13 +748,11 @@ export function Sidebar({
             effectiveCollapsed ? "justify-center px-0" : "gap-2 px-4",
           )}
         >
-          <img
-            src={logoIcon}
-            alt="SpatiumDDI"
-            className="h-7 w-7 flex-shrink-0"
-          />
+          <BrandLogo className="h-7 w-7 flex-shrink-0" />
           {!effectiveCollapsed && (
-            <span className="font-semibold tracking-tight">SpatiumDDI</span>
+            <span className="truncate font-semibold tracking-tight">
+              {appTitle}
+            </span>
           )}
           {mobileOpen && (
             <button

--- a/frontend/src/hooks/usePublicSettings.ts
+++ b/frontend/src/hooks/usePublicSettings.ts
@@ -43,6 +43,10 @@ export function usePublicSettings() {
     queryFn: publicSettingsApi.get,
     staleTime: 5 * 60 * 1000,
     refetchOnWindowFocus: false,
+    // One retry, not the default three. ``settled`` below gates the
+    // sign-in button, so the exponential-backoff window is time a user
+    // spends unable to log in when this endpoint is unhealthy — cap it.
+    retry: 1,
   });
 
   return {
@@ -50,6 +54,12 @@ export function usePublicSettings() {
     /** True once real values have arrived. Gate anything that would look
      *  wrong flashing the default first (the login banner, notably). */
     ready: !!query.data,
+    /** True once the query has stopped being unknown — success OR final
+     *  error. Use this, not ``ready``, to gate an ACTION (the sign-in
+     *  button): ``ready`` never flips on a failing endpoint, so gating a
+     *  control on it would lock users out rather than merely showing the
+     *  defaults. */
+    settled: query.isSuccess || query.isError,
     isLoading: query.isLoading,
   };
 }

--- a/frontend/src/hooks/usePublicSettings.ts
+++ b/frontend/src/hooks/usePublicSettings.ts
@@ -1,0 +1,68 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { publicSettingsApi, type PublicSettings } from "@/lib/api";
+
+/** The product's own identity, used until the API answers — and as the
+ *  permanent answer for installs that never customise anything. */
+export const DEFAULT_APP_TITLE = "SpatiumDDI";
+
+const FALLBACK: PublicSettings = {
+  app_title: DEFAULT_APP_TITLE,
+  login_banner: { enabled: false, title: "", text: "", require_ack: false },
+  env_banner: {
+    enabled: false,
+    text: "",
+    bg: "#b91c1c",
+    fg: "#ffffff",
+    position: "top",
+  },
+  logo_sha256: null,
+};
+
+/** Single React Query subscription for the unauthenticated branding slice
+ * (issues #885 / #886 / #887 / #888).
+ *
+ * One endpoint feeds four surfaces — the login page's banner + logo +
+ * title, the environment strip on every authenticated screen, the sidebar
+ * brand, and ``document.title``. The alternative was piggybacking the
+ * authenticated half on ``/health/platform`` (as maintenance mode does)
+ * and fetching the rest separately on the login page, which would have
+ * meant two payloads carrying the same fields and two chances to disagree.
+ *
+ * Cached for 5 min: branding changes are superadmin-rare, and the Settings
+ * save handler invalidates this key so the operator sees their own edit
+ * immediately rather than waiting out the TTL.
+ *
+ * On error the fallback above applies — a hiccup on this call must never
+ * blank the app's name or strand a banner on screen.
+ */
+export function usePublicSettings() {
+  const query = useQuery({
+    queryKey: ["public-settings"],
+    queryFn: publicSettingsApi.get,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    settings: query.data ?? FALLBACK,
+    /** True once real values have arrived. Gate anything that would look
+     *  wrong flashing the default first (the login banner, notably). */
+    ready: !!query.data,
+    isLoading: query.isLoading,
+  };
+}
+
+/** Applies ``app_title`` to the browser tab (issue #888 — the setting
+ *  existed and was documented as doing this, but reached nothing outside
+ *  the OpenAPI page). Called once from the app root so it covers the
+ *  login screen as well as the authenticated shell. */
+export function useBrandDocumentTitle() {
+  const { settings } = usePublicSettings();
+  const title = settings.app_title.trim() || DEFAULT_APP_TITLE;
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3903,9 +3903,12 @@ export interface AuditForwardTargetWrite {
 export const publicSettingsApi = {
   get: () => api.get<PublicSettings>("/settings/public").then((r) => r.data),
   /** Direct URL — the browser fetches the bytes itself, so no auth header
-   *  is available; the route is public for exactly that reason. The sha
-   *  busts the cache when the operator uploads a replacement. */
-  logoUrl: (sha256: string) => `/api/v1/settings/public/logo?v=${sha256}`,
+   *  is available; the route is public for exactly that reason. Built from
+   *  ``API_BASE`` rather than a hardcoded ``/api/v1`` so a deployment that
+   *  overrides ``VITE_API_BASE_URL`` (split-origin / sub-path) still points
+   *  at the real API. The sha busts the cache on re-upload. */
+  logoUrl: (sha256: string) =>
+    `${API_BASE.replace(/\/$/, "")}/settings/public/logo?v=${sha256}`,
 };
 
 export const settingsApi = {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3401,9 +3401,53 @@ export const searchApi = {
 
 // ── Settings ───────────────────────────────────────────────────────────────────
 
+export type EnvBannerPosition = "top" | "bottom" | "both";
+
+/** The deliberately-public slice of PlatformSettings, served unauthenticated
+ *  so the login page can render branding before anyone has a session
+ *  (issues #885 / #886 / #887 / #888). Never add a field here that an
+ *  anonymous visitor shouldn't see. */
+export interface PublicSettings {
+  app_title: string;
+  login_banner: {
+    enabled: boolean;
+    title: string;
+    text: string;
+    require_ack: boolean;
+  };
+  env_banner: {
+    enabled: boolean;
+    text: string;
+    bg: string;
+    fg: string;
+    position: EnvBannerPosition;
+  };
+  /** sha256 of the operator-uploaded logo, or null when none is set (the
+   *  frontend then falls back to the bundled asset). Doubles as the
+   *  cache-buster in the logo URL. */
+  logo_sha256: string | null;
+}
+
+export interface BrandingLogoInfo {
+  sha256: string;
+  byte_size: number;
+  media_type: string;
+}
+
 export interface PlatformSettings {
   app_title: string;
   app_base_url: string;
+  // Login-screen acceptable-use banner — issue #885.
+  login_banner_enabled: boolean;
+  login_banner_title: string;
+  login_banner_text: string;
+  login_banner_require_ack: boolean;
+  // Environment banner ("you are on the DEV box") — issue #887.
+  env_banner_enabled: boolean;
+  env_banner_text: string;
+  env_banner_bg: string;
+  env_banner_fg: string;
+  env_banner_position: EnvBannerPosition;
   dns_auto_sync_enabled: boolean;
   dns_auto_sync_interval_minutes: number;
   dns_auto_sync_delete_stale: boolean;
@@ -3853,10 +3897,36 @@ export interface AuditForwardTargetWrite {
   resource_types?: string[] | null;
 }
 
+/** Unauthenticated branding reads (issues #885–#888). Kept separate from
+ *  ``settingsApi`` because these are the only settings calls that work
+ *  without a session — the login page depends on that. */
+export const publicSettingsApi = {
+  get: () => api.get<PublicSettings>("/settings/public").then((r) => r.data),
+  /** Direct URL — the browser fetches the bytes itself, so no auth header
+   *  is available; the route is public for exactly that reason. The sha
+   *  busts the cache when the operator uploads a replacement. */
+  logoUrl: (sha256: string) => `/api/v1/settings/public/logo?v=${sha256}`,
+};
+
 export const settingsApi = {
   get: () => api.get<PlatformSettings>("/settings").then((r) => r.data),
   update: (data: Partial<PlatformSettings>) =>
     api.put<PlatformSettings>("/settings", data).then((r) => r.data),
+  /** Issue #886 — upload the branding logo (PNG, ≤512 KB). Superadmin
+   *  only, audited server-side. */
+  uploadLogo: (file: File) => {
+    const fd = new FormData();
+    fd.append("file", file);
+    return api
+      .put<BrandingLogoInfo>("/settings/branding/logo", fd, {
+        // Axios picks the multipart boundary itself when the body is a
+        // FormData; an explicit Content-Type would strip it.
+        headers: { "Content-Type": undefined },
+      })
+      .then((r) => r.data);
+  },
+  /** Issue #886 — remove the custom logo and fall back to the bundled one. */
+  deleteLogo: () => api.delete("/settings/branding/logo"),
   getDefaults: () =>
     api
       .get<Partial<PlatformSettings>>("/settings/defaults")

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -4,6 +4,13 @@ import { useAuth } from "@/hooks/useAuth";
 import { authApi, type PublicAuthProvider } from "@/lib/api";
 import { KeyRound, ShieldCheck } from "lucide-react";
 
+import { BrandLogo } from "@/components/BrandLogo";
+import { EnvironmentBanner } from "@/components/layout/EnvironmentBanner";
+import {
+  usePublicSettings,
+  DEFAULT_APP_TITLE,
+} from "@/hooks/usePublicSettings";
+
 function humanizeError(code: string | null): string {
   if (!code) return "";
   if (code === "oidc_rejected")
@@ -86,6 +93,21 @@ export function LoginPage() {
   const [mfaCode, setMfaCode] = useState("");
   const [recoveryCode, setRecoveryCode] = useState("");
 
+  // Branding (#885 / #886 / #887 / #888) — served unauthenticated so it can
+  // render here, before any session exists.
+  const { settings } = usePublicSettings();
+  const appTitle = settings.app_title.trim() || DEFAULT_APP_TITLE;
+  const loginBanner = settings.login_banner;
+  const bannerText = loginBanner.text.trim();
+  const showBanner = loginBanner.enabled && !!bannerText;
+  const [acknowledged, setAcknowledged] = useState(false);
+  // The acknowledgement gate is a consent affordance, not an auth control:
+  // it exists so the operator can say the notice was displayed and accepted.
+  // The API never sees it, and deliberately so — a client-side checkbox
+  // would be security theatre if we pretended otherwise.
+  const ackRequired = showBanner && loginBanner.require_ack;
+  const ackSatisfied = !ackRequired || acknowledged;
+
   useEffect(() => {
     authApi
       .publicProviders()
@@ -165,186 +187,235 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="w-full max-w-sm space-y-6 rounded-lg border bg-card p-8 shadow-sm">
-        <div className="space-y-1 text-center">
-          <h1 className="text-2xl font-bold tracking-tight">SpatiumDDI</h1>
-          <p className="text-sm text-muted-foreground">
-            {step.kind === "mfa"
-              ? "Two-factor verification"
-              : "Sign in to your account"}
-          </p>
-        </div>
-
-        {error && (
-          <div className="flex items-start justify-between gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-            <span>{error}</span>
-            <button
-              onClick={dismissErrorBanner}
-              className="font-semibold hover:underline"
-              type="button"
-            >
-              ×
-            </button>
-          </div>
-        )}
-
-        {step.kind === "password" ? (
-          <form onSubmit={handlePasswordSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <label htmlFor="username" className="text-sm font-medium">
-                Username
-              </label>
-              <input
-                id="username"
-                type="text"
-                autoComplete="username"
-                required
-                value={username}
-                onChange={(e) => setUsername(e.target.value)}
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-            </div>
-            <div className="space-y-2">
-              <label htmlFor="password" className="text-sm font-medium">
-                Password
-              </label>
-              <input
-                id="password"
-                type="password"
-                autoComplete="current-password"
-                required
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-              />
-            </div>
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            >
-              {loading ? "Signing in…" : "Sign in"}
-            </button>
-          </form>
-        ) : (
-          <form onSubmit={handleMfaSubmit} className="space-y-4">
-            <p className="text-xs text-muted-foreground">
-              {mfaMode === "code"
-                ? "Enter the 6-digit code from your authenticator app."
-                : "Enter one of your recovery codes (e.g. ABCD-EF12). Each code works once."}
+    <div className="flex min-h-screen flex-col bg-background">
+      {/* Which environment this is matters most at the sign-in prompt —
+          it is the last point before someone starts making changes. */}
+      <EnvironmentBanner edge="top" />
+      <div className="flex flex-1 items-center justify-center p-4">
+        <div className="w-full max-w-sm space-y-6 rounded-lg border bg-card p-8 shadow-sm">
+          <div className="space-y-2 text-center">
+            <BrandLogo className="mx-auto h-10 w-10" />
+            <h1 className="text-2xl font-bold tracking-tight">{appTitle}</h1>
+            <p className="text-sm text-muted-foreground">
+              {step.kind === "mfa"
+                ? "Two-factor verification"
+                : "Sign in to your account"}
             </p>
-            {mfaMode === "code" ? (
-              <div className="space-y-2">
-                <label htmlFor="mfa-code" className="text-sm font-medium">
-                  Authenticator code
-                </label>
-                <input
-                  id="mfa-code"
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  autoComplete="one-time-code"
-                  required
-                  autoFocus
-                  value={mfaCode}
-                  onChange={(e) =>
-                    setMfaCode(e.target.value.replace(/\D/g, "").slice(0, 6))
-                  }
-                  className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-lg tracking-[0.3em] focus:outline-none focus:ring-2 focus:ring-ring"
-                  placeholder="000000"
-                  maxLength={6}
-                />
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <label htmlFor="recovery-code" className="text-sm font-medium">
-                  Recovery code
-                </label>
-                <input
-                  id="recovery-code"
-                  type="text"
-                  autoComplete="off"
-                  required
-                  autoFocus
-                  value={recoveryCode}
-                  onChange={(e) =>
-                    setRecoveryCode(e.target.value.toUpperCase())
-                  }
-                  className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
-                  placeholder="ABCD-EF12"
-                />
-              </div>
-            )}
-            <button
-              type="submit"
-              disabled={
-                loading ||
-                (mfaMode === "code"
-                  ? mfaCode.length !== 6
-                  : recoveryCode.trim().length === 0)
-              }
-              className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
-            >
-              {loading ? "Verifying…" : "Verify"}
-            </button>
-            <div className="flex items-center justify-between text-xs">
-              <button
-                type="button"
-                onClick={() => {
-                  setMfaMode((m) => (m === "code" ? "recovery" : "code"));
-                  setError("");
-                }}
-                className="text-muted-foreground hover:text-foreground hover:underline"
-              >
-                {mfaMode === "code"
-                  ? "Use a recovery code instead"
-                  : "Use my authenticator code"}
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setStep({ kind: "password" });
-                  setError("");
-                  setPassword("");
-                }}
-                className="text-muted-foreground hover:text-foreground hover:underline"
-              >
-                Sign out
-              </button>
-            </div>
-          </form>
-        )}
+          </div>
 
-        {step.kind === "password" && providers.length > 0 && (
-          <>
-            <div className="relative">
-              <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t" />
-              </div>
-              <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-card px-2 text-muted-foreground">or</span>
-              </div>
+          {showBanner && (
+            <div className="max-h-64 overflow-y-auto rounded-md border bg-muted/40 px-3 py-2 text-xs">
+              {loginBanner.title.trim() && (
+                <div className="mb-1 font-semibold uppercase tracking-wide">
+                  {loginBanner.title.trim()}
+                </div>
+              )}
+              {/* Rendered as plain text with newlines preserved — the field
+                  is operator-authored but shown to anonymous visitors, so it
+                  never becomes markup. */}
+              <p className="whitespace-pre-wrap text-muted-foreground">
+                {bannerText}
+              </p>
+              {ackRequired && (
+                <label className="mt-2 flex items-start gap-2 font-medium text-foreground">
+                  <input
+                    type="checkbox"
+                    checked={acknowledged}
+                    onChange={(e) => setAcknowledged(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>I acknowledge and accept these terms</span>
+                </label>
+              )}
             </div>
-            <div className="space-y-2">
-              {providers.map((p) => (
-                <a
-                  key={p.id}
-                  href={`/api/v1/auth/${p.id}/authorize`}
-                  className="flex w-full items-center justify-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+          )}
+
+          {error && (
+            <div className="flex items-start justify-between gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              <span>{error}</span>
+              <button
+                onClick={dismissErrorBanner}
+                className="font-semibold hover:underline"
+                type="button"
+              >
+                ×
+              </button>
+            </div>
+          )}
+
+          {step.kind === "password" ? (
+            <form onSubmit={handlePasswordSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <label htmlFor="username" className="text-sm font-medium">
+                  Username
+                </label>
+                <input
+                  id="username"
+                  type="text"
+                  autoComplete="username"
+                  required
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="password" className="text-sm font-medium">
+                  Password
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  required
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading || !ackSatisfied}
+                className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {loading ? "Signing in…" : "Sign in"}
+              </button>
+            </form>
+          ) : (
+            <form onSubmit={handleMfaSubmit} className="space-y-4">
+              <p className="text-xs text-muted-foreground">
+                {mfaMode === "code"
+                  ? "Enter the 6-digit code from your authenticator app."
+                  : "Enter one of your recovery codes (e.g. ABCD-EF12). Each code works once."}
+              </p>
+              {mfaMode === "code" ? (
+                <div className="space-y-2">
+                  <label htmlFor="mfa-code" className="text-sm font-medium">
+                    Authenticator code
+                  </label>
+                  <input
+                    id="mfa-code"
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    autoComplete="one-time-code"
+                    required
+                    autoFocus
+                    value={mfaCode}
+                    onChange={(e) =>
+                      setMfaCode(e.target.value.replace(/\D/g, "").slice(0, 6))
+                    }
+                    className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-lg tracking-[0.3em] focus:outline-none focus:ring-2 focus:ring-ring"
+                    placeholder="000000"
+                    maxLength={6}
+                  />
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <label
+                    htmlFor="recovery-code"
+                    className="text-sm font-medium"
+                  >
+                    Recovery code
+                  </label>
+                  <input
+                    id="recovery-code"
+                    type="text"
+                    autoComplete="off"
+                    required
+                    autoFocus
+                    value={recoveryCode}
+                    onChange={(e) =>
+                      setRecoveryCode(e.target.value.toUpperCase())
+                    }
+                    className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    placeholder="ABCD-EF12"
+                  />
+                </div>
+              )}
+              <button
+                type="submit"
+                disabled={
+                  loading ||
+                  (mfaMode === "code"
+                    ? mfaCode.length !== 6
+                    : recoveryCode.trim().length === 0)
+                }
+                className="w-full rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+              >
+                {loading ? "Verifying…" : "Verify"}
+              </button>
+              <div className="flex items-center justify-between text-xs">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setMfaMode((m) => (m === "code" ? "recovery" : "code"));
+                    setError("");
+                  }}
+                  className="text-muted-foreground hover:text-foreground hover:underline"
                 >
-                  {p.type === "oidc" ? (
-                    <KeyRound className="h-4 w-4" />
-                  ) : (
-                    <ShieldCheck className="h-4 w-4" />
-                  )}
-                  Sign in with {p.name}
-                </a>
-              ))}
-            </div>
-          </>
-        )}
+                  {mfaMode === "code"
+                    ? "Use a recovery code instead"
+                    : "Use my authenticator code"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setStep({ kind: "password" });
+                    setError("");
+                    setPassword("");
+                  }}
+                  className="text-muted-foreground hover:text-foreground hover:underline"
+                >
+                  Sign out
+                </button>
+              </div>
+            </form>
+          )}
+
+          {step.kind === "password" && providers.length > 0 && (
+            <>
+              <div className="relative">
+                <div className="absolute inset-0 flex items-center">
+                  <div className="w-full border-t" />
+                </div>
+                <div className="relative flex justify-center text-xs uppercase">
+                  <span className="bg-card px-2 text-muted-foreground">or</span>
+                </div>
+              </div>
+              <div className="space-y-2">
+                {providers.map((p) => (
+                  <a
+                    key={p.id}
+                    // The SSO buttons honour the acknowledgement gate too —
+                    // otherwise the notice is trivially skipped by signing in
+                    // through the identity provider instead.
+                    href={
+                      ackSatisfied
+                        ? `/api/v1/auth/${p.id}/authorize`
+                        : undefined
+                    }
+                    aria-disabled={!ackSatisfied}
+                    className={
+                      ackSatisfied
+                        ? "flex w-full items-center justify-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium transition-colors hover:bg-accent"
+                        : "pointer-events-none flex w-full items-center justify-center gap-2 rounded-md border bg-background px-4 py-2 text-sm font-medium opacity-50"
+                    }
+                  >
+                    {p.type === "oidc" ? (
+                      <KeyRound className="h-4 w-4" />
+                    ) : (
+                      <ShieldCheck className="h-4 w-4" />
+                    )}
+                    Sign in with {p.name}
+                  </a>
+                ))}
+              </div>
+            </>
+          )}
+        </div>
       </div>
+      <EnvironmentBanner edge="bottom" />
     </div>
   );
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -95,7 +95,7 @@ export function LoginPage() {
 
   // Branding (#885 / #886 / #887 / #888) — served unauthenticated so it can
   // render here, before any session exists.
-  const { settings } = usePublicSettings();
+  const { settings, settled: brandingSettled } = usePublicSettings();
   const appTitle = settings.app_title.trim() || DEFAULT_APP_TITLE;
   const loginBanner = settings.login_banner;
   const bannerText = loginBanner.text.trim();
@@ -106,7 +106,12 @@ export function LoginPage() {
   // The API never sees it, and deliberately so — a client-side checkbox
   // would be security theatre if we pretended otherwise.
   const ackRequired = showBanner && loginBanner.require_ack;
-  const ackSatisfied = !ackRequired || acknowledged;
+  // Hold the sign-in affordances until the branding payload has settled.
+  // Until then the fallback says "no banner", so an autofilled form
+  // submitted on the first keypress would skip a notice the operator
+  // configured as mandatory. Gated on ``settled`` rather than ``ready``
+  // deliberately: a failing /settings/public must still let people log in.
+  const ackSatisfied = brandingSettled && (!ackRequired || acknowledged);
 
   useEffect(() => {
     authApi

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -22,8 +22,43 @@ import { Modal } from "@/components/ui/modal";
 import { Toggle } from "@/components/ui/toggle";
 import { AuditForwardTargets } from "@/components/AuditForwardTargets";
 import { AgentBootstrapKeysSection } from "@/components/AgentBootstrapKeysSection";
+import { BrandLogo } from "@/components/BrandLogo";
+import { usePublicSettings } from "@/hooks/usePublicSettings";
 
 const OUI_SOURCE_URL = "https://standards-oui.ieee.org/oui/oui.csv";
+
+/** One-click colour pairs for the environment banner (#887). These are the
+ *  four environments people actually label, in the colours they expect. */
+const ENV_BANNER_PRESETS: {
+  label: string;
+  bg: string;
+  fg: string;
+}[] = [
+  { label: "Dev", bg: "#b91c1c", fg: "#ffffff" },
+  { label: "Test", bg: "#b45309", fg: "#ffffff" },
+  { label: "Staging", bg: "#6d28d9", fg: "#ffffff" },
+  { label: "Prod", bg: "#15803d", fg: "#ffffff" },
+];
+
+/** WCAG 2.x relative luminance → contrast ratio, so the UI can warn before
+ *  an operator ships a banner nobody can read. Not a hard block: some
+ *  houses have brand colours that fail and still want them. */
+function contrastRatio(a: string, b: string): number {
+  const luminance = (hex: string): number => {
+    const m = /^#([0-9a-fA-F]{6})$/.exec(hex.trim());
+    if (!m) return 0;
+    const n = parseInt(m[1], 16);
+    const channels = [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((v) => {
+      const c = v / 255;
+      return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  };
+  const la = luminance(a);
+  const lb = luminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
 
 function Field({
   label,
@@ -105,7 +140,19 @@ const GROUP_ORDER: SectionGroup[] = [
 // Which PlatformSettings keys each section owns — drives the per-section
 // "Reset to defaults" button so it only overwrites that section's fields.
 const SECTION_FIELDS: Record<SectionId, (keyof PlatformSettings)[]> = {
-  branding: ["app_title", "app_base_url"],
+  branding: [
+    "app_title",
+    "app_base_url",
+    "login_banner_enabled",
+    "login_banner_title",
+    "login_banner_text",
+    "login_banner_require_ack",
+    "env_banner_enabled",
+    "env_banner_text",
+    "env_banner_bg",
+    "env_banner_fg",
+    "env_banner_position",
+  ],
   dns: [
     "dns_default_ttl",
     "dns_default_zone_type",
@@ -1012,9 +1059,38 @@ export function SettingsPage() {
     mutationFn: (patch: Partial<PlatformSettings>) => settingsApi.update(patch),
     onSuccess: (updated) => {
       qc.setQueryData(["settings"], updated);
+      // Branding fields are also served from the unauthenticated
+      // /settings/public payload the app shell reads (#885–#888). Without
+      // this the operator would save a banner and not see it until that
+      // query's 5-minute TTL expired.
+      qc.invalidateQueries({ queryKey: ["public-settings"] });
       setForm({});
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
+    },
+  });
+
+  // Issue #886 — branding logo. Independent of the settings form: the
+  // bytes go to their own multipart endpoint, not into the PUT patch.
+  const { settings: publicSettings } = usePublicSettings();
+  const [logoError, setLogoError] = useState("");
+  const logoUpload = useMutation({
+    mutationFn: (file: File) => settingsApi.uploadLogo(file),
+    onSuccess: () => {
+      setLogoError("");
+      qc.invalidateQueries({ queryKey: ["public-settings"] });
+    },
+    onError: (err: unknown) => {
+      const detail = (err as { response?: { data?: { detail?: string } } })
+        ?.response?.data?.detail;
+      setLogoError(typeof detail === "string" ? detail : "Logo upload failed.");
+    },
+  });
+  const logoDelete = useMutation({
+    mutationFn: () => settingsApi.deleteLogo(),
+    onSuccess: () => {
+      setLogoError("");
+      qc.invalidateQueries({ queryKey: ["public-settings"] });
     },
   });
 
@@ -1248,6 +1324,198 @@ export function SettingsPage() {
                     disabled={!isSuperadmin}
                     className={cn(inputCls, "w-72")}
                   />
+                </Field>
+
+                {/* ── Logo (#886) ──────────────────────────────────── */}
+                <Field
+                  label="Logo"
+                  description="PNG, 512 KB maximum. Shown on the sign-in screen and in the sidebar. Stored in the database, so it reaches every node without a shared volume."
+                >
+                  <div className="flex items-center gap-3">
+                    <BrandLogo className="h-8 w-8" />
+                    <input
+                      type="file"
+                      accept="image/png"
+                      disabled={!isSuperadmin || logoUpload.isPending}
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        // Reset the input so re-picking the same file
+                        // after a failed upload still fires onChange.
+                        e.target.value = "";
+                        if (file) logoUpload.mutate(file);
+                      }}
+                      className="max-w-[14rem] text-xs file:mr-2 file:rounded-md file:border file:bg-background file:px-2 file:py-1 file:text-xs"
+                    />
+                    {publicSettings.logo_sha256 && (
+                      <button
+                        type="button"
+                        onClick={() => logoDelete.mutate()}
+                        disabled={!isSuperadmin || logoDelete.isPending}
+                        className="rounded-md border px-2 py-1 text-xs hover:bg-accent disabled:opacity-40"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                </Field>
+                {logoError && (
+                  <div className="py-2 text-xs text-destructive">
+                    {logoError}
+                  </div>
+                )}
+
+                {/* ── Login banner (#885) ──────────────────────────── */}
+                <Field
+                  label="Login banner"
+                  description="Show an acceptable-use / consent notice above the sign-in form. This text is served unauthenticated — anyone who can reach the login page can read it."
+                >
+                  <Toggle
+                    checked={!!values.login_banner_enabled}
+                    onChange={(v) => set("login_banner_enabled", v)}
+                    disabled={!isSuperadmin}
+                  />
+                </Field>
+                <Field
+                  label="Banner heading"
+                  description="Optional short heading, e.g. NOTICE."
+                >
+                  <input
+                    value={values.login_banner_title ?? ""}
+                    onChange={(e) => set("login_banner_title", e.target.value)}
+                    placeholder="NOTICE"
+                    maxLength={120}
+                    disabled={!isSuperadmin || !values.login_banner_enabled}
+                    className={cn(inputCls, "w-48")}
+                  />
+                </Field>
+                <Field
+                  label="Banner text"
+                  description="Plain text; line breaks are preserved."
+                >
+                  <textarea
+                    value={values.login_banner_text ?? ""}
+                    onChange={(e) => set("login_banner_text", e.target.value)}
+                    rows={4}
+                    maxLength={8000}
+                    disabled={!isSuperadmin || !values.login_banner_enabled}
+                    className={cn(inputCls, "w-72 font-mono text-xs")}
+                  />
+                </Field>
+                <Field
+                  label="Require acknowledgement"
+                  description="Gate the sign-in button on an “I acknowledge” checkbox. A consent affordance, not an access control — the API never sees the acknowledgement."
+                >
+                  <Toggle
+                    checked={!!values.login_banner_require_ack}
+                    onChange={(v) => set("login_banner_require_ack", v)}
+                    disabled={!isSuperadmin || !values.login_banner_enabled}
+                  />
+                </Field>
+
+                {/* ── Environment banner (#887) ────────────────────── */}
+                <Field
+                  label="Environment banner"
+                  description="A coloured strip on every screen naming this environment — the cheap way to stop a change landing on the wrong box."
+                >
+                  <Toggle
+                    checked={!!values.env_banner_enabled}
+                    onChange={(v) => set("env_banner_enabled", v)}
+                    disabled={!isSuperadmin}
+                  />
+                </Field>
+                <Field label="Banner text">
+                  <input
+                    value={values.env_banner_text ?? ""}
+                    onChange={(e) => set("env_banner_text", e.target.value)}
+                    placeholder="DEVELOPMENT — not production"
+                    maxLength={200}
+                    disabled={!isSuperadmin || !values.env_banner_enabled}
+                    className={cn(inputCls, "w-72")}
+                  />
+                </Field>
+                <Field
+                  label="Position"
+                  description="“Both” frames the page top and bottom."
+                >
+                  <select
+                    value={values.env_banner_position ?? "top"}
+                    onChange={(e) =>
+                      set(
+                        "env_banner_position",
+                        e.target
+                          .value as PlatformSettings["env_banner_position"],
+                      )
+                    }
+                    disabled={!isSuperadmin || !values.env_banner_enabled}
+                    className={inputCls}
+                  >
+                    <option value="top">Top</option>
+                    <option value="bottom">Bottom</option>
+                    <option value="both">Both</option>
+                  </select>
+                </Field>
+                <Field
+                  label="Colours"
+                  description="Background and text colour for the strip."
+                >
+                  <div className="flex flex-col items-end gap-2">
+                    <div className="flex items-center gap-2">
+                      {ENV_BANNER_PRESETS.map((p) => (
+                        <button
+                          key={p.label}
+                          type="button"
+                          onClick={() => {
+                            set("env_banner_bg", p.bg);
+                            set("env_banner_fg", p.fg);
+                          }}
+                          disabled={!isSuperadmin || !values.env_banner_enabled}
+                          style={{ backgroundColor: p.bg, color: p.fg }}
+                          className="rounded-md px-2 py-1 text-xs font-semibold disabled:opacity-40"
+                        >
+                          {p.label}
+                        </button>
+                      ))}
+                    </div>
+                    <div className="flex items-center gap-2 text-xs">
+                      <label className="flex items-center gap-1">
+                        <span className="text-muted-foreground">Bg</span>
+                        <input
+                          type="color"
+                          value={values.env_banner_bg ?? "#b91c1c"}
+                          onChange={(e) => set("env_banner_bg", e.target.value)}
+                          disabled={!isSuperadmin || !values.env_banner_enabled}
+                          className="h-7 w-10 rounded border bg-background"
+                        />
+                      </label>
+                      <label className="flex items-center gap-1">
+                        <span className="text-muted-foreground">Text</span>
+                        <input
+                          type="color"
+                          value={values.env_banner_fg ?? "#ffffff"}
+                          onChange={(e) => set("env_banner_fg", e.target.value)}
+                          disabled={!isSuperadmin || !values.env_banner_enabled}
+                          className="h-7 w-10 rounded border bg-background"
+                        />
+                      </label>
+                    </div>
+                    <div
+                      className="w-72 rounded-md px-3 py-1 text-center text-xs font-semibold"
+                      style={{
+                        backgroundColor: values.env_banner_bg ?? "#b91c1c",
+                        color: values.env_banner_fg ?? "#ffffff",
+                      }}
+                    >
+                      {values.env_banner_text?.trim() || "Preview"}
+                    </div>
+                    {contrastRatio(
+                      values.env_banner_bg ?? "#b91c1c",
+                      values.env_banner_fg ?? "#ffffff",
+                    ) < 4.5 && (
+                      <div className="text-xs text-amber-600 dark:text-amber-400">
+                        Low contrast — this may be hard to read.
+                      </div>
+                    )}
+                  </div>
                 </Field>
               </>
             )}


### PR DESCRIPTION
Four issues that all needed the same missing piece — a way for the login page to know anything about the operator's branding *before* a session exists. Building that endpoint once is why these ship together rather than as four PRs stepping on the same files.

Closes #885
Closes #886
Closes #887
Closes #888

## The shared piece

`GET /api/v1/settings/public` is unauthenticated, following the `/auth/password-policy` precedent already in the auth router (there is no auth middleware — omitting the `CurrentUser` dependency is what makes a route public). It returns an **explicit whitelist** — title, both banners, logo hash — rather than a filtered dump of the settings row, so a column added to `PlatformSettings` next year cannot leak through by default.

Branding writes are **superadmin-only**, a stronger gate than the `write:settings` the rest of the PUT takes. These fields render to anonymous visitors, so a delegated settings editor could otherwise put arbitrary text on the login page — a phishing surface, not a preference. Every change is audited (`resource_id="branding"` / `"branding_logo"`).

## What each issue got

| Issue | Result |
|---|---|
| **#885** | Acceptable-use banner above the sign-in form, optional "I acknowledge" checkbox |
| **#886** | PNG logo upload, stored in Postgres, served to the login page and sidebar |
| **#887** | DEV/TEST/PROD strip with operator-chosen colours, top / bottom / both |
| **#888** | `app_title` finally drives the browser tab, login heading and sidebar wordmark |

## Decisions worth reviewing

**The acknowledgement gates the SSO buttons too.** Gating only the password form would have left the notice trivially skippable by signing in through the identity provider.

**The logo lives in the database.** The control plane is multi-node, and a file written to one API pod is invisible to the others — the problem that forced the slot-image mirror sidecar (#296) into existence, a whole extra Deployment plus PVC to fan one file out. A logo is tens of KB, Postgres is already shared, so a DB blob propagates everywhere for free and rides along in backups. It is its own table rather than a `platform_settings` column because that row is read on many request paths and none of them should pay to load a blob.

**PNG only, validated by magic bytes** rather than the client's declared content type. The logo is served same-origin, so accepting an SVG would turn a branding upload into stored XSS against unauthenticated visitors. #886 had proposed PNG-or-sanitised-SVG; this ships the refusal instead.

**One `/settings/public` fetch, not a `/health/platform` piggyback.** #887 proposed putting the authenticated half on the already-polled health payload. That would mean two payloads carrying the same fields and two chances to disagree, so there is a single `usePublicSettings` hook behind all four surfaces.

**The sign-in button waits for the branding query to *settle* — success or final error — not to succeed.** Gating on success alone would lock every user out of a system whose only fault is a sick branding endpoint. The query retries once rather than three times, because that backoff is now time someone spends unable to log in.

## Bugs caught before merge

- The public endpoint originally nested the logo lookup inside the settings-row check, so a logo uploaded on a fresh install — before anyone saved settings — would never have been served. Caught by a test.
- The login page gated on the payload having *arrived*, so an autofilled form submitted on the first Enter could sign in with a mandatory notice never shown.
- Logo upload was read-then-insert against a `UNIQUE(kind)`; concurrent uploads raced and the loser 500'd. Now an explicit last-write-wins upsert.
- `logoUrl` hardcoded `/api/v1`, breaking any deployment that sets `VITE_API_BASE_URL`.
- `BrandLogo` had no `onError`, so replacing the logo left other tabs showing a broken-image glyph until their cached query went stale.

## Testing

13 new tests in `backend/tests/test_settings_branding.py` covering the unauthenticated read, the whitelist shape, banner round-trip plus audit, the superadmin gate (proving the same user is refused on branding but succeeds on an ordinary setting), colour and length validation, and the full logo lifecycle including the SVG refusal, the size cap and the 304.

`make ci` passes end to end, as does `scripts/lint_migrations.py`. Verified live on a rebuilt dev stack: banners rendering top and bottom, logo round-tripping byte-identical through the frontend nginx proxy unauthenticated with a weak ETag and a 304 on conditional re-fetch, audit rows written, and the served JS bundle confirmed to contain the new code.

## Notes

- Migration `d3f8b6c02a41` adds nine `platform_settings` columns (all `NOT NULL` with `server_default`, so the singleton row backfills) plus the `branding_asset` table. Every default reproduces today's behaviour: an install that upgrades into this renders exactly as it did before.
- One new Copilot tool, `find_branding_settings`, read-only and default-enabled. Deliberately no `propose_update_branding` — the write path is superadmin-only for a reason, and that is not a gate to hand to a chat tool.
- `CHANGELOG.md` and `CLAUDE.md` are untouched: per the repo's convention those are release-prep edits, and #891 already tracks the roadmap entries for this batch of issues.
