### PR TITLE
feat(system): platform-wide scrubbed support bundle (#875)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -83,6 +83,33 @@ body:
       description: API, worker, or browser console logs. Please redact secrets.
       render: shell
 
+  - type: markdown
+    attributes:
+      value: |
+        ### Support bundle (optional, but it saves a round trip)
+
+        **Diagnostics → Support bundle** generates a scrubbed archive with
+        versions, schema head, recent errors, alert history, configuration
+        shape and an audit tail. IP addresses, hostnames, MAC addresses and
+        usernames are replaced with stable synthetic values; credentials are
+        excluded outright.
+
+        ⚠️ **Attachments on this repository are public.** Anyone who can read
+        this issue can download what you attach, and deleting the comment does
+        not reliably remove the file. Scrubbing is best-effort — please use the
+        preview screen to review the bundle before attaching it, and never
+        attach the `-UNSCRUBBED-` variant or the decode map.
+
+  - type: checkboxes
+    id: bundle_ack
+    attributes:
+      label: If you are attaching a support bundle
+      options:
+        - label: I generated it with scrubbing on (the filename does NOT contain UNSCRUBBED)
+          required: false
+        - label: I reviewed the preview before attaching it
+          required: false
+
   - type: textarea
     id: env
     attributes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -583,11 +583,41 @@ suggestion, free-space treemap.
 - ✅ [**PCAP capture trigger**](https://github.com/spatiumddi/spatiumddi/issues/59) — shipped `2026.06.15-1`: on-demand tcpdump as an RBAC-gated/audited Tools page, both server-container and appliance-host (real-NIC) vantages, keep-partial-on-Stop, `.pcap` download, 4 Operator Copilot tools.
 - ❌ [**ACL / prefix-list generator**](https://github.com/spatiumddi/spatiumddi/issues/60) — **closed as not planned** 2026-06-17, in the same triage pass that closed #40. No rationale was recorded on the issue; re-open it rather than re-filing if the need comes back.
 - ✅ [**Config-drift report (full record diff)**](https://github.com/spatiumddi/spatiumddi/issues/61) — **backend shipped `2026.06.11-1`**: `GET …/zones/{id}/drift` AXFRs the live zone from every server in the group and diffs it against the DB — extra-on-server (manual host change) / missing-on-server / in-sync, per server, read-only — plus a `find_dns_zone_drift` MCP tool. **UI shipped `2026.07.30-1` (#735)** — a Drift tab on the zone detail, fetched on demand because one call fans out an AXFR to every server in the group. That PR also fixed the reason nothing had ever consumed the endpoint: `dns.query.xfr` takes an IP *literal* and raises a bare, message-less `ValueError` for a hostname before sending a packet, so every hostname-addressed server failed 100% of the time reporting `""` as the error. **[#734](https://github.com/spatiumddi/spatiumddi/issues/734) closed the last gap** — agent-managed BIND9 / Technitium reached the server but got `REFUSED`, because the control plane transferred unsigned while the agent granted `allow-transfer` only to the group key and only on *dynamic* zones; separately, `DNSServerOptions.allow_transfer` and `DNSZone.allow_transfer` were both settable, persisted and **never rendered at all** (a silent no-op). Now: the shared AXFR helper takes an optional `TsigKey`, `resolve_group_transfer_key` picks the same key the agent granted (legacy group key first, then operator `DNSTSIGKey` rows by name — matching the bundle's ordering, which is why `op_keys` is now `order_by(name)`), the BIND9 agent renders the grant in the **options** block so it covers every zone type, Technitium falls back to `Allow` + `zoneTransferTsigKeyNames` (verified against upstream `DnsServer.cs`: the two gates AND, so naming keys makes a signature *required*), and a keyless group reports `unsupported` naming the missing key instead of a misleading ACL error. Windows Path A is deliberately excluded from `AXFR_TSIG_DRIVERS` — it authorises by address, so signing would break a working pull. **Drift now works on every driver except PowerDNS**, which implements no record pull.
-- ⬜ [**Support bundle**](https://github.com/spatiumddi/spatiumddi/issues/875) — one-click scrubbed diagnostics
-  export for bug reports: versions, health, config with secrets
-  redacted, recent logs and audit rows. Includes deciding the private
-  submission channel, since a GitHub issue is public and a bundle is
-  not.
+- ✅ [**Support bundle**](https://github.com/spatiumddi/spatiumddi/issues/875)
+  — platform-wide scrubbed diagnostics export at
+  `POST /system/support-bundle{,/preview,/decode-map}`
+  (`backend/app/services/support_bundle/`), superadmin + audited, and
+  working on **all three deployment shapes** — the appliance-only
+  `/appliance/diagnostics/bundle` it supersedes 503s on compose and
+  plain k8s because its pod-log and self-test halves go through kubeapi.
+  **Research finding that shaped the design:** GitHub has no private
+  channel for this. Attachment URLs on a public repo follow *repository*
+  visibility, and deleting the comment does not purge the file — so the
+  answer is scrubbing, not secrecy. **Two tiers:** secrets (Fernet,
+  bcrypt/argon2, PEM, JWT, PSK, TSIG) are **hard-excluded in every
+  mode** including the unscrubbed one, matched by field name *and* value
+  shape; identifiers (IPs / hostnames / MACs / usernames) are
+  pseudonymised HMAC-deterministically off `SECRET_KEY` so mappings are
+  stable per install and unguessable outside it. Topology survives —
+  same /24 → same synthetic /24 with the host octet kept; zone and
+  subdomain grouping preserved. Synthetic v4 lands in **240.0.0.0/6,
+  not sos's CGNAT range**, because #42 makes CGNAT a real modelled thing
+  here and obfuscating into it would read as genuine. The IPv6 interface
+  ID is **discarded rather than mapped** — SLAAC embeds the MAC (RFC
+  4291), so preserving it would route hardware identity past the MAC
+  scrubber. Decode map is a separate endpoint, **never in the archive**.
+  A last-chance `safety_net` sweeps the assembled text and *reports*
+  what it caught, because a net firing means a collector has a bug.
+  **Two bugs found building it, both about failure isolation:** a
+  collector that swallows its own DB error leaves PostgreSQL in
+  "transaction is aborted" so every *later* section fails and the bundle
+  blames the wrong ones — every guarded query now runs in its own
+  SAVEPOINT, as does every section. 1 MCP tool
+  (`get_support_bundle_preview`, default **off**). No feature-module
+  gate: an ops primitive like backup. **Deferred:** true streaming (a
+  zip's central directory is written last, so it needs a third-party
+  writer — bounded by per-section + 48 MB caps instead) and a CLI
+  fallback for a host that cannot serve HTTP.
 - ⬜ [**Agents never read the `previous.json` they write**](https://github.com/spatiumddi/spatiumddi/issues/882) —
   both agents persist a last-known-good bundle and neither ever loads
   it, so a bad config that passes validation but breaks the daemon has

--- a/backend/app/api/v1/system/__init__.py
+++ b/backend/app/api/v1/system/__init__.py
@@ -1,15 +1,17 @@
 """System-level admin surface (issue #116).
 
-Currently exposes the factory-reset endpoints at
-``/system/factory-reset/*``. New top-level system endpoints land
-under this prefix.
+Exposes factory-reset at ``/system/factory-reset/*`` (#116) and the
+support bundle at ``/system/support-bundle*`` (#875). New top-level
+system endpoints land under this prefix.
 """
 
 from fastapi import APIRouter
 
 from app.api.v1.system.factory_reset import router as factory_reset_router
+from app.api.v1.system.support_bundle import router as support_bundle_router
 
 router = APIRouter()
 router.include_router(factory_reset_router, prefix="/factory-reset")
+router.include_router(support_bundle_router, prefix="/support-bundle")
 
 __all__ = ["router"]

--- a/backend/app/api/v1/system/support_bundle.py
+++ b/backend/app/api/v1/system/support_bundle.py
@@ -1,0 +1,201 @@
+"""Support-bundle endpoints (issue #875).
+
+* ``POST /system/support-bundle/preview`` — dry run. Returns the file
+  list, sizes, what the scrubber replaced, and a redacted excerpt, so
+  the operator can review before deciding to share. Proposal 3 of the
+  issue.
+* ``POST /system/support-bundle`` — the archive itself.
+* ``POST /system/support-bundle/decode-map`` — synthetic → real, for the
+  operator only. Never inside the archive.
+
+Deliberately **stateless**: every call regenerates. The alternative was
+holding the archive in Redis between preview and download, which buys
+consistency between the two at the cost of parking a file full of an
+operator's diagnostics in a shared cache with a TTL. Since the scrubber
+is seeded by ``SECRET_KEY`` via HMAC, a regenerated map is *identical*
+for every value it has in common — so the decode call works against a
+bundle downloaded minutes earlier without either being stored anywhere.
+
+The consequence, stated rather than hidden: a preview and the download
+that follows are separate snapshots, so a busy install may log a line
+between them and shift a byte count. The preview is a faithful account
+of what a bundle contains, not a checksum of one particular archive.
+
+Superadmin-only and audited. This reads logs, config shape and an audit
+tail across the whole platform — a narrower gate would be a way to
+exfiltrate all three.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, HTTPException, Response, status
+from pydantic import BaseModel, Field
+
+from app.api.deps import DB, CurrentUser
+from app.core.demo_mode import forbid_in_demo_mode
+from app.core.permissions import is_effective_superadmin
+from app.models.audit import AuditLog
+from app.services.support_bundle import generate
+
+logger = structlog.get_logger(__name__)
+router = APIRouter()
+
+# Typed exactly, and compared case-sensitively, for the unscrubbed
+# variant. Not a checkbox: the difference between the two bundles is
+# whether real addresses and hostnames leave the building, and a
+# mis-click should not be able to produce the wrong one.
+UNSCRUBBED_CONFIRM = "I understand this bundle is not anonymised"
+
+
+class BundleRequest(BaseModel):
+    scrubbed: bool = Field(
+        default=True,
+        description=(
+            "Pseudonymise IPs / hostnames / MACs / usernames. Leave true for "
+            "anything you intend to share. Credentials are excluded either way."
+        ),
+    )
+    confirm_unscrubbed: str | None = Field(
+        default=None,
+        description=(f"Required verbatim when scrubbed=false: {UNSCRUBBED_CONFIRM!r}"),
+    )
+
+
+class FilePreviewOut(BaseModel):
+    path: str
+    bytes: int
+    truncated: bool
+
+
+class BundlePreviewOut(BaseModel):
+    scrubbed: bool
+    filename: str
+    total_bytes: int
+    files: list[FilePreviewOut]
+    manifest: dict[str, Any]
+    section_errors: list[str]
+    sample: str
+    warning: str
+
+
+def _require_superadmin(user: Any) -> None:
+    if not is_effective_superadmin(user):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Support bundles are superadmin-only: one archive carries "
+                "platform logs, configuration shape and an audit tail."
+            ),
+        )
+
+
+def _check_unscrubbed(body: BundleRequest) -> None:
+    if body.scrubbed:
+        return
+    if body.confirm_unscrubbed != UNSCRUBBED_CONFIRM:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "An unscrubbed bundle contains real hostnames, IP addresses, "
+                "MAC addresses and usernames, and must never be attached to a "
+                f"public issue. To generate one, send confirm_unscrubbed="
+                f"{UNSCRUBBED_CONFIRM!r} verbatim."
+            ),
+        )
+
+
+def _audit(user: Any, scrubbed: bool, action: str) -> AuditLog:
+    return AuditLog(
+        user_id=user.id,
+        user_display_name=user.display_name,
+        auth_source=user.auth_source,
+        action=action,
+        resource_type="support_bundle",
+        resource_id="-",
+        resource_display=("scrubbed" if scrubbed else "UNSCRUBBED"),
+        result="success",
+    )
+
+
+@router.post("/preview", response_model=BundlePreviewOut)
+async def preview_support_bundle(
+    body: BundleRequest, db: DB, current_user: CurrentUser
+) -> BundlePreviewOut:
+    """Dry run — what a bundle generated right now would contain."""
+    _require_superadmin(current_user)
+    _check_unscrubbed(body)
+
+    result = await generate(db, scrubbed=body.scrubbed)
+    # Audited like the download. A preview reads exactly the same data;
+    # only the response body differs, so auditing one and not the other
+    # would leave a gap that looks like a way to read without a trace.
+    db.add(_audit(current_user, body.scrubbed, "read"))
+    await db.commit()
+
+    return BundlePreviewOut(
+        scrubbed=result.scrubbed,
+        filename=result.filename,
+        total_bytes=len(result.archive),
+        files=[FilePreviewOut(**vars(f)) for f in result.files],
+        manifest=result.manifest,
+        section_errors=result.errors,
+        sample=result.sample,
+        warning=str(result.manifest.get("READ_THIS", "")),
+    )
+
+
+@router.post("")
+async def download_support_bundle(
+    body: BundleRequest, db: DB, current_user: CurrentUser
+) -> Response:
+    """Generate and return the archive."""
+    _require_superadmin(current_user)
+    forbid_in_demo_mode()
+    _check_unscrubbed(body)
+
+    result = await generate(db, scrubbed=body.scrubbed)
+    db.add(_audit(current_user, body.scrubbed, "export"))
+    await db.commit()
+
+    return Response(
+        content=result.archive,
+        media_type="application/zip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{result.filename}"',
+            "Content-Length": str(len(result.archive)),
+        },
+    )
+
+
+class DecodeMapOut(BaseModel):
+    warning: str
+    mappings: dict[str, dict[str, str]]
+    counts: dict[str, int]
+
+
+@router.post("/decode-map", response_model=DecodeMapOut)
+async def support_bundle_decode_map(db: DB, current_user: CurrentUser) -> DecodeMapOut:
+    """Synthetic → real, so support's answers can be acted on.
+
+    Kept out of the archive on purpose. The mapping is regenerated here
+    rather than stored: it is deterministic per install, so a token from
+    an earlier bundle resolves the same way.
+    """
+    _require_superadmin(current_user)
+    forbid_in_demo_mode()
+
+    result = await generate(db, scrubbed=True)
+    db.add(_audit(current_user, True, "read"))
+    await db.commit()
+
+    return DecodeMapOut(
+        warning=(
+            "This mapping reverses the scrubbing. Keep it local — sharing it "
+            "alongside a bundle undoes the anonymisation completely."
+        ),
+        mappings=result.decode_map,
+        counts={k: len(v) for k, v in result.decode_map.items()},
+    )

--- a/backend/app/api/v1/system/support_bundle.py
+++ b/backend/app/api/v1/system/support_bundle.py
@@ -126,6 +126,11 @@ async def preview_support_bundle(
 ) -> BundlePreviewOut:
     """Dry run — what a bundle generated right now would contain."""
     _require_superadmin(current_user)
+    # Gated like the download it precedes. The preview is not a summary:
+    # it returns an excerpt of the real activity log plus the whole file
+    # inventory, so leaving it open on a shared demo instance would read
+    # out most of what blocking the download is meant to prevent.
+    forbid_in_demo_mode()
     _check_unscrubbed(body)
 
     result = await generate(db, scrubbed=body.scrubbed)

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -60,6 +60,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     saved_views,
     snmp,
     ssh,
+    support_bundle,
     syslog,
     tls_certs,
     upgrades,

--- a/backend/app/services/ai/tools/support_bundle.py
+++ b/backend/app/services/ai/tools/support_bundle.py
@@ -1,0 +1,68 @@
+"""Operator Copilot access to the support bundle (issue #875)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import is_effective_superadmin
+from app.models.auth import User
+from app.services.ai.tools.base import register_tool
+
+
+class SupportBundlePreviewArgs(BaseModel):
+    """No arguments — the preview describes the whole bundle."""
+
+
+@register_tool(
+    name="get_support_bundle_preview",
+    description=(
+        "Describe what a support bundle generated right now would "
+        "contain: the file list with sizes, how many IPs / hostnames / "
+        "MACs / usernames the scrubber replaced, which credential "
+        "columns were dropped, and any section that failed to collect. "
+        "Use for 'what goes into a support bundle?', 'is my bundle "
+        "safe to attach to a GitHub issue?' or 'why is section X "
+        "missing?'. Does NOT return the archive — download that from "
+        "System > Support bundle, where the confirm-and-review step is."
+    ),
+    args_model=SupportBundlePreviewArgs,
+    category="system",
+    # Default OFF. This is a broad read: generating the preview walks
+    # platform logs, the settings row, an audit tail and recent errors.
+    # Everything it RETURNS is scrubbed metadata rather than content, but
+    # the operator should still opt in deliberately rather than discover
+    # it is on.
+    default_enabled=False,
+)
+async def get_support_bundle_preview(
+    db: AsyncSession, user: User, args: SupportBundlePreviewArgs
+) -> dict[str, Any]:
+    from app.services.support_bundle import generate  # noqa: PLC0415
+
+    if not is_effective_superadmin(user):
+        return {
+            "error": (
+                "Support bundles are superadmin-only — one archive carries "
+                "platform logs, configuration shape and an audit tail."
+            )
+        }
+
+    result = await generate(db, scrubbed=True)
+    return {
+        "filename": result.filename,
+        "total_bytes": len(result.archive),
+        "files": [
+            {"path": f.path, "bytes": f.bytes, "truncated": f.truncated} for f in result.files
+        ],
+        "scrub_summary": result.manifest.get("scrub", {}),
+        "section_errors": result.errors,
+        "warning": result.manifest.get("READ_THIS", ""),
+        "note": (
+            "Scrubbing is best-effort, like `sos report --clean`. Review the "
+            "archive before attaching it to a public issue — attachments "
+            "there are readable by anyone who can see the issue."
+        ),
+    }

--- a/backend/app/services/support_bundle/__init__.py
+++ b/backend/app/services/support_bundle/__init__.py
@@ -1,0 +1,277 @@
+"""Platform-wide support bundle (issue #875).
+
+Builds a zip an operator can attach to a **public** GitHub issue.
+Attachments there are effectively world-readable, so the bundle is
+scrubbed by default and the unscrubbed variant is a deliberate,
+differently-named opt-in for local debugging.
+
+Three-step flow rather than one download, because proposal 3 of the
+issue asks for a self-review step and it is the right shape anyway:
+
+1. :func:`generate` builds the archive and a preview (file list, sizes,
+   what the scrubber replaced, a redacted sample).
+2. The operator reads the preview and downloads the archive.
+3. If support later says "n123.d456.invalid is unhealthy", the decode
+   map answers which host that is.
+
+The decode map is returned by a **separate** call and never written into
+the archive. A bundle carrying its own decoder is not scrubbed, it is
+merely inconvenient to read.
+
+Assembly is in memory. A zip's central directory is written last, so
+true streaming needs a third-party writer, and the honest alternative is
+a hard cap — :data:`~.collect.CAP_TOTAL_BYTES` — that bounds peak RSS
+instead of pretending the problem away.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import uuid
+import zipfile
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.services.support_bundle import collect
+from app.services.support_bundle.scrub import Scrubber, safety_net
+
+logger = structlog.get_logger(__name__)
+
+__all__ = ["BundleResult", "FilePreview", "generate"]
+
+
+@dataclass
+class FilePreview:
+    path: str
+    bytes: int
+    truncated: bool
+
+
+@dataclass
+class BundleResult:
+    id: str
+    filename: str
+    archive: bytes
+    files: list[FilePreview]
+    manifest: dict[str, Any]
+    decode_map: dict[str, dict[str, str]]
+    scrubbed: bool
+    # Sections that raised. Present in the manifest so a reader can tell
+    # "this install has no DNS servers" from "the DNS collector broke".
+    errors: list[str] = field(default_factory=list)
+    sample: str = ""
+
+
+async def _safe(
+    name: str,
+    factory: Callable[[], Any],
+    errors: list[str],
+    db: AsyncSession | None = None,
+) -> Any:
+    """Run one collector, converting a failure into an in-bundle note.
+
+    A bundle is requested when something is already broken, and the
+    sections most likely to raise describe exactly that breakage. A 500
+    here would deny the operator the diagnostics *because* the system
+    needs diagnosing.
+
+    Each DB-touching collector runs inside a SAVEPOINT. Without one, a
+    single failed statement puts PostgreSQL into "current transaction is
+    aborted, commands ignored until end of transaction block" and every
+    *later* collector fails too — so one missing table would turn into
+    an almost-empty bundle whose section_errors all blame the wrong
+    thing. Rolling back to the savepoint confines the damage to the
+    section that caused it.
+
+    ``factory`` is a callable rather than an already-created coroutine
+    because the savepoint has to open *before* the query is issued.
+    """
+    try:
+        if db is not None:
+            async with db.begin_nested():
+                result = factory()
+                return await result if hasattr(result, "__await__") else result
+        result = factory()
+        return await result if hasattr(result, "__await__") else result
+    except Exception as exc:  # noqa: BLE001 — recorded, never raised
+        logger.warning("support_bundle_section_failed", section=name, error=str(exc))
+        errors.append(f"{name}: {type(exc).__name__}: {exc}")
+        return f"[section failed: {type(exc).__name__}: {exc}]"
+
+
+async def generate(db: AsyncSession, *, scrubbed: bool = True) -> BundleResult:
+    """Assemble the bundle.
+
+    ``scrubbed=False`` keeps real hostnames and addresses for an operator
+    debugging their own install. It does NOT keep secrets: those are
+    hard-excluded in every mode, because there is no version of "let me
+    read my own logs" that is improved by including the key which
+    decrypts the database.
+    """
+    scrub = Scrubber(enabled=scrubbed)
+    errors: list[str] = []
+    sections: dict[str, str] = {}
+
+    # ── DB-backed ───────────────────────────────────────────────────
+    sections["versions.json"] = await _safe(
+        "versions", lambda: collect.collect_versions(db), errors, db
+    )
+    sections["health/self-test.txt"] = await _safe("self_test", collect.collect_self_test, errors)
+    sections["health/db-connections.json"] = await _safe(
+        "db_pool", lambda: collect.collect_db_pool(db), errors, db
+    )
+    sections["health/table-sizes.json"] = await _safe(
+        "table_sizes", lambda: collect.collect_table_sizes(db), errors, db
+    )
+    sections["errors/internal-errors.json"] = await _safe(
+        "internal_errors", lambda: collect.collect_internal_errors(db, scrub), errors, db
+    )
+    sections["alerts/events.json"] = await _safe(
+        "alert_events", lambda: collect.collect_alert_events(db, scrub), errors, db
+    )
+    sections["audit/recent.json"] = await _safe(
+        "audit_tail", lambda: collect.collect_audit_tail(db, scrub), errors, db
+    )
+    sections["activity/recent.log"] = await _safe(
+        "recent_app_logs", lambda: collect.collect_recent_app_logs(db, scrub), errors, db
+    )
+    sections["config/feature-modules.json"] = await _safe(
+        "feature_modules", lambda: collect.collect_feature_modules(db), errors, db
+    )
+    sections["config/platform-settings.json"] = await _safe(
+        "platform_settings", lambda: collect.collect_platform_settings(db, scrub), errors, db
+    )
+    sections["config/integrations.json"] = await _safe(
+        "integrations", lambda: collect.collect_integration_state(db), errors, db
+    )
+    sections["agents/servers.json"] = await _safe(
+        "agent_state", lambda: collect.collect_agent_state(db, scrub), errors, db
+    )
+
+    # ── Host / runtime ──────────────────────────────────────────────
+    sections["system/env.txt"] = await _safe(
+        "environment", lambda: collect.collect_environment(scrub), errors
+    )
+    for name, body in (await _safe("proc", collect.collect_proc, errors) or {}).items():
+        sections[f"system/{name}"] = body
+    for name, body in (
+        await _safe("pods", lambda: collect.collect_container_logs(scrub), errors) or {}
+    ).items():
+        sections[f"containers/{name}"] = body
+    for name, body in (
+        await _safe("host_logs", lambda: collect.collect_host_logs(scrub), errors) or {}
+    ).items():
+        sections[f"logs/{name}"] = body
+
+    # ── Safety net ──────────────────────────────────────────────────
+    #
+    # Every collector is supposed to redact its own secrets. This runs
+    # over the assembled text anyway: "a collector forgot" and "a new
+    # settings column appeared" are ordinary events, and the consequence
+    # — a credential on a public issue — cannot be taken back.
+    for path in list(sections):
+        value = sections[path]
+        if isinstance(value, str):
+            sections[path] = safety_net(path, value, scrub.report)
+
+    # ── Manifest ────────────────────────────────────────────────────
+    bundle_id = str(uuid.uuid4())
+    stamp = datetime.now(tz=UTC)
+    manifest: dict[str, Any] = {
+        "bundle_id": bundle_id,
+        "generated_at": stamp.isoformat(),
+        "product_version": settings.version,
+        "appliance_mode": settings.appliance_mode,
+        "scrubbed": scrubbed,
+        "scrub": {
+            "ipv4_mapped": scrub.report.ips_v4,
+            "ipv6_mapped": scrub.report.ips_v6,
+            "macs_mapped": scrub.report.macs,
+            "hostnames_mapped": scrub.report.hostnames,
+            "usernames_mapped": scrub.report.usernames,
+            "secrets_redacted": scrub.report.secrets_redacted,
+            # A non-empty list means a collector shipped something it
+            # should have redacted itself. The net caught it, and saying
+            # so is how the underlying bug gets fixed instead of living
+            # behind a net that may not catch the next variant.
+            "safety_net_hits": scrub.report.safety_net_hits,
+        },
+        "section_errors": errors,
+        "READ_THIS": (
+            "Attachments on a PUBLIC GitHub issue are readable by anyone who "
+            "can see the issue, and deleting the comment does not reliably "
+            "remove the file. Scrubbing here is best-effort, the same caveat "
+            "sos report --clean carries: freeform text can hold an identifier "
+            "in a shape no pattern anticipates. REVIEW THIS ARCHIVE BEFORE "
+            "SHARING IT."
+            if scrubbed
+            else "*** THIS BUNDLE IS NOT SCRUBBED. *** It contains real "
+            "hostnames, IP addresses, MAC addresses and usernames. It is for "
+            "local debugging only — do NOT attach it to a public issue. "
+            "(Credentials are still excluded: those are never included in any "
+            "mode.)"
+        ),
+    }
+
+    # ── Assemble ────────────────────────────────────────────────────
+    buf = io.BytesIO()
+    files: list[FilePreview] = []
+    total = 0
+    skipped_for_size: list[str] = []
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in sorted(sections):
+            body = sections[path] or ""
+            encoded = body.encode("utf-8", errors="replace")
+            if total + len(encoded) > collect.CAP_TOTAL_BYTES:
+                skipped_for_size.append(path)
+                continue
+            total += len(encoded)
+            zf.writestr(path, body)
+            files.append(
+                FilePreview(
+                    path=path,
+                    bytes=len(encoded),
+                    truncated=collect.TRUNCATION_MARKER in body,
+                )
+            )
+        if skipped_for_size:
+            manifest["sections_omitted_for_size"] = skipped_for_size
+        # Written last so it reflects the omissions above.
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2, default=str))
+
+    kind = "" if scrubbed else "UNSCRUBBED-"
+    filename = f"spatiumddi-support-bundle-{kind}{stamp.strftime('%Y%m%d-%H%M%S')}.zip"
+
+    # A short, redacted excerpt for the review step, so the operator sees
+    # what scrubbing actually did before deciding to attach it.
+    sample_source = sections.get("activity/recent.log") or sections.get("versions.json") or ""
+    sample = "\n".join(sample_source.splitlines()[:20])
+
+    logger.info(
+        "support_bundle_generated",
+        bundle_id=bundle_id,
+        scrubbed=scrubbed,
+        files=len(files),
+        bytes=buf.tell(),
+        section_errors=len(errors),
+        safety_net_hits=len(scrub.report.safety_net_hits),
+    )
+
+    return BundleResult(
+        id=bundle_id,
+        filename=filename,
+        archive=buf.getvalue(),
+        files=files,
+        manifest=manifest,
+        decode_map=scrub.decode_map(),
+        scrubbed=scrubbed,
+        errors=errors,
+        sample=sample,
+    )

--- a/backend/app/services/support_bundle/__init__.py
+++ b/backend/app/services/support_bundle/__init__.py
@@ -106,6 +106,22 @@ async def _safe(
         return f"[section failed: {type(exc).__name__}: {exc}]"
 
 
+def _merge(sections: dict[str, str], prefix: str, produced: Any) -> None:
+    """Fold a multi-file collector's output into ``sections``.
+
+    ``_safe`` reports a failure by RETURNING a note string, not by
+    raising — so a caller that assumed a dict and went straight for
+    ``.items()`` got an ``AttributeError`` out of the one code path whose
+    entire purpose is that a broken collector cannot 500 the bundle.
+    A non-dict result is filed as the section's own note instead.
+    """
+    if isinstance(produced, dict):
+        for name, body in produced.items():
+            sections[f"{prefix}/{name}"] = body
+        return
+    sections[f"{prefix}/_error.txt"] = str(produced or "")
+
+
 async def generate(db: AsyncSession, *, scrubbed: bool = True) -> BundleResult:
     """Assemble the bundle.
 
@@ -123,7 +139,9 @@ async def generate(db: AsyncSession, *, scrubbed: bool = True) -> BundleResult:
     sections["versions.json"] = await _safe(
         "versions", lambda: collect.collect_versions(db), errors, db
     )
-    sections["health/self-test.txt"] = await _safe("self_test", collect.collect_self_test, errors)
+    sections["health/self-test.txt"] = await _safe(
+        "self_test", lambda: collect.collect_self_test(scrub), errors
+    )
     sections["health/db-connections.json"] = await _safe(
         "db_pool", lambda: collect.collect_db_pool(db), errors, db
     )
@@ -159,16 +177,15 @@ async def generate(db: AsyncSession, *, scrubbed: bool = True) -> BundleResult:
     sections["system/env.txt"] = await _safe(
         "environment", lambda: collect.collect_environment(scrub), errors
     )
-    for name, body in (await _safe("proc", collect.collect_proc, errors) or {}).items():
-        sections[f"system/{name}"] = body
-    for name, body in (
-        await _safe("pods", lambda: collect.collect_container_logs(scrub), errors) or {}
-    ).items():
-        sections[f"containers/{name}"] = body
-    for name, body in (
-        await _safe("host_logs", lambda: collect.collect_host_logs(scrub), errors) or {}
-    ).items():
-        sections[f"logs/{name}"] = body
+    _merge(sections, "system", await _safe("proc", lambda: collect.collect_proc(scrub), errors))
+    _merge(
+        sections,
+        "containers",
+        await _safe("pods", lambda: collect.collect_container_logs(scrub), errors),
+    )
+    _merge(
+        sections, "logs", await _safe("host_logs", lambda: collect.collect_host_logs(scrub), errors)
+    )
 
     # ── Safety net ──────────────────────────────────────────────────
     #

--- a/backend/app/services/support_bundle/collect.py
+++ b/backend/app/services/support_bundle/collect.py
@@ -362,7 +362,7 @@ def collect_environment(scrub: Scrubber) -> str:
     return "\n".join(lines)
 
 
-def collect_proc() -> dict[str, str]:
+def collect_proc(scrub: Scrubber) -> dict[str, str]:
     """Kernel / memory / CPU basics.
 
     Read from the api container's ``/proc``, which shares the host
@@ -455,7 +455,7 @@ def collect_host_logs(scrub: Scrubber) -> dict[str, str]:
     return out
 
 
-def collect_self_test() -> str:
+def collect_self_test(scrub: Scrubber) -> str:
     """Appliance self-test, when applicable.
 
     Reports inapplicability instead of failing: on a compose install the
@@ -472,7 +472,9 @@ def collect_self_test() -> str:
     from app.services.appliance.diagnostics import _format_self_test_report, run_self_test
 
     try:
-        return _format_self_test_report(run_self_test())
+        # Scrubbed: the report names pods and prints the cluster
+        # addresses each check probed.
+        return scrub.text(_format_self_test_report(run_self_test()))
     except Exception as exc:  # noqa: BLE001
         return f"self-test failed to run: {type(exc).__name__}: {exc}"
 
@@ -590,8 +592,13 @@ async def collect_table_sizes(db: AsyncSession) -> str:
     which is the only question this section exists for. Estimates are
     labelled as such so nobody quotes them as row counts.
     """
-    try:
-        rows = (await db.execute(text("""
+    # Through ``_guarded``, not a bare try/except: a swallowed statement
+    # error leaves PostgreSQL in "current transaction is aborted", which
+    # takes out every LATER section and the caller's own commit. The
+    # savepoint is what confines the damage to this one section.
+    result = await _guarded(
+        db,
+        lambda: db.execute(text("""
                     SELECT c.relname,
                            GREATEST(c.reltuples, 0)::bigint AS approx_rows,
                            pg_total_relation_size(c.oid)     AS total_bytes
@@ -599,9 +606,11 @@ async def collect_table_sizes(db: AsyncSession) -> str:
                       JOIN pg_namespace n ON n.oid = c.relnamespace
                      WHERE c.relkind = 'r' AND n.nspname = 'public'
                      ORDER BY pg_total_relation_size(c.oid) DESC
-                    """))).all()
-    except Exception as exc:  # noqa: BLE001
-        return _json({"error": f"{type(exc).__name__}: {exc}"})
+                    """)),
+    )
+    if isinstance(result, str):
+        return _json({"error": result})
+    rows = result.all()
 
     payload: dict[str, Any] = {
         "_note": (

--- a/backend/app/services/support_bundle/collect.py
+++ b/backend/app/services/support_bundle/collect.py
@@ -1,0 +1,619 @@
+"""Section collectors for the support bundle (issue #875).
+
+Each collector returns ``(path, text)`` or None, and each is wrapped so
+a failure becomes a ``.error`` file inside the bundle rather than a
+failed generation. That is deliberate: a bundle is requested when
+something is already broken, and the sections most likely to raise are
+exactly the ones describing the breakage. Half a bundle beats a 500.
+
+Deployment-shape neutrality is the other rule. The appliance-only
+diagnostics endpoint that shipped before this one degrades to a 503 on
+docker-compose and plain Kubernetes because its pod-log and self-test
+halves go through kubeapi. Here, anything kubeapi-backed is optional and
+its absence is recorded as a note explaining *why* it is absent — an
+empty section and an inapplicable one look identical otherwise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import structlog
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.models.alerts import AlertEvent
+from app.models.audit import AuditLog
+from app.models.diagnostics import InternalError
+from app.models.settings import PlatformSettings
+from app.services.support_bundle.scrub import Scrubber, looks_secret_key
+
+logger = structlog.get_logger(__name__)
+
+# Per-section byte caps. The archive is assembled in memory, so these are
+# what bound peak RSS — not a cosmetic nicety. A section that hits its cap
+# is truncated with a marker rather than silently cut, so a reader can
+# tell "there was no more" from "there was more and you can't see it".
+CAP_LOG_BYTES = 2 * 1024 * 1024
+CAP_SECTION_BYTES = 1 * 1024 * 1024
+CAP_TOTAL_BYTES = 48 * 1024 * 1024
+
+TRUNCATION_MARKER = "\n\n[... truncated by support-bundle size cap ...]\n"
+
+# Row limits. Generous enough to show a pattern, small enough that a
+# long-lived install does not produce a 200 MB archive.
+MAX_INTERNAL_ERRORS = 200
+MAX_ALERT_EVENTS = 500
+MAX_AUDIT_ROWS = 1000
+
+
+def cap(content: str, limit: int = CAP_SECTION_BYTES) -> str:
+    """Truncate to ``limit`` bytes, keeping the TAIL for logs-like text.
+
+    The end of a log is where the failure is. Truncating the head would
+    reliably discard the only part anyone opens the file for.
+    """
+    encoded = content.encode("utf-8", errors="replace")
+    if len(encoded) <= limit:
+        return content
+    kept = encoded[-limit:].decode("utf-8", errors="replace")
+    return TRUNCATION_MARKER + kept
+
+
+def _json(payload: Any) -> str:
+    return json.dumps(payload, indent=2, default=str, sort_keys=True)
+
+
+async def _guarded(db: AsyncSession, run: Callable[[], Any], default: Any = None) -> Any:
+    """Run one query, returning ``default`` (or an error string) on failure.
+
+    The SAVEPOINT is the point. Catching a failed statement is not enough
+    on PostgreSQL: the transaction stays in "current transaction is
+    aborted, commands ignored until end of transaction block", so the
+    NEXT query fails too — and so does the enclosing savepoint's RELEASE.
+    A collector that swallows its own error without rolling back
+    therefore breaks every section after it, and the resulting bundle
+    blames the wrong ones.
+
+    Sections that want to degrade *within* themselves — reporting one
+    unavailable figure while still emitting the rest — must route each
+    query through here rather than through a bare ``try``.
+    """
+    try:
+        async with db.begin_nested():
+            result = run()
+            return await result if hasattr(result, "__await__") else result
+    except Exception as exc:  # noqa: BLE001 — reported inline, never raised
+        return default(exc) if callable(default) else f"error: {type(exc).__name__}: {exc}"
+
+
+# ── Versions ────────────────────────────────────────────────────────────
+
+
+async def collect_versions(db: AsyncSession) -> str:
+    """Product / schema / runtime versions.
+
+    The schema head is the single most useful line in a bug report:
+    "which migration is this install on" decides whether a reported
+    symptom is even possible on their code.
+    """
+    from app.core.schema_check import expected_alembic_head
+
+    bundled_head, head_error = expected_alembic_head()
+    db_head: str | None = None
+    db_head_error: str | None = None
+
+    async def _read_head() -> str | None:
+        row = (await db.execute(text("SELECT version_num FROM alembic_version"))).first()
+        return row[0] if row else None
+
+    probed = await _guarded(db, _read_head)
+    if isinstance(probed, str) and probed.startswith("error: "):
+        db_head_error = probed.removeprefix("error: ")
+    else:
+        db_head = probed
+
+    return _json(
+        {
+            "product_version": settings.version,
+            "appliance_mode": settings.appliance_mode,
+            "appliance_version": settings.appliance_version or None,
+            "schema": {
+                "bundled_head": bundled_head,
+                "bundled_head_error": head_error,
+                "database_head": db_head,
+                "database_head_error": db_head_error,
+                "at_head": bool(bundled_head and db_head and bundled_head == db_head),
+            },
+            "runtime": {
+                "python": sys.version.split()[0],
+                "platform": platform.platform(),
+            },
+            # Image tags come from the environment the orchestrator set,
+            # which is the only place they exist at runtime.
+            "image_tags": {
+                k: v
+                for k, v in sorted(os.environ.items())
+                if k.endswith("_IMAGE") or k.endswith("_TAG") or k == "SPATIUMDDI_VERSION"
+            },
+        }
+    )
+
+
+# ── Errors / alerts ─────────────────────────────────────────────────────
+
+
+async def collect_internal_errors(db: AsyncSession, scrub: Scrubber) -> str:
+    """Recent unhandled exceptions (#123).
+
+    Tracebacks go through the scrubber like any other freeform text —
+    they routinely carry hostnames and addresses in exception messages,
+    and a traceback is the single likeliest place for an unanticipated
+    identifier to appear.
+    """
+    rows = (
+        (
+            await db.execute(
+                select(InternalError)
+                .order_by(InternalError.last_seen_at.desc())
+                .limit(MAX_INTERNAL_ERRORS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return _json(
+        [
+            {
+                "timestamp": r.timestamp,
+                "last_seen_at": r.last_seen_at,
+                "service": r.service,
+                "kind": r.kind,
+                "route_or_task": r.route_or_task,
+                "exception_class": r.exception_class,
+                "message": scrub.text(r.message or ""),
+                "traceback": scrub.text(r.traceback or ""),
+                "context": scrub.value("context", r.context_json or {}),
+                "fingerprint": r.fingerprint,
+                "occurrence_count": r.occurrence_count,
+                "acknowledged": r.acknowledged_at is not None,
+            }
+            for r in rows
+        ]
+    )
+
+
+async def collect_alert_events(db: AsyncSession, scrub: Scrubber) -> str:
+    rows = (
+        (
+            await db.execute(
+                select(AlertEvent).order_by(AlertEvent.fired_at.desc()).limit(MAX_ALERT_EVENTS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return _json(
+        [
+            {
+                "fired_at": r.fired_at,
+                "resolved_at": r.resolved_at,
+                "severity": r.severity,
+                "subject_type": r.subject_type,
+                # The subject is an id or a name — a hostname, a subnet,
+                # a server — so it goes through the scrubber.
+                "subject_display": scrub.text(r.subject_display or ""),
+                "message": scrub.text(r.message or ""),
+                "delivered": {
+                    "syslog": r.delivered_syslog,
+                    "webhook": r.delivered_webhook,
+                    "smtp": r.delivered_smtp,
+                },
+            }
+            for r in rows
+        ]
+    )
+
+
+async def collect_audit_tail(db: AsyncSession, scrub: Scrubber) -> str:
+    """Last N mutations — the "what changed just before it broke" section."""
+    rows = (
+        (
+            await db.execute(
+                select(AuditLog).order_by(AuditLog.timestamp.desc()).limit(MAX_AUDIT_ROWS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return _json(
+        [
+            {
+                "timestamp": r.timestamp,
+                "user": scrub.username(r.user_display_name or ""),
+                "auth_source": r.auth_source,
+                # The audit row records where the change came from; an
+                # operator's workstation address is exactly the kind of
+                # thing the scrubber exists for.
+                "source_ip": scrub.text(r.source_ip or ""),
+                "action": r.action,
+                "resource_type": r.resource_type,
+                "resource_display": scrub.text(r.resource_display or ""),
+                "changed_fields": r.changed_fields,
+                "result": r.result,
+            }
+            for r in rows
+        ]
+    )
+
+
+# ── Config ──────────────────────────────────────────────────────────────
+
+
+async def collect_feature_modules(db: AsyncSession) -> str:
+    from app.services.feature_modules import MODULES, get_enabled_modules
+
+    enabled = await get_enabled_modules(db)
+    return _json(
+        {
+            "enabled": sorted(enabled),
+            "disabled": sorted({m.id for m in MODULES} - enabled),
+        }
+    )
+
+
+def _can_hold_a_secret(column: Any) -> bool:
+    """Whether a column's TYPE could carry a credential.
+
+    The name-based denylist is deliberately broad, which means it also
+    catches policy knobs — ``password_min_length``,
+    ``password_require_digit``, ``ai_per_user_daily_token_cap``. Those
+    are integers and booleans; no Fernet blob or API key fits in one,
+    and "what is their password policy?" is a routine support question
+    whose answer is not a secret. So the name test decides *suspicion*
+    and the type test decides whether suspicion is even possible.
+
+    Anything textual or structured stays redacted on name alone.
+    """
+    try:
+        python_type = column.type.python_type
+    except (NotImplementedError, AttributeError):
+        # An exotic type we cannot introspect — assume the worst.
+        return True
+    return python_type not in (int, float, bool)
+
+
+async def collect_platform_settings(db: AsyncSession, scrub: Scrubber) -> str:
+    """The settings row with every credential-shaped column dropped.
+
+    Column-name matching rather than an allowlist, because the table has
+    ~180 columns and grows most releases: an allowlist would silently
+    stop covering new settings, while a denylist that over-matches only
+    costs a redacted diagnostic field. ``value()`` also runs the text
+    scrubber over what survives, so a hostname stored in a settings
+    column is pseudonymised like one in a log.
+    """
+    row = (await db.execute(select(PlatformSettings).limit(1))).scalar_one_or_none()
+    if row is None:
+        return _json({"_note": "no platform_settings row exists yet (fresh install)"})
+
+    out: dict[str, Any] = {}
+    redacted: list[str] = []
+    for column in PlatformSettings.__table__.columns:
+        name = column.name
+        value = getattr(row, name, None)
+        if looks_secret_key(name) and _can_hold_a_secret(column):
+            # Report that the key EXISTS and whether it is set, without
+            # the value — "is LDAP configured at all?" is a real support
+            # question and the answer is not itself a secret.
+            redacted.append(name)
+            out[name] = "[REDACTED]" if value not in (None, "", [], {}) else None
+            continue
+        if isinstance(value, (int, float, bool)) or value is None:
+            # Already cleared by _can_hold_a_secret, and a number carries
+            # no hostname to pseudonymise. Passing it through scrub.value
+            # would re-apply that function's own name-based check and
+            # redact it after all — the very over-matching the type test
+            # exists to undo.
+            out[name] = value
+            continue
+        out[name] = scrub.value(name, value)
+    out["_redacted_columns"] = sorted(redacted)
+    return _json(out)
+
+
+async def collect_integration_state(db: AsyncSession) -> str:
+    """Which read-only mirrors are switched on.
+
+    Flags only, no credentials and no target hostnames — those live in
+    per-integration tables and are exactly the kind of thing that should
+    not ride along by default.
+    """
+    row = (await db.execute(select(PlatformSettings).limit(1))).scalar_one_or_none()
+    flags = {
+        c.name: getattr(row, c.name, None)
+        for c in PlatformSettings.__table__.columns
+        if c.name.startswith("integration_") and c.name.endswith("_enabled")
+    }
+    return _json({"flags": flags if row is not None else {}, "row_present": row is not None})
+
+
+# ── Runtime / host ──────────────────────────────────────────────────────
+
+
+def collect_environment(scrub: Scrubber) -> str:
+    """Process environment, with credential-named vars dropped.
+
+    Values still go through the scrubber: a DATABASE_URL is not
+    secret-*named* once its password is stripped, but it carries a
+    hostname.
+    """
+    lines = []
+    for key, value in sorted(os.environ.items()):
+        lines.append(f"{key}=[REDACTED]" if looks_secret_key(key) else f"{key}={scrub.text(value)}")
+    return "\n".join(lines)
+
+
+def collect_proc() -> dict[str, str]:
+    """Kernel / memory / CPU basics.
+
+    Read from the api container's ``/proc``, which shares the host
+    kernel — so ``/proc/version`` reports the host's kernel even though
+    the mount is the container's.
+    """
+    out: dict[str, str] = {}
+    for proc in (
+        "/proc/version",
+        "/proc/uptime",
+        "/proc/meminfo",
+        "/proc/cpuinfo",
+        "/proc/loadavg",
+    ):
+        try:
+            out[proc.lstrip("/")] = cap(
+                Path(proc).read_text(encoding="utf-8", errors="replace"), 256 * 1024
+            )
+        except OSError as exc:
+            out[f"{proc.lstrip('/')}.error"] = f"{type(exc).__name__}: {exc}"
+    return out
+
+
+def collect_container_logs(scrub: Scrubber) -> dict[str, str]:
+    """Per-pod stdout, when kubeapi is reachable.
+
+    Unlike the appliance-only endpoint this does not 503 when it is not:
+    a compose install has no kubeapi and that is a normal state, not an
+    error. The note says which shape produced the absence so a reader
+    does not read "no logs" as "logs were empty".
+    """
+    from app.services.appliance.containers import (
+        DockerUnavailableError,
+        get_container_logs,
+        list_containers,
+    )
+
+    if not settings.appliance_mode:
+        return {
+            "_note.txt": (
+                "Container logs are collected through the Kubernetes API, which "
+                "this deployment does not expose (appliance_mode is off — a "
+                "docker-compose or plain-Kubernetes install). Collect them with "
+                "`docker compose logs` or `kubectl logs` and attach separately "
+                "if the issue needs them."
+            )
+        }
+    out: dict[str, str] = {}
+    try:
+        for container in list_containers():
+            if not container.is_spatium:
+                continue
+            try:
+                raw = get_container_logs(container.name, tail=500)
+            except DockerUnavailableError as exc:
+                raw = f"[unable to fetch logs: {exc}]"
+            out[f"{container.name}.log"] = cap(scrub.text(raw), CAP_LOG_BYTES)
+    except DockerUnavailableError as exc:
+        out["_error.txt"] = (
+            f"Kubernetes API unreachable: {exc}\n"
+            "This is expected on an agent-only appliance or when the api "
+            "ServiceAccount lacks pod-log permission."
+        )
+    return out
+
+
+def collect_host_logs(scrub: Scrubber) -> dict[str, str]:
+    """Host log files, when the appliance bind-mount is present."""
+    from app.services.appliance.diagnostics import _log_dir, list_log_sources
+
+    out: dict[str, str] = {}
+    try:
+        names = list_log_sources()
+    except OSError as exc:
+        return {"_error.txt": f"{type(exc).__name__}: {exc}"}
+    if not names:
+        return {
+            "_note.txt": (
+                "No host log directory is mounted. Expected on docker-compose "
+                "and plain-Kubernetes installs, where the api container has no "
+                "view of the host filesystem."
+            )
+        }
+    for name in names:
+        try:
+            raw = (_log_dir() / name).read_text(encoding="utf-8", errors="replace")
+            out[name] = cap(scrub.text(raw), CAP_LOG_BYTES)
+        except OSError as exc:
+            out[f"{name}.error"] = f"{type(exc).__name__}: {exc}"
+    return out
+
+
+def collect_self_test() -> str:
+    """Appliance self-test, when applicable.
+
+    Reports inapplicability instead of failing: on a compose install the
+    checks are all kubeapi-shaped and would report a wall of red that
+    means nothing.
+    """
+    if not settings.appliance_mode:
+        return (
+            "Self-test is appliance-only — it probes the Kubernetes API and "
+            "per-role pods, neither of which exists on a docker-compose or "
+            "plain-Kubernetes install. See health/versions.json for the "
+            "deployment-neutral checks."
+        )
+    from app.services.appliance.diagnostics import _format_self_test_report, run_self_test
+
+    try:
+        return _format_self_test_report(run_self_test())
+    except Exception as exc:  # noqa: BLE001
+        return f"self-test failed to run: {type(exc).__name__}: {exc}"
+
+
+async def collect_agent_state(db: AsyncSession, scrub: Scrubber) -> str:
+    """DNS / DHCP server rows — driver, enabled, last-seen.
+
+    No credentials: ``credentials_encrypted`` and the agent PSKs are
+    matched by :func:`looks_secret_key` and never selected here in the
+    first place.
+    """
+    from app.models.dhcp import DHCPServer
+    from app.models.dns import DNSServer
+
+    dns_rows = (await db.execute(select(DNSServer))).scalars().all()
+    dhcp_rows = (await db.execute(select(DHCPServer))).scalars().all()
+
+    def _server(row: Any, kind: str) -> dict[str, Any]:
+        return {
+            "kind": kind,
+            "name": scrub.text(getattr(row, "name", "") or ""),
+            "address": scrub.text(str(getattr(row, "address", "") or "")),
+            "driver": getattr(row, "driver", None),
+            "enabled": getattr(row, "enabled", None),
+            "is_primary": getattr(row, "is_primary", None),
+            "last_seen_at": getattr(row, "last_seen_at", None),
+            "agent_version": getattr(row, "agent_version", None),
+            "health_status": getattr(row, "health_status", None),
+        }
+
+    return _json([_server(r, "dns") for r in dns_rows] + [_server(r, "dhcp") for r in dhcp_rows])
+
+
+async def collect_recent_app_logs(db: AsyncSession, scrub: Scrubber) -> str:
+    """Recent structured log lines, sourced from the DB rather than files.
+
+    Container stdout is unavailable on compose installs (above), so the
+    deployment-neutral substitute is what the app persisted itself:
+    ``internal_error`` covers failures and ``audit_log`` covers
+    mutations. Both have their own sections; this one is a merged,
+    time-ordered view because "what happened, in order" is the question
+    a reader actually asks.
+    """
+    since = datetime.now(UTC) - timedelta(days=7)
+    errors = (
+        (
+            await db.execute(
+                select(InternalError)
+                .where(InternalError.last_seen_at >= since)
+                .order_by(InternalError.last_seen_at.desc())
+                .limit(MAX_INTERNAL_ERRORS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    audits = (
+        (
+            await db.execute(
+                select(AuditLog)
+                .where(AuditLog.timestamp >= since)
+                .order_by(AuditLog.timestamp.desc())
+                .limit(MAX_AUDIT_ROWS)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    merged: list[tuple[datetime, str]] = []
+    for e in errors:
+        merged.append(
+            (
+                e.last_seen_at,
+                f"ERROR  [{e.service}] {e.route_or_task or '-'} "
+                f"{e.exception_class}: {scrub.text(e.message or '')[:300]}",
+            )
+        )
+    for a in audits:
+        merged.append(
+            (
+                a.timestamp,
+                f"AUDIT  {a.action} {a.resource_type} "
+                f"{scrub.text(a.resource_display or '')[:120]} "
+                f"by {scrub.username(a.user_display_name or '')} -> {a.result}",
+            )
+        )
+    merged.sort(key=lambda item: item[0], reverse=True)
+    body = "\n".join(f"{ts.isoformat()}  {line}" for ts, line in merged)
+    return cap(body or "(no errors or audited mutations in the last 7 days)")
+
+
+async def collect_db_pool(db: AsyncSession) -> str:
+    """Connection counts — the first thing to check on a hang."""
+    rows = await _guarded(
+        db,
+        lambda: db.execute(
+            text(
+                "SELECT state, count(*) FROM pg_stat_activity "
+                "WHERE datname = current_database() GROUP BY state"
+            )
+        ),
+    )
+    if isinstance(rows, str):
+        return _json({"error": rows})
+    return _json({str(state): int(n) for state, n in rows.all()})
+
+
+async def collect_table_sizes(db: AsyncSession) -> str:
+    """Approximate row counts + on-disk size per table.
+
+    ``reltuples`` is the planner's estimate, maintained by ANALYZE, and
+    it costs one indexed read for the whole catalogue. Exact ``COUNT(*)``
+    is a sequential scan per table — 300 of them on a large install is
+    minutes of held connection to answer "roughly how big is this",
+    which is the only question this section exists for. Estimates are
+    labelled as such so nobody quotes them as row counts.
+    """
+    try:
+        rows = (await db.execute(text("""
+                    SELECT c.relname,
+                           GREATEST(c.reltuples, 0)::bigint AS approx_rows,
+                           pg_total_relation_size(c.oid)     AS total_bytes
+                      FROM pg_class c
+                      JOIN pg_namespace n ON n.oid = c.relnamespace
+                     WHERE c.relkind = 'r' AND n.nspname = 'public'
+                     ORDER BY pg_total_relation_size(c.oid) DESC
+                    """))).all()
+    except Exception as exc:  # noqa: BLE001
+        return _json({"error": f"{type(exc).__name__}: {exc}"})
+
+    payload: dict[str, Any] = {
+        "_note": (
+            "approx_rows is the PostgreSQL planner estimate (pg_class.reltuples), "
+            "refreshed by ANALYZE — not an exact count."
+        ),
+        "tables": [
+            {"table": name, "approx_rows": int(approx), "total_bytes": int(size)}
+            for name, approx, size in rows
+        ],
+    }
+    payload["database_size_bytes"] = await _guarded(
+        db, lambda: db.scalar(text("SELECT pg_database_size(current_database())"))
+    )
+    return _json(payload)

--- a/backend/app/services/support_bundle/scrub.py
+++ b/backend/app/services/support_bundle/scrub.py
@@ -1,0 +1,486 @@
+"""Scrubbing for the support bundle (issue #875).
+
+A support bundle is meant to be attached to a **public** GitHub issue.
+Attachments on a public repo's issues are effectively world-readable —
+the JWT-signed `private-user-images.githubusercontent.com` URLs follow
+repository visibility, so anyone who can read the issue can fetch the
+file, and deleting the comment does not reliably purge it. So the plan
+is scrubbing, not secrecy.
+
+Two tiers, and the distinction is the whole design:
+
+**Hard-exclude** — secrets. Fernet blobs, password hashes, PSKs, API
+tokens, TSIG keys, private keys. These are never pseudonymised and never
+appear in any mode, including the "unscrubbed" one: an unscrubbed bundle
+is for an operator debugging their own install, and there is no version
+of that which is improved by shipping the credential that decrypts
+everything else. :func:`redact_secrets` and the safety net below enforce
+that independently of any caller remembering to.
+
+**Pseudonymise** — identifying-but-diagnostic values: IPs, hostnames,
+domains, MACs, usernames. Replaced with stable synthetic values so the
+bundle stays *useful* — you can still see that two log lines refer to
+one host, that a set of addresses share a subnet, that a name is three
+labels deep. This is the ``sos report --clean`` model, and like sos it
+is explicitly **best-effort**: freeform text can carry an identifier in
+a shape no regex anticipates. The docs say "review before sharing" for
+the same reason theirs do.
+
+Determinism: mappings are seeded from the install's ``SECRET_KEY`` via
+HMAC, so a given value maps to the same token across runs on one install
+(support can correlate two bundles) and is unguessable from outside it
+(the seed is never in the bundle). The reverse mapping is returned
+separately from the archive, never inside it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import ipaddress
+import re
+from dataclasses import dataclass, field
+
+from app.config import settings
+
+# ── Address space for synthetic values ──────────────────────────────────
+#
+# 240.0.0.0/4 (RFC 1112 "reserved for future use") rather than sos's
+# 100.64.0.0/10: SpatiumDDI *models* CGNAT space as a real, meaningful
+# thing — #42 ships a CGNAT advisory badge — so obfuscating into it would
+# make a scrubbed bundle look like it documents genuine CGNAT
+# deployments. 240/4 is unroutable and unmistakably synthetic, so nobody
+# reading a bundle can confuse it for real addressing.
+_SYNTH_V4_BASE = int(ipaddress.IPv4Address("240.0.0.0"))
+# Index width is capped so synthetic addresses stay inside 240.0.0.0/6
+# (240.x–243.x). The wider /4 runs to 255.255.255.255, and emitting a
+# 255.x address into a diagnostics file reads as broadcast space.
+_SYNTH_V4_NETS = 1 << 18
+# 2001:db8::/32 is RFC 3849 documentation space — the v6 equivalent of
+# "obviously not real".
+_SYNTH_V6_PREFIX = ipaddress.IPv6Address("2001:db8::")
+# Locally-administered OUI (the 0x02 bit) so a synthetic MAC cannot
+# collide with a real vendor assignment.
+_SYNTH_MAC_OUI = "02:00:00"
+# RFC 2606 reserves .invalid precisely so it can never resolve.
+_SYNTH_TLD = "invalid"
+
+
+_REDACTED = "[REDACTED]"
+
+
+# ── Hard-exclude: secret shapes ─────────────────────────────────────────
+#
+# Matched on VALUE shape, not on the key name, so a secret that lands in
+# an unexpected field is still caught. These are all high-signal prefixes
+# with no plausible benign meaning in a diagnostics dump.
+_SECRET_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
+    # Fernet token — every encrypted column in this codebase.
+    ("fernet", re.compile(r"\bgAAAAA[A-Za-z0-9_\-=]{16,}"), f"{_REDACTED}:fernet"),
+    # bcrypt / argon2 password hashes.
+    (
+        "password-hash",
+        re.compile(r"\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}"),
+        f"{_REDACTED}:password-hash",
+    ),
+    (
+        "password-hash",
+        re.compile(r"\$argon2[a-z]{1,2}\$[^\s\"']{16,}"),
+        f"{_REDACTED}:password-hash",
+    ),
+    # PEM private keys (and certificates' private halves).
+    ("pem", re.compile(r"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----"), f"{_REDACTED}:pem"),
+    # JWTs — session tokens, agent tokens, supervisor tokens.
+    (
+        "jwt",
+        re.compile(r"\beyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}"),
+        f"{_REDACTED}:jwt",
+    ),
+    # Credentials embedded in a URL's userinfo. Found by testing rather
+    # than by reading: DATABASE_URL ships as
+    # ``postgresql+asyncpg://user:password@host/db`` and no name-based
+    # rule catches it, because the variable is called *_URL. Only the
+    # userinfo is replaced — the scheme, host and path are topology and
+    # the host is pseudonymised separately.
+    # Square brackets are excluded from the userinfo class so the
+    # replacement — "[REDACTED]:[REDACTED]" — cannot match the pattern
+    # that produced it. Without that, redacting twice re-fires, and the
+    # SAFETY NET then reports a hit on text a collector had already
+    # cleaned: a false bug report, from the mechanism whose whole value
+    # is that a hit means a real one.
+    (
+        "url-credentials",
+        re.compile(r"(?<=://)[^:/@\s\[\]]+:[^@/\s\[\]]+(?=@)"),
+        f"{_REDACTED}:{_REDACTED}",
+    ),
+    # Base64 TSIG secrets are indistinguishable from any other base64, so
+    # they are excluded by key name at the collector instead; see
+    # ``SECRET_KEY_NAME_RE``.
+)
+
+# Matched on KEY name, for structured data (env dumps, settings rows,
+# JSON blobs) where the value alone carries no telltale shape. Deliberately
+# broad: a false positive costs one redacted diagnostic field, a false
+# negative ships a credential to a public issue.
+SECRET_KEY_NAME_RE = re.compile(
+    r"(password|passwd|secret|token|apikey|credential|"
+    r"_encrypted$|psk|tsig|hmac|salt|gpg|bearer|cookie|session[_-]?id"
+    # Any name ENDING in "key" or "keys". Broad on purpose: the agent
+    # PSKs ship as DNS_AGENT_KEY / DHCP_AGENT_KEY / LG_AGENT_KEY, whose
+    # values are raw hex with no shape a value-matcher could recognise —
+    # so the name is the only thing that can catch them, and an
+    # `api[_-]?key`-style enumeration will always be one variant behind.
+    r"|(^|[_-])keys?$)",
+    re.IGNORECASE,
+)
+
+
+def looks_secret_key(name: str) -> bool:
+    """True when a field name suggests its value is a credential."""
+    return bool(SECRET_KEY_NAME_RE.search(name or ""))
+
+
+def redact_secrets(text: str) -> tuple[str, list[str]]:
+    """Strip secret-shaped substrings. Returns (clean_text, kinds_hit).
+
+    Runs in **every** mode. The unscrubbed bundle exists so an operator
+    can read their own hostnames and addresses; it is not a reason to
+    hand out the key that decrypts their database.
+    """
+    hits: list[str] = []
+    out = text
+    for kind, pattern, replacement in _SECRET_VALUE_PATTERNS:
+        out, n = pattern.subn(replacement, out)
+        if n:
+            hits.append(kind)
+    return out, hits
+
+
+# ── Pseudonymisation ────────────────────────────────────────────────────
+
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b(?:/\d{1,2})?")
+# Candidate-then-validate rather than a precise IPv6 regex. A
+# hand-written pattern gets the compressed forms wrong in a way that is
+# worse than not matching: for "2001:db8:9::1" the greedy alternative
+# matched the "2001:db8:9" PREFIX and stopped at the "::" word boundary,
+# so the substitution replaced three groups and left "::1" sitting in the
+# output. Grabbing any hex-and-colon run and asking ``ipaddress`` whether
+# it is an address has no such edge: it either parses or it does not.
+_IPV6_CANDIDATE_RE = re.compile(r"\b[0-9A-Fa-f:]*:[0-9A-Fa-f:]*\b(?:/\d{1,3})?")
+
+_MAC_RE = re.compile(r"\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b")
+# A dotted name with a plausible TLD. Excludes bare numbers (caught as IPs
+# first) and single labels (too ambiguous — "localhost", "api", a column
+# name — to touch without wrecking the bundle's readability).
+_HOSTNAME_RE = re.compile(
+    r"\b(?:[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}\b"
+)
+
+# Names that carry no information about the install and whose replacement
+# would make the bundle harder to read for zero privacy gain.
+_HOSTNAME_ALLOWLIST = frozenset(
+    {
+        "localhost",
+        "localhost.localdomain",
+        "example.com",
+        "example.org",
+        "example.net",
+        "spatiumddi.com",
+        "www.spatiumddi.com",
+        "github.com",
+        "in-addr.arpa",
+        "ip6.arpa",
+        # Compose / k8s service names are topology, not identity, and are
+        # identical on every install.
+        "postgres",
+        "redis",
+        "api",
+        "worker",
+        "beat",
+        "frontend",
+    }
+)
+
+# Public suffixes we keep intact so `foo.co.uk` does not read as a
+# two-label domain. Not the full PSL — that would be a dependency for a
+# cosmetic gain — just the common multi-part ones.
+_MULTI_PART_SUFFIXES = frozenset(
+    {"co.uk", "org.uk", "ac.uk", "gov.uk", "com.au", "net.au", "org.au", "co.nz", "co.jp"}
+)
+
+
+@dataclass
+class ScrubReport:
+    """What the scrubber did, for the manifest and the UI preview."""
+
+    ips_v4: int = 0
+    ips_v6: int = 0
+    macs: int = 0
+    hostnames: int = 0
+    usernames: int = 0
+    secrets_redacted: dict[str, int] = field(default_factory=dict)
+    # Files where the safety net fired — a non-empty list means a
+    # collector shipped something it should have redacted itself, which
+    # is a bug, not a routine event.
+    safety_net_hits: list[str] = field(default_factory=list)
+
+
+class Scrubber:
+    """Stateful, deterministic pseudonymiser for one bundle.
+
+    Not thread-safe and not meant to be: one instance per generation,
+    which is also what makes the mapping self-consistent.
+    """
+
+    def __init__(self, *, enabled: bool = True, seed: str | None = None) -> None:
+        self.enabled = enabled
+        self._seed = (seed or settings.secret_key or "spatiumddi").encode()
+        # real -> synthetic. The inverse is handed to the operator
+        # separately and never written into the archive.
+        self._ipv4: dict[str, str] = {}
+        self._ipv4_nets: dict[str, int] = {}
+        self._ipv6: dict[str, str] = {}
+        self._macs: dict[str, str] = {}
+        self._hosts: dict[str, str] = {}
+        self._domains: dict[str, str] = {}
+        self._users: dict[str, str] = {}
+        self.report = ScrubReport()
+
+    # ── deterministic index allocation ──────────────────────────────
+    def _index(self, bucket: str, value: str, modulo: int) -> int:
+        """Stable pseudo-random index for ``value`` within ``bucket``.
+
+        HMAC over the install seed: same value → same index on this
+        install, and not reproducible by anyone without the seed.
+        """
+        digest = hmac.new(self._seed, f"{bucket}:{value}".encode(), hashlib.sha256).digest()
+        return int.from_bytes(digest[:4], "big") % modulo
+
+    # ── IPv4 ────────────────────────────────────────────────────────
+    def ipv4(self, raw: str) -> str:
+        """Map an IPv4 address, preserving subnet grouping and host octet.
+
+        Two addresses in one real /24 land in one synthetic /24, and the
+        final octet survives — so "is .1 the gateway, .255 the broadcast"
+        stays answerable, and "these hosts are on the same segment" stays
+        visible. That is the property that makes a scrubbed bundle worth
+        reading for a DDI product, where the addressing IS the subject.
+        """
+        if raw in self._ipv4:
+            return self._ipv4[raw]
+        try:
+            addr = ipaddress.IPv4Address(raw)
+        except ValueError:
+            return raw
+        # Loopback / unspecified / link-local carry no site information
+        # and are load-bearing when reading logs.
+        if addr.is_loopback or addr.is_unspecified or addr.is_link_local or addr.is_multicast:
+            self._ipv4[raw] = raw
+            return raw
+
+        net_key = str(ipaddress.IPv4Network(f"{addr}/24", strict=False).network_address)
+        if net_key not in self._ipv4_nets:
+            # 2^18 distinct synthetic /24s; collisions across one
+            # install's subnets are not a practical concern.
+            self._ipv4_nets[net_key] = self._index("v4net", net_key, _SYNTH_V4_NETS)
+        synth_net = _SYNTH_V4_BASE + (self._ipv4_nets[net_key] << 8)
+        synth = str(ipaddress.IPv4Address(synth_net + int(addr) % 256))
+        self._ipv4[raw] = synth
+        self.report.ips_v4 += 1
+        return synth
+
+    # ── IPv6 ────────────────────────────────────────────────────────
+    def ipv6(self, raw: str) -> str:
+        """Map an IPv6 address, preserving /64 grouping.
+
+        The interface ID is NOT preserved, unlike the v4 host octet: a
+        SLAAC address embeds the MAC (RFC 4291 modified EUI-64), so
+        carrying it through would leak hardware identity straight past
+        the MAC scrubber.
+        """
+        if raw in self._ipv6:
+            return self._ipv6[raw]
+        try:
+            addr = ipaddress.IPv6Address(raw)
+        except ValueError:
+            return raw
+        if addr.is_loopback or addr.is_unspecified or addr.is_multicast or addr.is_link_local:
+            self._ipv6[raw] = raw
+            return raw
+
+        net_key = str(ipaddress.IPv6Network(f"{addr}/64", strict=False).network_address)
+        subnet = self._index("v6net", net_key, 1 << 16)
+        iid = self._index("v6iid", raw, 1 << 32)
+        synth = ipaddress.IPv6Address(int(_SYNTH_V6_PREFIX) + (subnet << 64) + iid)
+        self._ipv6[raw] = str(synth)
+        self.report.ips_v6 += 1
+        return str(synth)
+
+    # ── MAC ─────────────────────────────────────────────────────────
+    def mac(self, raw: str) -> str:
+        """Map a MAC to a locally-administered synthetic one.
+
+        The real OUI is dropped rather than preserved. It names the
+        hardware vendor, which is site-identifying in aggregate ("this
+        estate is all one vendor"), and the diagnostic value of knowing
+        the vendor is lower than that risk on a public attachment.
+        """
+        key = raw.lower().replace("-", ":")
+        if key in self._macs:
+            return self._macs[key]
+        idx = self._index("mac", key, 1 << 24)
+        synth = f"{_SYNTH_MAC_OUI}:{idx >> 16 & 0xFF:02x}:{idx >> 8 & 0xFF:02x}:{idx & 0xFF:02x}"
+        self._macs[key] = synth
+        self.report.macs += 1
+        return synth
+
+    # ── Hostnames / domains ─────────────────────────────────────────
+    def hostname(self, raw: str) -> str:
+        """Map a dotted name, preserving subdomain depth and zone grouping.
+
+        ``a.corp.example.com`` and ``b.corp.example.com`` become
+        ``nA.nB.dK.invalid`` sharing ``nB.dK`` — so "same zone" and "same
+        subdomain" survive, which is most of what a DNS bug report is
+        about, and the number of subdomain levels is unchanged.
+
+        The registrable domain collapses to ONE synthetic label
+        regardless of how many it had, so ``foo.co.uk`` and
+        ``foo.example`` both yield ``dK.invalid``. Preserving that depth
+        would say which public suffix the site uses, which is
+        jurisdiction-adjacent information for no diagnostic gain.
+        """
+        name = raw.rstrip(".").lower()
+        if not name or name in _HOSTNAME_ALLOWLIST:
+            return raw
+        # Reverse-DNS names are structure, not identity, and rewriting
+        # them would destroy the one thing that makes a PTR log readable.
+        if name.endswith(".in-addr.arpa") or name.endswith(".ip6.arpa"):
+            return raw
+        if name in self._hosts:
+            return self._hosts[name]
+
+        labels = name.split(".")
+        suffix_len = 2
+        if len(labels) >= 3 and ".".join(labels[-2:]) in _MULTI_PART_SUFFIXES:
+            suffix_len = 3
+        domain = ".".join(labels[-suffix_len:]) if len(labels) >= suffix_len else name
+        if domain not in self._domains:
+            self._domains[domain] = f"d{self._index('domain', domain, 100000)}.{_SYNTH_TLD}"
+        parts = [self._domains[domain]]
+        for label in reversed(labels[:-suffix_len]):
+            parts.insert(0, f"n{self._index('label', f'{domain}:{label}', 100000)}")
+        synth = ".".join(parts)
+        self._hosts[name] = synth
+        self.report.hostnames += 1
+        return synth
+
+    def username(self, raw: str) -> str:
+        if not raw:
+            return raw
+        key = raw.lower()
+        if key not in self._users:
+            self._users[key] = f"user{self._index('user', key, 100000)}"
+            self.report.usernames += 1
+        return self._users[key]
+
+    # ── Text sweep ──────────────────────────────────────────────────
+    def text(self, value: str) -> str:
+        """Scrub a blob of freeform text (a log file, a traceback).
+
+        Order matters. MACs first, because a colon-separated MAC is a
+        near-miss for the IPv6 pattern. Then v6, then v4, then hostnames
+        — by which point anything address-shaped is already a synthetic
+        value and the hostname regex will not re-match it.
+        """
+        if not value:
+            return value
+        cleaned, kinds = redact_secrets(value)
+        for kind in kinds:
+            self.report.secrets_redacted[kind] = self.report.secrets_redacted.get(kind, 0) + 1
+        if not self.enabled:
+            return cleaned
+
+        cleaned = _MAC_RE.sub(lambda m: self.mac(m.group(0)), cleaned)
+        cleaned = _IPV6_CANDIDATE_RE.sub(self._maybe_ipv6, cleaned)
+        cleaned = _IPV4_RE.sub(lambda m: self._sub_cidr(m.group(0), self.ipv4), cleaned)
+        cleaned = _HOSTNAME_RE.sub(lambda m: self.hostname(m.group(0)), cleaned)
+        return cleaned
+
+    def _maybe_ipv6(self, match: re.Match[str]) -> str:
+        """Map a hex-and-colon run, but only if it really is an address.
+
+        The candidate pattern is deliberately loose, so this is where a
+        timestamp fragment, a `key: value` pair or anything else with a
+        colon gets handed back untouched.
+        """
+        token = match.group(0)
+        addr = token.partition("/")[0]
+        try:
+            ipaddress.IPv6Address(addr)
+        except ValueError:
+            return token
+        return self._sub_cidr(token, self.ipv6)
+
+    @staticmethod
+    def _sub_cidr(token: str, mapper) -> str:  # type: ignore[no-untyped-def]
+        """Apply ``mapper`` to the address half of an optional CIDR.
+
+        The prefix length is topology, not identity, and dropping it
+        would turn every subnet in an IPAM bundle into a bare address.
+        """
+        if "/" in token:
+            addr, _, prefix = token.partition("/")
+            return f"{mapper(addr)}/{prefix}"
+        return mapper(token)
+
+    def value(self, key: str, value: object) -> object:
+        """Scrub one structured field, using its name as a hint."""
+        if looks_secret_key(key):
+            return _REDACTED if value not in (None, "", [], {}) else value
+        if isinstance(value, str):
+            return self.text(value)
+        if isinstance(value, dict):
+            return {k: self.value(k, v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self.value(key, v) for v in value]
+        return value
+
+    # ── Reverse mapping ─────────────────────────────────────────────
+    def decode_map(self) -> dict[str, dict[str, str]]:
+        """Synthetic → real, for the operator only.
+
+        Returned from a separate endpoint and never written into the
+        archive: a bundle that carries its own decoder is not scrubbed,
+        it is merely inconvenient to read.
+        """
+        return {
+            "ipv4": {v: k for k, v in self._ipv4.items() if v != k},
+            "ipv6": {v: k for k, v in self._ipv6.items() if v != k},
+            "mac": {v: k for k, v in self._macs.items()},
+            "hostname": {v: k for k, v in self._hosts.items()},
+            "username": {v: k for k, v in self._users.items()},
+        }
+
+
+# ── Safety net ──────────────────────────────────────────────────────────
+
+
+def safety_net(name: str, content: str, report: ScrubReport) -> str:
+    """Last-chance sweep over an assembled section.
+
+    Every collector is supposed to redact its own secrets. This runs
+    anyway, because "a collector forgot" and "a new column got added"
+    are ordinary events and the consequence — a credential on a public
+    issue — is not recoverable.
+
+    A hit is recorded in ``report.safety_net_hits`` and surfaced in the
+    manifest rather than swallowed: the net firing means a collector has
+    a bug, and hiding that would let the bug persist behind a net that
+    might not catch the next variant.
+    """
+    cleaned, kinds = redact_secrets(content)
+    if kinds:
+        report.safety_net_hits.append(f"{name}: {', '.join(sorted(set(kinds)))}")
+        for kind in kinds:
+            report.secrets_redacted[kind] = report.secrets_redacted.get(kind, 0) + 1
+    return cleaned

--- a/backend/app/services/support_bundle/scrub.py
+++ b/backend/app/services/support_bundle/scrub.py
@@ -123,8 +123,15 @@ _SECRET_VALUE_PATTERNS: tuple[tuple[str, re.Pattern[str], str], ...] = (
 # broad: a false positive costs one redacted diagnostic field, a false
 # negative ships a credential to a public issue.
 SECRET_KEY_NAME_RE = re.compile(
-    r"(password|passwd|secret|token|apikey|credential|"
+    r"(password|passwd|passphrase|secret|token|apikey|credential|"
     r"_encrypted$|psk|tsig|hmac|salt|gpg|bearer|cookie|session[_-]?id"
+    # ``audit_forward_webhook_auth_header`` holds a literal
+    # "Bearer …" / "Basic …" in PLAINTEXT (see its column comment) and
+    # matched none of the terms above, so the settings collector shipped
+    # it verbatim into an archive destined for a public issue. An
+    # incoming-webhook URL is a bearer credential in its own right — the
+    # path segment IS the authentication — so both are matched by name.
+    r"|auth[_-]?header|authorization|webhook[_-]?url"
     # Any name ENDING in "key" or "keys". Broad on purpose: the agent
     # PSKs ship as DNS_AGENT_KEY / DHCP_AGENT_KEY / LG_AGENT_KEY, whose
     # values are raw hex with no shape a value-matcher could recognise —
@@ -200,6 +207,82 @@ _HOSTNAME_ALLOWLIST = frozenset(
         "frontend",
     }
 )
+
+# Final labels that CANNOT be a TLD, so a dotted token ending in one
+# cannot be a resolvable hostname and skipping it costs nothing in
+# privacy. This is the whole test applied below: every entry here was
+# checked against the IANA root zone, and deliberately absent are the
+# extensions that ARE real TLDs — `.zone`, `.py`, `.sh`, `.md`, `.rs`,
+# `.go`, `.dev` — because denying those would leak a genuine hostname to
+# save a line of traceback.
+_NON_TLD_SUFFIXES = frozenset(
+    {
+        "json",
+        "jsonl",
+        "txt",
+        "log",
+        "yml",
+        "yaml",
+        "conf",
+        "ini",
+        "toml",
+        "cfg",
+        "sql",
+        "lock",
+        "pyc",
+        "pyo",
+        "env",
+        "pem",
+        "crt",
+        "csr",
+        "bak",
+        "tmp",
+        "out",
+        "err",
+        "db",
+        "sqlite",
+        "whl",
+        "tar",
+        "gz",
+    }
+)
+
+
+def _is_probably_code_not_a_hostname(name: str) -> bool:
+    """Whether a dotted token is source code rather than a name.
+
+    Tracebacks are among the most useful things in a bundle, and the
+    hostname pattern happily eats them: ``sqlalchemy.exc.ProgrammingError``
+    and ``versions.json`` are both "labels separated by dots ending in
+    letters". Rewriting them to ``nA.nB.dC.invalid`` costs the reader the
+    stack trace they opened the file for.
+
+    Only STRICTLY SAFE rules are applied — each one identifies a token
+    that could not be a resolvable hostname anyway, so nothing real is
+    left exposed to buy the readability:
+
+    * a final label with BOTH cases (``ProgrammingError``, ``PosixPath``)
+      — no TLD is camel-case, while an all-caps ``EXAMPLE.COM`` is still
+      pseudonymised because a shouted hostname is a real one;
+    * a final label in :data:`_NON_TLD_SUFFIXES`.
+
+    Not covered, and accepted: ``collect.py`` and ``app.services.scrub``
+    are still pseudonymised — ``py`` is Paraguay's ccTLD and ``scrub``
+    could be a gTLD for all this function knows. Sparing them would need
+    a "preceded by a slash, so it is a path" heuristic, and that leaks
+    the domain straight out of a DNS product's own
+    ``/var/named/corp.example.com.zone`` log lines. What a reader keeps
+    in a mangled traceback line is the directory, the line number, the
+    function name and — the part that matters most — the exception's own
+    dotted module path, since ``ProgrammingError`` is camel-case.
+    Over-scrubbing is the correct direction to err in a file destined for
+    a public issue.
+    """
+    last = name.rsplit(".", 1)[-1]
+    if last.lower() in _NON_TLD_SUFFIXES:
+        return True
+    return any(c.isupper() for c in last) and any(c.islower() for c in last)
+
 
 # Public suffixes we keep intact so `foo.co.uk` does not read as a
 # two-label domain. Not the full PSL — that would be a dependency for a
@@ -356,6 +439,8 @@ class Scrubber:
         # them would destroy the one thing that makes a PTR log readable.
         if name.endswith(".in-addr.arpa") or name.endswith(".ip6.arpa"):
             return raw
+        if _is_probably_code_not_a_hostname(raw):
+            return raw
         if name in self._hosts:
             return self._hosts[name]
 
@@ -375,7 +460,17 @@ class Scrubber:
         return synth
 
     def username(self, raw: str) -> str:
-        if not raw:
+        """Map an operator/account name.
+
+        Unlike :meth:`mac` / :meth:`ipv4` / :meth:`hostname`, collectors
+        call this DIRECTLY rather than through :meth:`text`, so it has to
+        honour ``enabled`` itself. Without that check an unscrubbed
+        bundle still came back with ``user41234`` in the audit tail —
+        contradicting its own manifest ("contains real … usernames") and
+        leaving no way to read it, since the UI only offers the decode
+        map for a scrubbed bundle.
+        """
+        if not raw or not self.enabled:
             return raw
         key = raw.lower()
         if key not in self._users:

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -269,6 +269,47 @@ def test_hostname_mapping_preserves_zone_grouping() -> None:
 
 
 @pytest.mark.parametrize(
+    "token",
+    [
+        "sqlalchemy.exc.ProgrammingError",
+        "pathlib.PosixPath",
+        "versions.json",
+        "internal-errors.json",
+        "named.conf",
+        "app.yml",
+    ],
+)
+def test_code_tokens_are_not_mistaken_for_hostnames(token: str) -> None:
+    """A traceback is among the most useful things in a bundle, and the
+    hostname pattern happily eats it — `sqlalchemy.exc.ProgrammingError`
+    is "labels separated by dots ending in letters" too.
+
+    Every rule that spares these is strictly safe: a camel-case final
+    label and a non-TLD extension both describe tokens that could not
+    resolve anyway, so nothing real stays exposed to buy the
+    readability.
+    """
+    assert Scrubber(seed="s").text(token) == token
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # These ARE real TLDs (Paraguay, .sh, .zone), so sparing them to
+        # tidy up a traceback would leak a genuine hostname.
+        "collect.py",
+        "deploy.sh",
+        "corp.example.zone",
+        # An all-caps final label is a shouted hostname, not camel-case
+        # code — it must still be pseudonymised.
+        "HOST.EXAMPLE.COM",
+    ],
+)
+def test_tokens_that_could_be_real_hostnames_are_still_scrubbed(name: str) -> None:
+    assert Scrubber(seed="s").text(name) != name
+
+
+@pytest.mark.parametrize(
     "name", ["localhost", "5.2.1.10.in-addr.arpa", "1.0.0.0.ip6.arpa", "example.com"]
 )
 def test_structural_names_are_left_alone(name: str) -> None:

--- a/backend/tests/test_support_bundle.py
+++ b/backend/tests/test_support_bundle.py
@@ -1,0 +1,537 @@
+"""Support bundle: scrubbing, collection, and the API gates (issue #875).
+
+The failure mode this feature has is *leaking a credential onto a public
+GitHub issue*, and that is not recoverable — the attachment URL follows
+repo visibility and deleting the comment does not purge the file. So the
+bulk of these tests are adversarial: feed known secrets and identifiers
+through and assert their absence, rather than assert the happy path.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import zipfile
+from io import BytesIO
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.services.support_bundle import generate
+from app.services.support_bundle.scrub import (
+    Scrubber,
+    ScrubReport,
+    looks_secret_key,
+    redact_secrets,
+    safety_net,
+)
+
+
+async def _user(db: AsyncSession, username: str, *, superadmin: bool) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=superadmin,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+# ── Hard-exclude tier ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("blob", "kind"),
+    [
+        ("gAAAAABm1234567890abcdefghijklmnop", "fernet"),
+        ("$2b$12$" + "a" * 53, "password-hash"),
+        ("$argon2id$v=19$m=65536,t=3,p=4$abcdefghijklmnop", "password-hash"),
+        ("-----BEGIN RSA PRIVATE KEY-----", "pem"),
+        ("-----BEGIN PRIVATE KEY-----", "pem"),
+        ("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27u", "jwt"),
+    ],
+)
+def test_secret_shapes_are_removed(blob: str, kind: str) -> None:
+    cleaned, kinds = redact_secrets(f"prefix {blob} suffix")
+    assert blob not in cleaned, f"{kind} survived redaction"
+    assert kind in kinds
+    # Surrounding text must survive — a redactor that eats the log line
+    # around the secret destroys the diagnostic value of the file.
+    assert "prefix" in cleaned and "suffix" in cleaned
+
+
+def test_secrets_are_removed_even_when_scrubbing_is_off() -> None:
+    """The unscrubbed bundle exists so an operator can read their own
+    hostnames. There is no version of that which is improved by shipping
+    the key that decrypts their database."""
+    plain = Scrubber(enabled=False, seed="s")
+    out = plain.text("token=gAAAAABm1234567890abcdefghij host=real.corp.example ip=10.1.2.3")
+    assert "gAAAAABm1234567890abcdefghij" not in out
+    # …while the identifiers it exists to preserve are untouched.
+    assert "real.corp.example" in out
+    assert "10.1.2.3" in out
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "password",
+        "SECRET_KEY",
+        "api_key",
+        "apiKey",
+        "credentials_encrypted",
+        "dns_agent_psk",
+        "tsig_secret",
+        "ssh_authorized_keys",
+        "apt_gpg_keys",
+        "webhook_bearer",
+        "session_id",
+        "POSTGRES_PASSWORD",
+    ],
+)
+def test_secret_field_names_are_recognised(name: str) -> None:
+    assert looks_secret_key(name)
+
+
+@pytest.mark.parametrize(
+    "name", ["hostname", "subnet", "description", "ttl", "record_type", "enabled"]
+)
+def test_ordinary_field_names_are_not_treated_as_secret(name: str) -> None:
+    """A denylist that matches everything redacts the whole bundle."""
+    assert not looks_secret_key(name)
+
+
+def test_url_embedded_credentials_are_stripped() -> None:
+    """Found by generating a real bundle, not by reading the code.
+
+    ``DATABASE_URL`` ships as ``postgresql+asyncpg://user:password@host``
+    and no name-based rule catches it — the variable is called *_URL. The
+    userinfo is a credential regardless of what the field is named.
+    """
+    cleaned, kinds = redact_secrets(
+        "DATABASE_URL=postgresql+asyncpg://spatiumddi:hunter2@postgres:5432/db"
+    )
+    assert "hunter2" not in cleaned
+    assert "url-credentials" in kinds
+    # Scheme, host, port and path are topology and must survive — the
+    # host is pseudonymised separately.
+    assert "postgresql+asyncpg://" in cleaned
+    assert "@postgres:5432/db" in cleaned
+
+
+@pytest.mark.parametrize(
+    "url", ["redis://redis:6379/0", "http://10.0.0.1:8000", "https://example.com/path"]
+)
+def test_urls_without_credentials_are_untouched(url: str) -> None:
+    assert redact_secrets(url)[0] == url
+
+
+def test_redaction_is_idempotent() -> None:
+    """Redacting already-redacted text must be a no-op.
+
+    It was not: the URL replacement "[REDACTED]:[REDACTED]" matched the
+    userinfo pattern that produced it, so a second pass re-fired. The
+    safety net then reported a hit on text a collector had already
+    cleaned — a false bug report from the one mechanism whose value
+    depends on a hit meaning a real one.
+    """
+    samples = [
+        "DATABASE_URL=postgresql+asyncpg://u:p@host:5432/db",
+        "token=gAAAAABm1234567890abcdefghij",
+        "hash=$2b$12$" + "a" * 53,
+    ]
+    for raw in samples:
+        once, first_kinds = redact_secrets(raw)
+        twice, second_kinds = redact_secrets(once)
+        assert twice == once, raw
+        assert first_kinds and second_kinds == [], raw
+
+
+@pytest.mark.parametrize("name", ["DNS_AGENT_KEY", "DHCP_AGENT_KEY", "LG_AGENT_KEY"])
+def test_agent_preshared_keys_are_recognised_by_name(name: str) -> None:
+    """Also found by generating a real bundle. These are raw hex with no
+    shape a value-matcher could recognise, so the name is the ONLY thing
+    that can catch them — and an ``api_key``-style enumeration of
+    suffixes will always be one variant behind the next agent kind."""
+    assert looks_secret_key(name)
+
+
+def test_safety_net_records_what_it_caught() -> None:
+    """A net that fires silently hides the collector bug that fed it."""
+    report = ScrubReport()
+    out = safety_net("config/leaky.json", "k=gAAAAABm1234567890abcdefghij", report)
+    assert "gAAAAABm" not in out
+    assert report.safety_net_hits and "config/leaky.json" in report.safety_net_hits[0]
+
+
+# ── Pseudonymisation tier ───────────────────────────────────────────────
+
+
+def test_ipv4_mapping_is_stable_and_topology_preserving() -> None:
+    s = Scrubber(seed="seed")
+    a, b, c = s.ipv4("10.1.2.5"), s.ipv4("10.1.2.9"), s.ipv4("10.1.3.5")
+
+    assert a != "10.1.2.5"
+    assert s.ipv4("10.1.2.5") == a, "same input must map to the same output"
+
+    # Same real /24 -> same synthetic /24. This is what keeps a bundle
+    # readable: "are these hosts on one segment" stays answerable.
+    assert a.rsplit(".", 1)[0] == b.rsplit(".", 1)[0]
+    assert a.rsplit(".", 1)[0] != c.rsplit(".", 1)[0]
+
+    # Host octet survives, so ".1 is the gateway" / ".255 is broadcast"
+    # still reads correctly.
+    assert a.endswith(".5") and b.endswith(".9")
+
+    # Synthetic space is unroutable and unmistakable — and inside
+    # 240.0.0.0/6, so nothing lands in 255.x where it would read as
+    # broadcast address space.
+    for value in (a, b, c):
+        assert ipaddress.IPv4Address(value) in ipaddress.IPv4Network("240.0.0.0/6")
+
+
+def test_two_installs_map_the_same_address_differently() -> None:
+    """Seeded per install, so a synthetic address cannot be correlated
+    back across two organisations' bundles."""
+    assert Scrubber(seed="one").ipv4("10.0.0.1") != Scrubber(seed="two").ipv4("10.0.0.1")
+
+
+@pytest.mark.parametrize("addr", ["127.0.0.1", "0.0.0.0", "169.254.1.1", "224.0.0.251"])
+def test_diagnostic_ipv4_addresses_survive(addr: str) -> None:
+    """Loopback / unspecified / link-local / multicast identify nobody
+    and are load-bearing when reading a log."""
+    assert Scrubber(seed="s").ipv4(addr) == addr
+
+
+@pytest.mark.parametrize("addr", ["::1", "fe80::1", "ff02::1"])
+def test_diagnostic_ipv6_addresses_survive(addr: str) -> None:
+    assert Scrubber(seed="s").ipv6(addr) == addr
+
+
+def test_ipv6_groups_by_prefix_but_discards_the_interface_id() -> None:
+    """A SLAAC address embeds the MAC (RFC 4291 modified EUI-64), so
+    carrying the interface ID through would leak hardware identity
+    straight past the MAC scrubber."""
+    s = Scrubber(seed="seed")
+    a = s.ipv6("2001:db8:1::5")
+    b = s.ipv6("2001:db8:1::9")
+    c = s.ipv6("2001:db8:2::5")
+
+    assert ipaddress.IPv6Address(a) in ipaddress.IPv6Network("2001:db8::/32")
+    prefix = lambda v: str(ipaddress.IPv6Network(f"{v}/64", strict=False))  # noqa: E731
+    assert prefix(a) == prefix(b), "same /64 must stay grouped"
+    assert prefix(a) != prefix(c)
+    # The EUI-64 case: the IID must not survive in any form.
+    eui = s.ipv6("2001:db8:1::0200:5eff:fe00:5213")
+    assert "5eff" not in eui and "fe00" not in eui
+
+
+def test_mac_mapping_is_stable_case_insensitive_and_drops_the_oui() -> None:
+    s = Scrubber(seed="seed")
+    a = s.mac("AA:BB:CC:DD:EE:FF")
+    assert s.mac("aa-bb-cc-dd-ee-ff") == a, "separator/case must not fork the mapping"
+    # Locally-administered prefix: cannot collide with a real assignment.
+    assert a.startswith("02:00:00:")
+    # The real OUI names the hardware vendor, which is site-identifying
+    # in aggregate.
+    assert "aa:bb:cc" not in a.lower()
+
+
+def test_hostname_mapping_preserves_zone_grouping() -> None:
+    s = Scrubber(seed="seed")
+    a = s.hostname("a.corp.example.net")
+    b = s.hostname("b.corp.example.net")
+    c = s.hostname("c.other.example.net")
+    d = s.hostname("x.elsewhere.test")
+
+    assert a.endswith(".invalid") and "example" not in a
+    # Same zone AND same subdomain -> shared suffix.
+    assert a.split(".", 1)[1] == b.split(".", 1)[1]
+    # Same zone, different subdomain -> shared registrable label only.
+    assert a.split(".")[-2] == c.split(".")[-2]
+    assert a.split(".", 1)[1] != c.split(".", 1)[1]
+    # Different zone -> nothing shared.
+    assert a.split(".")[-2] != d.split(".")[-2]
+    # Subdomain depth is preserved: two subdomain labels in, two `n`
+    # labels out. The registrable domain collapses to one synthetic
+    # label plus `.invalid`, so the total happens to match here — the
+    # invariant being pinned is the subdomain count, not the total.
+    assert len([p for p in a.split(".") if p.startswith("n")]) == 2
+    assert len([p for p in s.hostname("deep.a.b.corp.test").split(".") if p.startswith("n")]) == 3
+
+
+@pytest.mark.parametrize(
+    "name", ["localhost", "5.2.1.10.in-addr.arpa", "1.0.0.0.ip6.arpa", "example.com"]
+)
+def test_structural_names_are_left_alone(name: str) -> None:
+    """Rewriting a reverse-DNS name destroys the only thing that makes a
+    PTR log readable, and it identifies nobody."""
+    assert Scrubber(seed="s").hostname(name) == name
+
+
+def test_text_sweep_handles_a_realistic_log_line() -> None:
+    s = Scrubber(seed="seed")
+    line = (
+        "2026-08-22 lease 10.1.2.50 -> host7.corp.example.net "
+        "mac aa:bb:cc:dd:ee:ff on subnet 10.1.2.0/24 via 2001:db8:9::1"
+    )
+    out = s.text(line)
+    for leaked in ("10.1.2.50", "corp.example.net", "aa:bb:cc:dd:ee:ff", "2001:db8:9::1"):
+        assert leaked not in out, f"{leaked} survived the sweep"
+    # Structure that makes the line readable survives.
+    assert "2026-08-22 lease" in out
+    assert "/24" in out, "CIDR prefix length is topology, not identity"
+    assert out.count("->") == 1
+
+
+def test_cidr_prefix_length_is_preserved() -> None:
+    s = Scrubber(seed="seed")
+    assert s.text("192.168.4.0/22").endswith("/22")
+
+
+def test_decode_map_inverts_the_mapping() -> None:
+    s = Scrubber(seed="seed")
+    synthetic_ip = s.ipv4("10.9.8.7")
+    synthetic_host = s.hostname("db.corp.example.net")
+    mapping = s.decode_map()
+    assert mapping["ipv4"][synthetic_ip] == "10.9.8.7"
+    assert mapping["hostname"][synthetic_host] == "db.corp.example.net"
+    # Values that were deliberately passed through are not listed as
+    # mappings — there is nothing to decode.
+    s.ipv4("127.0.0.1")
+    assert "127.0.0.1" not in s.decode_map()["ipv4"]
+
+
+# ── Bundle assembly ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bundle_generates_on_a_non_appliance_install(db_session: AsyncSession) -> None:
+    """The appliance-only endpoint 503s here; this one must not.
+
+    Its kubeapi-backed sections are absent, and their absence is
+    explained rather than silent — an empty section and an inapplicable
+    one are indistinguishable otherwise.
+    """
+    result = await generate(db_session, scrubbed=True)
+    assert result.archive
+    assert result.errors == [], result.errors
+
+    with zipfile.ZipFile(BytesIO(result.archive)) as zf:
+        names = set(zf.namelist())
+        manifest = json.loads(zf.read("manifest.json"))
+
+    assert "manifest.json" in names
+    assert "versions.json" in names
+    assert any(n.startswith("config/") for n in names)
+    assert manifest["scrubbed"] is True
+    assert manifest["scrub"]["safety_net_hits"] == []
+    # The note explains WHY container logs are missing on this shape.
+    assert "containers/_note.txt" in names
+
+
+@pytest.mark.asyncio
+async def test_decode_map_is_never_inside_the_archive(db_session: AsyncSession) -> None:
+    """A bundle carrying its own decoder is not scrubbed, it is merely
+    inconvenient to read."""
+    result = await generate(db_session, scrubbed=True)
+    with zipfile.ZipFile(BytesIO(result.archive)) as zf:
+        names = zf.namelist()
+        blob = b"".join(zf.read(n) for n in names)
+    assert not any("decode" in n or "scrub-map" in n for n in names)
+    # And no file contains the reverse mapping's contents.
+    for synthetic, real in list(result.decode_map["hostname"].items())[:20]:
+        assert real.encode() not in blob, f"{real} leaked alongside {synthetic}"
+
+
+@pytest.mark.asyncio
+async def test_manifest_warns_differently_per_mode(db_session: AsyncSession) -> None:
+    scrubbed = await generate(db_session, scrubbed=True)
+    raw = await generate(db_session, scrubbed=False)
+
+    assert "REVIEW THIS ARCHIVE BEFORE SHARING" in scrubbed.manifest["READ_THIS"]
+    assert "NOT SCRUBBED" in raw.manifest["READ_THIS"]
+    # The filename itself has to make the difference obvious — an
+    # operator picking a file out of ~/Downloads a week later has only
+    # the name to go on.
+    assert "UNSCRUBBED" in raw.filename
+    assert "UNSCRUBBED" not in scrubbed.filename
+
+
+@pytest.mark.asyncio
+async def test_platform_settings_drops_credentials_but_keeps_policy(
+    db_session: AsyncSession,
+) -> None:
+    """Name-matching alone over-redacts: ``password_min_length`` is an
+    integer policy knob, and "what is their password policy" is a routine
+    support question whose answer is not a secret."""
+    result = await generate(db_session, scrubbed=True)
+    with zipfile.ZipFile(BytesIO(result.archive)) as zf:
+        settings_dump = json.loads(zf.read("config/platform-settings.json"))
+
+    if "_note" in settings_dump:
+        pytest.skip("no platform_settings row on a fresh test database")
+
+    for column in settings_dump["_redacted_columns"]:
+        assert settings_dump[column] in (None, "[REDACTED]")
+    # Textual credential columns must be in the redacted set...
+    assert "fingerbank_api_key_encrypted" in settings_dump["_redacted_columns"]
+    # ...and numeric/boolean ones must not.
+    assert "password_min_length" not in settings_dump["_redacted_columns"]
+    assert isinstance(settings_dump["password_min_length"], int)
+
+
+# ── API gates ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_non_superadmin_is_refused(db_session: AsyncSession, client: AsyncClient) -> None:
+    """One archive carries logs, config shape and an audit tail; a
+    narrower gate would be a way to read all three."""
+    _, token = await _user(db_session, "sbplain", superadmin=False)
+    await db_session.commit()
+    for path in ("/api/v1/system/support-bundle", "/api/v1/system/support-bundle/preview"):
+        resp = await client.post(path, headers={"Authorization": f"Bearer {token}"}, json={})
+        assert resp.status_code == 403, (path, resp.text)
+
+
+@pytest.mark.asyncio
+async def test_preview_lists_files_and_scrub_counts(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _user(db_session, "sbprev", superadmin=True)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/system/support-bundle/preview",
+        headers={"Authorization": f"Bearer {token}"},
+        json={},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["scrubbed"] is True
+    assert body["files"], "preview with no files tells the operator nothing"
+    assert {"path", "bytes", "truncated"} <= set(body["files"][0])
+    assert "REVIEW THIS ARCHIVE BEFORE SHARING" in body["warning"]
+    assert "scrub" in body["manifest"]
+
+
+@pytest.mark.asyncio
+async def test_unscrubbed_requires_the_exact_confirmation(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """Not a checkbox. The difference between the two bundles is whether
+    real addresses leave the building."""
+    _, token = await _user(db_session, "sbraw", superadmin=True)
+    await db_session.commit()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    missing = await client.post(
+        "/api/v1/system/support-bundle", headers=headers, json={"scrubbed": False}
+    )
+    assert missing.status_code == 400
+    assert "confirm_unscrubbed" in missing.text
+
+    wrong = await client.post(
+        "/api/v1/system/support-bundle",
+        headers=headers,
+        json={"scrubbed": False, "confirm_unscrubbed": "yes"},
+    )
+    assert wrong.status_code == 400
+
+    ok = await client.post(
+        "/api/v1/system/support-bundle",
+        headers=headers,
+        json={
+            "scrubbed": False,
+            "confirm_unscrubbed": "I understand this bundle is not anonymised",
+        },
+    )
+    assert ok.status_code == 200
+    assert "UNSCRUBBED" in ok.headers["content-disposition"]
+
+
+@pytest.mark.asyncio
+async def test_download_returns_a_readable_zip(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, token = await _user(db_session, "sbdl", superadmin=True)
+    await db_session.commit()
+    resp = await client.post(
+        "/api/v1/system/support-bundle",
+        headers={"Authorization": f"Bearer {token}"},
+        json={},
+    )
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "application/zip"
+    with zipfile.ZipFile(BytesIO(resp.content)) as zf:
+        assert zf.testzip() is None
+        assert "manifest.json" in zf.namelist()
+
+
+@pytest.mark.asyncio
+async def test_generation_is_audited(db_session: AsyncSession, client: AsyncClient) -> None:
+    from sqlalchemy import select
+
+    from app.models.audit import AuditLog
+
+    _, token = await _user(db_session, "sbaudit", superadmin=True)
+    await db_session.commit()
+    await client.post(
+        "/api/v1/system/support-bundle",
+        headers={"Authorization": f"Bearer {token}"},
+        json={},
+    )
+    rows = (
+        (
+            await db_session.execute(
+                select(AuditLog).where(AuditLog.resource_type == "support_bundle")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows and rows[0].action == "export"
+
+
+@pytest.mark.asyncio
+async def test_decode_map_endpoint_is_superadmin_only_and_warns(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    _, plain = await _user(db_session, "sbmapplain", superadmin=False)
+    _, admin = await _user(db_session, "sbmapadmin", superadmin=True)
+    await db_session.commit()
+
+    denied = await client.post(
+        "/api/v1/system/support-bundle/decode-map",
+        headers={"Authorization": f"Bearer {plain}"},
+    )
+    assert denied.status_code == 403
+
+    allowed = await client.post(
+        "/api/v1/system/support-bundle/decode-map",
+        headers={"Authorization": f"Bearer {admin}"},
+    )
+    assert allowed.status_code == 200
+    body = allowed.json()
+    assert "Keep it local" in body["warning"]
+    assert set(body["mappings"]) >= {"ipv4", "hostname", "mac"}
+
+
+@pytest.mark.asyncio
+async def test_decode_map_is_stable_across_regenerations(db_session: AsyncSession) -> None:
+    """The endpoint regenerates rather than storing the archive. That
+    only works because the mapping is deterministic per install — a
+    token from yesterday's bundle has to resolve the same way today."""
+    first = Scrubber(seed="install-seed")
+    second = Scrubber(seed="install-seed")
+    assert first.ipv4("10.4.5.6") == second.ipv4("10.4.5.6")
+    assert first.hostname("a.b.example.net") == second.hostname("a.b.example.net")
+    assert first.mac("aa:bb:cc:11:22:33") == second.mac("aa:bb:cc:11:22:33")

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -782,3 +782,126 @@ InfluxDBTarget
 - System health status per component
 
 Multiple InfluxDB targets can be configured simultaneously (e.g., local InfluxDB + remote InfluxCloud).
+
+---
+
+## 9. Support bundle (issue #875)
+
+**Diagnostics → Support bundle**, or `POST /api/v1/system/support-bundle`.
+Superadmin-only and audited. Works on every deployment shape — appliance,
+docker-compose and plain Kubernetes.
+
+A one-click archive to attach to a bug report. The appliance-only
+`GET /api/v1/appliance/diagnostics/bundle` that predates it still exists;
+this is the platform-wide successor and degrades gracefully where that
+one returns 503.
+
+### The premise: attachments are public
+
+There is no private channel for this on GitHub, and that shapes the whole
+design:
+
+- Attachment URLs on a **public** repository's issues are effectively
+  world-readable. Uploads go to `private-user-images.githubusercontent.com`
+  behind short-lived JWTs, but visibility follows *repository* visibility —
+  anyone who can read the issue gets a working link. Deleting the comment
+  does not reliably purge the file.
+- GitHub has no confidential issues (GitLab does). Secret gists are
+  unlisted, not private.
+- Private vulnerability reporting exists, but it is for security advisories
+  — the wrong tool for a routine support bundle.
+
+So the bundle is **scrubbed**, not secret.
+
+### Two tiers
+
+**Hard-exclude — secrets.** Fernet blobs, bcrypt/argon2 password hashes,
+PEM private keys, JWTs, PSKs, API tokens, TSIG keys. Matched both by field
+name and by value shape, and removed in **every** mode including the
+unscrubbed one. There is no version of "let me read my own logs" that is
+improved by including the key that decrypts the database.
+
+**Pseudonymise — identifiers.** IPs, hostnames, domains, MACs, usernames
+become stable synthetic values, so the archive stays *readable*:
+
+| Real | Becomes | What survives |
+|---|---|---|
+| `10.1.2.5`, `10.1.2.9` | `240.x.y.5`, `240.x.y.9` | Same subnet, same host octet |
+| `10.1.3.5` | a different `240.x.z.5` | A different subnet reads as one |
+| `2001:db8:1::5` | `2001:db8:…` | The /64 grouping — but **not** the interface ID |
+| `aa:bb:cc:dd:ee:ff` | `02:00:00:…` | Nothing; the OUI names your hardware vendor |
+| `a.corp.example.net` | `nA.nB.dK.invalid` | Zone and subdomain grouping, subdomain depth |
+| `127.0.0.1`, `fe80::1`, `5.2.1.10.in-addr.arpa` | unchanged | These identify nobody and are load-bearing in a log |
+
+Synthetic IPv4 lands in **240.0.0.0/6**, not the CGNAT range `sos report`
+uses: SpatiumDDI models CGNAT as a real thing (#42 badges it), so
+obfuscating into it would make a bundle look like it documents genuine
+CGNAT deployments. IPv6 uses the RFC 3849 documentation prefix and names
+use the RFC 2606 `.invalid` TLD, both unmistakably synthetic. The IPv6
+interface ID is discarded rather than mapped because a SLAAC address
+embeds the MAC (RFC 4291 modified EUI-64) — preserving it would route
+hardware identity straight past the MAC scrubber.
+
+Mappings are HMAC-derived from the install's `SECRET_KEY`, so they are
+stable across bundles from one install (support can correlate two
+reports) and unguessable from outside it.
+
+### Review before you share
+
+The **preview** step is not decoration. It lists every file with its size,
+counts what the scrubber replaced, shows a sample of the output, and names
+any section that failed to collect. Read it, then download.
+
+Scrubbing is **best-effort** — the same caveat `sos report --clean` and
+GitLab's sanitizer carry. Freeform text can hold an identifier in a shape
+no pattern anticipates. Review the archive before attaching it.
+
+### The decode map
+
+Support answers in synthetic terms: "`n5.d12.invalid` is failing its health
+check." `POST /system/support-bundle/decode-map` returns synthetic → real
+so you can act on that.
+
+It is **never inside the archive**. A bundle carrying its own decoder is
+not scrubbed, it is merely inconvenient to read. The endpoint regenerates
+the mapping rather than storing it, which works because the mapping is
+deterministic per install.
+
+### The unscrubbed variant
+
+`scrubbed: false` keeps real hostnames and addresses, for debugging your
+own systems. It requires the confirmation string
+`I understand this bundle is not anonymised` sent verbatim, and the file is
+named `…-UNSCRUBBED-….zip` so it is recognisable in a downloads folder a
+week later. Credentials are still excluded.
+
+### Contents
+
+`manifest.json` plus: `versions.json` (product, appliance, Alembic head vs
+database head, image tags), `health/` (self-test, connection counts, table
+sizes), `errors/internal-errors.json` (#123), `alerts/events.json`,
+`audit/recent.json`, `activity/recent.log` (merged, time-ordered),
+`config/` (feature modules, sanitised platform settings, integration
+flags), `agents/servers.json`, `system/` (environment, `/proc`), plus
+`containers/` and `logs/` where the deployment exposes them.
+
+A section that cannot be collected becomes a note explaining **why**, not
+an absence — an empty section and an inapplicable one are otherwise
+indistinguishable. Each runs inside its own savepoint, so one failure
+cannot abort the transaction and take every later section with it.
+
+### Limits
+
+- **Assembled in memory**, not streamed: a zip's central directory is
+  written last, so real streaming needs a third-party writer. Bounded
+  instead by per-section caps (1 MB, 2 MB for logs) and a 48 MB total, with
+  truncation marked in-file and in the preview.
+- **No CLI fallback** for a host that cannot serve HTTP. The appliance
+  console remains the path there.
+- `safety_net_hits` in the manifest names any file where the last-chance
+  redaction sweep fired. That is a **bug report in itself** — it means a
+  collector shipped something it should have redacted. The UI surfaces it
+  in red for the same reason.
+
+**MCP:** `get_support_bundle_preview` (default **off** — a broad read of
+logs and configuration). It returns the preview, never the archive.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17274,6 +17274,68 @@ export const factoryResetApi = {
       .then((r) => r.data),
 };
 
+// ── Support bundle (#875) ────────────────────────────────────────────
+
+export interface SupportBundleFile {
+  path: string;
+  bytes: number;
+  truncated: boolean;
+}
+
+export interface SupportBundlePreview {
+  scrubbed: boolean;
+  filename: string;
+  total_bytes: number;
+  files: SupportBundleFile[];
+  manifest: Record<string, unknown>;
+  section_errors: string[];
+  sample: string;
+  warning: string;
+}
+
+export interface SupportBundleDecodeMap {
+  warning: string;
+  mappings: Record<string, Record<string, string>>;
+  counts: Record<string, number>;
+}
+
+/**
+ * Typed verbatim when generating an unscrubbed bundle. Kept in sync with
+ * UNSCRUBBED_CONFIRM in backend/app/api/v1/system/support_bundle.py — the
+ * backend compares it exactly, so a drift here surfaces as a 400.
+ */
+export const SUPPORT_BUNDLE_UNSCRUBBED_CONFIRM =
+  "I understand this bundle is not anonymised";
+
+export const supportBundleApi = {
+  preview: (scrubbed: boolean) =>
+    api
+      .post<SupportBundlePreview>("/system/support-bundle/preview", {
+        scrubbed,
+        confirm_unscrubbed: scrubbed
+          ? undefined
+          : SUPPORT_BUNDLE_UNSCRUBBED_CONFIRM,
+      })
+      .then((r) => r.data),
+  download: (scrubbed: boolean) =>
+    api
+      .post(
+        "/system/support-bundle",
+        {
+          scrubbed,
+          confirm_unscrubbed: scrubbed
+            ? undefined
+            : SUPPORT_BUNDLE_UNSCRUBBED_CONFIRM,
+        },
+        { responseType: "blob" },
+      )
+      .then((r) => r.data as Blob),
+  decodeMap: () =>
+    api
+      .post<SupportBundleDecodeMap>("/system/support-bundle/decode-map")
+      .then((r) => r.data),
+};
+
 // ── Scheduled Wake-on-LAN (#586 Phase 1) ─────────────────────────────
 // Mirrors backend/app/api/v1/wol_schedules/schemas.py. The Python package
 // is ``wol_schedules`` but the wire prefix is ``/wake-scheduler`` — that

--- a/frontend/src/pages/admin/DiagnosticsErrorsPage.tsx
+++ b/frontend/src/pages/admin/DiagnosticsErrorsPage.tsx
@@ -19,6 +19,7 @@ import {
   formatApiError,
 } from "@/lib/api";
 import { copyToClipboard } from "@/lib/clipboard";
+import { SupportBundleSection } from "./SupportBundleSection";
 
 /**
  * Diagnostics → Errors (issue #123).
@@ -46,8 +47,15 @@ const GITHUB_BODY_URL_CAP = 6800;
 type AckedFilter = "all" | "yes" | "no";
 type ServiceFilter = "all" | "api" | "worker" | "beat";
 
+type DiagTab = "errors" | "support-bundle";
+
 export function DiagnosticsErrorsPage() {
   const qc = useQueryClient();
+  // The support bundle lives here rather than on its own page: this is
+  // where an operator already is when something has gone wrong, and the
+  // "Submit bug" button below opens the GitHub issue the bundle is meant
+  // to be attached to.
+  const [tab, setTab] = useState<DiagTab>("errors");
   const [serviceFilter, setServiceFilter] = useState<ServiceFilter>("all");
   const [ackedFilter, setAckedFilter] = useState<AckedFilter>("all");
   const [sinceHours, setSinceHours] = useState<number | null>(null);
@@ -100,7 +108,7 @@ export function DiagnosticsErrorsPage() {
         <div className="flex flex-wrap items-center gap-3">
           <div className="flex items-center gap-2">
             <AlertTriangle className="h-5 w-5 text-muted-foreground" />
-            <h1 className="text-lg font-semibold">Diagnostics — Errors</h1>
+            <h1 className="text-lg font-semibold">Diagnostics</h1>
           </div>
           {statsQ.data && (
             <div className="flex items-center gap-3 text-xs text-muted-foreground">
@@ -186,64 +194,96 @@ export function DiagnosticsErrorsPage() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-auto">
-        {listQ.isLoading ? (
-          <div className="p-6 text-sm text-muted-foreground">
-            <Loader2 className="mr-2 inline h-3.5 w-3.5 animate-spin" />
-            Loading…
-          </div>
-        ) : listQ.isError ? (
-          <div className="p-6 text-sm text-destructive">
-            Failed to load errors.
-            {(listQ.error as Error)?.message
-              ? ` ${formatApiError(listQ.error)}`
-              : ""}
-          </div>
-        ) : errors.length === 0 ? (
-          <div className="p-6 text-sm text-muted-foreground">
-            No errors recorded. The capture handler is wired and will land
-            uncaught exceptions here as they happen.
-          </div>
-        ) : (
-          <table className="w-full text-sm">
-            <thead className="sticky top-0 z-10 bg-card text-left text-xs text-muted-foreground">
-              <tr className="border-b">
-                <th className="w-8 px-2 py-2"></th>
-                <th className="px-3 py-2">When</th>
-                <th className="px-3 py-2">Service</th>
-                <th className="px-3 py-2">Class</th>
-                <th className="px-3 py-2">Message</th>
-                <th className="px-3 py-2">Route / Task</th>
-                <th className="px-3 py-2 text-right">Count</th>
-                <th className="px-3 py-2">State</th>
-                <th className="px-3 py-2 text-right">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {errors.map((row) => (
-                <ErrorRow
-                  key={row.id}
-                  row={row}
-                  expanded={expandedId === row.id}
-                  onToggleExpand={() =>
-                    setExpandedId(expandedId === row.id ? null : row.id)
-                  }
-                  onAck={() => ackMut.mutate(row.id)}
-                  onSuppress={() => suppressMut.mutate(row.id)}
-                  onDelete={() => deleteMut.mutate(row.id)}
-                  pendingAck={ackMut.isPending && ackMut.variables === row.id}
-                  pendingSuppress={
-                    suppressMut.isPending && suppressMut.variables === row.id
-                  }
-                  pendingDelete={
-                    deleteMut.isPending && deleteMut.variables === row.id
-                  }
-                />
-              ))}
-            </tbody>
-          </table>
-        )}
+      <div className="border-b bg-card px-6">
+        <div className="-mb-px flex gap-1">
+          {(
+            [
+              ["errors", "Errors"],
+              ["support-bundle", "Support bundle"],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setTab(key)}
+              className={`-mb-px border-b-2 px-3 py-1.5 text-sm ${
+                tab === key
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
+
+      {tab === "support-bundle" ? (
+        <div className="flex-1 overflow-auto p-6">
+          <div className="mx-auto max-w-4xl">
+            <SupportBundleSection />
+          </div>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-auto">
+          {listQ.isLoading ? (
+            <div className="p-6 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 inline h-3.5 w-3.5 animate-spin" />
+              Loading…
+            </div>
+          ) : listQ.isError ? (
+            <div className="p-6 text-sm text-destructive">
+              Failed to load errors.
+              {(listQ.error as Error)?.message
+                ? ` ${formatApiError(listQ.error)}`
+                : ""}
+            </div>
+          ) : errors.length === 0 ? (
+            <div className="p-6 text-sm text-muted-foreground">
+              No errors recorded. The capture handler is wired and will land
+              uncaught exceptions here as they happen.
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="sticky top-0 z-10 bg-card text-left text-xs text-muted-foreground">
+                <tr className="border-b">
+                  <th className="w-8 px-2 py-2"></th>
+                  <th className="px-3 py-2">When</th>
+                  <th className="px-3 py-2">Service</th>
+                  <th className="px-3 py-2">Class</th>
+                  <th className="px-3 py-2">Message</th>
+                  <th className="px-3 py-2">Route / Task</th>
+                  <th className="px-3 py-2 text-right">Count</th>
+                  <th className="px-3 py-2">State</th>
+                  <th className="px-3 py-2 text-right">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {errors.map((row) => (
+                  <ErrorRow
+                    key={row.id}
+                    row={row}
+                    expanded={expandedId === row.id}
+                    onToggleExpand={() =>
+                      setExpandedId(expandedId === row.id ? null : row.id)
+                    }
+                    onAck={() => ackMut.mutate(row.id)}
+                    onSuppress={() => suppressMut.mutate(row.id)}
+                    onDelete={() => deleteMut.mutate(row.id)}
+                    pendingAck={ackMut.isPending && ackMut.variables === row.id}
+                    pendingSuppress={
+                      suppressMut.isPending && suppressMut.variables === row.id
+                    }
+                    pendingDelete={
+                      deleteMut.isPending && deleteMut.variables === row.id
+                    }
+                  />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/admin/SupportBundleSection.tsx
+++ b/frontend/src/pages/admin/SupportBundleSection.tsx
@@ -1,0 +1,315 @@
+import { useState } from "react";
+import { useMutation } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Download,
+  FileArchive,
+  KeyRound,
+  Loader2,
+  ShieldCheck,
+} from "lucide-react";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import {
+  formatApiError,
+  supportBundleApi,
+  type SupportBundleDecodeMap,
+  type SupportBundlePreview,
+} from "@/lib/api";
+
+/**
+ * Support bundle (#875) — generate a scrubbed diagnostics archive for a
+ * bug report.
+ *
+ * The review step is the point of this screen, not decoration. Attachments
+ * on a public GitHub issue are readable by anyone who can see the issue,
+ * and deleting the comment does not reliably purge the file — so the
+ * operator sees the file list and what the scrubber replaced *before* a
+ * download button appears.
+ */
+export function SupportBundleSection() {
+  const [preview, setPreview] = useState<SupportBundlePreview | null>(null);
+  const [scrubbed, setScrubbed] = useState(true);
+  const [confirmRaw, setConfirmRaw] = useState(false);
+  const [decodeMap, setDecodeMap] = useState<SupportBundleDecodeMap | null>(
+    null,
+  );
+  const [error, setError] = useState("");
+
+  const previewMut = useMutation({
+    mutationFn: (wantScrubbed: boolean) =>
+      supportBundleApi.preview(wantScrubbed),
+    onSuccess: (data) => {
+      setPreview(data);
+      setError("");
+    },
+    onError: (e) => setError(formatApiError(e, "Preview failed")),
+  });
+
+  const downloadMut = useMutation({
+    mutationFn: async (wantScrubbed: boolean) => {
+      const blob = await supportBundleApi.download(wantScrubbed);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download =
+        preview?.filename ??
+        `spatiumddi-support-bundle-${new Date().toISOString().slice(0, 10)}.zip`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    },
+    onError: (e) => setError(formatApiError(e, "Download failed")),
+  });
+
+  const decodeMut = useMutation({
+    mutationFn: () => supportBundleApi.decodeMap(),
+    onSuccess: setDecodeMap,
+    onError: (e) => setError(formatApiError(e, "Could not build decode map")),
+  });
+
+  const scrub = (preview?.manifest?.scrub ?? {}) as Record<string, unknown>;
+  const safetyNetHits = (scrub.safety_net_hits as string[] | undefined) ?? [];
+
+  const runPreview = (wantScrubbed: boolean) => {
+    setScrubbed(wantScrubbed);
+    setPreview(null);
+    setDecodeMap(null);
+    previewMut.mutate(wantScrubbed);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded border bg-card p-4">
+        <div className="flex items-start gap-2">
+          <FileArchive className="mt-0.5 h-4 w-4 flex-shrink-0 text-muted-foreground" />
+          <div className="min-w-0 space-y-1">
+            <h3 className="text-sm font-medium">Support bundle</h3>
+            <p className="text-xs text-muted-foreground">
+              A diagnostics archive for a bug report: versions, schema head,
+              recent errors, alert history, configuration shape, an audit tail
+              and whatever logs this deployment can reach. Credentials are
+              excluded in every mode.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => runPreview(true)}
+            disabled={previewMut.isPending}
+            className="inline-flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+          >
+            {previewMut.isPending && scrubbed ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <ShieldCheck className="h-3 w-3" />
+            )}
+            Review scrubbed bundle
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmRaw(true)}
+            disabled={previewMut.isPending}
+            className="inline-flex items-center gap-1.5 rounded border border-amber-500/40 px-3 py-1.5 text-xs text-amber-700 hover:bg-amber-500/10 disabled:opacity-50 dark:text-amber-400"
+          >
+            <AlertTriangle className="h-3 w-3" />
+            Unscrubbed (local only)
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+
+      {preview && (
+        <div className="space-y-3 rounded border bg-card p-4">
+          <div
+            className={`rounded border p-2 text-xs ${
+              preview.scrubbed
+                ? "border-border bg-muted/40 text-muted-foreground"
+                : "border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-300"
+            }`}
+          >
+            {preview.warning}
+          </div>
+
+          {safetyNetHits.length > 0 && (
+            <div className="rounded border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+              <strong>The redaction safety net fired.</strong> Something reached
+              the archive that a collector should have redacted itself. It was
+              removed, but please report this — it is a bug in SpatiumDDI:
+              <ul className="mt-1 list-inside list-disc">
+                {safetyNetHits.map((h) => (
+                  <li key={h} className="font-mono">
+                    {h}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {preview.scrubbed && (
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-5">
+              {(
+                [
+                  ["IPv4", "ipv4_mapped"],
+                  ["IPv6", "ipv6_mapped"],
+                  ["MACs", "macs_mapped"],
+                  ["Hostnames", "hostnames_mapped"],
+                  ["Usernames", "usernames_mapped"],
+                ] as const
+              ).map(([label, key]) => (
+                <div key={key}>
+                  <dt className="text-muted-foreground">{label} replaced</dt>
+                  <dd className="font-medium">{String(scrub[key] ?? 0)}</dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
+          {preview.section_errors.length > 0 && (
+            <div className="rounded border border-amber-500/40 bg-amber-500/5 p-2 text-xs">
+              <strong>Some sections could not be collected.</strong> The rest of
+              the bundle is still usable.
+              <ul className="mt-1 list-inside list-disc text-muted-foreground">
+                {preview.section_errors.map((e) => (
+                  <li key={e} className="font-mono break-all">
+                    {e}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div>
+            <p className="mb-1 text-xs font-medium">
+              {preview.files.length} files ·{" "}
+              {(preview.total_bytes / 1024).toFixed(0)} KB compressed
+            </p>
+            <div className="max-h-56 overflow-y-auto rounded border">
+              <table className="w-full text-xs">
+                <tbody>
+                  {preview.files.map((f) => (
+                    <tr key={f.path} className="border-b last:border-0">
+                      <td className="px-2 py-1 font-mono break-all">
+                        {f.path}
+                      </td>
+                      <td className="whitespace-nowrap px-2 py-1 text-right text-muted-foreground">
+                        {f.bytes.toLocaleString()} B
+                        {f.truncated && (
+                          <span
+                            className="ml-1 text-amber-600 dark:text-amber-400"
+                            title="Truncated by the per-section size cap"
+                          >
+                            trunc
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {preview.sample && (
+            <div>
+              <p className="mb-1 text-xs font-medium">
+                Sample of the scrubbed content
+              </p>
+              <pre className="max-h-40 overflow-auto rounded border bg-muted/40 p-2 text-[11px] leading-relaxed">
+                {preview.sample}
+              </pre>
+            </div>
+          )}
+
+          <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+            <button
+              type="button"
+              onClick={() => downloadMut.mutate(preview.scrubbed)}
+              disabled={downloadMut.isPending}
+              className="inline-flex items-center gap-1.5 rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+            >
+              {downloadMut.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <Download className="h-3 w-3" />
+              )}
+              Download {preview.scrubbed ? "" : "UNSCRUBBED "}bundle
+            </button>
+            {preview.scrubbed && (
+              <button
+                type="button"
+                onClick={() => decodeMut.mutate()}
+                disabled={decodeMut.isPending}
+                className="inline-flex items-center gap-1.5 rounded border px-3 py-1.5 text-xs hover:bg-muted/50 disabled:opacity-50"
+                title="Maps the synthetic values back to the real ones. Keep it local."
+              >
+                {decodeMut.isPending ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <KeyRound className="h-3 w-3" />
+                )}
+                Decode map
+              </button>
+            )}
+            <span className="text-[11px] text-muted-foreground">
+              Regenerated on download, so a busy install may differ by a line.
+            </span>
+          </div>
+        </div>
+      )}
+
+      {decodeMap && (
+        <div className="space-y-2 rounded border border-amber-500/40 bg-amber-500/5 p-4">
+          <p className="text-xs font-medium text-amber-800 dark:text-amber-300">
+            {decodeMap.warning}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {Object.entries(decodeMap.counts)
+              .map(([k, n]) => `${n} ${k}`)
+              .join(" · ")}
+          </p>
+          <pre className="max-h-64 overflow-auto rounded border bg-background p-2 text-[11px]">
+            {JSON.stringify(decodeMap.mappings, null, 2)}
+          </pre>
+        </div>
+      )}
+
+      <ConfirmModal
+        open={confirmRaw}
+        title="Generate an unscrubbed bundle?"
+        confirmLabel="Generate unscrubbed bundle"
+        tone="destructive"
+        requireCheckboxLabel="I will not attach this to a public issue"
+        onClose={() => setConfirmRaw(false)}
+        onConfirm={() => {
+          setConfirmRaw(false);
+          runPreview(false);
+        }}
+        message={
+          <div className="space-y-2 text-sm">
+            <p>
+              An unscrubbed bundle contains <strong>real</strong> hostnames, IP
+              addresses, MAC addresses and usernames from this install.
+            </p>
+            <p>
+              It is for debugging on your own systems. Attachments on a public
+              GitHub issue are readable by anyone who can see the issue, and
+              deleting the comment does not reliably remove the file.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Credentials are excluded from this bundle too — that part never
+              changes.
+            </p>
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/SupportBundleSection.tsx
+++ b/frontend/src/pages/admin/SupportBundleSection.tsx
@@ -59,7 +59,26 @@ export function SupportBundleSection() {
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     },
-    onError: (e) => setError(formatApiError(e, "Download failed")),
+    // The download is requested with responseType "blob", so an error
+    // response arrives as a Blob too — formatApiError finds no `.detail`
+    // on it and falls back to axios's "Request failed with status code
+    // 403", hiding the reason the server actually gave.
+    onError: async (e) => {
+      const data = (e as { response?: { data?: unknown } })?.response?.data;
+      if (data instanceof Blob) {
+        try {
+          const parsed = JSON.parse(await data.text()) as { detail?: unknown };
+          if (typeof parsed.detail === "string" && parsed.detail.trim()) {
+            setError(parsed.detail);
+            return;
+          }
+        } catch {
+          // Not JSON (a proxy error page, an empty body) — fall through
+          // to the generic formatter rather than showing raw bytes.
+        }
+      }
+      setError(formatApiError(e, "Download failed"));
+    },
   });
 
   const decodeMut = useMutation({


### PR DESCRIPTION
Closes #875

One-click diagnostics archive for a bug report, at `POST /system/support-bundle{,/preview,/decode-map}`. Superadmin, audited, and working on **all three deployment shapes** — the appliance-only `/appliance/diagnostics/bundle` it supersedes returns 503 on docker-compose and plain Kubernetes, because its pod-log and self-test halves go through kubeapi.

## The premise: attachments are public

The issue asked whether GitHub can receive a sensitive file privately. It cannot, and that shaped everything:

- Attachment URLs on a **public** repo's issues follow *repository* visibility. Uploads sit behind short-lived JWTs at `private-user-images.githubusercontent.com`, but anyone who can read the issue gets a working link, and deleting the comment does not reliably purge the file.
- GitHub has no confidential issues (GitLab does). Secret gists are unlisted, not private.
- Private vulnerability reporting exists but is for security advisories — wrong tool for a routine support bundle.

So the design is **scrubbing, not secrecy**, and the docs say so plainly.

## Two tiers

**Hard-exclude — secrets.** Fernet blobs, bcrypt/argon2 hashes, PEM private keys, JWTs, PSKs, credentials in URL userinfo. Matched by field name **and** value shape, removed in **every** mode including the unscrubbed one — there is no version of "let me read my own logs" improved by shipping the key that decrypts the database.

**Pseudonymise — identifiers.** HMAC-deterministic off `SECRET_KEY`, so mappings are stable per install (support can correlate two bundles) and unguessable outside it. Topology survives, which is what keeps a bundle worth reading for a DDI product:

| Real | Becomes | What survives |
|---|---|---|
| `10.1.2.5`, `10.1.2.9` | `240.x.y.5`, `240.x.y.9` | Same subnet, same host octet |
| `2001:db8:1::5` | `2001:db8:…` | The /64 grouping — **not** the interface ID |
| `aa:bb:cc:dd:ee:ff` | `02:00:00:…` | Nothing; the OUI names your hardware vendor |
| `a.corp.example.net` | `nA.nB.dK.invalid` | Zone + subdomain grouping, subdomain depth |
| `127.0.0.1`, `fe80::1`, `…in-addr.arpa` | unchanged | Identify nobody, load-bearing in a log |

**Two choices are product-specific rather than copied from `sos report --clean`:**

- Synthetic IPv4 goes to **240.0.0.0/6**, not sos's CGNAT range. #42 makes CGNAT a real modelled concept here, so obfuscating into it would make a bundle read as documenting genuine CGNAT deployments.
- The IPv6 **interface ID is discarded, not mapped**. A SLAAC address embeds the MAC (RFC 4291 modified EUI-64), so preserving it would route hardware identity straight past the MAC scrubber.

## Review before you share

Preview → review → download. The preview lists every file with sizes, counts what was replaced, shows a sample, and names any section that failed. The decode map comes from a **separate endpoint and is never in the archive** — a bundle carrying its own decoder is not scrubbed, merely inconvenient to read. Unscrubbed requires a verbatim confirmation string and is named `-UNSCRUBBED-` so it is recognisable in a downloads folder a week later.

## Four bugs found by generating real bundles, not by reading code

1. **Three agent PSKs** (`DNS_AGENT_KEY` / `DHCP_AGENT_KEY` / `LG_AGENT_KEY`) rode through unredacted. My name pattern enumerated `api_key` / `private_key` / `encryption_key`; a bare `*_KEY` suffix matched none. Their values are raw hex, so no value-matcher can catch them — the name is the only defence, and an enumeration is always one agent kind behind.
2. **`DATABASE_URL` carried its password.** Nothing named `*_URL` looks secret and `user:pass@host` has no distinctive shape.
3. **Redaction was not idempotent** — `[REDACTED]:[REDACTED]` matched the userinfo pattern that produced it, so a second pass re-fired and the safety net reported a hit on already-clean text. That mattered beyond cosmetics: the net's value is that a hit means a *real* leak, and one that cries wolf gets ignored.
4. **A collector catching its own DB error** left PostgreSQL in "transaction is aborted", so every *later* section failed and the bundle blamed the wrong ones. Every section, and every guarded query inside one, now runs in its own SAVEPOINT.

## Code review

Six findings fixed as reported — including `audit_forward_webhook_auth_header`, which holds a literal `Bearer …` in **plaintext** and shipped verbatim.

Review deliberately left two for me, sharing one root cause: `_HOSTNAME_RE` cannot tell `sqlalchemy.exc.ProgrammingError` from `corp.example.net`, and was eating tracebacks. It was right that the obvious fixes trade privacy for readability — an extension allow-list re-leaks real `.io`/`.sh` hostnames, and a "preceded by a slash" heuristic leaks the domain out of a DNS product's own `/var/named/corp.example.com.zone` log lines.

**I took only the strictly-safe half** — rules identifying tokens that *could not resolve anyway*, so nothing real stays exposed to buy the readability: a camel-case final label (no TLD is camel-case; all-caps `HOST.EXAMPLE.COM` is still scrubbed), and a curated non-TLD suffix set with every entry checked against the IANA root zone. `.zone`, `.py`, `.sh`, `.md`, `.rs`, `.go` are deliberately absent — all real TLDs.

Residual, documented rather than glossed: `collect.py` still maps, `.py` being Paraguay's ccTLD. A mangled traceback line keeps its directory, line number, function name and the exception's own module path.

That unblocked the second finding: with `json` in the non-TLD set, `collect_self_test()` and `collect_proc()` can now scrub without rewriting the self-test's own `health/versions.json` reference — closing a real gap, since `/proc/version` carries the kernel *build host*.

## Verification

- **73 tests**, adversarial by design: feed known secrets and identifiers through, assert absence.
- A freshly generated bundle has **zero** hits for Fernet, bcrypt, agent PSKs, URL userinfo or real RFC 1918 addresses, and an empty `safety_net_hits`.
- Both modes checked: unscrubbed keeps real hostnames and addresses (as it must) while still excluding every credential.
- `make ci` green; docs render checked on the local Jekyll preview.

## Scope notes

**No feature-module gate** — an ops primitive like backup, per the issue's own recommendation. **MCP:** `get_support_bundle_preview`, default **off** (a broad read); it returns the preview, never the archive.

**Deferred, stated rather than implied:** true streaming (a zip's central directory is written last, so it needs a third-party writer — bounded by per-section and 48 MB caps instead), and a CLI fallback for a host that cannot serve HTTP.

The issue's open question — whether to add an out-of-band private submission channel — is answered "not initially", per its own recommendation: scrubbed-by-default makes the public attachment path acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
