### PR TITLE
feat(search): global search v2 — ranking, RBAC, 20 types, command palette (#879)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -677,10 +677,42 @@ suggestion, free-space treemap.
   Note for anyone adding a binding: declare it here and match via
   `matchesShortcut` rather than adding another described-only row.
 - ✅ [**Print / PDF export for IPAM tree + subnet detail**](https://github.com/spatiumddi/spatiumddi/issues/82) — shipped `2026.07.30-1` (#739): `GET /ipam/export.pdf` takes the same scope selector as the CSV/JSON/XLSX exporter (and reuses its `_collect`, so the two can't disagree about the subtree) and renders one of two shapes — a **tree** report for a space / block, or a **detail** report for a subnet. Surfaced as *Print / PDF* in both Export dropdowns. **reportlab, not the weasyprint the issue text proposed** — two reportlab PDFs already ship and a second engine would add Cairo / Pango to every image for no new capability. Unlike #48 and the conformity report, this one paginates: `repeatRows=1` plus a two-pass `_NumberedCanvas` for "Page N of M". Two things worth knowing if you touch it: reportlab's `Paragraph` parses mini-XML, so **all** DB-sourced text must go through `_para()` (an unescaped `a<b>c` space name 500s the export, and `<legacy> net` silently renders as "net"); and the tree indent must stay inside WinAnsiEncoding, or reportlab swaps in ZapfDingbats and nested blocks render as `■■`. Both have regression tests. *(GitHub auto-closed this issue on 2026-06-18 in error — PR [#446](https://github.com/spatiumddi/spatiumddi/pull/446) said `CodeQL #82`, meaning alert 82. Reopened 2026-07-28, genuinely shipped now.)*
-- ⬜ [**Global search v2**](https://github.com/spatiumddi/spatiumddi/issues/879) — relevance ranking, trigram
-  indexes, wider resource coverage, and command actions. The existing
-  typeahead works; this is about it being useful past ~3 resource
-  types.
+- ✅ [**Global search v2**](https://github.com/spatiumddi/spatiumddi/issues/879) — all six gaps closed.
+  Matching, ranking and gating moved out of the router into
+  `backend/app/services/search/` (`ranking` / `providers` / `engine`),
+  which the `global_search` MCP tool now calls instead of carrying its
+  own copy of the fan-out. Coverage went 7 types → 20 via a
+  `SearchProvider` registry that the engine, the scope chips, the MCP
+  tool and `GET /search/types` all read from. **Ranking is computed in
+  SQL, before each type's `LIMIT`** — the ordering bug was not really
+  about order: with no `ORDER BY`, the database returned any N matching
+  rows and the exact hit was routinely not among them, which sorting in
+  Python afterwards cannot fix. Trigram GIN indexes (migration
+  `f4b91d38a70c`) back the leading-wildcard `ILIKE` on the tables that
+  actually grow; small tables are left unindexed on purpose. Frontend:
+  scope chips, sessionStorage recents, and go-to-page commands sourced
+  from the sidebar's own nav tree, extracted to `lib/navigation.ts` so
+  the palette can't drift from the sidebar (the `lib/shortcuts.ts`
+  argument from #737).
+  **Four bugs found on the way, three of them pre-existing.** (1) Search
+  applied **no permission filtering at all** — it was the widest read
+  surface in the product and the only one that checked nothing, so an
+  IPAM-only operator could read DNS zones and records straight out of a
+  palette whose `GET /dns/zones` would have 403'd them; the Copilot tool
+  had the same hole. (2) The query was interpolated raw into `%…%`, so
+  searching `50%` matched every row in every table. (3) The MAC branch
+  in the address query was unindexable and sat in an `OR` beside two
+  indexed predicates, forcing the whole query to a sequential scan —
+  the two working indexes bought nothing until it was normalised.
+  (4) `_statement_references` in `app/db.py` called
+  `statement.get_final_froms()` once per soft-delete model, ~1.9 ms
+  each × 8, i.e. **~16 ms of Python on every ORM SELECT in the
+  application** — invisible because it was uniform. Resolving the FROM
+  graph once cut a 20-provider fan-out over 500k addresses from 734 ms
+  to 93 ms. **Deferred:** an expression index for custom-field values
+  (the field name is runtime-chosen, so no trigram index can serve
+  `custom_fields ->> 'x' ILIKE …`), and action commands that *do*
+  something rather than navigate.
 - ⬜ [**Native mobile app**](https://github.com/spatiumddi/spatiumddi/issues/884) — PWA groundwork first, then iOS
   (SwiftUI) against the REST API. Non-negotiable #1 means the API is
   already complete enough to build against.

--- a/backend/alembic/versions/f4b91d38a70c_search_trigram_indexes.py
+++ b/backend/alembic/versions/f4b91d38a70c_search_trigram_indexes.py
@@ -1,0 +1,136 @@
+"""Trigram indexes for global search (issue #879)
+
+Global search matches with ``ILIKE '%term%'``. A leading wildcard makes a
+B-tree index unusable, so every keystroke was a sequential scan of every
+searched table — and search fans out across all of them at once.
+
+``pg_trgm`` GIN indexes fix that: they support leading-wildcard ILIKE
+directly. Two caveats worth knowing before reading an EXPLAIN and
+concluding this migration did nothing:
+
+* A pattern shorter than three characters produces no full trigram, so
+  1–2 character queries still seq-scan. That is fine — the palette is
+  debounced and those queries match nearly everything anyway.
+* GIN is chosen over GiST deliberately: lookups are much faster, and the
+  slower build and larger index matter far less for a workload that reads
+  on every keystroke and writes on operator action.
+
+**Only the tables where a scan actually hurts are indexed.** ``ip_address``
+and ``dns_record`` reach millions of rows on a real install; ``ip_space``,
+``dns_view``, ``site`` and friends hold tens to hundreds, where a seq scan
+is already the fastest plan and a GIN index would be pure write
+amplification. Adding one later is a one-line migration.
+
+Extension creation is attempted inside a SAVEPOINT. ``pg_trgm`` has been a
+*trusted* extension since PostgreSQL 13, so a database owner can create it
+without superuser — but a locked-down managed instance may still refuse. If
+it does, this migration logs and skips the indexes rather than failing:
+search degrades to the sequential scans it already used, which is a slow
+search, not a broken upgrade. Doing that without the SAVEPOINT would leave
+the connection in "current transaction is aborted" and take down every
+later statement in the migration with it.
+
+Revision ID: f4b91d38a70c
+Revises: c8a3f207e51b
+Create Date: 2026-08-22
+
+"""
+
+from __future__ import annotations
+
+import structlog
+from alembic import op
+
+revision = "f4b91d38a70c"
+down_revision = "c8a3f207e51b"
+branch_labels = None
+depends_on = None
+
+logger = structlog.get_logger(__name__)
+
+# (index name, table, column). Ordinary column indexes.
+_TRGM_INDEXES: tuple[tuple[str, str, str], ...] = (
+    ("ix_trgm_ip_address_hostname", "ip_address", "hostname"),
+    ("ix_trgm_ip_address_description", "ip_address", "description"),
+    ("ix_trgm_dns_record_fqdn", "dns_record", "fqdn"),
+    ("ix_trgm_dns_record_value", "dns_record", "value"),
+    ("ix_trgm_dns_zone_name", "dns_zone", "name"),
+    ("ix_trgm_subnet_name", "subnet", "name"),
+    ("ix_trgm_subnet_description", "subnet", "description"),
+    ("ix_trgm_dhcp_static_hostname", "dhcp_static_assignment", "hostname"),
+)
+# Deliberately not indexed: ``dhcp_static_assignment.ip_address`` and
+# ``network_device.ip_address``. Both are ``inet``, which ``gin_trgm_ops``
+# rejects outright, so they would need an index over ``CAST(… AS text)``
+# spelled exactly as the query spells it. Neither table is large enough for
+# that fragility to buy anything — a reservation list is bounded by the
+# scopes an operator maintains, not by address space.
+
+# The MAC lookup normalises separators away on both sides, so the index has
+# to be over that same expression — the planner matches expression indexes
+# by comparing the parsed expression, and any divergence silently costs the
+# index rather than raising. The live query builds this string from
+# ``app.services.search.providers._mac_normalized_sql``; it is spelled out
+# again here rather than imported, because a migration is a historical
+# record that has to keep running after the code it was written against has
+# moved on. ``test_search.py::test_mac_index_expression_matches_the_query``
+# fails if the two ever diverge, which is the right place for that check:
+# it catches drift in CI instead of in an EXPLAIN nobody runs.
+_MAC_NORMALIZE_SQL = (
+    "REPLACE(REPLACE(REPLACE(CAST(mac_address AS text), ':', ''), '-', ''), '.', '')"
+)
+_MAC_INDEX = "ix_trgm_ip_address_mac_normalized"
+
+
+def _ensure_pg_trgm() -> bool:
+    """Create the extension if needed. Returns whether it is usable."""
+    bind = op.get_bind()
+    existing = bind.exec_driver_sql("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'").scalar()
+    if existing:
+        return True
+    try:
+        with bind.begin_nested():
+            bind.exec_driver_sql("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+    except Exception as exc:  # noqa: BLE001 — degrade, never fail the upgrade
+        logger.warning(
+            "search_trgm_extension_unavailable",
+            error=str(exc),
+            detail=(
+                "Global search will use sequential scans. Grant the database "
+                "owner rights to CREATE EXTENSION pg_trgm and re-run this "
+                "migration to enable the indexes."
+            ),
+        )
+        return False
+    return True
+
+
+def upgrade() -> None:
+    if not _ensure_pg_trgm():
+        return
+
+    for name, table, column in _TRGM_INDEXES:
+        op.create_index(
+            name,
+            table,
+            [column],
+            unique=False,
+            postgresql_using="gin",
+            postgresql_ops={column: "gin_trgm_ops"},
+        )
+
+    op.execute(
+        f"CREATE INDEX {_MAC_INDEX} ON ip_address "
+        f"USING gin (({_MAC_NORMALIZE_SQL}) gin_trgm_ops)"
+    )
+
+
+def downgrade() -> None:
+    # IF EXISTS throughout: upgrade() legitimately creates none of these
+    # when the extension is unavailable, so an unconditional DROP would make
+    # the downgrade fail on exactly the installs that took that path.
+    op.execute(f"DROP INDEX IF EXISTS {_MAC_INDEX}")
+    for name, _table, _column in _TRGM_INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {name}")
+    # The extension is deliberately left in place — something else may have
+    # come to depend on it, and dropping it would cascade away their indexes.

--- a/backend/app/api/v1/search/router.py
+++ b/backend/app/api/v1/search/router.py
@@ -1,549 +1,36 @@
-"""Global search — IPAM + DNS resources."""
+"""Global search — every resource type the caller is allowed to see.
+
+The matching, ranking and permission filtering live in
+``app.services.search``; this module is the HTTP surface over it. The
+service split exists because the ``global_search`` MCP tool used to carry
+its own copy of the fan-out, and copies drift (issue #879).
+"""
 
 from __future__ import annotations
 
-import ipaddress
-import re
-
-import structlog
 from fastapi import APIRouter, Query
-from pydantic import BaseModel
-from sqlalchemy import or_, select, text
-from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser
-from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
-from app.models.ipam import CustomFieldDefinition, IPAddress, IPBlock, IPSpace, Subnet
+from app.services.search import execute, visible_providers
+from app.services.search.schemas import SearchResponse, SearchResult, SearchTypeInfo
 
-logger = structlog.get_logger(__name__)
+__all__ = ["SearchResponse", "SearchResult", "SearchTypeInfo", "router"]
+
 router = APIRouter()
 
 
-# ── Query-type detection ───────────────────────────────────────────────────────
+@router.get("/types", response_model=list[SearchTypeInfo])
+async def searchable_types(current_user: CurrentUser, db: DB) -> list[SearchTypeInfo]:
+    """Types this caller may search, for building scope filters.
 
-
-def _is_ip(q: str) -> bool:
-    try:
-        ipaddress.ip_address(q)
-        return True
-    except ValueError:
-        return False
-
-
-def _is_cidr(q: str) -> bool:
-    if "/" not in q:
-        return False
-    try:
-        ipaddress.ip_network(q, strict=False)
-        return True
-    except ValueError:
-        return False
-
-
-_MAC_PATTERNS = [
-    re.compile(r"^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"),
-    re.compile(r"^([0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$"),
-    re.compile(r"^[0-9a-fA-F]{12}$"),
-    re.compile(r"^([0-9a-fA-F]{4}\.){2}[0-9a-fA-F]{4}$"),  # Cisco dotted
-]
-
-
-def _is_mac(q: str) -> bool:
-    return any(p.match(q) for p in _MAC_PATTERNS)
-
-
-def _normalize_mac(q: str) -> str:
-    """Strip separators and lowercase, for partial ILIKE matching."""
-    return re.sub(r"[:\-\.]", "", q).lower()
-
-
-# ── Response schema ────────────────────────────────────────────────────────────
-
-
-class SearchResult(BaseModel):
-    """One hit from any resource type."""
-
-    type: str  # "ip_address"|"subnet"|"block"|"space"|"dns_zone"|"dns_record"|"dns_group"
-    id: str
-
-    # Primary display
-    display: str  # e.g. "10.0.0.42" or "example.com."
-    name: str | None  # human name if set
-
-    # Status / detail
-    status: str | None  # ip or subnet status
-    description: str | None
-
-    # IP-address specific
-    hostname: str | None
-    mac_address: str | None
-
-    # Breadcrumb context (IPAM)
-    subnet_id: str | None
-    subnet_network: str | None
-    block_id: str | None
-    space_id: str | None
-    space_name: str | None
-
-    # DNS context
-    dns_group_id: str | None = None
-    dns_group_name: str | None = None
-    dns_zone_id: str | None = None
-    dns_zone_name: str | None = None
-    dns_record_type: str | None = None
-    dns_record_value: str | None = None
-
-    # Hint showing WHY this row matched (e.g. "custom_field:owner=alice" or
-    # "hostname"); populated for custom-field hits and reserved for future
-    # per-column match annotations.
-    matched_field: str | None = None
-
-
-class SearchResponse(BaseModel):
-    query: str
-    total: int
-    results: list[SearchResult]
-
-
-# ── Helpers ────────────────────────────────────────────────────────────────────
-
-
-async def _search_addresses(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    is_ip = _is_ip(q)
-    is_mac = _is_mac(q)
-
-    stmt = (
-        select(IPAddress, Subnet, IPSpace)
-        .join(Subnet, IPAddress.subnet_id == Subnet.id)
-        .join(IPSpace, Subnet.space_id == IPSpace.id)
-    )
-
-    if is_ip:
-        stmt = stmt.where(text("CAST(ip_address.address AS inet) = CAST(:q AS inet)")).params(q=q)
-    elif is_mac:
-        norm = _normalize_mac(q)
-        stmt = stmt.where(
-            text(
-                "REPLACE(REPLACE(REPLACE(CAST(ip_address.mac_address AS text), ':', ''), '-', ''), '.', '') ILIKE :norm"
-            )
-        ).params(norm=f"%{norm}%")
-    else:
-        stmt = stmt.where(
-            or_(
-                IPAddress.hostname.ilike(f"%{q}%"),
-                IPAddress.description.ilike(f"%{q}%"),
-                text("CAST(ip_address.mac_address AS text) ILIKE :q").params(q=f"%{q}%"),
-            )
-        )
-
-    result = await db.execute(stmt.limit(limit))
-    rows = result.all()
-
-    out = []
-    for ip, subnet, space in rows:
-        out.append(
-            SearchResult(
-                type="ip_address",
-                id=str(ip.id),
-                display=str(ip.address),
-                name=ip.hostname,
-                status=ip.status,
-                description=ip.description or None,
-                hostname=ip.hostname,
-                mac_address=str(ip.mac_address) if ip.mac_address else None,
-                subnet_id=str(ip.subnet_id),
-                subnet_network=str(subnet.network),
-                block_id=str(subnet.block_id) if subnet.block_id else None,
-                space_id=str(space.id),
-                space_name=space.name,
-            )
-        )
-    return out
-
-
-async def _search_subnets(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    is_ip = _is_ip(q)
-    is_cidr = _is_cidr(q)
-
-    stmt = select(Subnet, IPSpace).join(IPSpace, Subnet.space_id == IPSpace.id)
-
-    if is_cidr:
-        # Subnets that are within or equal to the query CIDR
-        stmt = stmt.where(text("CAST(subnet.network AS cidr) <<= CAST(:q AS cidr)").params(q=q))
-    elif is_ip:
-        # Subnets containing this IP
-        stmt = stmt.where(text("CAST(subnet.network AS cidr) >> CAST(:q AS inet)").params(q=q))
-    else:
-        stmt = stmt.where(
-            or_(
-                Subnet.name.ilike(f"%{q}%"),
-                Subnet.description.ilike(f"%{q}%"),
-            )
-        )
-
-    result = await db.execute(stmt.limit(limit))
-    rows = result.all()
-
-    out = []
-    for subnet, space in rows:
-        out.append(
-            SearchResult(
-                type="subnet",
-                id=str(subnet.id),
-                display=str(subnet.network),
-                name=subnet.name or None,
-                status=subnet.status,
-                description=subnet.description or None,
-                hostname=None,
-                mac_address=None,
-                subnet_id=str(subnet.id),
-                subnet_network=str(subnet.network),
-                block_id=str(subnet.block_id) if subnet.block_id else None,
-                space_id=str(space.id),
-                space_name=space.name,
-            )
-        )
-    return out
-
-
-async def _search_blocks(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    is_cidr = _is_cidr(q)
-    is_ip = _is_ip(q)
-
-    stmt = select(IPBlock, IPSpace).join(IPSpace, IPBlock.space_id == IPSpace.id)
-
-    if is_cidr:
-        stmt = stmt.where(text("CAST(ip_block.network AS cidr) <<= CAST(:q AS cidr)").params(q=q))
-    elif is_ip:
-        stmt = stmt.where(text("CAST(ip_block.network AS cidr) >> CAST(:q AS inet)").params(q=q))
-    else:
-        stmt = stmt.where(
-            or_(
-                IPBlock.name.ilike(f"%{q}%"),
-                IPBlock.description.ilike(f"%{q}%"),
-            )
-        )
-
-    result = await db.execute(stmt.limit(limit))
-    rows = result.all()
-
-    out = []
-    for block, space in rows:
-        out.append(
-            SearchResult(
-                type="block",
-                id=str(block.id),
-                display=str(block.network),
-                name=block.name or None,
-                status=None,
-                description=block.description or None,
-                hostname=None,
-                mac_address=None,
-                subnet_id=None,
-                subnet_network=None,
-                block_id=str(block.id),
-                space_id=str(space.id),
-                space_name=space.name,
-            )
-        )
-    return out
-
-
-async def _search_spaces(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    stmt = select(IPSpace).where(
-        or_(
-            IPSpace.name.ilike(f"%{q}%"),
-            IPSpace.description.ilike(f"%{q}%"),
-        )
-    )
-    result = await db.execute(stmt.limit(limit))
-    spaces = result.scalars().all()
-
-    out = []
-    for space in spaces:
-        out.append(
-            SearchResult(
-                type="space",
-                id=str(space.id),
-                display=space.name,
-                name=space.name,
-                status=None,
-                description=space.description or None,
-                hostname=None,
-                mac_address=None,
-                subnet_id=None,
-                subnet_network=None,
-                block_id=None,
-                space_id=str(space.id),
-                space_name=space.name,
-            )
-        )
-    return out
-
-
-async def _search_dns_groups(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    stmt = select(DNSServerGroup).where(
-        or_(
-            DNSServerGroup.name.ilike(f"%{q}%"),
-            DNSServerGroup.description.ilike(f"%{q}%"),
-        )
-    )
-    result = await db.execute(stmt.limit(limit))
-    groups = result.scalars().all()
-
+    Permission- and module-filtered, so the UI never offers a scope chip
+    that can only ever come back empty.
+    """
     return [
-        SearchResult(
-            type="dns_group",
-            id=str(g.id),
-            display=g.name,
-            name=g.name,
-            status=None,
-            description=g.description or None,
-            hostname=None,
-            mac_address=None,
-            subnet_id=None,
-            subnet_network=None,
-            block_id=None,
-            space_id=None,
-            space_name=None,
-            dns_group_id=str(g.id),
-            dns_group_name=g.name,
-        )
-        for g in groups
+        SearchTypeInfo(type=p.type, label=p.label, group=p.group)
+        for p in await visible_providers(db, current_user)
+        if not p.also_emits
     ]
-
-
-async def _search_dns_zones(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    stmt = (
-        select(DNSZone, DNSServerGroup)
-        .join(DNSServerGroup, DNSZone.group_id == DNSServerGroup.id)
-        .where(DNSZone.name.ilike(f"%{q}%"))
-    )
-    result = await db.execute(stmt.limit(limit))
-    rows = result.all()
-
-    return [
-        SearchResult(
-            type="dns_zone",
-            id=str(z.id),
-            display=z.name,
-            name=z.name,
-            status=z.zone_type,
-            description=None,
-            hostname=None,
-            mac_address=None,
-            subnet_id=None,
-            subnet_network=None,
-            block_id=None,
-            space_id=None,
-            space_name=None,
-            dns_group_id=str(g.id),
-            dns_group_name=g.name,
-            dns_zone_id=str(z.id),
-            dns_zone_name=z.name,
-        )
-        for z, g in rows
-    ]
-
-
-async def _search_dns_records(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    stmt = (
-        select(DNSRecord, DNSZone, DNSServerGroup)
-        .join(DNSZone, DNSRecord.zone_id == DNSZone.id)
-        .join(DNSServerGroup, DNSZone.group_id == DNSServerGroup.id)
-        .where(
-            or_(
-                DNSRecord.fqdn.ilike(f"%{q}%"),
-                DNSRecord.value.ilike(f"%{q}%"),
-            )
-        )
-    )
-    result = await db.execute(stmt.limit(limit))
-    rows = result.all()
-
-    return [
-        SearchResult(
-            type="dns_record",
-            id=str(r.id),
-            display=r.fqdn,
-            name=r.fqdn,
-            status=r.record_type,
-            description=None,
-            hostname=None,
-            mac_address=None,
-            subnet_id=None,
-            subnet_network=None,
-            block_id=None,
-            space_id=None,
-            space_name=None,
-            dns_group_id=str(g.id),
-            dns_group_name=g.name,
-            dns_zone_id=str(z.id),
-            dns_zone_name=z.name,
-            dns_record_type=r.record_type,
-            dns_record_value=r.value,
-        )
-        for r, z, g in rows
-    ]
-
-
-async def _searchable_field_names(db: AsyncSession, resource_type: str) -> list[str]:
-    """Return the list of custom-field names flagged searchable for the given
-    resource_type ('ip_address', 'subnet', 'ip_block', 'ip_space')."""
-    result = await db.execute(
-        select(CustomFieldDefinition.name).where(
-            CustomFieldDefinition.resource_type == resource_type,
-            CustomFieldDefinition.is_searchable.is_(True),
-        )
-    )
-    return [row[0] for row in result.all()]
-
-
-async def _search_custom_fields(db: AsyncSession, q: str, limit: int) -> list[SearchResult]:
-    """Substring-match any searchable custom-field value on blocks, subnets
-    and IP addresses.  Returns a `matched_field` hint like
-    `custom_field:owner=alice` so the UI can show WHY each row matched."""
-    out: list[SearchResult] = []
-    like = f"%{q}%"
-
-    # ── IPBlock ──
-    block_fields = await _searchable_field_names(db, "ip_block")
-    if block_fields:
-        clauses = [
-            text(f"ip_block.custom_fields ->> :k_{i} ILIKE :q").bindparams(
-                **{f"k_{i}": name}, q=like
-            )
-            for i, name in enumerate(block_fields)
-        ]
-        stmt = (
-            select(IPBlock, IPSpace)
-            .join(IPSpace, IPBlock.space_id == IPSpace.id)
-            .where(or_(*clauses))
-            .limit(limit)
-        )
-        for block, space in (await db.execute(stmt)).all():
-            hit_field, hit_value = None, None
-            for name in block_fields:
-                val = (block.custom_fields or {}).get(name)
-                if val is not None and q.lower() in str(val).lower():
-                    hit_field, hit_value = name, val
-                    break
-            out.append(
-                SearchResult(
-                    type="block",
-                    id=str(block.id),
-                    display=str(block.network),
-                    name=block.name or None,
-                    status=None,
-                    description=block.description or None,
-                    hostname=None,
-                    mac_address=None,
-                    subnet_id=None,
-                    subnet_network=None,
-                    block_id=str(block.id),
-                    space_id=str(space.id),
-                    space_name=space.name,
-                    matched_field=(
-                        f"custom_field:{hit_field}={hit_value}"
-                        if hit_field is not None
-                        else "custom_field"
-                    ),
-                )
-            )
-
-    # ── Subnet ──
-    subnet_fields = await _searchable_field_names(db, "subnet")
-    if subnet_fields:
-        clauses = [
-            text(f"subnet.custom_fields ->> :k_{i} ILIKE :q").bindparams(**{f"k_{i}": name}, q=like)
-            for i, name in enumerate(subnet_fields)
-        ]
-        stmt = (
-            select(Subnet, IPSpace)
-            .join(IPSpace, Subnet.space_id == IPSpace.id)
-            .where(or_(*clauses))
-            .limit(limit)
-        )
-        for subnet, space in (await db.execute(stmt)).all():
-            hit_field, hit_value = None, None
-            for name in subnet_fields:
-                val = (subnet.custom_fields or {}).get(name)
-                if val is not None and q.lower() in str(val).lower():
-                    hit_field, hit_value = name, val
-                    break
-            out.append(
-                SearchResult(
-                    type="subnet",
-                    id=str(subnet.id),
-                    display=str(subnet.network),
-                    name=subnet.name or None,
-                    status=subnet.status,
-                    description=subnet.description or None,
-                    hostname=None,
-                    mac_address=None,
-                    subnet_id=str(subnet.id),
-                    subnet_network=str(subnet.network),
-                    block_id=str(subnet.block_id) if subnet.block_id else None,
-                    space_id=str(space.id),
-                    space_name=space.name,
-                    matched_field=(
-                        f"custom_field:{hit_field}={hit_value}"
-                        if hit_field is not None
-                        else "custom_field"
-                    ),
-                )
-            )
-
-    # ── IPAddress ──
-    addr_fields = await _searchable_field_names(db, "ip_address")
-    if addr_fields:
-        clauses = [
-            text(f"ip_address.custom_fields ->> :k_{i} ILIKE :q").bindparams(
-                **{f"k_{i}": name}, q=like
-            )
-            for i, name in enumerate(addr_fields)
-        ]
-        stmt = (
-            select(IPAddress, Subnet, IPSpace)
-            .join(Subnet, IPAddress.subnet_id == Subnet.id)
-            .join(IPSpace, Subnet.space_id == IPSpace.id)
-            .where(or_(*clauses))
-            .limit(limit)
-        )
-        for ip, subnet, space in (await db.execute(stmt)).all():
-            hit_field, hit_value = None, None
-            for name in addr_fields:
-                val = (ip.custom_fields or {}).get(name)
-                if val is not None and q.lower() in str(val).lower():
-                    hit_field, hit_value = name, val
-                    break
-            out.append(
-                SearchResult(
-                    type="ip_address",
-                    id=str(ip.id),
-                    display=str(ip.address),
-                    name=ip.hostname,
-                    status=ip.status,
-                    description=ip.description or None,
-                    hostname=ip.hostname,
-                    mac_address=str(ip.mac_address) if ip.mac_address else None,
-                    subnet_id=str(ip.subnet_id),
-                    subnet_network=str(subnet.network),
-                    block_id=str(subnet.block_id) if subnet.block_id else None,
-                    space_id=str(space.id),
-                    space_name=space.name,
-                    matched_field=(
-                        f"custom_field:{hit_field}={hit_value}"
-                        if hit_field is not None
-                        else "custom_field"
-                    ),
-                )
-            )
-
-    return out
-
-
-# ── Endpoint ───────────────────────────────────────────────────────────────────
 
 
 @router.get("", response_model=SearchResponse)
@@ -553,67 +40,31 @@ async def global_search(
     q: str = Query(..., min_length=1, max_length=200, description="Search query"),
     types: str | None = Query(
         default=None,
-        description="Comma-separated resource types: ip_address,subnet,block,space,dns_group,dns_zone,dns_record",
+        description=(
+            "Comma-separated resource types to restrict the search to. "
+            "See GET /search/types for the list this caller may use; "
+            "unknown or forbidden entries are ignored."
+        ),
     ),
     limit: int = Query(default=25, ge=1, le=100),
 ) -> SearchResponse:
-    """Search across IPAM and DNS resources.
+    """Search across IPAM, DNS, DHCP, network and administration resources.
 
     Query interpretation:
-    - Valid IP (e.g. 10.0.0.1) → exact IP match + subnets/blocks containing it
-    - CIDR (e.g. 10.0.0.0/24) → subnets/blocks matching the range
-    - MAC address → IP addresses with that MAC
-    - Text → hostname, name, FQDN, record value, description substring match
+
+    - Valid IP (``10.0.0.1``) → exact address match, the subnets and blocks
+      containing it, DNS records pointing at it, reservations holding it.
+    - CIDR (``10.0.0.0/24``) → subnets and blocks within that range.
+    - MAC (any common separator style) → addresses and reservations.
+    - Anything else → substring match over names, hostnames, FQDNs, record
+      values, descriptions and searchable custom fields.
+
+    Results are ranked by match quality (exact > prefix > substring) before
+    the per-type limit is applied, then re-ranked across types, so an exact
+    hit cannot be crowded out by weak matches from a type queried earlier.
+
+    Every type is filtered against the caller's own ``read`` permission and
+    the feature modules this install has enabled.
     """
-    q = q.strip()
-    requested = {t.strip() for t in types.split(",")} if types else None
-
-    per_type_limit = max(limit, 10)
-    results: list[SearchResult] = []
-
-    if not requested or "ip_address" in requested:
-        results.extend(await _search_addresses(db, q, per_type_limit))
-
-    if not requested or "subnet" in requested:
-        results.extend(await _search_subnets(db, q, per_type_limit))
-
-    if not requested or "block" in requested:
-        results.extend(await _search_blocks(db, q, per_type_limit))
-
-    if not requested or "space" in requested:
-        results.extend(await _search_spaces(db, q, per_type_limit))
-
-    if not requested or "dns_group" in requested:
-        results.extend(await _search_dns_groups(db, q, per_type_limit))
-
-    if not requested or "dns_zone" in requested:
-        results.extend(await _search_dns_zones(db, q, per_type_limit))
-
-    if not requested or "dns_record" in requested:
-        results.extend(await _search_dns_records(db, q, per_type_limit))
-
-    # Custom-field substring hits across IPAM resources.
-    if not requested or requested & {"ip_address", "subnet", "block"}:
-        results.extend(await _search_custom_fields(db, q, per_type_limit))
-
-    # De-duplicate (same id can appear in multiple passes when q is an IP or
-    # when both a direct field and a custom-field match fire). Prefer entries
-    # that carry a `matched_field` hint so the UI can explain the match.
-    by_key: dict[str, SearchResult] = {}
-    for r in results:
-        key = f"{r.type}:{r.id}"
-        existing = by_key.get(key)
-        if existing is None:
-            by_key[key] = r
-        elif existing.matched_field is None and r.matched_field is not None:
-            by_key[key] = r
-    deduped = list(by_key.values())
-
-    logger.info(
-        "search_executed",
-        user=current_user.username,
-        query=q,
-        total=len(deduped),
-    )
-
-    return SearchResponse(query=q, total=len(deduped), results=deduped[:limit])
+    requested = {t.strip() for t in types.split(",") if t.strip()} if types else None
+    return await execute(db, current_user, q, types=requested, limit=limit)

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -185,31 +185,44 @@ def _get_soft_delete_models() -> tuple[type, ...]:
     return _CACHED_SOFT_DELETE_MODELS
 
 
-def _statement_references(statement: Any, model: type) -> bool:
-    """Cheap check — is ``model`` mentioned in the FROM-clause graph?
+def _referenced_soft_delete_models(statement: Any, models: tuple[type, ...]) -> set[type]:
+    """Which of ``models`` the statement mentions — resolved in ONE pass.
 
-    Walks the statement's ``column_descriptions`` (top-level entities)
-    plus any explicit FROMs reachable via ``get_final_froms``. Avoids the
-    cost of injecting loader criteria for models that aren't in the
-    query at all (e.g. an audit-log SELECT shouldn't carry six dangling
-    loader options for IPSpace / IPBlock / Subnet / DNSZone / DNSRecord
-    / DHCPScope just because they exist).
+    This used to be called once per model, and each call did its own
+    ``statement.get_final_froms()``. That method is not a cheap accessor: it
+    resolves and compiles the FROM graph, ~1.9 ms on a modest ORM select. At
+    eight in-scope models that is ~15 ms of pure Python **on every ORM
+    SELECT in the application** — measured at 16.7 ms for a query against
+    ``vlan``, a table with no soft-delete column, versus 0.35 ms for the
+    same query with the filter skipped. It went unnoticed because it is
+    uniform: nothing looks slow relative to anything else.
+
+    Resolving the FROM graph once and testing all eight models against it
+    is behaviour-identical and roughly eight times cheaper. Surfaced while
+    profiling global search (#879), which issues up to twenty of these per
+    keystroke and so paid the cost twenty times over.
     """
-
     try:
-        for desc in getattr(statement, "column_descriptions", None) or []:
-            if desc.get("entity") is model:
-                return True
+        entities = {
+            desc.get("entity") for desc in getattr(statement, "column_descriptions", None) or []
+        }
+        classes: set[Any] = set()
+        table_names: set[Any] = set()
         froms = statement.get_final_froms() if hasattr(statement, "get_final_froms") else []
         for fr in froms or []:
             mapper = getattr(fr, "_annotations", {}).get("parententity")
-            if mapper is not None and getattr(mapper, "class_", None) is model:
-                return True
-            if getattr(fr, "name", None) == getattr(model, "__tablename__", None):
-                return True
+            if mapper is not None:
+                classes.add(getattr(mapper, "class_", None))
+            table_names.add(getattr(fr, "name", None))
     except Exception:  # pragma: no cover — defensive, never block a query
-        return True
-    return False
+        # Same conservative answer the per-model version gave: assume every
+        # model is present rather than risk leaking soft-deleted rows.
+        return set(models)
+    return {
+        m
+        for m in models
+        if m in entities or m in classes or getattr(m, "__tablename__", None) in table_names
+    }
 
 
 @event.listens_for(Session, "before_flush")
@@ -252,8 +265,15 @@ def _filter_soft_deleted(execute_state: Any) -> None:
         return
 
     statement = execute_state.statement
-    for model in _get_soft_delete_models():
-        if not _statement_references(statement, model):
+    all_models = _get_soft_delete_models()
+    referenced = _referenced_soft_delete_models(statement, all_models)
+    if not referenced:
+        return
+    # Iterate the canonical tuple, not the set, so the options are applied
+    # in a deterministic order — a set's iteration order would vary the
+    # statement's cache key between processes for no reason.
+    for model in all_models:
+        if model not in referenced:
             continue
         # NOTE: no late-binding-closure bug here. ``model`` (the outer
         # loop var) is NOT captured by the lambda — it's passed to

--- a/backend/app/services/ai/tools/observability.py
+++ b/backend/app/services/ai/tools/observability.py
@@ -18,9 +18,11 @@ open the UI":
   roll-ups from the ``dns_metric_sample`` / ``dhcp_metric_sample``
   tables (caps default to 24 buckets so payload stays compact).
 * ``global_search`` — cross-resource lookup matching the UI's
-  Cmd-K palette. Calls the same internal helpers
-  ``app.api.v1.search.router`` exposes; output is the same hit
-  shape (type / id / display / breadcrumb).
+  Cmd-K palette. Calls ``app.services.search.execute``, the same
+  entry point ``GET /api/v1/search`` uses, so it sees the same
+  twenty resource types and the same per-type permission filtering
+  (#879); output is the same hit shape (type / id / display /
+  breadcrumb).
 
 All read-only. No tool here is gated by a feature_module — log /
 metric / search surfaces are always-on platform infrastructure.
@@ -376,10 +378,12 @@ async def get_dhcp_lease_rate(
 
 # ── global_search ─────────────────────────────────────────────────────
 #
-# Reuses the helpers behind ``GET /api/v1/search`` so the tool's
-# response shape matches what the UI's Cmd-K palette returns. We
-# import lazily inside the tool body to avoid pulling the search
-# router's full FastAPI namespace on backend boot.
+# Delegates to ``app.services.search.execute`` — the same call
+# ``GET /api/v1/search`` makes. This tool previously re-implemented the
+# fan-out by reaching into the router's private ``_search_*`` helpers,
+# which meant it silently missed every resource type added to the HTTP
+# endpoint and, more seriously, none of the permission filtering: the
+# Copilot would happily read out DNS rows to an IPAM-only operator.
 
 
 class GlobalSearchArgs(BaseModel):
@@ -394,9 +398,11 @@ class GlobalSearchArgs(BaseModel):
     types: list[str] | None = Field(
         default=None,
         description=(
-            "Restrict to specific resource types. Allowed values: "
-            "ip_address, subnet, block, space, dns_group, dns_zone, "
-            "dns_record. Default returns matches across all types."
+            "Restrict to specific resource types, e.g. ip_address, subnet, "
+            "block, space, dns_zone, dns_record, dhcp_scope, "
+            "dhcp_reservation, vlan, device, site, circuit. Types the "
+            "caller may not read are ignored. Default searches every type "
+            "they are permitted to see."
         ),
     )
     limit: int = Field(default=25, ge=1, le=100)
@@ -419,43 +425,18 @@ class GlobalSearchArgs(BaseModel):
 async def global_search(
     db: AsyncSession, user: User, args: GlobalSearchArgs
 ) -> list[dict[str, Any]]:
-    # Lazy import — the router module pulls in FastAPI router glue on
-    # import; we only need the helpers.
-    from app.api.v1.search import router as search_router  # noqa: PLC0415
+    # Lazy import to keep the search service (and the twenty models it
+    # touches) off the tool-registry import path.
+    from app.services.search import execute as run_search  # noqa: PLC0415
 
-    requested = set(args.types) if args.types else None
-    per_type = max(args.limit, 10)
-    results: list[Any] = []
-
-    if not requested or "ip_address" in requested:
-        results.extend(await search_router._search_addresses(db, args.query, per_type))
-    if not requested or "subnet" in requested:
-        results.extend(await search_router._search_subnets(db, args.query, per_type))
-    if not requested or "block" in requested:
-        results.extend(await search_router._search_blocks(db, args.query, per_type))
-    if not requested or "space" in requested:
-        results.extend(await search_router._search_spaces(db, args.query, per_type))
-    if not requested or "dns_group" in requested:
-        results.extend(await search_router._search_dns_groups(db, args.query, per_type))
-    if not requested or "dns_zone" in requested:
-        results.extend(await search_router._search_dns_zones(db, args.query, per_type))
-    if not requested or "dns_record" in requested:
-        results.extend(await search_router._search_dns_records(db, args.query, per_type))
-    if not requested or requested & {"ip_address", "subnet", "block"}:
-        results.extend(await search_router._search_custom_fields(db, args.query, per_type))
-
-    # Dedup by (type, id) — the same row can hit multiple passes.
-    seen: set[tuple[str, str]] = set()
-    out: list[dict[str, Any]] = []
-    for r in results:
-        key = (r.type, r.id)
-        if key in seen:
-            continue
-        seen.add(key)
-        out.append(r.model_dump())
-        if len(out) >= args.limit:
-            break
-    return out
+    response = await run_search(
+        db,
+        user,
+        args.query,
+        types=set(args.types) if args.types else None,
+        limit=args.limit,
+    )
+    return [r.model_dump() for r in response.results]
 
 
 # Silence the false-positive "imported but unused" — ``or_`` is part

--- a/backend/app/services/search/__init__.py
+++ b/backend/app/services/search/__init__.py
@@ -1,0 +1,23 @@
+"""Global search (issue #879)."""
+
+from app.services.search.engine import execute, visible_providers
+from app.services.search.providers import PROVIDERS, SearchProvider
+from app.services.search.schemas import (
+    QueryShape,
+    SearchResponse,
+    SearchResult,
+    SearchTypeInfo,
+    shape_of,
+)
+
+__all__ = [
+    "PROVIDERS",
+    "QueryShape",
+    "SearchProvider",
+    "SearchResponse",
+    "SearchResult",
+    "SearchTypeInfo",
+    "execute",
+    "shape_of",
+    "visible_providers",
+]

--- a/backend/app/services/search/engine.py
+++ b/backend/app/services/search/engine.py
@@ -1,0 +1,151 @@
+"""Global-search execution (issue #879).
+
+One entry point, :func:`execute`, shared by the REST endpoint and the
+``global_search`` MCP tool. They used to be two copies of the same fan-out —
+which meant the Copilot's search silently missed every type added to the
+HTTP one, and would have missed the permission filtering added here too.
+"""
+
+from __future__ import annotations
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import is_effective_superadmin, user_has_permission
+from app.models.auth import User
+from app.services.feature_modules import get_enabled_modules
+from app.services.search.providers import PROVIDERS, SearchProvider
+from app.services.search.schemas import (
+    SearchResponse,
+    SearchResult,
+    SearchTypeInfo,
+    shape_of,
+)
+
+logger = structlog.get_logger(__name__)
+
+__all__ = ["execute", "visible_providers"]
+
+
+def _may_read(user: User, provider: SearchProvider) -> bool:
+    if provider.superadmin_only:
+        return is_effective_superadmin(user)
+    return any(user_has_permission(user, "read", rt) for rt in provider.resource_types)
+
+
+async def visible_providers(db: AsyncSession, user: User) -> list[SearchProvider]:
+    """Providers this user may run, after RBAC and feature-module gating."""
+    enabled = await get_enabled_modules(db)
+    return [
+        p for p in PROVIDERS if (p.module is None or p.module in enabled) and _may_read(user, p)
+    ]
+
+
+def _emitted_types(providers: list[SearchProvider]) -> set[str]:
+    """Result ``type`` strings the caller is allowed to receive.
+
+    Only single-type providers contribute. A multi-type provider — the IPAM
+    custom-field pass, which is one query returning block, subnet and
+    address rows — contributes nothing of its own, because its gate is
+    "read on ANY of the three". Letting it widen this set would mean a
+    caller with ``read`` on ``subnet`` but not ``ip_address`` receives
+    address rows through the custom-field door, which is the whole reason
+    the filtering happens on emitted rows rather than on providers.
+
+    So a custom-field hit on an address survives only if the ``ip_address``
+    provider itself passed its own gate.
+    """
+    return {p.type for p in providers if not p.also_emits}
+
+
+async def execute(
+    db: AsyncSession,
+    user: User,
+    q: str,
+    *,
+    types: set[str] | None = None,
+    limit: int = 25,
+) -> SearchResponse:
+    q = q.strip()
+    shape = shape_of(q)
+    allowed = await visible_providers(db, user)
+    allowed_types = _emitted_types(allowed)
+
+    # A type the caller cannot see is dropped from the request rather than
+    # rejected: a stale scope chip in an open tab should return nothing for
+    # that scope, not fail the whole search.
+    wanted = types & allowed_types if types else None
+
+    to_run = [
+        p
+        for p in allowed
+        if shape.kind in p.shapes
+        and (wanted is None or bool(set(p.also_emits or (p.type,)) & wanted))
+    ]
+
+    # Fetch more per type than we will show. The engine reranks across types
+    # afterwards, so a type whose rows all lose the rerank must not have
+    # consumed the whole budget.
+    per_type = max(limit, 10)
+
+    results: list[SearchResult] = []
+    for provider in to_run:
+        try:
+            # The SAVEPOINT is what makes the ``except`` mean what it says.
+            # Catching the exception alone is not enough on PostgreSQL: a
+            # failed statement leaves the session in "current transaction is
+            # aborted", so every *later* provider dies with
+            # PendingRollbackError and the caller gets an empty result set
+            # with a 200. Since ``ip_address`` runs first, one bad query
+            # there would blank the entire palette — the exact opposite of
+            # the isolation this block is here to provide.
+            async with db.begin_nested():
+                results.extend(await provider.fn(db, shape, per_type))
+        except Exception:  # noqa: BLE001 — one broken type must not blank the palette
+            logger.warning("search_provider_failed", type=provider.type, exc_info=True)
+
+    # Post-filter: covers ``also_emits`` rows and any provider that returns a
+    # type other than its own.
+    results = [
+        r for r in results if r.type in allowed_types and (wanted is None or r.type in wanted)
+    ]
+
+    # De-duplicate. The same row can arrive from a direct column match and
+    # from the custom-field pass; keep the higher-scoring copy, preferring
+    # the one that can explain itself when the scores tie.
+    by_key: dict[str, SearchResult] = {}
+    for r in results:
+        key = f"{r.type}:{r.id}"
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = r
+        elif r.score > existing.score:
+            by_key[key] = r
+        elif r.score == existing.score and existing.matched_field is None:
+            by_key[key] = r
+
+    # Relevance first; then a stable display-order tiebreak so equal-scoring
+    # rows don't shuffle between identical requests.
+    ranked = sorted(by_key.values(), key=lambda r: (-r.score, r.type, r.display))
+
+    searched = [
+        SearchTypeInfo(type=p.type, label=p.label, group=p.group)
+        for p in allowed
+        if not p.also_emits  # the custom-field pass is not a chip of its own
+    ]
+
+    logger.info(
+        "search_executed",
+        user=user.username,
+        query=q,
+        shape=shape.kind,
+        providers_run=len(to_run),
+        total=len(ranked),
+    )
+
+    return SearchResponse(
+        query=q,
+        total=len(ranked),
+        results=ranked[:limit],
+        searched_types=searched,
+    )

--- a/backend/app/services/search/providers.py
+++ b/backend/app/services/search/providers.py
@@ -1,0 +1,1322 @@
+"""Searchable resource types for global search (issue #879).
+
+Each type is one :class:`SearchProvider`: a query function plus the
+metadata the engine needs to decide whether the *calling user* may see it.
+
+Two gates, both server-side, both mandatory (non-negotiable #3):
+
+* ``resource_types`` — the caller needs ``read`` on at least one of them.
+  v1 had no gate at all, so an IPAM-only operator searching ``example.com``
+  got back DNS zones and records that ``GET /api/v1/dns/zones`` would have
+  refused them. Search was the widest read surface in the product and the
+  only one that checked nothing.
+* ``module`` — the feature-module id, when the type has one. A disabled
+  module removes the surface from the sidebar and 404s its router; leaving
+  its rows searchable would put back exactly what the operator turned off.
+
+Adding a type means adding one entry to :data:`PROVIDERS`. The engine, the
+scope chips, the MCP tool and the response's ``searched_types`` all read
+from that list, so there is no second place to update.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from sqlalchemy import Select, Text, cast, literal_column, or_, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.appliance import Appliance
+from app.models.auth import Group, User
+from app.models.circuit import Circuit
+from app.models.dhcp import DHCPScope, DHCPServer, DHCPStaticAssignment
+from app.models.dns import DNSBlockList, DNSRecord, DNSServer, DNSServerGroup, DNSView, DNSZone
+from app.models.ipam import CustomFieldDefinition, IPAddress, IPBlock, IPSpace, Subnet
+from app.models.network import NetworkDevice
+from app.models.ownership import Site
+from app.models.vlans import VLAN
+from app.services.search.ranking import (
+    EXACT,
+    escape_like,
+    like_pattern,
+    pick_match,
+    sql_rank,
+    total_score,
+)
+from app.services.search.schemas import QueryShape, SearchResult
+
+__all__ = ["PROVIDERS", "SearchProvider", "provider_for"]
+
+SearchFn = Callable[[AsyncSession, QueryShape, int], Awaitable[list[SearchResult]]]
+
+# Query kinds a provider can usefully answer (see ``QueryShape.kind``).
+ALL_SHAPES = frozenset({"text", "ip", "cidr", "mac"})
+TEXT_ONLY = frozenset({"text"})
+# Types with an address-bearing column (a host, a value, an ip_address) —
+# their plain text predicate is meaningful when the operator pastes an IP.
+TEXT_AND_IP = frozenset({"text", "ip"})
+
+
+@dataclass(frozen=True)
+class SearchProvider:
+    type: str
+    label: str
+    # Scope chip this type belongs to in the UI.
+    group: str
+    # Caller needs ``read`` on ANY of these RBAC resource types.
+    resource_types: tuple[str, ...]
+    fn: SearchFn
+    # Feature-module id gating the type, when it has one.
+    module: str | None = None
+    # Superadmin-only regardless of RBAC — for surfaces whose own routers
+    # are superadmin-gated rather than permission-gated (users).
+    superadmin_only: bool = False
+    # Extra types whose results this provider can also emit. The IPAM
+    # custom-field pass is one query returning blocks, subnets and
+    # addresses, so requesting any of the three has to run it.
+    also_emits: tuple[str, ...] = field(default_factory=tuple)
+    # Query kinds worth running this provider for.
+    shapes: frozenset[str] = ALL_SHAPES
+
+
+# ── shared query helpers ──────────────────────────────────────────────────
+
+
+def _ranked(
+    stmt: Select,
+    rank: Any,
+    limit: int,
+    *,
+    tiebreak: Any = None,
+) -> Select:
+    """Order by relevance before the limit is applied.
+
+    The ``ORDER BY`` is the entire reason ranking lives in SQL: without it
+    the database is free to return any ``limit`` rows that satisfy the
+    predicate, and on a table where thousands of rows contain the substring
+    the exact match is usually not among them.
+
+    A stable secondary key keeps paging and test assertions deterministic
+    when several rows share a bucket.
+
+    ``rank`` may be a plain int for the branches where every matching row
+    is by definition an exact hit (an ``inet`` equality, a normalised MAC).
+    Those are selected as a constant and deliberately NOT ordered by:
+    ``ORDER BY 100`` means "order by the hundredth output column" in SQL,
+    not "order by the number 100", so emitting it would be an error rather
+    than a no-op.
+    """
+    order: list[Any] = []
+    if isinstance(rank, int):
+        rank_col: Any = literal_column(str(rank))
+    else:
+        rank_col = rank
+        order.append(rank.desc())
+    if tiebreak is not None:
+        order.append(tiebreak.asc())
+    return stmt.add_columns(rank_col.label("rank")).order_by(*order).limit(limit)
+
+
+def _mac_normalized_sql(table: str) -> str:
+    """SQL that strips a ``macaddr`` column down to bare hex.
+
+    A MAC is written four different ways in the wild and stored
+    canonically, so both sides of the comparison are normalised before
+    matching — otherwise ``aa-bb-cc-dd-ee-ff`` finds nothing.
+
+    On ``ip_address`` this expression is also the definition of the
+    ``ix_trgm_ip_address_mac_normalized`` index (migration
+    ``f4b91d38a70c``). PostgreSQL matches expression indexes by comparing
+    the parsed expression, so any divergence between the two — a different
+    cast spelling, a reordered REPLACE — silently costs the index rather
+    than failing. That is exactly why it is generated from one function.
+
+    No ``ESCAPE`` clause: backslash is PostgreSQL's default LIKE escape,
+    which is what :func:`~app.services.search.ranking.escape_like` emits.
+    Spelling it out in an f-string here would need the backslash doubled
+    for Python and then again for the SQL literal, and getting that wrong
+    is a runtime error rather than a lint failure.
+    """
+    return (
+        f"REPLACE(REPLACE(REPLACE(CAST({table}.mac_address AS text), ':', ''),"
+        " '-', ''), '.', '')"
+    )
+
+
+IP_MAC_NORMALIZED_SQL = _mac_normalized_sql("ip_address")
+
+
+def _txt(col: Any) -> Any:
+    """Cast a column to text so the pattern operators apply to it.
+
+    Several columns that the ORM annotates ``Mapped[str]`` are ``inet`` or
+    ``macaddr`` in PostgreSQL — ``DHCPStaticAssignment.ip_address`` and
+    ``NetworkDevice.ip_address`` among them. ``ILIKE`` and ``lower()`` have
+    no overload for those types, so matching one without this cast is not a
+    silently-wrong result, it is a 500 on every search that touches the
+    provider.
+    """
+    return cast(col, Text)
+
+
+def _text_clauses(q: str, *columns: Any) -> Any:
+    pattern = like_pattern(q)
+    return or_(*[col.ilike(pattern, escape="\\") for col in columns])
+
+
+def _annotate(result: SearchResult, quality: int, matched: str | None) -> SearchResult:
+    result.matched_field = result.matched_field or matched
+    result.score = total_score(quality, result.type)
+    return result
+
+
+async def _subnet_context(db: AsyncSession, subnet_ids: set) -> dict:
+    """Load the subnet → space breadcrumb for a set of subnet ids.
+
+    Deliberately a **second query** rather than a join on the search itself.
+    Joining the parents in looks harmless — they are tiny tables — but the
+    global soft-delete filter adds ``subnet.deleted_at IS NULL`` and
+    ``ip_space.deleted_at IS NULL`` to the same statement, and the planner
+    responds by driving the join from ``subnet`` (a couple of dozen rows)
+    and re-running the ``ip_address`` bitmap scan once per subnet. Measured
+    on 500k addresses: 9 ms as a standalone scan, 188 ms as a nested loop
+    inside that join. Splitting it keeps both queries on their fast plan.
+
+    Rows whose subnet is missing from the result are dropped by the
+    callers. ``IPAddress`` carries no ``SoftDeleteMixin``, so an address
+    under a soft-deleted subnet is only hidden by its parent being hidden —
+    which the join used to do for us and this query still does, because the
+    soft-delete filter applies here too.
+    """
+    if not subnet_ids:
+        return {}
+    rows = await db.execute(
+        select(Subnet, IPSpace)
+        .join(IPSpace, Subnet.space_id == IPSpace.id)
+        .where(Subnet.id.in_(subnet_ids))
+    )
+    return {sn.id: (sn, sp) for sn, sp in rows.all()}
+
+
+# ── IPAM ──────────────────────────────────────────────────────────────────
+
+
+async def search_addresses(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    # Single-table match; the subnet/space breadcrumb is a second query.
+    # See :func:`_subnet_context` for why joining it here is a 20x slowdown.
+    stmt = select(IPAddress)
+
+    if s.is_ip:
+        stmt = stmt.where(text("CAST(ip_address.address AS inet) = CAST(:q AS inet)")).params(
+            q=s.raw
+        )
+        rank: Any = EXACT
+    elif s.is_mac:
+        stmt = stmt.where(text(f"{IP_MAC_NORMALIZED_SQL} ILIKE :norm")).params(
+            norm=f"%{escape_like(s.mac_normalized)}%"
+        )
+        rank = EXACT
+    else:
+        pattern = like_pattern(s.raw)
+        stmt = stmt.where(
+            or_(
+                IPAddress.hostname.ilike(pattern, escape="\\"),
+                IPAddress.description.ilike(pattern, escape="\\"),
+                # Partial MACs — an OUI prefix, "aa:bb:cc" — don't parse as
+                # a MAC, so they land here. Normalising both sides makes the
+                # match separator-insensitive and, just as importantly, is
+                # the one spelling the trigram index covers. The previous
+                # raw ``CAST(mac_address AS text) ILIKE`` branch could use
+                # no index, and because it sat in an OR beside the two
+                # indexed predicates it forced the whole query to a
+                # sequential scan: a single-hostname lookup over 500k rows
+                # took 489 ms with hostname AND description both indexed,
+                # because this third branch made them unusable.
+                text(f"{IP_MAC_NORMALIZED_SQL} ILIKE :mac_norm").bindparams(
+                    mac_norm=f"%{escape_like(s.mac_normalized)}%"
+                ),
+            )
+        )
+        rank = sql_rank(s.raw, IPAddress.hostname, IPAddress.description)
+
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=IPAddress.address))).all()
+    context = await _subnet_context(db, {ip.subnet_id for ip, _ in rows})
+
+    out: list[SearchResult] = []
+    for ip, row_rank in rows:
+        parent = context.get(ip.subnet_id)
+        if parent is None:
+            # Subnet is soft-deleted (or vanished between the two queries).
+            # The old single-statement join dropped these implicitly; do the
+            # same rather than emit a result with no breadcrumb.
+            continue
+        subnet, space = parent
+        quality, matched = pick_match(
+            s.raw,
+            [
+                ("hostname", ip.hostname),
+                ("mac_address", str(ip.mac_address) if ip.mac_address else None),
+                ("description", ip.description),
+            ],
+        )
+        if s.is_ip or s.is_mac:
+            quality = int(row_rank)
+            matched = "address" if s.is_ip else "mac_address"
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="ip_address",
+                    id=str(ip.id),
+                    display=str(ip.address),
+                    name=ip.hostname,
+                    status=ip.status,
+                    description=ip.description or None,
+                    hostname=ip.hostname,
+                    mac_address=str(ip.mac_address) if ip.mac_address else None,
+                    subnet_id=str(ip.subnet_id),
+                    subnet_network=str(subnet.network),
+                    block_id=str(subnet.block_id) if subnet.block_id else None,
+                    space_id=str(space.id),
+                    space_name=space.name,
+                ),
+                quality,
+                matched,
+            )
+        )
+    return out
+
+
+async def search_subnets(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = select(Subnet, IPSpace).join(IPSpace, Subnet.space_id == IPSpace.id)
+
+    if s.is_cidr:
+        stmt = stmt.where(text("CAST(subnet.network AS cidr) <<= CAST(:q AS cidr)").params(q=s.raw))
+        rank: Any = EXACT
+    elif s.is_ip:
+        stmt = stmt.where(text("CAST(subnet.network AS cidr) >> CAST(:q AS inet)").params(q=s.raw))
+        rank = EXACT
+    else:
+        stmt = stmt.where(_text_clauses(s.raw, Subnet.name, Subnet.description))
+        rank = sql_rank(s.raw, Subnet.name, Subnet.description)
+
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=Subnet.network))).all()
+
+    out: list[SearchResult] = []
+    for subnet, space, row_rank in rows:
+        quality, matched = pick_match(
+            s.raw, [("name", subnet.name), ("description", subnet.description)]
+        )
+        if s.is_address_like:
+            quality, matched = int(row_rank), "network"
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="subnet",
+                    id=str(subnet.id),
+                    display=str(subnet.network),
+                    name=subnet.name or None,
+                    status=subnet.status,
+                    description=subnet.description or None,
+                    subnet_id=str(subnet.id),
+                    subnet_network=str(subnet.network),
+                    block_id=str(subnet.block_id) if subnet.block_id else None,
+                    space_id=str(space.id),
+                    space_name=space.name,
+                ),
+                quality,
+                matched,
+            )
+        )
+    return out
+
+
+async def search_blocks(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = select(IPBlock, IPSpace).join(IPSpace, IPBlock.space_id == IPSpace.id)
+
+    if s.is_cidr:
+        stmt = stmt.where(
+            text("CAST(ip_block.network AS cidr) <<= CAST(:q AS cidr)").params(q=s.raw)
+        )
+        rank: Any = EXACT
+    elif s.is_ip:
+        stmt = stmt.where(
+            text("CAST(ip_block.network AS cidr) >> CAST(:q AS inet)").params(q=s.raw)
+        )
+        rank = EXACT
+    else:
+        stmt = stmt.where(_text_clauses(s.raw, IPBlock.name, IPBlock.description))
+        rank = sql_rank(s.raw, IPBlock.name, IPBlock.description)
+
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=IPBlock.network))).all()
+
+    out: list[SearchResult] = []
+    for block, space, row_rank in rows:
+        quality, matched = pick_match(
+            s.raw, [("name", block.name), ("description", block.description)]
+        )
+        if s.is_address_like:
+            quality, matched = int(row_rank), "network"
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="block",
+                    id=str(block.id),
+                    display=str(block.network),
+                    name=block.name or None,
+                    description=block.description or None,
+                    block_id=str(block.id),
+                    space_id=str(space.id),
+                    space_name=space.name,
+                ),
+                quality,
+                matched,
+            )
+        )
+    return out
+
+
+async def search_spaces(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = select(IPSpace).where(_text_clauses(s.raw, IPSpace.name, IPSpace.description))
+    rank = sql_rank(s.raw, IPSpace.name, IPSpace.description)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=IPSpace.name))).all()
+
+    out: list[SearchResult] = []
+    for space, _rank in rows:
+        quality, matched = pick_match(
+            s.raw, [("name", space.name), ("description", space.description)]
+        )
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="space",
+                    id=str(space.id),
+                    display=space.name,
+                    name=space.name,
+                    description=space.description or None,
+                    space_id=str(space.id),
+                    space_name=space.name,
+                ),
+                quality,
+                matched,
+            )
+        )
+    return out
+
+
+# ── DNS ───────────────────────────────────────────────────────────────────
+
+
+async def search_dns_groups(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = select(DNSServerGroup).where(
+        _text_clauses(s.raw, DNSServerGroup.name, DNSServerGroup.description)
+    )
+    rank = sql_rank(s.raw, DNSServerGroup.name, DNSServerGroup.description)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DNSServerGroup.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dns_group",
+                id=str(g.id),
+                display=g.name,
+                name=g.name,
+                description=g.description or None,
+                dns_group_id=str(g.id),
+                dns_group_name=g.name,
+            ),
+            *pick_match(s.raw, [("name", g.name), ("description", g.description)]),
+        )
+        for g, _rank in rows
+    ]
+
+
+async def search_dns_zones(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = (
+        select(DNSZone, DNSServerGroup)
+        .join(DNSServerGroup, DNSZone.group_id == DNSServerGroup.id)
+        .where(DNSZone.name.ilike(like_pattern(s.raw), escape="\\"))
+    )
+    rank = sql_rank(s.raw, DNSZone.name)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DNSZone.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dns_zone",
+                id=str(z.id),
+                display=z.name,
+                name=z.name,
+                status=z.zone_type,
+                dns_group_id=str(g.id),
+                dns_group_name=g.name,
+                dns_zone_id=str(z.id),
+                dns_zone_name=z.name,
+            ),
+            *pick_match(s.raw, [("name", z.name)]),
+        )
+        for z, g, _rank in rows
+    ]
+
+
+async def search_dns_records(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    # Single-table match, breadcrumb second — ``dns_record`` is the other
+    # table that reaches millions of rows, and the same soft-delete-driven
+    # nested loop that cost ``ip_address`` 20x applies to its zone join.
+    stmt = select(DNSRecord).where(_text_clauses(s.raw, DNSRecord.fqdn, DNSRecord.value))
+    rank = sql_rank(s.raw, DNSRecord.fqdn, DNSRecord.value)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DNSRecord.fqdn))).all()
+    if not rows:
+        return []
+
+    zone_rows = await db.execute(
+        select(DNSZone, DNSServerGroup)
+        .join(DNSServerGroup, DNSZone.group_id == DNSServerGroup.id)
+        .where(DNSZone.id.in_({r.zone_id for r, _ in rows}))
+    )
+    zones = {z.id: (z, g) for z, g in zone_rows.all()}
+
+    out: list[SearchResult] = []
+    for r, _rank in rows:
+        parent = zones.get(r.zone_id)
+        if parent is None:
+            continue
+        z, g = parent
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="dns_record",
+                    id=str(r.id),
+                    display=r.fqdn,
+                    name=r.fqdn,
+                    status=r.record_type,
+                    dns_group_id=str(g.id),
+                    dns_group_name=g.name,
+                    dns_zone_id=str(z.id),
+                    dns_zone_name=z.name,
+                    dns_record_type=r.record_type,
+                    dns_record_value=r.value,
+                ),
+                *pick_match(s.raw, [("fqdn", r.fqdn), ("value", r.value)]),
+            )
+        )
+    return out
+
+
+async def search_dns_servers(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = (
+        select(DNSServer, DNSServerGroup)
+        .join(DNSServerGroup, DNSServer.group_id == DNSServerGroup.id)
+        .where(_text_clauses(s.raw, DNSServer.name, DNSServer.host, DNSServer.notes))
+    )
+    rank = sql_rank(s.raw, DNSServer.name, DNSServer.host, DNSServer.notes)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DNSServer.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dns_server",
+                id=str(srv.id),
+                display=srv.name,
+                name=srv.name,
+                status=srv.status,
+                description=srv.notes or None,
+                context=f"{g.name} · {srv.driver} · {srv.host}",
+                dns_group_id=str(g.id),
+                dns_group_name=g.name,
+                route="/dns",
+            ),
+            *pick_match(s.raw, [("name", srv.name), ("host", srv.host), ("notes", srv.notes)]),
+        )
+        for srv, g, _rank in rows
+    ]
+
+
+async def search_dns_views(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = (
+        select(DNSView, DNSServerGroup)
+        .join(DNSServerGroup, DNSView.group_id == DNSServerGroup.id)
+        .where(_text_clauses(s.raw, DNSView.name, DNSView.description))
+    )
+    rank = sql_rank(s.raw, DNSView.name, DNSView.description)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DNSView.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dns_view",
+                id=str(v.id),
+                display=v.name,
+                name=v.name,
+                description=v.description or None,
+                context=f"View in {g.name}",
+                dns_group_id=str(g.id),
+                dns_group_name=g.name,
+                route="/dns",
+            ),
+            *pick_match(s.raw, [("name", v.name), ("description", v.description)]),
+        )
+        for v, g, _rank in rows
+    ]
+
+
+async def search_dns_blocklists(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = select(DNSBlockList).where(
+        _text_clauses(s.raw, DNSBlockList.name, DNSBlockList.description, DNSBlockList.category)
+    )
+    rank = sql_rank(s.raw, DNSBlockList.name, DNSBlockList.description, DNSBlockList.category)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DNSBlockList.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dns_blocklist",
+                id=str(bl.id),
+                display=bl.name,
+                name=bl.name,
+                status="enabled" if bl.enabled else "disabled",
+                description=bl.description or None,
+                context=f"{bl.category} · {bl.entry_count} entries",
+                route="/admin/dns-blocklists",
+            ),
+            *pick_match(
+                s.raw,
+                [
+                    ("name", bl.name),
+                    ("category", bl.category),
+                    ("description", bl.description),
+                ],
+            ),
+        )
+        for bl, _rank in rows
+    ]
+
+
+# ── DHCP ──────────────────────────────────────────────────────────────────
+
+
+async def search_dhcp_scopes(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = (
+        select(DHCPScope, Subnet)
+        .join(Subnet, DHCPScope.subnet_id == Subnet.id)
+        .where(_text_clauses(s.raw, DHCPScope.name, DHCPScope.description))
+    )
+    rank = sql_rank(s.raw, DHCPScope.name, DHCPScope.description)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DHCPScope.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dhcp_scope",
+                id=str(sc.id),
+                display=sc.name,
+                name=sc.name,
+                status="active" if sc.is_active else "inactive",
+                description=sc.description or None,
+                context=str(subnet.network),
+                subnet_id=str(subnet.id),
+                subnet_network=str(subnet.network),
+                route=f"/dhcp?group={sc.group_id}",
+            ),
+            *pick_match(s.raw, [("name", sc.name), ("description", sc.description)]),
+        )
+        for sc, subnet, _rank in rows
+    ]
+
+
+async def search_dhcp_reservations(
+    db: AsyncSession, s: QueryShape, limit: int
+) -> list[SearchResult]:
+    stmt = select(DHCPStaticAssignment, DHCPScope).join(
+        DHCPScope, DHCPStaticAssignment.scope_id == DHCPScope.id
+    )
+
+    if s.is_mac:
+        # ``macaddr`` renders canonically as ``aa:bb:cc:dd:ee:ff``, so the
+        # separators are stripped from both sides and the query is matched
+        # against the normalised form — a dashed or Cisco-dotted query finds
+        # the same row.
+        stmt = stmt.where(
+            text(f"{_mac_normalized_sql('dhcp_static_assignment')} ILIKE :norm").params(
+                norm=f"%{escape_like(s.mac_normalized)}%"
+            )
+        )
+        rank: Any = EXACT
+    else:
+        cols = (
+            DHCPStaticAssignment.hostname,
+            _txt(DHCPStaticAssignment.ip_address),
+            _txt(DHCPStaticAssignment.mac_address),
+            DHCPStaticAssignment.description,
+        )
+        stmt = stmt.where(_text_clauses(s.raw, *cols))
+        rank = sql_rank(s.raw, *cols)
+
+    rows = (
+        await db.execute(_ranked(stmt, rank, limit, tiebreak=DHCPStaticAssignment.ip_address))
+    ).all()
+
+    out: list[SearchResult] = []
+    for res, scope, row_rank in rows:
+        quality, matched = pick_match(
+            s.raw,
+            [
+                ("hostname", res.hostname),
+                ("ip_address", str(res.ip_address) if res.ip_address else None),
+                ("mac_address", str(res.mac_address) if res.mac_address else None),
+                ("description", res.description),
+            ],
+        )
+        if s.is_mac:
+            quality, matched = int(row_rank), "mac_address"
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="dhcp_reservation",
+                    id=str(res.id),
+                    display=str(res.ip_address),
+                    name=res.hostname or None,
+                    description=res.description or None,
+                    hostname=res.hostname or None,
+                    mac_address=str(res.mac_address) if res.mac_address else None,
+                    context=f"Reserved in {scope.name}",
+                    route=f"/dhcp?group={scope.group_id}",
+                ),
+                quality,
+                matched,
+            )
+        )
+    return out
+
+
+async def search_dhcp_servers(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    cols = (DHCPServer.name, DHCPServer.description, DHCPServer.host)
+    stmt = select(DHCPServer).where(_text_clauses(s.raw, *cols))
+    rank = sql_rank(s.raw, *cols)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=DHCPServer.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="dhcp_server",
+                id=str(srv.id),
+                display=srv.name,
+                name=srv.name,
+                status=srv.status,
+                description=srv.description or None,
+                context=f"{srv.driver} · {srv.host}",
+                route=f"/dhcp?server={srv.id}",
+            ),
+            *pick_match(
+                s.raw,
+                [("name", srv.name), ("host", srv.host), ("description", srv.description)],
+            ),
+        )
+        for srv, _rank in rows
+    ]
+
+
+# ── Network ───────────────────────────────────────────────────────────────
+
+
+async def search_vlans(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    clauses: list[Any] = [
+        VLAN.name.ilike(like_pattern(s.raw), escape="\\"),
+        VLAN.description.ilike(like_pattern(s.raw), escape="\\"),
+    ]
+    # A bare number is almost always a VLAN id, not a name fragment.
+    # ``str.isdigit`` is true for digits int() rejects (superscripts,
+    # other scripts' numerals), so the conversion is still guarded.
+    if s.raw.isdigit():
+        try:
+            clauses.append(VLAN.vlan_id == int(s.raw))
+        except ValueError:
+            pass
+
+    stmt = select(VLAN).where(or_(*clauses))
+    # ``vlan_id`` has to be in the SQL rank, not only in the Python fix-up
+    # below: the id match is an equality on an integer column, so without it
+    # here the exact row scores 0 and ``ORDER BY rank DESC … LIMIT`` drops it
+    # before any Python ever sees it — the precise failure this module's
+    # SQL-side ranking exists to prevent.
+    rank = sql_rank(s.raw, _txt(VLAN.vlan_id), VLAN.name, VLAN.description)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=VLAN.vlan_id))).all()
+
+    out: list[SearchResult] = []
+    for vlan, _rank in rows:
+        quality, matched = pick_match(
+            s.raw,
+            [
+                ("vlan_id", str(vlan.vlan_id)),
+                ("name", vlan.name),
+                ("description", vlan.description),
+            ],
+        )
+        out.append(
+            _annotate(
+                SearchResult(
+                    type="vlan",
+                    id=str(vlan.id),
+                    display=f"VLAN {vlan.vlan_id}",
+                    name=vlan.name or None,
+                    description=vlan.description or None,
+                    route="/network/vlans",
+                ),
+                quality,
+                matched,
+            )
+        )
+    return out
+
+
+async def search_devices(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    cols = (
+        NetworkDevice.name,
+        NetworkDevice.hostname,
+        _txt(NetworkDevice.ip_address),
+        NetworkDevice.vendor,
+    )
+    stmt = select(NetworkDevice).where(_text_clauses(s.raw, *cols))
+    rank = sql_rank(s.raw, *cols)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=NetworkDevice.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="device",
+                id=str(d.id),
+                display=d.name or d.hostname or str(d.ip_address),
+                name=d.name or None,
+                status=d.device_type or None,
+                hostname=d.hostname or None,
+                context=" · ".join(x for x in (d.vendor, str(d.ip_address)) if x),
+                route=f"/network/devices/{d.id}",
+            ),
+            *pick_match(
+                s.raw,
+                [
+                    ("name", d.name),
+                    ("hostname", d.hostname),
+                    ("ip_address", str(d.ip_address) if d.ip_address else None),
+                    ("vendor", d.vendor),
+                ],
+            ),
+        )
+        for d, _rank in rows
+    ]
+
+
+async def search_sites(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    cols = (Site.name, Site.code, Site.notes)
+    stmt = select(Site).where(_text_clauses(s.raw, *cols))
+    rank = sql_rank(s.raw, *cols)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=Site.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="site",
+                id=str(site.id),
+                display=site.name,
+                name=site.name,
+                status=site.kind or None,
+                description=site.notes or None,
+                context=" · ".join(x for x in (site.code, site.region) if x) or None,
+                route="/network/sites",
+            ),
+            *pick_match(s.raw, [("name", site.name), ("code", site.code), ("notes", site.notes)]),
+        )
+        for site, _rank in rows
+    ]
+
+
+async def search_circuits(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    cols = (Circuit.name, Circuit.ckt_id, Circuit.notes)
+    stmt = select(Circuit).where(_text_clauses(s.raw, *cols))
+    rank = sql_rank(s.raw, *cols)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=Circuit.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="circuit",
+                id=str(c.id),
+                display=c.name,
+                name=c.name,
+                status=c.status or None,
+                description=c.notes or None,
+                context=" · ".join(x for x in (c.ckt_id, c.transport_class) if x) or None,
+                route="/network/circuits",
+            ),
+            *pick_match(s.raw, [("name", c.name), ("ckt_id", c.ckt_id), ("notes", c.notes)]),
+        )
+        for c, _rank in rows
+    ]
+
+
+# ── Administration ────────────────────────────────────────────────────────
+
+
+async def search_users(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    cols = (User.username, User.email, User.display_name)
+    stmt = select(User).where(_text_clauses(s.raw, *cols))
+    rank = sql_rank(s.raw, *cols)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=User.username))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="user",
+                id=str(u.id),
+                display=u.username,
+                name=u.display_name or None,
+                status="active" if u.is_active else "disabled",
+                context=" · ".join(x for x in (u.email, u.auth_source) if x) or None,
+                route="/admin/users",
+            ),
+            *pick_match(
+                s.raw,
+                [
+                    ("username", u.username),
+                    ("display_name", u.display_name),
+                    ("email", u.email),
+                ],
+            ),
+        )
+        for u, _rank in rows
+    ]
+
+
+async def search_groups(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    cols = (Group.name, Group.description)
+    stmt = select(Group).where(_text_clauses(s.raw, *cols))
+    rank = sql_rank(s.raw, *cols)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=Group.name))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="group",
+                id=str(g.id),
+                display=g.name,
+                name=g.name,
+                description=g.description or None,
+                context=g.auth_source or None,
+                route="/admin/groups",
+            ),
+            *pick_match(s.raw, [("name", g.name), ("description", g.description)]),
+        )
+        for g, _rank in rows
+    ]
+
+
+async def search_appliances(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    stmt = select(Appliance).where(_text_clauses(s.raw, Appliance.hostname))
+    rank = sql_rank(s.raw, Appliance.hostname)
+    rows = (await db.execute(_ranked(stmt, rank, limit, tiebreak=Appliance.hostname))).all()
+
+    return [
+        _annotate(
+            SearchResult(
+                type="appliance",
+                id=str(a.id),
+                display=a.hostname,
+                name=a.hostname,
+                status=a.state,
+                hostname=a.hostname,
+                context=a.appliance_variant or None,
+                route="/appliance",
+            ),
+            *pick_match(s.raw, [("hostname", a.hostname)]),
+        )
+        for a, _rank in rows
+    ]
+
+
+# ── IPAM custom fields ────────────────────────────────────────────────────
+
+
+async def _searchable_field_names(db: AsyncSession, resource_type: str) -> list[str]:
+    result = await db.execute(
+        select(CustomFieldDefinition.name).where(
+            CustomFieldDefinition.resource_type == resource_type,
+            CustomFieldDefinition.is_searchable.is_(True),
+        )
+    )
+    return [row[0] for row in result.all()]
+
+
+def _custom_field_hit(q: str, values: dict | None, names: list[str]) -> tuple[int, str | None]:
+    """Best (quality, ``custom_field:name=value``) over the searchable fields.
+
+    Delegates the scoring to :func:`pick_match` rather than re-deriving the
+    ladder. An earlier version inlined the bucket values, which meant
+    retuning them in ``ranking.py`` silently desynced custom-field scores
+    from every other kind of hit.
+    """
+    return pick_match(
+        q,
+        [
+            (f"custom_field:{name}={values[name]}", str(values[name]))
+            for name in names
+            if (values or {}).get(name) is not None
+        ],
+    )
+
+
+async def search_custom_fields(db: AsyncSession, s: QueryShape, limit: int) -> list[SearchResult]:
+    """Substring-match searchable custom-field values on blocks/subnets/IPs.
+
+    One provider rather than three because the ``custom_field_definition``
+    lookup and the JSONB predicate shape are shared; the emitted rows still
+    carry their own ``type`` and are filtered by the engine against what the
+    caller asked for and may see.
+    """
+    out: list[SearchResult] = []
+
+    def jsonb_cols(model: Any, names: list[str]) -> list[Any]:
+        """``custom_fields ->> 'name'`` as real column expressions.
+
+        Built through the ORM rather than as ``text()`` fragments so they
+        can also feed :func:`sql_rank` — without an ``ORDER BY``, these
+        three queries had the same "database returns any N matching rows"
+        flaw this module exists to fix, and an exact custom-field hit among
+        thousands of substring hits was routinely never fetched.
+        """
+        return [model.custom_fields[name].astext for name in names]
+
+    block_fields = await _searchable_field_names(db, "ip_block")
+    if block_fields:
+        stmt = (
+            select(IPBlock, IPSpace)
+            .join(IPSpace, IPBlock.space_id == IPSpace.id)
+            .where(
+                or_(
+                    *[
+                        c.ilike(like_pattern(s.raw), escape="\\")
+                        for c in jsonb_cols(IPBlock, block_fields)
+                    ]
+                )
+            )
+        )
+        stmt = _ranked(
+            stmt,
+            sql_rank(s.raw, *jsonb_cols(IPBlock, block_fields)),
+            limit,
+            tiebreak=IPBlock.network,
+        )
+        for block, space, _rank in (await db.execute(stmt)).all():
+            quality, label = _custom_field_hit(s.raw, block.custom_fields, block_fields)
+            out.append(
+                _annotate(
+                    SearchResult(
+                        type="block",
+                        id=str(block.id),
+                        display=str(block.network),
+                        name=block.name or None,
+                        description=block.description or None,
+                        block_id=str(block.id),
+                        space_id=str(space.id),
+                        space_name=space.name,
+                        matched_field=label or "custom_field",
+                    ),
+                    quality,
+                    label,
+                )
+            )
+
+    subnet_fields = await _searchable_field_names(db, "subnet")
+    if subnet_fields:
+        stmt = (
+            select(Subnet, IPSpace)
+            .join(IPSpace, Subnet.space_id == IPSpace.id)
+            .where(
+                or_(
+                    *[
+                        c.ilike(like_pattern(s.raw), escape="\\")
+                        for c in jsonb_cols(Subnet, subnet_fields)
+                    ]
+                )
+            )
+        )
+        stmt = _ranked(
+            stmt,
+            sql_rank(s.raw, *jsonb_cols(Subnet, subnet_fields)),
+            limit,
+            tiebreak=Subnet.network,
+        )
+        for subnet, space, _rank in (await db.execute(stmt)).all():
+            quality, label = _custom_field_hit(s.raw, subnet.custom_fields, subnet_fields)
+            out.append(
+                _annotate(
+                    SearchResult(
+                        type="subnet",
+                        id=str(subnet.id),
+                        display=str(subnet.network),
+                        name=subnet.name or None,
+                        status=subnet.status,
+                        description=subnet.description or None,
+                        subnet_id=str(subnet.id),
+                        subnet_network=str(subnet.network),
+                        block_id=str(subnet.block_id) if subnet.block_id else None,
+                        space_id=str(space.id),
+                        space_name=space.name,
+                        matched_field=label or "custom_field",
+                    ),
+                    quality,
+                    label,
+                )
+            )
+
+    addr_fields = await _searchable_field_names(db, "ip_address")
+    if addr_fields:
+        stmt = select(IPAddress).where(
+            or_(
+                *[
+                    c.ilike(like_pattern(s.raw), escape="\\")
+                    for c in jsonb_cols(IPAddress, addr_fields)
+                ]
+            )
+        )
+        stmt = _ranked(
+            stmt,
+            sql_rank(s.raw, *jsonb_cols(IPAddress, addr_fields)),
+            limit,
+            tiebreak=IPAddress.address,
+        )
+        addr_rows = [row[0] for row in (await db.execute(stmt)).all()]
+        ctx = await _subnet_context(db, {ip.subnet_id for ip in addr_rows})
+        for ip in addr_rows:
+            parent = ctx.get(ip.subnet_id)
+            if parent is None:
+                continue
+            subnet, space = parent
+            quality, label = _custom_field_hit(s.raw, ip.custom_fields, addr_fields)
+            out.append(
+                _annotate(
+                    SearchResult(
+                        type="ip_address",
+                        id=str(ip.id),
+                        display=str(ip.address),
+                        name=ip.hostname,
+                        status=ip.status,
+                        description=ip.description or None,
+                        hostname=ip.hostname,
+                        mac_address=str(ip.mac_address) if ip.mac_address else None,
+                        subnet_id=str(ip.subnet_id),
+                        subnet_network=str(subnet.network),
+                        block_id=str(subnet.block_id) if subnet.block_id else None,
+                        space_id=str(space.id),
+                        space_name=space.name,
+                        matched_field=label or "custom_field",
+                    ),
+                    quality,
+                    label,
+                )
+            )
+
+    return out
+
+
+# ── registry ──────────────────────────────────────────────────────────────
+
+PROVIDERS: tuple[SearchProvider, ...] = (
+    # ── IPAM ──
+    SearchProvider(
+        type="ip_address",
+        label="IP Address",
+        group="ipam",
+        resource_types=("ip_address",),
+        fn=search_addresses,
+        # Not "cidr": an address row can't equal a prefix, and the fallback
+        # text branch would substring-match "10.0.0.0/24" against hostnames.
+        shapes=frozenset({"text", "ip", "mac"}),
+    ),
+    SearchProvider(
+        type="subnet",
+        label="Subnet",
+        group="ipam",
+        resource_types=("subnet",),
+        fn=search_subnets,
+        shapes=frozenset({"text", "ip", "cidr"}),
+    ),
+    SearchProvider(
+        type="block",
+        label="Block",
+        group="ipam",
+        resource_types=("ip_block",),
+        fn=search_blocks,
+        shapes=frozenset({"text", "ip", "cidr"}),
+    ),
+    SearchProvider(
+        type="space",
+        label="Space",
+        group="ipam",
+        resource_types=("ip_space",),
+        fn=search_spaces,
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="custom_field",
+        label="Custom Field",
+        group="ipam",
+        resource_types=("ip_address", "subnet", "ip_block"),
+        fn=search_custom_fields,
+        also_emits=("ip_address", "subnet", "block"),
+        # A custom field can legitimately hold an address ("gateway",
+        # "management_ip"), so an IP query is worth running here.
+        shapes=TEXT_AND_IP,
+    ),
+    # ── DNS ──
+    SearchProvider(
+        type="dns_group",
+        label="DNS Group",
+        group="dns",
+        resource_types=("dns_group",),
+        fn=search_dns_groups,
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="dns_zone",
+        label="DNS Zone",
+        group="dns",
+        resource_types=("dns_zone",),
+        fn=search_dns_zones,
+        # Reverse zones are named after addresses, but as ``…in-addr.arpa``
+        # rather than dotted-quad, so an IP query never matches one.
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="dns_record",
+        label="DNS Record",
+        group="dns",
+        resource_types=("dns_record",),
+        fn=search_dns_records,
+        # An A record's value IS an address — "which name points here?" is
+        # one of the most common lookups in the product.
+        shapes=TEXT_AND_IP,
+    ),
+    SearchProvider(
+        type="dns_server",
+        label="DNS Server",
+        group="dns",
+        resource_types=("dns_group",),
+        fn=search_dns_servers,
+        shapes=TEXT_AND_IP,
+    ),
+    SearchProvider(
+        type="dns_view",
+        label="DNS View",
+        group="dns",
+        resource_types=("dns_group",),
+        fn=search_dns_views,
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="dns_blocklist",
+        label="Blocklist",
+        group="dns",
+        resource_types=("dns_blocklist",),
+        fn=search_dns_blocklists,
+        shapes=TEXT_ONLY,
+    ),
+    # ── DHCP ──
+    SearchProvider(
+        type="dhcp_scope",
+        label="DHCP Scope",
+        group="dhcp",
+        resource_types=("dhcp_scope",),
+        fn=search_dhcp_scopes,
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="dhcp_reservation",
+        label="Reservation",
+        group="dhcp",
+        resource_types=("dhcp_static",),
+        fn=search_dhcp_reservations,
+        # The reservation table is where a MAC lookup usually lands.
+        shapes=frozenset({"text", "ip", "mac"}),
+    ),
+    SearchProvider(
+        type="dhcp_server",
+        label="DHCP Server",
+        group="dhcp",
+        resource_types=("dhcp_server",),
+        fn=search_dhcp_servers,
+        shapes=TEXT_AND_IP,
+    ),
+    # ── Network ──
+    SearchProvider(
+        type="vlan",
+        label="VLAN",
+        group="network",
+        resource_types=("vlan",),
+        fn=search_vlans,
+        module="network.vlan",
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="device",
+        label="Device",
+        group="network",
+        resource_types=("manage_network_devices",),
+        fn=search_devices,
+        module="network.device",
+        shapes=TEXT_AND_IP,
+    ),
+    SearchProvider(
+        type="site",
+        label="Site",
+        group="network",
+        resource_types=("site",),
+        fn=search_sites,
+        module="network.site",
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="circuit",
+        label="Circuit",
+        group="network",
+        resource_types=("circuit",),
+        fn=search_circuits,
+        module="network.circuit",
+        shapes=TEXT_ONLY,
+    ),
+    # ── Administration ──
+    SearchProvider(
+        type="user",
+        label="User",
+        group="admin",
+        resource_types=("user",),
+        fn=search_users,
+        # /api/v1/users is superadmin-only, not permission-gated, so the
+        # search view of it has to be too — otherwise search becomes a
+        # username and email directory for anyone who can log in.
+        superadmin_only=True,
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="group",
+        label="Group",
+        group="admin",
+        resource_types=("group",),
+        fn=search_groups,
+        shapes=TEXT_ONLY,
+    ),
+    SearchProvider(
+        type="appliance",
+        label="Appliance",
+        group="admin",
+        resource_types=("appliance",),
+        fn=search_appliances,
+        shapes=TEXT_ONLY,
+    ),
+)
+
+_BY_TYPE = {p.type: p for p in PROVIDERS}
+
+
+def provider_for(type_name: str) -> SearchProvider | None:
+    return _BY_TYPE.get(type_name)

--- a/backend/app/services/search/providers.py
+++ b/backend/app/services/search/providers.py
@@ -726,12 +726,15 @@ async def search_vlans(db: AsyncSession, s: QueryShape, limit: int) -> list[Sear
         VLAN.description.ilike(like_pattern(s.raw), escape="\\"),
     ]
     # A bare number is almost always a VLAN id, not a name fragment.
-    # ``str.isdigit`` is true for digits int() rejects (superscripts,
-    # other scripts' numerals), so the conversion is still guarded.
     if s.raw.isdigit():
         try:
             clauses.append(VLAN.vlan_id == int(s.raw))
         except ValueError:
+            # ``str.isdigit`` is True for characters ``int()`` rejects —
+            # superscripts like "²", and other scripts' numerals. The query
+            # simply isn't a VLAN id, so fall through to the name and
+            # description clauses already in the list rather than failing
+            # the whole search on an unusual keystroke.
             pass
 
     stmt = select(VLAN).where(or_(*clauses))

--- a/backend/app/services/search/ranking.py
+++ b/backend/app/services/search/ranking.py
@@ -1,0 +1,159 @@
+"""Relevance scoring for global search (issue #879).
+
+Search v1 concatenated per-type result lists in a fixed order and cut the
+combined list at ``limit``. Two things went wrong with that:
+
+* **Order.** A weak substring hit on an IP *space* name outranked an exact
+  ``dns_record`` FQDN match purely because spaces were queried earlier.
+* **Truncation.** Each type ran ``LIMIT n`` with no ``ORDER BY``, so on a
+  type with thousands of substring matches the exact hit was frequently not
+  in the rows the database chose to return at all. No amount of re-sorting
+  in Python can recover a row that was never fetched — which is why the
+  ranking has to exist in SQL, before the limit, and not only here.
+
+So there are two halves, and they must agree:
+
+* :func:`sql_rank` builds the ``ORDER BY`` expression the query uses to pick
+  *which* rows come back.
+* :func:`pick_match` re-derives the same quality bucket in Python to decide
+  *which field* matched, for the ``matched_field`` hint the UI shows.
+
+The buckets are deliberately far apart (100 / 60 / 25) relative to the type
+weights (0–12), so quality always dominates type: an exact match on a
+lowly-weighted type still beats a substring match on a favoured one. That
+ordering property is what the issue asked for, and it is pinned by a test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from sqlalchemy import case, func
+
+__all__ = [
+    "EXACT",
+    "PREFIX",
+    "SUBSTRING",
+    "TYPE_WEIGHTS",
+    "escape_like",
+    "like_pattern",
+    "match_quality",
+    "pick_match",
+    "sql_rank",
+    "total_score",
+]
+
+# Match-quality buckets. Gaps are wide on purpose — see module docstring.
+EXACT = 100
+PREFIX = 60
+SUBSTRING = 25
+
+# Per-type nudge applied on top of the quality bucket, used only to break
+# ties *within* a bucket. Ordered by how specific a hit of that type usually
+# is: an operator who types a string that exactly matches a DNS record wanted
+# that record; one whose string happens to appear in a space description
+# almost never did.
+TYPE_WEIGHTS: dict[str, int] = {
+    "ip_address": 12,
+    "dns_record": 11,
+    "dhcp_reservation": 10,
+    "subnet": 9,
+    "dns_zone": 9,
+    "dhcp_scope": 8,
+    "block": 7,
+    "vlan": 7,
+    "device": 6,
+    "dns_view": 5,
+    "dns_blocklist": 5,
+    "space": 4,
+    "dns_group": 4,
+    "dns_server": 4,
+    "dhcp_server": 4,
+    "circuit": 3,
+    "site": 3,
+    "user": 2,
+    "group": 2,
+    "appliance": 2,
+}
+
+
+def escape_like(value: str) -> str:
+    r"""Escape ``LIKE`` metacharacters so a query is matched literally.
+
+    Search v1 interpolated the raw query into ``%{q}%``, so an operator
+    searching for the string ``50%`` matched every row in the table and one
+    typing ``a_b`` matched ``axb``. Both read as "search is broken" rather
+    than as a wildcard feature nobody documented.
+
+    The backslash is escaped first, or escaping the others would then be
+    re-escaped by this function's own output.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def like_pattern(value: str, *, prefix: bool = False) -> str:
+    """``%value%`` (or ``value%``) with metacharacters neutralised."""
+    escaped = escape_like(value)
+    return f"{escaped}%" if prefix else f"%{escaped}%"
+
+
+def sql_rank(q: str, *columns: Any) -> Any:
+    """An integer relevance expression over ``columns``, for ``ORDER BY``.
+
+    Every column contributes its own bucket and the row takes the best one,
+    so a row whose *name* matches exactly is not dragged down by a
+    *description* that merely contains the term.
+
+    NULL columns score 0 rather than NULL: ``CASE`` falls through to
+    ``ELSE`` when its conditions are NULL, which keeps ``GREATEST`` from
+    having to reason about NULLs at all.
+    """
+    lowered = q.lower()
+    branches = [
+        case(
+            (func.lower(col) == lowered, EXACT),
+            (func.lower(col).like(like_pattern(lowered, prefix=True), escape="\\"), PREFIX),
+            (func.lower(col).like(like_pattern(lowered), escape="\\"), SUBSTRING),
+            else_=0,
+        )
+        for col in columns
+    ]
+    if len(branches) == 1:
+        return branches[0]
+    return func.greatest(*branches)
+
+
+def match_quality(q_lower: str, value: str | None) -> int:
+    """Python twin of one :func:`sql_rank` branch."""
+    if not value:
+        return 0
+    low = value.lower()
+    if low == q_lower:
+        return EXACT
+    if low.startswith(q_lower):
+        return PREFIX
+    if q_lower in low:
+        return SUBSTRING
+    return 0
+
+
+def pick_match(q: str, candidates: Sequence[tuple[str, str | None]]) -> tuple[int, str | None]:
+    """Best (quality, field-name) over ``(field_name, value)`` pairs.
+
+    Ties keep the earliest candidate, so callers order the sequence by how
+    much they want that field named in the UI — ``hostname`` before
+    ``description``, say.
+    """
+    best_score = 0
+    best_field: str | None = None
+    for field_name, value in candidates:
+        score = match_quality(q.lower(), value)
+        if score > best_score:
+            best_score, best_field = score, field_name
+    return best_score, best_field
+
+
+def total_score(quality: int, result_type: str) -> int:
+    """Combine a quality bucket with its type weight."""
+    return quality + TYPE_WEIGHTS.get(result_type, 0)

--- a/backend/app/services/search/schemas.py
+++ b/backend/app/services/search/schemas.py
@@ -1,0 +1,172 @@
+"""Wire shapes for global search (issue #879)."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+from dataclasses import dataclass
+
+from pydantic import BaseModel, Field
+
+__all__ = ["QueryShape", "SearchResponse", "SearchResult", "shape_of"]
+
+
+_MAC_PATTERNS = (
+    re.compile(r"^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"),
+    re.compile(r"^([0-9a-fA-F]{2}-){5}[0-9a-fA-F]{2}$"),
+    re.compile(r"^[0-9a-fA-F]{12}$"),
+    re.compile(r"^([0-9a-fA-F]{4}\.){2}[0-9a-fA-F]{4}$"),  # Cisco dotted
+)
+
+
+@dataclass(frozen=True)
+class QueryShape:
+    """What the operator typed, classified once instead of per provider.
+
+    v1 re-ran ``_is_ip`` / ``_is_cidr`` / ``_is_mac`` inside every search
+    helper. Cheap individually, but it also meant each helper could drift on
+    what counts as an IP — so the classification now happens once and is
+    passed down.
+    """
+
+    raw: str
+    lowered: str
+    is_ip: bool
+    is_cidr: bool
+    is_mac: bool
+    mac_normalized: str
+
+    @property
+    def is_address_like(self) -> bool:
+        return self.is_ip or self.is_cidr
+
+    @property
+    def kind(self) -> str:
+        """One of ``ip`` / ``cidr`` / ``mac`` / ``text``.
+
+        Providers declare which kinds they can serve, so a MAC lookup runs
+        the two queries that could possibly match it instead of all twenty.
+        That is both faster and more accurate — a MAC substring-matched
+        against a site's notes was never a result anybody wanted.
+        """
+        if self.is_cidr:
+            return "cidr"
+        if self.is_ip:
+            return "ip"
+        if self.is_mac:
+            return "mac"
+        return "text"
+
+
+def _is_ip(q: str) -> bool:
+    try:
+        ipaddress.ip_address(q)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_cidr(q: str) -> bool:
+    if "/" not in q:
+        return False
+    try:
+        ipaddress.ip_network(q, strict=False)
+    except ValueError:
+        return False
+    return True
+
+
+def _is_mac(q: str) -> bool:
+    return any(p.match(q) for p in _MAC_PATTERNS)
+
+
+def shape_of(q: str) -> QueryShape:
+    return QueryShape(
+        raw=q,
+        lowered=q.lower(),
+        is_ip=_is_ip(q),
+        is_cidr=_is_cidr(q),
+        is_mac=_is_mac(q),
+        mac_normalized=re.sub(r"[:\-.]", "", q).lower(),
+    )
+
+
+class SearchResult(BaseModel):
+    """One hit from any resource type.
+
+    Every context field defaults to ``None``. They used to be required-but-
+    nullable, so each of the (now twenty) providers had to spell out
+    ``hostname=None, mac_address=None, subnet_id=None, …`` — noise that
+    grew linearly with both the number of providers and the number of
+    fields, and that silently forced every new field onto every existing
+    provider.
+    """
+
+    type: str
+    id: str
+
+    # Primary display
+    display: str
+    name: str | None = None
+
+    # Status / detail
+    status: str | None = None
+    description: str | None = None
+
+    # IP-address specific
+    hostname: str | None = None
+    mac_address: str | None = None
+
+    # Breadcrumb context (IPAM)
+    subnet_id: str | None = None
+    subnet_network: str | None = None
+    block_id: str | None = None
+    space_id: str | None = None
+    space_name: str | None = None
+
+    # DNS context
+    dns_group_id: str | None = None
+    dns_group_name: str | None = None
+    dns_zone_id: str | None = None
+    dns_zone_name: str | None = None
+    dns_record_type: str | None = None
+    dns_record_value: str | None = None
+
+    # Free-form breadcrumb for the types added in v2, which have no shared
+    # parent shape to model (a DHCP reservation's parent is a scope, a
+    # circuit's is a provider). One string the UI renders verbatim beats
+    # twenty type-specific columns nothing else reads.
+    context: str | None = None
+
+    # Where selecting this row should navigate. The original seven types
+    # are dispatched client-side because they pass react-router *state*
+    # (which subnet to open, which row to highlight) rather than a path;
+    # everything added since carries its path here instead of growing that
+    # switch statement once per type.
+    route: str | None = None
+
+    # Why this row matched — "hostname", "description",
+    # "custom_field:owner=alice". Rendered as a hint chip.
+    matched_field: str | None = None
+
+    # Relevance. Returned so the ordering is inspectable rather than
+    # something the operator has to infer from the sequence.
+    score: int = 0
+
+
+class SearchTypeInfo(BaseModel):
+    """One searchable type, as visible to the calling user."""
+
+    type: str
+    label: str
+    group: str
+
+
+class SearchResponse(BaseModel):
+    query: str
+    total: int
+    results: list[SearchResult]
+    # Types actually consulted for this request, after permission and
+    # feature-module filtering. The UI builds its scope chips from this, so
+    # an operator is never offered a filter that can only return nothing.
+    searched_types: list[SearchTypeInfo] = Field(default_factory=list)

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,749 @@
+"""Global search v2 (issue #879) — ranking, RBAC, coverage, query shapes.
+
+The load-bearing assertions here are the two things v1 got wrong:
+
+* **Ranking happens before the limit.** A weak substring hit must never
+  crowd out an exact match, including when the weak hits outnumber the
+  per-type limit.
+* **Results are permission-filtered server-side.** v1 checked nothing, so
+  ``/api/v1/search`` returned DNS rows to an operator whose own
+  ``GET /api/v1/dns/zones`` would 403.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import Group, Role, User
+from app.models.dns import DNSRecord, DNSServerGroup, DNSZone
+from app.models.ipam import IPAddress, IPBlock, IPSpace, Subnet
+from app.services import feature_modules
+from app.services.search import execute
+from app.services.search.providers import PROVIDERS, _mac_normalized_sql
+from app.services.search.ranking import EXACT, PREFIX, SUBSTRING, escape_like, pick_match
+from app.services.search.schemas import shape_of
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_module_cache():
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+async def _user(
+    db: AsyncSession, *, permissions: list[dict[str, Any]] | None = None, superadmin: bool = False
+) -> tuple[User, str]:
+    tag = uuid.uuid4().hex[:8]
+    user = User(
+        username=f"u-{tag}",
+        email=f"{tag}@example.com",
+        display_name="U",
+        hashed_password=hash_password("x"),
+        is_superadmin=superadmin,
+    )
+    if permissions is not None:
+        role = Role(name=f"r-{tag}", description="", is_builtin=False, permissions=permissions)
+        group = Group(name=f"g-{tag}", description="")
+        group.roles = [role]
+        group.users = [user]
+        db.add(group)
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _space(db: AsyncSession, name: str = "default") -> IPSpace:
+    space = IPSpace(name=f"{name}-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    return space
+
+
+async def _subnet(db: AsyncSession, space: IPSpace, network: str = "10.0.0.0/24", **kw) -> Subnet:
+    net = ipaddress.ip_network(network)
+    block = IPBlock(
+        space_id=space.id,
+        # A block wide enough to hold the subnet — ``subnet.block_id`` is
+        # NOT NULL, so every subnet needs one.
+        network=ipaddress.ip_network(
+            f"{net.network_address}/{max(net.prefixlen - 8, 8)}", strict=False
+        ),
+        name=f"blk-{uuid.uuid4().hex[:6]}",
+        description="",
+    )
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(
+        space_id=space.id,
+        block_id=block.id,
+        network=net,
+        name=kw.pop("name", "sn"),
+        description=kw.pop("description", ""),
+        status="active",
+        **kw,
+    )
+    db.add(subnet)
+    await db.flush()
+    return subnet
+
+
+async def _address(db: AsyncSession, subnet: Subnet, address: str, **kw) -> IPAddress:
+    ip = IPAddress(
+        subnet_id=subnet.id,
+        address=ipaddress.ip_address(address),
+        status=kw.pop("status", "allocated"),
+        hostname=kw.pop("hostname", ""),
+        description=kw.pop("description", ""),
+        **kw,
+    )
+    db.add(ip)
+    await db.flush()
+    return ip
+
+
+async def _zone_with_record(
+    db: AsyncSession, zone_name: str, fqdn: str, value: str = "10.0.0.1"
+) -> tuple[DNSServerGroup, DNSZone, DNSRecord]:
+    group = DNSServerGroup(name=f"grp-{uuid.uuid4().hex[:6]}", description="")
+    db.add(group)
+    await db.flush()
+    zone = DNSZone(group_id=group.id, name=zone_name, zone_type="master")
+    db.add(zone)
+    await db.flush()
+    record = DNSRecord(
+        zone_id=zone.id,
+        name=fqdn.split(".")[0],
+        fqdn=fqdn,
+        record_type="A",
+        value=value,
+        ttl=300,
+    )
+    db.add(record)
+    await db.flush()
+    return group, zone, record
+
+
+IPAM_READ = [
+    {"action": "read", "resource_type": t} for t in ("ip_space", "ip_block", "subnet", "ip_address")
+]
+DNS_READ = [{"action": "read", "resource_type": t} for t in ("dns_group", "dns_zone", "dns_record")]
+
+
+# ── ranking ───────────────────────────────────────────────────────────────
+
+
+async def test_exact_match_outranks_substring_across_types(client: AsyncClient, db_session):
+    """The headline v1 bug: type order decided the result order."""
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    # A space whose *description* merely contains the term...
+    space.description = "hosts the widget cluster"
+    space.name = "widget-adjacent-space"
+    subnet = await _subnet(db_session, space)
+    # ...and an address whose hostname IS the term.
+    await _address(db_session, subnet, "10.0.0.5", hostname="widget")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "widget"})
+    assert r.status_code == 200, r.text
+    results = r.json()["results"]
+    assert results, "expected hits"
+    assert results[0]["type"] == "ip_address"
+    assert results[0]["display"] == "10.0.0.5"
+    # And the ordering is explained by the score, not by luck.
+    assert results[0]["score"] > results[-1]["score"]
+
+
+async def test_exact_match_survives_a_flood_of_substring_matches(client: AsyncClient, db_session):
+    """Ranking must be applied in SQL, before the per-type LIMIT.
+
+    With 60 substring matches and a per-type limit of 25, an unordered
+    query returns whichever rows the database felt like — and the exact
+    match was routinely not among them. Sorting in Python afterwards
+    cannot recover a row that was never fetched.
+    """
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, "10.1.0.0/16")
+    for i in range(60):
+        await _address(
+            db_session, subnet, f"10.1.{i // 254}.{i % 254 + 1}", hostname=f"pre-needle-{i}"
+        )
+    await _address(db_session, subnet, "10.1.250.250", hostname="needle")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "needle", "limit": 5})
+    results = r.json()["results"]
+    assert results[0]["display"] == "10.1.250.250"
+    assert results[0]["matched_field"] == "hostname"
+
+
+async def test_prefix_beats_substring(client: AsyncClient, db_session):
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.2", hostname="not-the-db-server")
+    await _address(db_session, subnet, "10.0.0.3", hostname="db-server-primary")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "db-server"})
+    ordered = [x["display"] for x in r.json()["results"] if x["type"] == "ip_address"]
+    assert ordered.index("10.0.0.3") < ordered.index("10.0.0.2")
+
+
+def test_quality_buckets_dominate_type_weights():
+    """An exact hit on the lowest-weighted type must still beat a substring
+    hit on the highest. This is the property that makes ranking meaningful
+    rather than a tiebreak, so it is pinned rather than left implicit."""
+    from app.services.search.ranking import TYPE_WEIGHTS, total_score
+
+    best, worst = max(TYPE_WEIGHTS.values()), min(TYPE_WEIGHTS.values())
+    assert EXACT + worst > SUBSTRING + best
+    assert PREFIX + worst > SUBSTRING + best
+    assert total_score(EXACT, "user") > total_score(SUBSTRING, "ip_address")
+
+
+def test_pick_match_reports_the_best_field_not_the_first():
+    score, field = pick_match("alpha", [("description", "contains alpha here"), ("name", "alpha")])
+    assert (score, field) == (EXACT, "name")
+
+
+# ── LIKE metacharacters ───────────────────────────────────────────────────
+
+
+def test_escape_like_neutralises_metacharacters():
+    assert escape_like("50%") == "50\\%"
+    assert escape_like("a_b") == "a\\_b"
+    # Backslash first, or the escapes would themselves be escaped.
+    assert escape_like("a\\b") == "a\\\\b"
+
+
+async def test_wildcard_in_query_is_matched_literally(client: AsyncClient, db_session):
+    """``%`` used to be interpolated straight into the LIKE pattern, so
+    searching for it matched every row in every table."""
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.7", hostname="load-50%-host")
+    await _address(db_session, subnet, "10.0.0.8", hostname="unrelated")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "50%"})
+    hits = [x["display"] for x in r.json()["results"]]
+    assert hits == ["10.0.0.7"]
+
+
+async def test_underscore_is_not_a_single_character_wildcard(client: AsyncClient, db_session):
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.9", hostname="axb")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "a_b"})
+    assert r.json()["results"] == []
+
+
+# ── permission filtering ──────────────────────────────────────────────────
+
+
+async def test_ipam_only_user_cannot_see_dns_rows(client: AsyncClient, db_session):
+    """The v1 leak. ``/api/v1/dns/*`` requires read on a dns_* type; search
+    returned the same rows to anyone with a session."""
+    _, token = await _user(db_session, permissions=IPAM_READ)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, name="shared-name")
+    await _address(db_session, subnet, "10.0.0.10", hostname="shared-name-host")
+    await _zone_with_record(db_session, "shared-name.example.com.", "www.shared-name.example.com.")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "shared-name"})
+    types = {x["type"] for x in r.json()["results"]}
+    assert types, "IPAM user should still get their own rows"
+    assert types <= {"ip_address", "subnet", "block", "space"}
+    assert not any(t.startswith("dns") for t in types)
+
+
+async def test_dns_only_user_cannot_see_ipam_rows(client: AsyncClient, db_session):
+    _, token = await _user(db_session, permissions=DNS_READ)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, name="shared-name")
+    await _address(db_session, subnet, "10.0.0.11", hostname="shared-name-host")
+    await _zone_with_record(db_session, "shared-name.example.com.", "www.shared-name.example.com.")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "shared-name"})
+    types = {x["type"] for x in r.json()["results"]}
+    assert types
+    assert types <= {"dns_group", "dns_zone", "dns_record"}
+
+
+async def test_user_directory_is_superadmin_only(client: AsyncClient, db_session):
+    """``/api/v1/users`` is superadmin-gated rather than permission-gated,
+    so a wildcard ``read`` grant must not turn search into a staff
+    directory."""
+    target, _ = await _user(db_session)
+    _, reader = await _user(db_session, permissions=[{"action": "read", "resource_type": "*"}])
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(reader), params={"q": target.username})
+    assert not [x for x in r.json()["results"] if x["type"] == "user"]
+
+    _, admin = await _user(db_session, superadmin=True)
+    await db_session.flush()
+    r = await client.get("/api/v1/search", headers=_hdr(admin), params={"q": target.username})
+    assert [x for x in r.json()["results"] if x["type"] == "user"]
+
+
+async def test_searched_types_reflects_the_callers_permissions(client: AsyncClient, db_session):
+    _, token = await _user(db_session, permissions=IPAM_READ)
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search/types", headers=_hdr(token))
+    assert r.status_code == 200
+    groups = {t["group"] for t in r.json()}
+    assert groups == {"ipam"}
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "x"})
+    assert {t["group"] for t in r.json()["searched_types"]} == {"ipam"}
+
+
+async def test_requesting_a_forbidden_type_returns_nothing_not_an_error(
+    client: AsyncClient, db_session
+):
+    """A stale scope chip in an open tab should come back empty, not 403 the
+    whole search."""
+    _, token = await _user(db_session, permissions=IPAM_READ)
+    await _zone_with_record(db_session, "forbidden.example.com.", "www.forbidden.example.com.")
+    await db_session.flush()
+
+    r = await client.get(
+        "/api/v1/search",
+        headers=_hdr(token),
+        params={"q": "forbidden", "types": "dns_zone,dns_record"},
+    )
+    assert r.status_code == 200
+    assert r.json()["results"] == []
+
+
+async def test_custom_field_pass_cannot_bypass_the_type_gate(client: AsyncClient, db_session):
+    """The IPAM custom-field pass is one query emitting three row types.
+    A caller who may read subnets but not addresses must not receive an
+    address row through it."""
+    from app.models.ipam import CustomFieldDefinition
+
+    db_session.add(
+        CustomFieldDefinition(
+            resource_type="ip_address",
+            name="owner",
+            label="Owner",
+            field_type="text",
+            is_searchable=True,
+        )
+    )
+    _, token = await _user(db_session, permissions=[{"action": "read", "resource_type": "subnet"}])
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.12", custom_fields={"owner": "zaphod"})
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "zaphod"})
+    assert [x["type"] for x in r.json()["results"] if x["type"] == "ip_address"] == []
+
+
+# ── feature-module gating ─────────────────────────────────────────────────
+
+
+async def test_disabled_module_removes_its_type(client: AsyncClient, db_session):
+    _, token = await _user(db_session, superadmin=True)
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search/types", headers=_hdr(token))
+    assert "vlan" in {t["type"] for t in r.json()}
+
+    await feature_modules.set_module_enabled(db_session, "network.vlan", False, user_id=None)
+    await db_session.flush()
+    feature_modules.invalidate_cache()
+
+    r = await client.get("/api/v1/search/types", headers=_hdr(token))
+    assert "vlan" not in {t["type"] for t in r.json()}
+
+
+# ── query shapes ──────────────────────────────────────────────────────────
+
+
+def test_shape_detection():
+    assert shape_of("10.0.0.1").kind == "ip"
+    assert shape_of("10.0.0.0/24").kind == "cidr"
+    assert shape_of("aa:bb:cc:dd:ee:ff").kind == "mac"
+    assert shape_of("aabbccddeeff").kind == "mac"
+    assert shape_of("aabb.ccdd.eeff").kind == "mac"
+    assert shape_of("web-01").kind == "text"
+
+
+def test_every_provider_declares_at_least_one_shape():
+    for p in PROVIDERS:
+        assert p.shapes, f"{p.type} would never run"
+        assert p.shapes <= {"text", "ip", "cidr", "mac"}, p.type
+
+
+def test_mac_shape_runs_only_the_providers_that_can_match_one():
+    """A MAC substring-matched against a site's notes was never a result
+    anybody wanted, and running twenty queries to prove it is waste."""
+    runs = {p.type for p in PROVIDERS if "mac" in p.shapes}
+    assert runs == {"ip_address", "dhcp_reservation"}
+
+
+async def test_mac_lookup_is_separator_insensitive(client: AsyncClient, db_session):
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(
+        db_session, subnet, "10.0.0.20", hostname="printer", mac_address="aa:bb:cc:dd:ee:ff"
+    )
+    await db_session.flush()
+
+    for spelling in ("aa:bb:cc:dd:ee:ff", "AA-BB-CC-DD-EE-FF", "aabbccddeeff", "aabb.ccdd.eeff"):
+        r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": spelling})
+        hits = [x["display"] for x in r.json()["results"]]
+        assert hits == ["10.0.0.20"], f"{spelling} found {hits}"
+
+
+async def test_partial_mac_matches_via_the_normalised_form(client: AsyncClient, db_session):
+    """An OUI prefix doesn't parse as a MAC, so it takes the text path —
+    which now also normalises, meaning ``aa:bb:cc`` finds a row stored with
+    any separator style."""
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.21", mac_address="aa:bb:cc:11:22:33")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "aa-bb-cc"})
+    assert [x["display"] for x in r.json()["results"]] == ["10.0.0.21"]
+
+
+async def test_ip_query_finds_the_address_and_its_containers(client: AsyncClient, db_session):
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, "10.5.0.0/24")
+    await _address(db_session, subnet, "10.5.0.42", hostname="host42")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "10.5.0.42"})
+    by_type = {x["type"]: x for x in r.json()["results"]}
+    assert by_type["ip_address"]["display"] == "10.5.0.42"
+    assert by_type["subnet"]["display"] == "10.5.0.0/24"
+
+
+async def test_ip_query_finds_dns_records_pointing_at_it(client: AsyncClient, db_session):
+    """ "Which name resolves here?" is one of the most common lookups in a
+    DDI tool, and v1 could not answer it — an IP query never reached the
+    record *value* column."""
+    _, token = await _user(db_session, superadmin=True)
+    await _zone_with_record(db_session, "example.com.", "api.example.com.", value="10.9.9.9")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "10.9.9.9"})
+    records = [x for x in r.json()["results"] if x["type"] == "dns_record"]
+    assert [x["display"] for x in records] == ["api.example.com."]
+
+
+async def test_vlan_id_match_is_ranked_in_sql(client: AsyncClient, db_session):
+    """A bare number matches ``vlan_id``, which is an integer equality — so
+    it has to contribute to the SQL rank too. Ranked only in Python, the
+    exact row scores 0 and the LIMIT drops it before Python runs."""
+    from app.models.vlans import VLAN, Router
+
+    _, token = await _user(db_session, superadmin=True)
+    router = Router(name=f"rtr-{uuid.uuid4().hex[:6]}", description="")
+    db_session.add(router)
+    await db_session.flush()
+    # Enough decoys containing "42" in their names to exhaust a LIMIT.
+    for i in range(30):
+        db_session.add(
+            VLAN(router_id=router.id, vlan_id=1000 + i, name=f"legacy-42-net-{i}", description="")
+        )
+    db_session.add(VLAN(router_id=router.id, vlan_id=42, name="the-real-one", description=""))
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "42", "limit": 5})
+    vlans = [x for x in r.json()["results"] if x["type"] == "vlan"]
+    assert vlans and vlans[0]["display"] == "VLAN 42"
+    assert vlans[0]["matched_field"] == "vlan_id"
+
+
+async def test_custom_field_exact_hit_survives_the_limit(client: AsyncClient, db_session):
+    """The custom-field pass had ``.limit()`` with no ``ORDER BY`` — the same
+    "database returns any N rows" flaw the rest of the module fixes."""
+    from app.models.ipam import CustomFieldDefinition
+
+    db_session.add(
+        CustomFieldDefinition(
+            resource_type="ip_address",
+            name="owner",
+            label="Owner",
+            field_type="text",
+            is_searchable=True,
+        )
+    )
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, "10.2.0.0/16")
+    for i in range(40):
+        await _address(
+            db_session,
+            subnet,
+            f"10.2.{i // 254}.{i % 254 + 1}",
+            custom_fields={"owner": f"team-ops-and-{i}"},
+        )
+    await _address(db_session, subnet, "10.2.250.250", custom_fields={"owner": "ops"})
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "ops", "limit": 5})
+    hits = [x for x in r.json()["results"] if x["type"] == "ip_address"]
+    assert hits and hits[0]["display"] == "10.2.250.250"
+    assert hits[0]["matched_field"] == "custom_field:owner=ops"
+
+
+def test_custom_field_scoring_uses_the_shared_ladder():
+    """Inlined bucket values would silently desync from ``ranking.py``."""
+    from app.services.search.providers import _custom_field_hit
+
+    assert _custom_field_hit("ops", {"owner": "ops"}, ["owner"]) == (
+        EXACT,
+        "custom_field:owner=ops",
+    )
+    assert _custom_field_hit("ops", {"owner": "ops-team"}, ["owner"])[0] == PREFIX
+    assert _custom_field_hit("ops", {"owner": "the-ops-team"}, ["owner"])[0] == SUBSTRING
+    assert _custom_field_hit("ops", {"owner": "nothing"}, ["owner"]) == (0, None)
+
+
+# ── coverage + shape of the response ──────────────────────────────────────
+
+
+def test_provider_registry_is_internally_consistent():
+    seen = set()
+    for p in PROVIDERS:
+        assert p.type not in seen, f"duplicate provider type {p.type}"
+        seen.add(p.type)
+        assert p.group in {"ipam", "dns", "dhcp", "network", "admin"}, p.type
+        assert p.resource_types, p.type
+        assert p.label
+
+
+def test_every_emitted_type_has_a_ranking_weight():
+    """A type with no weight silently ranks as if it were the least
+    specific thing in the product."""
+    from app.services.search.ranking import TYPE_WEIGHTS
+
+    for p in PROVIDERS:
+        for emitted in p.also_emits or (p.type,):
+            assert emitted in TYPE_WEIGHTS, f"{emitted} has no type weight"
+
+
+async def test_new_types_carry_a_route(client: AsyncClient, db_session):
+    """Types added in v2 are navigated by path rather than by extending the
+    client-side switch, so a missing route makes the row unclickable."""
+    from app.models.dhcp import DHCPScope, DHCPServerGroup
+
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    grp = DHCPServerGroup(name=f"dg-{uuid.uuid4().hex[:6]}", description="")
+    db_session.add(grp)
+    await db_session.flush()
+    db_session.add(
+        DHCPScope(group_id=grp.id, subnet_id=subnet.id, name="office-wifi", description="")
+    )
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "office-wifi"})
+    scopes = [x for x in r.json()["results"] if x["type"] == "dhcp_scope"]
+    assert scopes and scopes[0]["route"].startswith("/dhcp?group=")
+
+
+async def test_results_are_deduplicated_keeping_the_explained_hit(client: AsyncClient, db_session):
+    """One row can match a direct column and a custom field. It should
+    appear once, with the hint that explains why."""
+    from app.models.ipam import CustomFieldDefinition
+
+    db_session.add(
+        CustomFieldDefinition(
+            resource_type="ip_address",
+            name="owner",
+            label="Owner",
+            field_type="text",
+            is_searchable=True,
+        )
+    )
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(
+        db_session, subnet, "10.0.0.30", hostname="marvin", custom_fields={"owner": "marvin"}
+    )
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "marvin"})
+    hits = [x for x in r.json()["results"] if x["type"] == "ip_address"]
+    assert len(hits) == 1
+
+
+async def test_soft_deleted_parent_hides_its_addresses(client: AsyncClient, db_session):
+    """``IPAddress`` has no soft-delete column of its own — it is hidden by
+    its subnet being hidden. The breadcrumb is a separate query now, so
+    this is the assertion that keeps that split honest."""
+    from datetime import UTC, datetime
+
+    _, token = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.31", hostname="trashcan")
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "trashcan"})
+    assert [x["display"] for x in r.json()["results"]] == ["10.0.0.31"]
+
+    subnet.deleted_at = datetime.now(tz=UTC)
+    await db_session.flush()
+
+    r = await client.get("/api/v1/search", headers=_hdr(token), params={"q": "trashcan"})
+    assert r.json()["results"] == []
+
+
+# ── the MCP tool shares the engine ────────────────────────────────────────
+
+
+async def test_mcp_global_search_is_permission_filtered(db_session):
+    """The Copilot tool used to re-implement the fan-out over the router's
+    private helpers, so it inherited neither new types nor any gating."""
+    from app.services.ai.tools.observability import GlobalSearchArgs, global_search
+
+    user, _ = await _user(db_session, permissions=IPAM_READ)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, name="tooltest")
+    await _address(db_session, subnet, "10.0.0.40", hostname="tooltest-host")
+    await _zone_with_record(db_session, "tooltest.example.com.", "www.tooltest.example.com.")
+    await db_session.flush()
+
+    rows = await global_search(db_session, user, GlobalSearchArgs(query="tooltest"))
+    assert rows
+    assert not any(r["type"].startswith("dns") for r in rows)
+
+
+def _with_broken_provider(broken_type: str, fn):
+    """Copy of the registry with one provider's query function replaced."""
+    from app.services.search import providers as provider_module
+
+    return tuple(
+        provider_module.SearchProvider(
+            type=p.type,
+            label=p.label,
+            group=p.group,
+            resource_types=p.resource_types,
+            fn=fn if p.type == broken_type else p.fn,
+            module=p.module,
+            superadmin_only=p.superadmin_only,
+            also_emits=p.also_emits,
+            shapes=p.shapes,
+        )
+        for p in PROVIDERS
+    )
+
+
+async def test_engine_survives_a_broken_provider(db_session, monkeypatch):
+    """One failing type must not blank the whole palette."""
+    user, _ = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space)
+    await _address(db_session, subnet, "10.0.0.50", hostname="resilient")
+    await db_session.flush()
+
+    async def boom(*_args, **_kw):
+        raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(
+        "app.services.search.engine.PROVIDERS", _with_broken_provider("subnet", boom)
+    )
+
+    response = await execute(db_session, user, "resilient")
+    assert [r.display for r in response.results if r.type == "ip_address"] == ["10.0.0.50"]
+
+
+async def test_a_failing_db_query_does_not_poison_the_later_providers(db_session, monkeypatch):
+    """The isolation has to survive a **database** error, not just a Python one.
+
+    Catching the exception is not enough on PostgreSQL: a failed statement
+    leaves the session in "current transaction is aborted", so every later
+    provider dies too and the caller gets ``200 {"results": []}``. The
+    provider that fails here is ``ip_address``, which runs first — so
+    without a SAVEPOINT per provider this blanks everything behind it.
+    """
+    from sqlalchemy import text as sqltext
+
+    user, _ = await _user(db_session, superadmin=True)
+    space = await _space(db_session)
+    subnet = await _subnet(db_session, space, name="survivor")
+    await _address(db_session, subnet, "10.0.0.51", hostname="survivor-host")
+    await db_session.flush()
+
+    async def bad_sql(db, *_args, **_kw):
+        await db.execute(sqltext("SELECT * FROM a_table_that_does_not_exist"))
+        return []
+
+    monkeypatch.setattr(
+        "app.services.search.engine.PROVIDERS", _with_broken_provider("ip_address", bad_sql)
+    )
+
+    response = await execute(db_session, user, "survivor")
+    assert [r.display for r in response.results if r.type == "subnet"] == ["10.0.0.0/24"]
+
+
+# ── index / query drift ───────────────────────────────────────────────────
+
+
+def test_mac_index_expression_matches_the_query():
+    """The trigram index on the normalised MAC is an *expression* index.
+
+    PostgreSQL matches those by comparing the parsed expression, so a
+    divergence between the migration and the live query costs the index
+    silently — the search keeps working, just slowly, and nothing fails.
+    The migration is a frozen historical record and must not import from
+    the service, so the two spellings are compared here instead.
+    """
+    migration = (
+        Path(__file__).resolve().parents[1]
+        / "alembic"
+        / "versions"
+        / "f4b91d38a70c_search_trigram_indexes.py"
+    ).read_text()
+    # Tolerant of how black chooses to wrap the assignment.
+    match = re.search(r'_MAC_NORMALIZE_SQL\s*=\s*\(?\s*"([^"]+)"', migration)
+    assert match, "migration no longer declares _MAC_NORMALIZE_SQL as a single literal"
+    indexed = match.group(1)
+
+    # The migration spells the column bare (it is inside CREATE INDEX ON
+    # ip_address); the query qualifies it with the table name.
+    queried = _mac_normalized_sql("ip_address").replace("ip_address.mac_address", "mac_address")
+    assert indexed == queried

--- a/docs/features/IPAM.md
+++ b/docs/features/IPAM.md
@@ -1,6 +1,6 @@
 # IPAM Feature Specification
 
-> **Implementation status (post-`2026.04.28-2`):** Full hierarchical CRUD (spaces, blocks with nesting, subnets, addresses); next-available allocation that skips dynamic DHCP pool ranges; orphan soft-delete + bulk orphan purge modal; block utilization rollup via recursive CTE; block/subnet overlap validation via PostgreSQL `cidr &&` operator; **grow-only subnet + block resize** with blast-radius preview, cross-subtree overlap scan, typed-CIDR confirmation gate, and pg advisory lock during commit; **subnet planner** at `/ipam/plans` (draggable multi-level CIDR design saved as `SubnetPlan` rows, validated live, applied transactionally); **planning tools** — CIDR calculator at `/tools/cidr`, address planner that packs `{count, prefix_len}` requests into block free space, aggregation suggestion banner for clean-merge opportunities, free-space treemap toggleable from the Allocation map header; block-detail bulk-select reaches parity with the space view (child blocks selectable + bulk-deletable alongside subnets); DNS assignment inheritance (space → block → subnet) with dual-listbox picker for additional zones and shared `ZoneOptions` primary/additional separator across Create / Edit / Bulk-edit flows; DNS sync check (subnet / block / space scope) reconciling missing, mismatched, and stale records, with a `[Sync ▾]` dropdown (DNS / DHCP / All) on the subnet header plus result modals for each; **scheduled IPAM ↔ DNS auto-sync** (opt-in Celery beat task gated on `PlatformSettings.dns_auto_sync_enabled`); reverse-zone auto-create + backfill; IP aliases (CNAME/A tied to the IP, auto-cleaned on purge) with single-step delete confirmation + query-invalidation fix for the subnet Aliases tab; VLAN association (router + VLAN columns); DHCP scope/pool/static linkage with per-IP pool-membership badge, **pool boundary rows in the IP listing**, and **dynamic-pool allocation gates** (422 on manual allocation, skipped by `/next-ip`); static DHCP creation flow integrated into Allocate IP; drag-drop reparenting; **bulk-edit IPs with per-field opt-in toggles** (status, description, tags-merge-or-replace, custom-fields merge, DNS zone); **IP assignment collision warnings** (FQDN + MAC collisions across any subnet; 409 with `force`-flag reconfirm); import/export (CSV/JSON/XLSX) with UTC-timestamped filenames + **subnet-scoped IP address importer**; custom fields per resource type with inherited-value placeholders on Edit Subnet / Edit Block modals; global search (Cmd+K); **mobile-responsive layout** (sidebar drawer, horizontally scrollable tables, modals cap at `95vw`); every modal is draggable (`bg-black/20` backdrop, Esc close). **IPv6:** storage, UI, subnet create, AAAA/PTR sync, `/blocks/{id}/available-subnets` up to `/128`, per-block "Find by size" with family-aware prefix options, next-available allocation (`sequential` / `random` / `eui64` strategies, defaulting to `Subnet.ipv6_allocation_policy`), and Kea Dhcp6 scope rendering with v6 option-name translation all land.
+> **Implementation status (post-`2026.04.28-2`):** Full hierarchical CRUD (spaces, blocks with nesting, subnets, addresses); next-available allocation that skips dynamic DHCP pool ranges; orphan soft-delete + bulk orphan purge modal; block utilization rollup via recursive CTE; block/subnet overlap validation via PostgreSQL `cidr &&` operator; **grow-only subnet + block resize** with blast-radius preview, cross-subtree overlap scan, typed-CIDR confirmation gate, and pg advisory lock during commit; **subnet planner** at `/ipam/plans` (draggable multi-level CIDR design saved as `SubnetPlan` rows, validated live, applied transactionally); **planning tools** — CIDR calculator at `/tools/cidr`, address planner that packs `{count, prefix_len}` requests into block free space, aggregation suggestion banner for clean-merge opportunities, free-space treemap toggleable from the Allocation map header; block-detail bulk-select reaches parity with the space view (child blocks selectable + bulk-deletable alongside subnets); DNS assignment inheritance (space → block → subnet) with dual-listbox picker for additional zones and shared `ZoneOptions` primary/additional separator across Create / Edit / Bulk-edit flows; DNS sync check (subnet / block / space scope) reconciling missing, mismatched, and stale records, with a `[Sync ▾]` dropdown (DNS / DHCP / All) on the subnet header plus result modals for each; **scheduled IPAM ↔ DNS auto-sync** (opt-in Celery beat task gated on `PlatformSettings.dns_auto_sync_enabled`); reverse-zone auto-create + backfill; IP aliases (CNAME/A tied to the IP, auto-cleaned on purge) with single-step delete confirmation + query-invalidation fix for the subnet Aliases tab; VLAN association (router + VLAN columns); DHCP scope/pool/static linkage with per-IP pool-membership badge, **pool boundary rows in the IP listing**, and **dynamic-pool allocation gates** (422 on manual allocation, skipped by `/next-ip`); static DHCP creation flow integrated into Allocate IP; drag-drop reparenting; **bulk-edit IPs with per-field opt-in toggles** (status, description, tags-merge-or-replace, custom-fields merge, DNS zone); **IP assignment collision warnings** (FQDN + MAC collisions across any subnet; 409 with `force`-flag reconfirm); import/export (CSV/JSON/XLSX) with UTC-timestamped filenames + **subnet-scoped IP address importer**; custom fields per resource type with inherited-value placeholders on Edit Subnet / Edit Block modals; **global search v2** (Cmd/Ctrl+K palette over twenty permission-filtered resource types, relevance-ranked in SQL, trigram-indexed, with scope chips, recent searches and go-to-page commands — see §10); **mobile-responsive layout** (sidebar drawer, horizontally scrollable tables, modals cap at `95vw`); every modal is draggable (`bg-black/20` backdrop, Esc close). **IPv6:** storage, UI, subnet create, AAAA/PTR sync, `/blocks/{id}/available-subnets` up to `/128`, per-block "Find by size" with family-aware prefix options, next-available allocation (`sequential` / `random` / `eui64` strategies, defaulting to `Subnet.ipv6_allocation_policy`), and Kea Dhcp6 scope rendering with v6 option-name translation all land.
 
 ## Overview
 
@@ -1049,18 +1049,60 @@ enabled-gate + interval. Each sweep writes one summary audit row.
 
 ---
 
-## 10. IP Search
+## 10. Global search
 
-Global search across all IP resources:
+`GET /api/v1/search`, and the Cmd/Ctrl+K palette over it, reach well past
+IPAM — twenty resource types across IPAM, DNS, DHCP, Network and
+Administration. `GET /api/v1/search/types` returns the subset the calling
+user may search, which is what the palette's scope chips are built from.
 
-- Search by IP address (exact or CIDR contains)
-- Search by hostname (prefix, suffix, regex)
-- Search by MAC address
-- Search by custom field value (for indexed fields)
-- Search by tag key/value
-- Filters: status, subnet, space, block, assigned user/group
+**Query shapes.** The query string is classified once, and only the
+providers that could match that shape run:
 
-Search is implemented via PostgreSQL full-text search + `inet` operators, not a separate search engine.
+| Shape | Example | Reaches |
+|---|---|---|
+| IP | `10.0.0.42` | exact address, containing subnet/block, DNS records whose *value* is that address, reservations, devices, server hosts |
+| CIDR | `10.0.0.0/24` | subnets and blocks within the range |
+| MAC | `aa:bb:cc:dd:ee:ff` | addresses and DHCP reservations |
+| Text | `web-01` | names, hostnames, FQDNs, record values, descriptions, searchable custom fields |
+
+MAC matching is separator-insensitive in both directions: the stored value
+and the query are both reduced to bare hex, so a dashed query finds a
+colon-form row, and a partial MAC (an OUI prefix) works too.
+
+**Ranking.** Hits are scored exact (100) > prefix (60) > substring (25),
+plus a small per-type weight used only to break ties within a bucket. The
+score is computed **in SQL, before each type's `LIMIT`** — otherwise the
+database is free to return any N matching rows and the exact hit is
+routinely not among them, which no amount of re-sorting afterwards can
+fix. The returned `score` and `matched_field` make the ordering
+inspectable rather than something to infer.
+
+**Permissions.** Every type is filtered against the caller's own `read`
+permission and the install's enabled feature modules, server-side
+(non-negotiable #3). A type the caller cannot read is dropped from the
+request rather than rejected, so a stale scope chip returns nothing for
+that scope instead of failing the whole search. `user` is superadmin-only,
+matching `/api/v1/users`.
+
+**Indexing.** `pg_trgm` GIN indexes back the leading-wildcard `ILIKE`
+matches on the tables that grow large — `ip_address`, `dns_record`,
+`dns_zone`, `subnet`, `dhcp_static_assignment` (migration
+`f4b91d38a70c`). Small tables are deliberately left unindexed: a
+sequential scan of a few hundred rows is already the fastest plan and a
+GIN index there is pure write amplification. Queries shorter than three
+characters produce no full trigram and still scan; the palette is
+debounced and those match nearly everything anyway. If `CREATE EXTENSION
+pg_trgm` is refused on a locked-down managed instance, the migration logs
+and skips the indexes — search degrades to sequential scans rather than
+failing the upgrade.
+
+One known cost remains: matching *custom-field* values uses
+`custom_fields ->> 'name' ILIKE …`, which no trigram index can serve
+because the field name is chosen at runtime. On a table with hundreds of
+thousands of addresses that is a sequential scan of a few tens of
+milliseconds. Indexing it would mean creating an expression index when an
+operator flags a field searchable — worth doing, not yet done.
 
 ---
 

--- a/frontend/src/components/GlobalSearch.tsx
+++ b/frontend/src/components/GlobalSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Search,
@@ -10,9 +10,25 @@ import {
   X,
   Server,
   FileText,
+  Boxes,
+  Cable,
+  CornerDownLeft,
+  Clock,
+  HardDrive,
+  Router as RouterIcon,
+  ShieldAlert,
+  Users,
+  UsersRound,
+  Waypoints,
+  Eye,
 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { searchApi, type SearchResult } from "@/lib/api";
+import {
+  searchApi,
+  type SearchResult,
+  type SearchResultType,
+  type SearchTypeInfo,
+} from "@/lib/api";
 import { cn } from "@/lib/utils";
 import {
   formatCombo,
@@ -21,6 +37,13 @@ import {
 } from "@/lib/shortcuts";
 import { askAI } from "@/components/copilot/askAI";
 import { useAiAvailable } from "@/components/copilot/useAiAvailable";
+import { useFeatureModules } from "@/hooks/useFeatureModules";
+import { useSessionState } from "@/lib/useSessionState";
+import {
+  ALL_NAV_DESTINATIONS,
+  navEntryVisible,
+  type NavDestination,
+} from "@/lib/navigation";
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -31,7 +54,7 @@ function useDebounce<T>(value: T, delay: number): T {
   return debounced;
 }
 
-const TYPE_LABELS: Record<SearchResult["type"], string> = {
+const TYPE_LABELS: Record<SearchResultType, string> = {
   ip_address: "IP Address",
   subnet: "Subnet",
   block: "Block",
@@ -39,9 +62,22 @@ const TYPE_LABELS: Record<SearchResult["type"], string> = {
   dns_group: "DNS Group",
   dns_zone: "DNS Zone",
   dns_record: "DNS Record",
+  dns_server: "DNS Server",
+  dns_view: "DNS View",
+  dns_blocklist: "Blocklist",
+  dhcp_scope: "DHCP Scope",
+  dhcp_reservation: "Reservation",
+  dhcp_server: "DHCP Server",
+  vlan: "VLAN",
+  device: "Device",
+  site: "Site",
+  circuit: "Circuit",
+  user: "User",
+  group: "Group",
+  appliance: "Appliance",
 };
 
-const TYPE_ICONS: Record<SearchResult["type"], React.ElementType> = {
+const TYPE_ICONS: Record<SearchResultType, React.ElementType> = {
   ip_address: MapPin,
   subnet: Network,
   block: Layers,
@@ -49,9 +85,22 @@ const TYPE_ICONS: Record<SearchResult["type"], React.ElementType> = {
   dns_group: Server,
   dns_zone: Globe,
   dns_record: FileText,
+  dns_server: Server,
+  dns_view: Eye,
+  dns_blocklist: ShieldAlert,
+  dhcp_scope: Boxes,
+  dhcp_reservation: MapPin,
+  dhcp_server: Server,
+  vlan: RouterIcon,
+  device: Cable,
+  site: MapPin,
+  circuit: Waypoints,
+  user: Users,
+  group: UsersRound,
+  appliance: HardDrive,
 };
 
-const TYPE_COLORS: Record<SearchResult["type"], string> = {
+const TYPE_COLORS: Record<SearchResultType, string> = {
   ip_address: "text-emerald-500",
   subnet: "text-blue-500",
   block: "text-violet-500",
@@ -59,7 +108,58 @@ const TYPE_COLORS: Record<SearchResult["type"], string> = {
   dns_group: "text-sky-500",
   dns_zone: "text-cyan-500",
   dns_record: "text-teal-500",
+  dns_server: "text-sky-500",
+  dns_view: "text-cyan-500",
+  dns_blocklist: "text-rose-500",
+  dhcp_scope: "text-indigo-500",
+  dhcp_reservation: "text-indigo-400",
+  dhcp_server: "text-indigo-500",
+  vlan: "text-amber-500",
+  device: "text-lime-500",
+  site: "text-pink-500",
+  circuit: "text-fuchsia-500",
+  user: "text-slate-500",
+  group: "text-slate-500",
+  appliance: "text-stone-500",
 };
+
+/** Scope chips, in display order. Only groups the server actually returned
+ *  a type for are rendered, so an operator without DHCP permission never
+ *  sees a DHCP filter that can only come back empty. */
+const SCOPE_ORDER: { id: string; label: string }[] = [
+  { id: "ipam", label: "IPAM" },
+  { id: "dns", label: "DNS" },
+  { id: "dhcp", label: "DHCP" },
+  { id: "network", label: "Network" },
+  { id: "admin", label: "Admin" },
+];
+
+const RECENTS_KEY = "global-search-recents";
+const MAX_RECENTS = 6;
+const MAX_COMMANDS = 5;
+
+/** Rank a navigation destination against the typed query.
+ *
+ *  Deliberately the same exact > prefix > substring ladder the backend
+ *  ranks records with (`app/services/search/ranking.py`), so the two halves
+ *  of one result list don't order themselves by different rules. */
+function commandScore(query: string, dest: NavDestination): number {
+  const q = query.toLowerCase();
+  const label = dest.label.toLowerCase();
+  if (label === q) return 100;
+  if (label.startsWith(q)) return 60;
+  if (label.includes(q)) return 25;
+  // Section match ranks last: typing "network" should surface the pages in
+  // that section, but below anything whose own name matched.
+  if (dest.section.toLowerCase().includes(q)) return 10;
+  return 0;
+}
+
+type Row =
+  | { kind: "recent"; key: string; query: string }
+  | { kind: "result"; key: string; result: SearchResult }
+  | { kind: "command"; key: string; dest: NavDestination }
+  | { kind: "ai"; key: string };
 
 function ResultRow({
   result,
@@ -70,7 +170,7 @@ function ResultRow({
   isActive: boolean;
   onSelect: (r: SearchResult) => void;
 }) {
-  const Icon = TYPE_ICONS[result.type];
+  const Icon = TYPE_ICONS[result.type] ?? FileText;
   return (
     <button
       className={cn(
@@ -83,7 +183,10 @@ function ResultRow({
       }}
     >
       <Icon
-        className={cn("mt-0.5 h-4 w-4 flex-shrink-0", TYPE_COLORS[result.type])}
+        className={cn(
+          "mt-0.5 h-4 w-4 flex-shrink-0",
+          TYPE_COLORS[result.type] ?? "text-muted-foreground",
+        )}
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
@@ -96,15 +199,14 @@ function ResultRow({
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span className="rounded bg-muted px-1 py-0.5 text-[10px] font-medium">
-            {TYPE_LABELS[result.type]}
+            {TYPE_LABELS[result.type] ?? result.type}
           </span>
           {/* IPAM context */}
           {result.space_name &&
-            result.type !== "dns_group" &&
-            result.type !== "dns_zone" &&
-            result.type !== "dns_record" && <span>{result.space_name}</span>}
+            !result.type.startsWith("dns_") &&
+            result.type !== "dhcp_scope" && <span>{result.space_name}</span>}
           {result.subnet_network && result.type === "ip_address" && (
             <span>{result.subnet_network}</span>
           )}
@@ -116,6 +218,8 @@ function ResultRow({
           {result.mac_address && (
             <span className="font-mono">{result.mac_address}</span>
           )}
+          {/* Generic breadcrumb for the types added in #879 */}
+          {result.context && <span className="truncate">{result.context}</span>}
           {result.status &&
             result.type !== "dns_zone" &&
             result.type !== "dns_record" && (
@@ -149,13 +253,11 @@ function ResultRow({
               {result.dns_record_value}
             </span>
           )}
-          {/* DNS zone type badge */}
           {result.type === "dns_zone" && result.status && (
             <span className="rounded bg-cyan-500/10 px-1 py-0.5 text-[10px] font-medium text-cyan-600">
               {result.status}
             </span>
           )}
-          {/* Match hint (e.g. custom_field:owner=alice) */}
           {result.matched_field && (
             <span
               className="truncate rounded bg-amber-500/10 px-1 py-0.5 text-[10px] font-medium text-amber-600"
@@ -173,29 +275,98 @@ function ResultRow({
 export function GlobalSearch() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<string>("all");
   const [activeIdx, setActiveIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
+  const { enabled: moduleEnabled } = useFeatureModules();
+
+  const [recents, setRecents] = useSessionState<string[]>(RECENTS_KEY, []);
 
   const debouncedQuery = useDebounce(query.trim(), 250);
 
+  // Which types this caller may search — drives the scope chips. Fetched
+  // once when the palette first opens rather than on mount, so the request
+  // never fires for an operator who doesn't use search.
+  const { data: availableTypes } = useQuery({
+    queryKey: ["search", "types"],
+    queryFn: searchApi.types,
+    enabled: open,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const scopes = useMemo(() => {
+    const present = new Set((availableTypes ?? []).map((t) => t.group));
+    return SCOPE_ORDER.filter((s) => present.has(s.id));
+  }, [availableTypes]);
+
+  const typesParam = useMemo(() => {
+    if (scope === "all" || !availableTypes) return undefined;
+    const inScope = availableTypes
+      .filter((t: SearchTypeInfo) => t.group === scope)
+      .map((t) => t.type);
+    return inScope.length ? inScope.join(",") : undefined;
+  }, [scope, availableTypes]);
+
   const { data, isFetching } = useQuery({
-    queryKey: ["search", debouncedQuery],
-    queryFn: () => searchApi.search(debouncedQuery, undefined, 20),
+    queryKey: ["search", debouncedQuery, typesParam],
+    queryFn: () => searchApi.search(debouncedQuery, typesParam, 20),
     enabled: debouncedQuery.length >= 1,
     staleTime: 10_000,
   });
 
-  const results = data?.results ?? [];
+  const results = useMemo(() => data?.results ?? [], [data]);
 
-  // Reset active index when results change
+  // Command-palette entries: the sidebar's own destinations, filtered by
+  // the enabled feature modules exactly as the sidebar filters them. Only
+  // shown in the "all" scope — a DHCP-scoped search asking for DHCP rows
+  // shouldn't answer with a link to the Alerts page.
+  const commands = useMemo(() => {
+    if (!debouncedQuery || scope !== "all") return [];
+    return ALL_NAV_DESTINATIONS.filter((d) => navEntryVisible(d, moduleEnabled))
+      .map((d) => ({ dest: d, score: commandScore(debouncedQuery, d) }))
+      .filter((c) => c.score > 0)
+      .sort(
+        (a, b) => b.score - a.score || a.dest.label.localeCompare(b.dest.label),
+      )
+      .slice(0, MAX_COMMANDS)
+      .map((c) => c.dest);
+  }, [debouncedQuery, scope, moduleEnabled]);
+
+  const aiAvailable = useAiAvailable();
+  const askAIVisible = aiAvailable && debouncedQuery.length > 0;
+
+  // One flat row list. Keyboard navigation used to do index arithmetic
+  // across two separate lists ("the AI row sits at index results.length"),
+  // which only stayed correct while there were exactly two kinds of row.
+  const rows: Row[] = useMemo(() => {
+    const out: Row[] = [];
+    if (!query) {
+      for (const r of recents)
+        out.push({ kind: "recent", key: `r:${r}`, query: r });
+      return out;
+    }
+    for (const r of results)
+      out.push({ kind: "result", key: `${r.type}:${r.id}`, result: r });
+    for (const d of commands)
+      out.push({ kind: "command", key: `c:${d.to}`, dest: d });
+    if (askAIVisible) out.push({ kind: "ai", key: "ai" });
+    return out;
+  }, [query, recents, results, commands, askAIVisible]);
+
   useEffect(() => {
     setActiveIdx(0);
-  }, [debouncedQuery]);
+  }, [debouncedQuery, scope]);
 
-  // Cmd+K / Ctrl+K to open. The combo comes from ``lib/shortcuts.ts``
-  // (issue #81) so the help overlay and this listener can't disagree —
-  // retuning the binding there retunes both.
+  // Keep the highlighted row in view when arrowing past the fold.
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>(
+      '[data-active="true"]',
+    );
+    el?.scrollIntoView({ block: "nearest" });
+  }, [activeIdx]);
+
   useEffect(() => {
     function handler(e: KeyboardEvent) {
       if (matchesShortcut(e, OPEN_GLOBAL_SEARCH)) {
@@ -213,12 +384,29 @@ export function GlobalSearch() {
       setTimeout(() => inputRef.current?.focus(), 50);
     } else {
       setQuery("");
+      setScope("all");
     }
   }, [open]);
+
+  const remember = useCallback(
+    (q: string) => {
+      const trimmed = q.trim();
+      if (trimmed.length < 2) return;
+      setRecents((prev) =>
+        [trimmed, ...prev.filter((p) => p !== trimmed)].slice(0, MAX_RECENTS),
+      );
+    },
+    [setRecents],
+  );
 
   const handleSelect = useCallback(
     (result: SearchResult) => {
       setOpen(false);
+      remember(query);
+      // The original seven types pass react-router *state* (which subnet to
+      // expand, which row to highlight), which a path can't express. Newer
+      // types carry their own `route` from the server instead of extending
+      // this switch once per type.
       if (result.type === "ip_address") {
         navigate("/ipam", {
           state: {
@@ -249,43 +437,50 @@ export function GlobalSearch() {
             highlightRecord: result.id,
           },
         });
+      } else if (result.route) {
+        navigate(result.route);
       }
     },
-    [navigate],
+    [navigate, query, remember],
   );
-
-  // The "Ask AI" row sits at index ``results.length`` after every
-  // structured search hit. Showing it whenever the operator has typed
-  // something gives them a deterministic escape hatch — even if the
-  // search service didn't match anything, they can hit ↓-Enter to
-  // hand the query straight to the Copilot.
-  const aiAvailable = useAiAvailable();
-  const askAIVisible = aiAvailable && debouncedQuery.length > 0;
-  const askAIIdx = results.length;
-  const totalRows = results.length + (askAIVisible ? 1 : 0);
 
   const handleAskAI = useCallback(() => {
     setOpen(false);
+    remember(query);
     askAI({ prompt: query.trim() });
-  }, [query]);
+  }, [query, remember]);
+
+  const activate = useCallback(
+    (row: Row) => {
+      if (row.kind === "result") handleSelect(row.result);
+      else if (row.kind === "command") {
+        setOpen(false);
+        remember(query);
+        navigate(row.dest.to);
+      } else if (row.kind === "recent") {
+        setQuery(row.query);
+        inputRef.current?.focus();
+      } else handleAskAI();
+    },
+    [handleSelect, handleAskAI, navigate, query, remember],
+  );
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (e.key === "ArrowDown") {
       e.preventDefault();
-      setActiveIdx((i) => Math.min(i + 1, totalRows - 1));
+      setActiveIdx((i) => Math.min(i + 1, rows.length - 1));
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setActiveIdx((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
-      if (askAIVisible && activeIdx === askAIIdx) {
-        handleAskAI();
-      } else if (results[activeIdx]) {
-        handleSelect(results[activeIdx]);
-      }
+      const row = rows[activeIdx];
+      if (row) activate(row);
     } else if (e.key === "Escape") {
       setOpen(false);
     }
   }
+
+  const firstCommandIdx = rows.findIndex((r) => r.kind === "command");
 
   return (
     <>
@@ -295,7 +490,7 @@ export function GlobalSearch() {
         className="flex items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground w-80"
       >
         <Search className="h-3.5 w-3.5 flex-shrink-0" />
-        <span className="flex-1 text-left">Search IP, zone, record…</span>
+        <span className="flex-1 text-left">Search or jump to…</span>
         {/* Rendered from the shortcut definition, not hardcoded — this
             used to read "⌘K" on every platform, so Linux / Windows
             operators were shown a key their keyboard doesn't have. */}
@@ -310,10 +505,8 @@ export function GlobalSearch() {
           className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
           onClick={() => setOpen(false)}
         >
-          {/* Backdrop */}
           <div className="absolute inset-0 bg-black/50" />
 
-          {/* Dialog */}
           <div
             className="relative z-10 w-full max-w-xl rounded-xl border bg-card shadow-2xl"
             onClick={(e) => e.stopPropagation()}
@@ -326,7 +519,7 @@ export function GlobalSearch() {
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={handleKeyDown}
-                placeholder="Search IP, hostname, MAC, subnet, zone, record…"
+                placeholder="Search IP, hostname, MAC, subnet, zone, record, page…"
                 className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
               />
               {query && (
@@ -342,13 +535,39 @@ export function GlobalSearch() {
               </kbd>
             </div>
 
+            {/* Scope chips */}
+            {scopes.length > 1 && (
+              <div className="flex flex-wrap items-center gap-1 border-b px-3 py-2">
+                {[{ id: "all", label: "All" }, ...scopes].map((s) => (
+                  <button
+                    key={s.id}
+                    type="button"
+                    onClick={() => setScope(s.id)}
+                    className={cn(
+                      "rounded-full px-2.5 py-0.5 text-[11px] font-medium transition-colors",
+                      scope === s.id
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted/60 text-muted-foreground hover:bg-muted",
+                    )}
+                  >
+                    {s.label}
+                  </button>
+                ))}
+              </div>
+            )}
+
             {/* Results */}
-            <div className="max-h-96 overflow-y-auto">
-              {!query && (
+            <div ref={listRef} className="max-h-96 overflow-y-auto">
+              {!query && recents.length === 0 && (
                 <p className="px-4 py-6 text-center text-sm text-muted-foreground">
-                  Type to search across IP addresses, subnets, DNS zones,
-                  records, and more.
+                  Search IP addresses, subnets, zones, records, scopes, VLANs
+                  and more — or type a page name to jump straight to it.
                 </p>
+              )}
+              {!query && recents.length > 0 && (
+                <div className="px-4 pt-3 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                  Recent searches
+                </div>
               )}
               {query && isFetching && results.length === 0 && (
                 <p className="px-4 py-6 text-center text-sm text-muted-foreground">
@@ -357,52 +576,118 @@ export function GlobalSearch() {
               )}
               {query &&
                 !isFetching &&
-                results.length === 0 &&
+                rows.length === 0 &&
                 debouncedQuery.length > 0 && (
                   <p className="px-4 py-6 text-center text-sm text-muted-foreground">
                     No results for{" "}
                     <span className="font-mono font-medium">
                       "{debouncedQuery}"
                     </span>
+                    {scope !== "all" && " in this scope"}
                   </p>
                 )}
-              {results.map((r, i) => (
-                <ResultRow
-                  key={`${r.type}:${r.id}`}
-                  result={r}
-                  isActive={i === activeIdx}
-                  onSelect={handleSelect}
-                />
-              ))}
-              {askAIVisible && (
-                <button
-                  type="button"
-                  onClick={handleAskAI}
-                  className={cn(
-                    "flex w-full items-center gap-3 border-t px-4 py-2.5 text-left text-sm transition-colors",
-                    activeIdx === askAIIdx
-                      ? "bg-primary/5"
-                      : "hover:bg-accent/50",
-                  )}
-                >
-                  <Sparkles className="h-4 w-4 flex-shrink-0 text-primary" />
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate">
-                      Ask AI:{" "}
-                      <span className="font-medium">"{debouncedQuery}"</span>
+
+              {rows.map((row, i) => {
+                const isActive = i === activeIdx;
+                if (row.kind === "result") {
+                  return (
+                    <div key={row.key} data-active={isActive}>
+                      <ResultRow
+                        result={row.result}
+                        isActive={isActive}
+                        onSelect={handleSelect}
+                      />
                     </div>
-                    <div className="text-[11px] text-muted-foreground">
-                      Open Copilot with this query pre-filled
+                  );
+                }
+                if (row.kind === "recent") {
+                  return (
+                    <button
+                      key={row.key}
+                      type="button"
+                      data-active={isActive}
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        activate(row);
+                      }}
+                      className={cn(
+                        "flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors",
+                        isActive ? "bg-accent" : "hover:bg-accent/50",
+                      )}
+                    >
+                      <Clock className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+                      <span className="truncate font-mono">{row.query}</span>
+                    </button>
+                  );
+                }
+                if (row.kind === "command") {
+                  const Icon = row.dest.icon;
+                  return (
+                    <div key={row.key}>
+                      {i === firstCommandIdx && (
+                        <div className="border-t px-4 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                          Go to
+                        </div>
+                      )}
+                      <button
+                        type="button"
+                        data-active={isActive}
+                        onMouseDown={(e) => {
+                          e.preventDefault();
+                          activate(row);
+                        }}
+                        className={cn(
+                          "flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors",
+                          isActive ? "bg-accent" : "hover:bg-accent/50",
+                        )}
+                      >
+                        <Icon className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                        <span className="flex-1 truncate">
+                          {row.dest.label}
+                        </span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {row.dest.section}
+                        </span>
+                        <CornerDownLeft className="h-3 w-3 flex-shrink-0 text-muted-foreground/60" />
+                      </button>
                     </div>
-                  </div>
-                </button>
-              )}
+                  );
+                }
+                return (
+                  <button
+                    key={row.key}
+                    type="button"
+                    data-active={isActive}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      activate(row);
+                    }}
+                    className={cn(
+                      "flex w-full items-center gap-3 border-t px-4 py-2.5 text-left text-sm transition-colors",
+                      isActive ? "bg-primary/5" : "hover:bg-accent/50",
+                    )}
+                  >
+                    <Sparkles className="h-4 w-4 flex-shrink-0 text-primary" />
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate">
+                        Ask AI:{" "}
+                        <span className="font-medium">"{debouncedQuery}"</span>
+                      </div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Open Copilot with this query pre-filled
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
             </div>
 
             {results.length > 0 && (
               <div className="flex items-center justify-between border-t px-4 py-2 text-xs text-muted-foreground">
                 <span>
                   {data?.total ?? 0} result{(data?.total ?? 0) !== 1 ? "s" : ""}
+                  {(data?.total ?? 0) > results.length &&
+                    ` · showing top ${results.length}`}
                 </span>
                 <span className="flex items-center gap-2">
                   <span>↑↓ navigate</span>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,74 +2,14 @@ import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
-  Activity,
-  AudioLines,
-  Building2,
-  Scan,
-  Factory,
-  Power,
-  Network,
-  Globe,
-  Inbox,
-  LayoutDashboard,
-  Server,
-  Router as RouterIcon,
-  Route as RouteIcon,
-  Briefcase,
-  Cable,
-  Code2,
   Github,
-  Hash,
-  MapPin,
-  Package,
-  Spline,
-  Truck,
-  Users,
-  UsersRound,
-  KeyRound,
-  KeySquare,
-  ClipboardList,
   ChevronsLeft,
   ChevronsRight,
   ChevronDown,
   ChevronRight,
   Settings,
-  Tags,
-  ShieldCheck,
-  ShieldAlert,
-  ShieldBan,
-  ShieldQuestion,
-  ScrollText,
-  BellRing,
-  Bird,
   Sparkles,
-  Boxes,
-  Cloud,
-  Container as ContainerIcon,
-  Cpu,
-  Earth,
-  Flame,
-  Rss,
-  HardDrive,
-  LayoutTemplate,
-  Wifi,
-  Waypoints,
-  Radio,
-  Binoculars,
-  Shuffle,
-  Trash2,
-  History,
-  Search,
-  Calculator,
-  BarChart3,
-  Webhook,
-  Workflow,
-  GitPullRequest,
-  Monitor,
   ToggleLeft,
-  Upload,
-  AlertTriangle,
-  Database,
   Wrench,
   X,
 } from "lucide-react";
@@ -82,356 +22,28 @@ import {
   usePublicSettings,
   DEFAULT_APP_TITLE,
 } from "@/hooks/usePublicSettings";
+import {
+  adminConfigurationNav,
+  adminIdentityNav,
+  adminInsightsNav,
+  adminNotificationsNav,
+  adminReferenceNav,
+  baseMainNav,
+  coreDnsNav,
+  coreIpamNav,
+  filterNav,
+  integrationsNav,
+  networkInfrastructureNav,
+  networkLogicalNav,
+  operationsNav,
+  reportsNav,
+  toolsNav,
+} from "@/lib/navigation";
 
-// Core section. The flat list had grown to 11 rows — the four canonical
-// anchors (Dashboard / IPAM / DHCP / DNS) plus seven grown-in sub-features
-// that mixed daily-driver surfaces with mis-filed child resources (e.g.
-// "Domains" routing under /admin). Reorganised (sidebar IA pass): the four
-// anchors stay first + prominent, then the grown-in items group under
-// lightweight ``SubNavLabel`` sub-headings by family — IPAM-family under
-// "IPAM", DNS-family under "DNS" — reusing the same primitive Network +
-// Administration already use. Routes + module-gating are unchanged; only
-// sidebar adjacency moves. (Logs left Core entirely → its own "Operations"
-// section below, since it's cross-cutting telemetry, not an IPAM/DNS child.)
-const baseMainNav = [
-  { label: "Dashboard", icon: LayoutDashboard, to: "/dashboard" },
-  { label: "IPAM", icon: Network, to: "/ipam", end: true },
-  { label: "DHCP", icon: Server, to: "/dhcp" },
-  { label: "DNS", icon: Globe, to: "/dns", end: true },
-  // #696 — top-level rather than under Administration on purpose: the
-  // audience is ordinary users asking for a resource, and most of them will
-  // never see the admin section at all.
-  {
-    label: "Requests",
-    icon: Inbox,
-    to: "/requests",
-    module: "governance.requests",
-  },
-];
-// IPAM-family children (all route under /ipam/*). Alphabetised, matching the
-// Network/Administration sub-group convention.
-const coreIpamNav = [
-  { label: "NAT Mappings", icon: Shuffle, to: "/ipam/nat" },
-  { label: "Stale IPs", icon: History, to: "/ipam/stale" },
-  { label: "Subnet Planner", icon: Workflow, to: "/ipam/plans" },
-];
-// DNS-family children. "Domains" keeps its /admin/domains route — it's the
-// registrar/expiry/RDAP registry side of a name (linked to dns_zone.domain_id),
-// so it belongs beside DNS in the sidebar even though the route lives under
-// /admin.
-const coreDnsNav = [
-  { label: "DNS Pools", icon: Workflow, to: "/dns/pools" },
-  { label: "DNSSEC Policies", icon: KeyRound, to: "/dns/dnssec-policies" },
-  { label: "Domains", icon: Earth, to: "/admin/domains" },
-];
-// Operations — cross-cutting live telemetry. Logs aggregates DNS query logs,
-// DHCP activity, Windows event log + DHCP audit, so it's not an IPAM/DNS child;
-// it gets its own small top-level section (future home for the pending
-// operational-triage surfaces: PCAP trigger #59, config-drift #61, time-travel
-// #56).
-const operationsNav = [{ label: "Logs", icon: ScrollText, to: "/logs" }];
-
-// Network section — grouped under a collapsible header. As the
-// section grew (4 → 8 items, with #94/#95 still to come), a flat
-// list got hard to scan, so we sub-group it the same way
-// Administration does — ``SubNavLabel`` rows split the contents
-// into two themed bunches:
-//
-// * **Logical** — operator-facing ownership / deliverable rows
-//   (Customers / Providers / Services / Sites from #91 + #94).
-//   These cross-cut every other resource type; not network entities
-//   themselves.
-// * **Infrastructure** — the actual network entities (ASNs,
-//   Circuits, Devices, VLANs, VRFs).
-//
-// Each list is alphabetised so new entries slot in without
-// reshuffling.
-// Each network nav item carries the feature-module id that gates it
-// (see ``app.services.feature_modules.MODULES`` on the backend). The
-// renderer below filters by ``useFeatureModules.enabled(id)`` so a
-// disabled module disappears from the sidebar entirely.
-const networkLogicalNav = [
-  {
-    label: "Customers",
-    icon: Briefcase,
-    to: "/network/customers",
-    module: "network.customer",
-  },
-  {
-    label: "Providers",
-    icon: Truck,
-    to: "/network/providers",
-    module: "network.provider",
-  },
-  {
-    label: "Services",
-    icon: Package,
-    to: "/network/services",
-    module: "network.service",
-  },
-  {
-    label: "Sites",
-    icon: MapPin,
-    to: "/network/sites",
-    module: "network.site",
-  },
-];
-const networkInfrastructureNav = [
-  {
-    label: "ASNs",
-    icon: Hash,
-    to: "/network/asns",
-    module: "network.asn",
-  },
-  {
-    label: "AV over IP",
-    icon: AudioLines,
-    to: "/network/av",
-    module: "network.av",
-  },
-  {
-    label: "BACnet Devices",
-    icon: Building2,
-    to: "/network/bacnet",
-    module: "network.bacnet",
-  },
-  {
-    label: "Certificates",
-    icon: ShieldCheck,
-    to: "/network/certificates",
-    module: "security.tls_certs",
-  },
-  {
-    label: "Circuits",
-    icon: Waypoints,
-    to: "/network/circuits",
-    module: "network.circuit",
-  },
-  {
-    label: "DICOM AEs",
-    icon: Scan,
-    to: "/network/dicom",
-    module: "network.dicom",
-  },
-  {
-    label: "Devices",
-    icon: Cable,
-    to: "/network/devices",
-    module: "network.device",
-  },
-  {
-    label: "Looking Glass",
-    icon: Binoculars,
-    to: "/network/looking-glass",
-    module: "network.looking_glass",
-  },
-  {
-    label: "Multicast",
-    icon: Radio,
-    to: "/network/multicast",
-    module: "network.multicast",
-  },
-  {
-    label: "OT Devices",
-    icon: Factory,
-    to: "/network/ot",
-    module: "network.ot",
-  },
-  {
-    label: "Overlays",
-    icon: Spline,
-    to: "/network/overlays",
-    module: "network.overlay",
-  },
-  {
-    label: "VLANs",
-    icon: RouterIcon,
-    to: "/network/vlans",
-    module: "network.vlan",
-  },
-  {
-    label: "VRFs",
-    icon: RouteIcon,
-    to: "/network/vrfs",
-    module: "network.vrf",
-  },
-];
-
-// Keep this list alphabetised by label.
-const toolsNav = [
-  {
-    label: "Block Sync",
-    icon: ShieldBan,
-    to: "/security/block-sync",
-    module: "security.block_sync",
-  },
-  { label: "CIDR Calculator", icon: Calculator, to: "/tools/cidr" },
-  {
-    label: "Firewall Feeds",
-    icon: Rss,
-    to: "/security/firewall-feeds",
-    module: "security.firewall_feeds",
-  },
-  {
-    label: "Network Tools",
-    icon: Wrench,
-    to: "/tools/network",
-    module: "tools.network",
-  },
-  {
-    label: "New Devices",
-    icon: ShieldQuestion,
-    to: "/security/new-devices",
-    module: "security.new_device_watch",
-  },
-  { label: "Nmap", icon: Search, to: "/tools/nmap", module: "tools.nmap" },
-  {
-    label: "Packet Capture",
-    icon: Activity,
-    to: "/tools/pcap",
-    module: "tools.pcap",
-  },
-  {
-    label: "Wake Schedules",
-    icon: Power,
-    to: "/tools/wake-schedules",
-    module: "tools.wake_scheduler",
-  },
-];
-
-// Reports section (issue #47) — fixed Top-N rollups derived from
-// existing tables. Module-gated so operators who don't want the surface
-// can hide it via Settings → Features.
-const reportsNav = [
-  {
-    label: "Top-N Reports",
-    icon: BarChart3,
-    to: "/reports",
-    module: "reports.top_n",
-  },
-];
-
-const adminIdentityNav = [
-  { label: "API Tokens", icon: KeySquare, to: "/admin/api-tokens" },
-  { label: "Auth Providers", icon: ShieldCheck, to: "/admin/auth-providers" },
-  { label: "Groups", icon: UsersRound, to: "/admin/groups" },
-  { label: "Roles", icon: KeyRound, to: "/admin/roles" },
-  { label: "Sessions", icon: Monitor, to: "/admin/sessions" },
-  { label: "Users", icon: Users, to: "/admin/users" },
-];
-
-// Administration → Platform was getting unwieldy at 9-10 items; split it
-// into three sub-groups rendered with small non-collapsible labels.
-// "Settings" deliberately lives in the sidebar footer (above the
-// GitHub link), not in this list — it was getting buried in
-// Administration → Configuration as the platform grew, and it's
-// the one entry every operator hits often enough that it earns
-// dedicated chrome.
-const adminConfigurationNav = [
-  {
-    label: "AI Providers",
-    icon: Sparkles,
-    to: "/admin/ai/providers",
-    module: "ai.copilot",
-  },
-  {
-    label: "AI Prompts",
-    icon: Sparkles,
-    to: "/admin/ai/prompts",
-    module: "ai.copilot",
-  },
-  {
-    label: "AI Tool Catalog",
-    icon: Sparkles,
-    to: "/admin/ai/tools",
-    module: "ai.copilot",
-  },
-  { label: "Custom Fields", icon: Tags, to: "/admin/custom-fields" },
-  // Import hub (#36) — the one-shot DHCP (#129) / DNS (#128) / NetBox (#36)
-  // importers plus the guided Windows cutover (#756) share a single
-  // Configuration entry with a left sub-nav (see ImportPage), mirroring
-  // Appliance → Fleet. ``anyModule`` hides the entry only when ALL of those
-  // modules are off; the sub-nav inside gates each family individually.
-  {
-    label: "Import",
-    icon: Upload,
-    to: "/admin/import",
-    anyModule: [
-      "dhcp.import",
-      "dns.import",
-      "ipam.import.netbox",
-      "migration.cutover",
-    ],
-  },
-  // ``Features`` lives in the footer next to Settings — it's a
-  // platform-wide control, not a per-area config, and ops teams expect
-  // to find it next to "Settings" rather than buried in the sidebar.
-  {
-    label: "IPAM Templates",
-    icon: LayoutTemplate,
-    to: "/admin/ipam/templates",
-  },
-];
-
-const adminNotificationsNav = [
-  { label: "Alerts", icon: BellRing, to: "/admin/alerts" },
-  {
-    label: "DNS Blocklists",
-    icon: ShieldAlert,
-    to: "/admin/dns-blocklists",
-    module: "security.dnsbl",
-  },
-  {
-    label: "Change Requests",
-    icon: GitPullRequest,
-    to: "/admin/change-requests",
-    module: "governance.approvals",
-  },
-  { label: "Webhooks", icon: Webhook, to: "/admin/webhooks" },
-];
-
-const adminInsightsNav = [
-  { label: "Audit Log", icon: ClipboardList, to: "/admin/audit" },
-  // Backup + restore (issue #117 Phase 1a). Sits in the Insights
-  // group alongside Trash + Diagnostics — all "platform-state
-  // lifecycle" surfaces.
-  // Backup admin (issue #117) — also hosts the Factory Reset tab
-  // (issue #116). Factory reset doesn't get its own sidebar entry;
-  // it lives as a third tab alongside Manual + Destinations.
-  { label: "Backup", icon: Database, to: "/admin/backup" },
-  { label: "Compliance", icon: ShieldCheck, to: "/admin/compliance" },
-  {
-    label: "Conformity",
-    icon: ShieldCheck,
-    to: "/admin/conformity",
-    module: "compliance.conformity",
-  },
-  // Diagnostics → Errors (issue #123). Visible to all admins; the
-  // backend enforces superadmin on read, so non-superadmins land on
-  // a 403 page. We don't gate the nav entry itself so superadmins
-  // discover it.
-  {
-    label: "Diagnostics",
-    icon: AlertTriangle,
-    to: "/admin/diagnostics/errors",
-  },
-  { label: "Platform Insights", icon: Cpu, to: "/admin/platform-insights" },
-  { label: "Trash", icon: Trash2, to: "/admin/trash" },
-];
-
-// External documentation links — opened in a new tab via
-// ``NavExternalItem``. Kept in their own group so the visual
-// separator below the in-app entries reads as "you're leaving the
-// app". Matches the pattern from issue #96 (preferred ReDoc for
-// browsing; Swagger UI for interactive try-it-out).
-const adminReferenceNav: {
-  label: string;
-  icon: React.ElementType;
-  href: string;
-}[] = [
-  { label: "API Docs", icon: Code2, href: "/api/redoc" },
-  { label: "API Docs (interactive)", icon: Code2, href: "/api/docs" },
-];
+// The nav tree itself lives in ``lib/navigation.ts`` so the Cmd/Ctrl+K
+// command palette can render the same destinations without a second,
+// drifting copy of the list (issue #879). Adding a page means adding it
+// there; both surfaces pick it up.
 
 function NavSection({
   label,
@@ -646,16 +258,11 @@ export function Sidebar({
   // Loading / error state defaults to "everything visible" so the
   // sidebar never blinks empty on a slow network.
   const { enabled: moduleEnabled } = useFeatureModules();
+  // Shared with the command palette (``lib/navigation.ts``) so a
+  // module-gated page is hidden identically in both places.
   const filterByModule = <T extends { module?: string; anyModule?: string[] }>(
     items: T[],
-  ): T[] =>
-    items.filter(
-      (it) =>
-        (!it.module || moduleEnabled(it.module)) &&
-        // ``anyModule`` keeps a consolidated entry (e.g. Import) visible as
-        // long as at least one of its underlying modules is enabled.
-        (!it.anyModule || it.anyModule.some((m) => moduleEnabled(m))),
-    );
+  ): T[] => filterNav(items, moduleEnabled);
 
   // Pending approval-queue count → the Change Requests nav badge. Only
   // polls when the (default-off) governance.approvals module is on, so a
@@ -678,41 +285,7 @@ export function Sidebar({
   // Sorted alphabetically by label so the order is stable regardless
   // of the order we added integrations here — adding a new one later
   // shouldn't re-shuffle the sidebar for operators already using it.
-  const integrationsNav = [
-    ...(moduleEnabled("integrations.cloud")
-      ? [{ label: "Cloud", icon: Cloud, to: "/cloud" }]
-      : []),
-    ...(moduleEnabled("integrations.kubernetes")
-      ? [{ label: "Kubernetes", icon: Boxes, to: "/kubernetes" }]
-      : []),
-    ...(moduleEnabled("integrations.docker")
-      ? [{ label: "Docker", icon: ContainerIcon, to: "/docker" }]
-      : []),
-    ...(moduleEnabled("integrations.opnsense")
-      ? [{ label: "OPNsense", icon: ShieldCheck, to: "/opnsense" }]
-      : []),
-    ...(moduleEnabled("integrations.paloalto")
-      ? [{ label: "Palo Alto", icon: ShieldAlert, to: "/paloalto" }]
-      : []),
-    ...(moduleEnabled("integrations.fortinet")
-      ? [{ label: "Fortinet", icon: Flame, to: "/fortinet" }]
-      : []),
-    ...(moduleEnabled("integrations.meraki")
-      ? [{ label: "Meraki", icon: Network, to: "/meraki" }]
-      : []),
-    ...(moduleEnabled("integrations.netbird")
-      ? [{ label: "NetBird", icon: Bird, to: "/netbird" }]
-      : []),
-    ...(moduleEnabled("integrations.proxmox")
-      ? [{ label: "Proxmox", icon: HardDrive, to: "/proxmox" }]
-      : []),
-    ...(moduleEnabled("integrations.tailscale")
-      ? [{ label: "Tailscale", icon: Waypoints, to: "/tailscale" }]
-      : []),
-    ...(moduleEnabled("integrations.unifi")
-      ? [{ label: "UniFi", icon: Wifi, to: "/unifi" }]
-      : []),
-  ].sort((a, b) => a.label.localeCompare(b.label));
+  const visibleIntegrations = filterByModule(integrationsNav);
   // #696 — baseMainNav now carries a module-gated entry (Requests), so it
   // has to go through the same filter every other nav group uses. Without
   // this the item renders on every install even though governance.requests
@@ -910,14 +483,14 @@ export function Sidebar({
             );
           })()}
 
-          {integrationsNav.length > 0 && (
+          {visibleIntegrations.length > 0 && (
             <NavSection
               label="Integrations"
               storageKey="sidebar-section-integrations-open"
               collapsed={effectiveCollapsed}
               showDivider
             >
-              {integrationsNav.map((item) => (
+              {visibleIntegrations.map((item) => (
                 <NavItem
                   key={item.to}
                   {...item}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3354,15 +3354,33 @@ export const diagnosticsApi = {
 
 // ── Search ─────────────────────────────────────────────────────────────────────
 
+/** Every type `app/services/search/providers.py` can emit. Keep in step
+ *  with the `PROVIDERS` registry there — a type missing here still returns
+ *  from the API, it just renders with the fallback icon and label. */
+export type SearchResultType =
+  | "ip_address"
+  | "subnet"
+  | "block"
+  | "space"
+  | "dns_group"
+  | "dns_zone"
+  | "dns_record"
+  | "dns_server"
+  | "dns_view"
+  | "dns_blocklist"
+  | "dhcp_scope"
+  | "dhcp_reservation"
+  | "dhcp_server"
+  | "vlan"
+  | "device"
+  | "site"
+  | "circuit"
+  | "user"
+  | "group"
+  | "appliance";
+
 export interface SearchResult {
-  type:
-    | "ip_address"
-    | "subnet"
-    | "block"
-    | "space"
-    | "dns_group"
-    | "dns_zone"
-    | "dns_record";
+  type: SearchResultType;
   id: string;
   display: string;
   name: string | null;
@@ -3383,13 +3401,30 @@ export interface SearchResult {
   dns_zone_name: string | null;
   dns_record_type: string | null;
   dns_record_value: string | null;
+  /** Free-form breadcrumb for types with no shared parent shape. */
+  context?: string | null;
+  /** Path to navigate to. Present for every type added in #879; the
+   *  original seven are dispatched client-side because they pass
+   *  react-router state rather than a path. */
+  route?: string | null;
   matched_field?: string | null;
+  /** Relevance: match quality plus type weight. Higher is better. */
+  score?: number;
+}
+
+/** A type the calling user is permitted to search, used for scope chips. */
+export interface SearchTypeInfo {
+  type: SearchResultType;
+  label: string;
+  /** Scope chip this type belongs to: ipam | dns | dhcp | network | admin. */
+  group: string;
 }
 
 export interface SearchResponse {
   query: string;
   total: number;
   results: SearchResult[];
+  searched_types: SearchTypeInfo[];
 }
 
 export const searchApi = {
@@ -3397,6 +3432,8 @@ export const searchApi = {
     api
       .get<SearchResponse>("/search", { params: { q, types, limit } })
       .then((r) => r.data),
+  /** Types this caller may search — permission- and module-filtered. */
+  types: () => api.get<SearchTypeInfo[]>("/search/types").then((r) => r.data),
 };
 
 // ── Settings ───────────────────────────────────────────────────────────────────

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,0 +1,522 @@
+import {
+  Activity,
+  AudioLines,
+  AlertTriangle,
+  BarChart3,
+  BellRing,
+  Bird,
+  Boxes,
+  Briefcase,
+  Building2,
+  Binoculars,
+  Cable,
+  Calculator,
+  Cloud,
+  ClipboardList,
+  Code2,
+  Container as ContainerIcon,
+  Cpu,
+  Database,
+  Earth,
+  Factory,
+  Flame,
+  GitPullRequest,
+  Globe,
+  HardDrive,
+  Hash,
+  Inbox,
+  KeyRound,
+  KeySquare,
+  LayoutDashboard,
+  LayoutTemplate,
+  MapPin,
+  Monitor,
+  Network,
+  Package,
+  Power,
+  Radio,
+  Route as RouteIcon,
+  Router as RouterIcon,
+  Rss,
+  Scan,
+  ScrollText,
+  Search,
+  Server,
+  Settings,
+  ShieldAlert,
+  ShieldBan,
+  ShieldCheck,
+  ShieldQuestion,
+  Sparkles,
+  Spline,
+  Tags,
+  ToggleLeft,
+  Trash2,
+  Truck,
+  Upload,
+  Users,
+  UsersRound,
+  Waypoints,
+  Webhook,
+  Wifi,
+  Workflow,
+  Wrench,
+  Shuffle,
+  History,
+} from "lucide-react";
+
+/**
+ * The sidebar's navigation tree, extracted so more than one surface can
+ * read it (issue #879).
+ *
+ * It lives here rather than inside `Sidebar.tsx` because the Cmd/Ctrl+K
+ * command palette also needs it. A second hand-maintained list of pages
+ * would drift the first time somebody adds a route and updates only the
+ * sidebar — the same argument `lib/shortcuts.ts` makes for keybindings
+ * (#737): one definition, several consumers, so retuning it moves
+ * everything at once.
+ *
+ * Module gating is data on the entry, not a branch at the render site, so
+ * both consumers apply it identically via {@link navEntryVisible}.
+ */
+export interface NavEntry {
+  label: string;
+  icon: React.ElementType;
+  to: string;
+  /** Feature-module id gating this entry. */
+  module?: string;
+  /** Visible while ANY of these modules is on (consolidated entries). */
+  anyModule?: string[];
+  /** react-router `end` matching for the active state. */
+  end?: boolean;
+}
+
+export interface NavExternalEntry {
+  label: string;
+  icon: React.ElementType;
+  href: string;
+}
+
+// Core section. The four canonical anchors (Dashboard / IPAM / DHCP / DNS)
+// stay first and prominent; grown-in sub-features group under lightweight
+// sub-headings by family below.
+export const baseMainNav: NavEntry[] = [
+  { label: "Dashboard", icon: LayoutDashboard, to: "/dashboard" },
+  { label: "IPAM", icon: Network, to: "/ipam", end: true },
+  { label: "DHCP", icon: Server, to: "/dhcp" },
+  { label: "DNS", icon: Globe, to: "/dns", end: true },
+  // #696 — top-level rather than under Administration on purpose: the
+  // audience is ordinary users asking for a resource, and most of them will
+  // never see the admin section at all.
+  {
+    label: "Requests",
+    icon: Inbox,
+    to: "/requests",
+    module: "governance.requests",
+  },
+];
+
+// IPAM-family children (all route under /ipam/*). Alphabetised, matching the
+// Network/Administration sub-group convention.
+export const coreIpamNav: NavEntry[] = [
+  { label: "NAT Mappings", icon: Shuffle, to: "/ipam/nat" },
+  { label: "Stale IPs", icon: History, to: "/ipam/stale" },
+  { label: "Subnet Planner", icon: Workflow, to: "/ipam/plans" },
+];
+
+// DNS-family children. "Domains" keeps its /admin/domains route — it's the
+// registrar/expiry/RDAP registry side of a name (linked to dns_zone.domain_id),
+// so it belongs beside DNS in the sidebar even though the route lives under
+// /admin.
+export const coreDnsNav: NavEntry[] = [
+  { label: "DNS Pools", icon: Workflow, to: "/dns/pools" },
+  { label: "DNSSEC Policies", icon: KeyRound, to: "/dns/dnssec-policies" },
+  { label: "Domains", icon: Earth, to: "/admin/domains" },
+];
+
+// Operations — cross-cutting live telemetry.
+export const operationsNav: NavEntry[] = [
+  { label: "Logs", icon: ScrollText, to: "/logs" },
+];
+
+// Network → Logical: operator-facing ownership / deliverable rows that
+// cross-cut every other resource type.
+export const networkLogicalNav: NavEntry[] = [
+  {
+    label: "Customers",
+    icon: Briefcase,
+    to: "/network/customers",
+    module: "network.customer",
+  },
+  {
+    label: "Providers",
+    icon: Truck,
+    to: "/network/providers",
+    module: "network.provider",
+  },
+  {
+    label: "Services",
+    icon: Package,
+    to: "/network/services",
+    module: "network.service",
+  },
+  {
+    label: "Sites",
+    icon: MapPin,
+    to: "/network/sites",
+    module: "network.site",
+  },
+];
+
+// Network → Infrastructure: the actual network entities. Alphabetised so
+// new entries slot in without reshuffling.
+export const networkInfrastructureNav: NavEntry[] = [
+  { label: "ASNs", icon: Hash, to: "/network/asns", module: "network.asn" },
+  {
+    label: "AV over IP",
+    icon: AudioLines,
+    to: "/network/av",
+    module: "network.av",
+  },
+  {
+    label: "BACnet Devices",
+    icon: Building2,
+    to: "/network/bacnet",
+    module: "network.bacnet",
+  },
+  {
+    label: "Certificates",
+    icon: ShieldCheck,
+    to: "/network/certificates",
+    module: "security.tls_certs",
+  },
+  {
+    label: "Circuits",
+    icon: Waypoints,
+    to: "/network/circuits",
+    module: "network.circuit",
+  },
+  {
+    label: "DICOM AEs",
+    icon: Scan,
+    to: "/network/dicom",
+    module: "network.dicom",
+  },
+  {
+    label: "Devices",
+    icon: Cable,
+    to: "/network/devices",
+    module: "network.device",
+  },
+  {
+    label: "Looking Glass",
+    icon: Binoculars,
+    to: "/network/looking-glass",
+    module: "network.looking_glass",
+  },
+  {
+    label: "Multicast",
+    icon: Radio,
+    to: "/network/multicast",
+    module: "network.multicast",
+  },
+  {
+    label: "OT Devices",
+    icon: Factory,
+    to: "/network/ot",
+    module: "network.ot",
+  },
+  {
+    label: "Overlays",
+    icon: Spline,
+    to: "/network/overlays",
+    module: "network.overlay",
+  },
+  {
+    label: "VLANs",
+    icon: RouterIcon,
+    to: "/network/vlans",
+    module: "network.vlan",
+  },
+  {
+    label: "VRFs",
+    icon: RouteIcon,
+    to: "/network/vrfs",
+    module: "network.vrf",
+  },
+];
+
+// Keep this list alphabetised by label.
+export const toolsNav: NavEntry[] = [
+  {
+    label: "Block Sync",
+    icon: ShieldBan,
+    to: "/security/block-sync",
+    module: "security.block_sync",
+  },
+  { label: "CIDR Calculator", icon: Calculator, to: "/tools/cidr" },
+  {
+    label: "Firewall Feeds",
+    icon: Rss,
+    to: "/security/firewall-feeds",
+    module: "security.firewall_feeds",
+  },
+  {
+    label: "Network Tools",
+    icon: Wrench,
+    to: "/tools/network",
+    module: "tools.network",
+  },
+  {
+    label: "New Devices",
+    icon: ShieldQuestion,
+    to: "/security/new-devices",
+    module: "security.new_device_watch",
+  },
+  { label: "Nmap", icon: Search, to: "/tools/nmap", module: "tools.nmap" },
+  {
+    label: "Packet Capture",
+    icon: Activity,
+    to: "/tools/pcap",
+    module: "tools.pcap",
+  },
+  {
+    label: "Wake Schedules",
+    icon: Power,
+    to: "/tools/wake-schedules",
+    module: "tools.wake_scheduler",
+  },
+];
+
+// Reports section (issue #47) — fixed Top-N rollups derived from existing
+// tables. Module-gated so operators who don't want the surface can hide it.
+export const reportsNav: NavEntry[] = [
+  {
+    label: "Top-N Reports",
+    icon: BarChart3,
+    to: "/reports",
+    module: "reports.top_n",
+  },
+];
+
+// Integrations. Previously assembled inline in the sidebar as a chain of
+// `moduleEnabled(...) ? [entry] : []` spreads; the module id is now data on
+// the entry like every other group, so the shared filter handles it and the
+// palette can read the list without re-implementing the gating.
+// Alphabetised by label — adding an integration shouldn't re-shuffle the
+// sidebar for operators already using it.
+export const integrationsNav: NavEntry[] = [
+  { label: "Cloud", icon: Cloud, to: "/cloud", module: "integrations.cloud" },
+  {
+    label: "Docker",
+    icon: ContainerIcon,
+    to: "/docker",
+    module: "integrations.docker",
+  },
+  {
+    label: "Fortinet",
+    icon: Flame,
+    to: "/fortinet",
+    module: "integrations.fortinet",
+  },
+  {
+    label: "Kubernetes",
+    icon: Boxes,
+    to: "/kubernetes",
+    module: "integrations.kubernetes",
+  },
+  {
+    label: "Meraki",
+    icon: Network,
+    to: "/meraki",
+    module: "integrations.meraki",
+  },
+  {
+    label: "NetBird",
+    icon: Bird,
+    to: "/netbird",
+    module: "integrations.netbird",
+  },
+  {
+    label: "OPNsense",
+    icon: ShieldCheck,
+    to: "/opnsense",
+    module: "integrations.opnsense",
+  },
+  {
+    label: "Palo Alto",
+    icon: ShieldAlert,
+    to: "/paloalto",
+    module: "integrations.paloalto",
+  },
+  {
+    label: "Proxmox",
+    icon: HardDrive,
+    to: "/proxmox",
+    module: "integrations.proxmox",
+  },
+  {
+    label: "Tailscale",
+    icon: Waypoints,
+    to: "/tailscale",
+    module: "integrations.tailscale",
+  },
+  { label: "UniFi", icon: Wifi, to: "/unifi", module: "integrations.unifi" },
+];
+
+export const adminIdentityNav: NavEntry[] = [
+  { label: "API Tokens", icon: KeySquare, to: "/admin/api-tokens" },
+  { label: "Auth Providers", icon: ShieldCheck, to: "/admin/auth-providers" },
+  { label: "Groups", icon: UsersRound, to: "/admin/groups" },
+  { label: "Roles", icon: KeyRound, to: "/admin/roles" },
+  { label: "Sessions", icon: Monitor, to: "/admin/sessions" },
+  { label: "Users", icon: Users, to: "/admin/users" },
+];
+
+export const adminConfigurationNav: NavEntry[] = [
+  {
+    label: "AI Providers",
+    icon: Sparkles,
+    to: "/admin/ai/providers",
+    module: "ai.copilot",
+  },
+  {
+    label: "AI Prompts",
+    icon: Sparkles,
+    to: "/admin/ai/prompts",
+    module: "ai.copilot",
+  },
+  {
+    label: "AI Tool Catalog",
+    icon: Sparkles,
+    to: "/admin/ai/tools",
+    module: "ai.copilot",
+  },
+  { label: "Custom Fields", icon: Tags, to: "/admin/custom-fields" },
+  // Import hub (#36) — the one-shot DHCP (#129) / DNS (#128) / NetBox (#36)
+  // importers plus the guided Windows cutover (#756) share a single
+  // Configuration entry with a left sub-nav. ``anyModule`` hides the entry
+  // only when ALL of those modules are off.
+  {
+    label: "Import",
+    icon: Upload,
+    to: "/admin/import",
+    anyModule: [
+      "dhcp.import",
+      "dns.import",
+      "ipam.import.netbox",
+      "migration.cutover",
+    ],
+  },
+  {
+    label: "IPAM Templates",
+    icon: LayoutTemplate,
+    to: "/admin/ipam/templates",
+  },
+];
+
+export const adminNotificationsNav: NavEntry[] = [
+  { label: "Alerts", icon: BellRing, to: "/admin/alerts" },
+  {
+    label: "DNS Blocklists",
+    icon: ShieldAlert,
+    to: "/admin/dns-blocklists",
+    module: "security.dnsbl",
+  },
+  {
+    label: "Change Requests",
+    icon: GitPullRequest,
+    to: "/admin/change-requests",
+    module: "governance.approvals",
+  },
+  { label: "Webhooks", icon: Webhook, to: "/admin/webhooks" },
+];
+
+export const adminInsightsNav: NavEntry[] = [
+  { label: "Audit Log", icon: ClipboardList, to: "/admin/audit" },
+  { label: "Backup", icon: Database, to: "/admin/backup" },
+  { label: "Compliance", icon: ShieldCheck, to: "/admin/compliance" },
+  {
+    label: "Conformity",
+    icon: ShieldCheck,
+    to: "/admin/conformity",
+    module: "compliance.conformity",
+  },
+  // Diagnostics → Errors (issue #123). Visible to all admins; the backend
+  // enforces superadmin on read, so non-superadmins land on a 403 page. We
+  // don't gate the nav entry itself so superadmins discover it.
+  {
+    label: "Diagnostics",
+    icon: AlertTriangle,
+    to: "/admin/diagnostics/errors",
+  },
+  { label: "Platform Insights", icon: Cpu, to: "/admin/platform-insights" },
+  { label: "Trash", icon: Trash2, to: "/admin/trash" },
+];
+
+// External documentation links — opened in a new tab.
+export const adminReferenceNav: NavExternalEntry[] = [
+  { label: "API Docs", icon: Code2, href: "/api/redoc" },
+  { label: "API Docs (interactive)", icon: Code2, href: "/api/docs" },
+];
+
+// Footer entries. These render in the sidebar's footer rather than in a
+// section — they are ungated, always-visible destinations — but they are
+// real pages and belong in the palette. Labels and icons mirror what the
+// footer renders so the two read as the same entry.
+export const footerNav: NavEntry[] = [
+  { label: "Appliance", icon: Wrench, to: "/appliance" },
+  { label: "Features & Integrations", icon: ToggleLeft, to: "/admin/features" },
+  { label: "Settings", icon: Settings, to: "/settings" },
+];
+
+/**
+ * Every in-app destination, tagged with the section it appears under.
+ *
+ * The section name is what the palette shows as context ("Network",
+ * "Administration"), so an operator who types "vlan" can tell the VLANs
+ * *page* from a VLAN *record*.
+ */
+export const NAV_SECTIONS: { section: string; items: NavEntry[] }[] = [
+  { section: "Core", items: baseMainNav },
+  { section: "IPAM", items: coreIpamNav },
+  { section: "DNS", items: coreDnsNav },
+  { section: "Operations", items: operationsNav },
+  { section: "Network", items: networkLogicalNav },
+  { section: "Network", items: networkInfrastructureNav },
+  { section: "Tools", items: toolsNav },
+  { section: "Reports", items: reportsNav },
+  { section: "Integrations", items: integrationsNav },
+  { section: "Administration", items: adminIdentityNav },
+  { section: "Administration", items: adminConfigurationNav },
+  { section: "Administration", items: adminNotificationsNav },
+  { section: "Administration", items: adminInsightsNav },
+  { section: "System", items: footerNav },
+];
+
+export interface NavDestination extends NavEntry {
+  section: string;
+}
+
+export const ALL_NAV_DESTINATIONS: NavDestination[] = NAV_SECTIONS.flatMap(
+  ({ section, items }) => items.map((item) => ({ ...item, section })),
+);
+
+/** Shared module-gating predicate for a nav entry. */
+export function navEntryVisible(
+  entry: Pick<NavEntry, "module" | "anyModule">,
+  moduleEnabled: (id: string) => boolean,
+): boolean {
+  if (entry.module && !moduleEnabled(entry.module)) return false;
+  if (entry.anyModule && !entry.anyModule.some((m) => moduleEnabled(m)))
+    return false;
+  return true;
+}
+
+/** Filter a nav list by the enabled feature modules. */
+export function filterNav<T extends Pick<NavEntry, "module" | "anyModule">>(
+  items: T[],
+  moduleEnabled: (id: string) => boolean,
+): T[] {
+  return items.filter((it) => navEntryVisible(it, moduleEnabled));
+}


### PR DESCRIPTION
Closes #879

All six gaps from the issue. Matching, ranking and gating move out of the
router into `backend/app/services/search/` (`ranking` / `providers` /
`engine`), and the `global_search` MCP tool now calls that engine instead
of carrying its own copy of the fan-out over the router's private
helpers — which is why it had silently missed every type added to the
HTTP endpoint.

## The six gaps

| # | Gap | What landed |
|---|---|---|
| 1 | No relevance ranking | exact (100) > prefix (60) > substring (25), plus a small per-type weight for ties. Buckets are far enough apart that quality always dominates type, pinned by a test |
| 2 | Sequential scans per keystroke | `pg_trgm` GIN indexes (migration `f4b91d38a70c`) on the tables that actually grow |
| 3 | IPAM + DNS only | 7 types → 20, via a `SearchProvider` registry |
| 4 | `types=` filter had no UI | scope chips, built from `GET /search/types` so a chip that can only return nothing is never offered |
| 5 | Static empty state | sessionStorage recents |
| 6 | No command actions | go-to-page commands from the sidebar's own nav tree |

**Ranking is computed in SQL, before each type's `LIMIT`.** The ordering
complaint in the issue was the visible half of a worse bug: with no
`ORDER BY`, the database returned whichever N rows satisfied the
predicate and the exact hit was routinely not among them — which no
amount of re-sorting in Python can recover.

Coverage is one registry that the engine, the scope chips, the MCP tool
and `GET /search/types` all read from, so adding a type has one edit
site.

The command palette reads `lib/navigation.ts`, extracted out of
`Sidebar.tsx`, rather than a parallel list of pages — the same
load-bearing-not-duplicated argument `lib/shortcuts.ts` makes for
keybindings (#737). Adding a sidebar entry now makes it reachable by
Cmd+K automatically.

## Four bugs found on the way, three pre-existing

**Search applied no permission filtering at all.** It was the widest read
surface in the product and the only one that checked nothing: an
IPAM-only operator could read DNS zones and records out of a palette
whose own `GET /dns/zones` would have 403'd them. The Copilot tool had
the same hole. Every type is now gated on the caller's `read` permission
and the install's enabled feature modules; `user` is superadmin-only,
matching `/api/v1/users`.

**`_statement_references` in `app/db.py` cost ~16 ms of Python on every
ORM SELECT in the application.** It called `statement.get_final_froms()`
once per soft-delete model — that method resolves and compiles the FROM
graph, ~1.9 ms, times eight models. Measured: 16.7 ms for a query against
`vlan`, a table with no soft-delete column at all, versus 0.35 ms with
the filter skipped. It went unnoticed because it is uniform — nothing
looks slow relative to anything else. Resolving the FROM graph once and
testing all eight models against it is behaviour-identical.

**The query was interpolated raw into `%…%`**, so searching `50%` matched
every row in every table and `a_b` matched `axb`.

**The MAC branch of the address query was unindexable** and sat in an
`OR` beside two indexed predicates, forcing the whole query to a
sequential scan — the two working indexes bought nothing until it was
normalised to the spelling the index covers. That also fixed a real
semantic gap: partial MAC search is now separator-insensitive.

## Measured

20-provider fan-out over 500k addresses, dev box:

| | before | after |
|---|---|---|
| text query | 734 ms | 93 ms |
| MAC lookup | 38 ms | 3 ms |
| single hostname on `ip_address` | 489 ms | 15 ms |

Indexes verified chosen by the planner at 500k rows (`Bitmap Index Scan`
including the MAC expression index), not merely created.

## Notes on the choices

`inet` / `macaddr` columns are cast before matching — `ILIKE` has no
overload for them, so `DHCPStaticAssignment.ip_address` and
`NetworkDevice.ip_address` would have 500'd, not silently mismatched.

Breadcrumbs are a **second query**, not a join. Joining the parents in
looks free — they are tiny tables — but the soft-delete filter adds
`subnet.deleted_at IS NULL` to the same statement and the planner
responds by driving from `subnet` and re-running the `ip_address` bitmap
scan once per subnet: 9 ms standalone, 188 ms as a nested loop.

Small tables are deliberately **not** trigram-indexed: a sequential scan
of a few hundred rows is already the fastest plan and a GIN index there
is pure write amplification. `CREATE EXTENSION` runs in a SAVEPOINT and
degrades to sequential scans rather than failing an upgrade on a
locked-down managed instance.

## Deferred

An expression index for custom-field values — the field name is chosen at
runtime, so no trigram index can serve `custom_fields ->> 'x' ILIKE …`;
doing it properly means creating an index when an operator flags a field
searchable. And action commands that *do* something rather than navigate.

## Tests

34 new in `backend/tests/test_search.py`, adversarial where it matters:
an exact match buried under 60 substring hits, the two RBAC leaks in both
directions, `50%` and `a_b` as literals, all four MAC spellings, a
soft-deleted parent hiding its addresses, and a provider whose *database*
query fails (a plain Python exception isn't enough — PostgreSQL's aborted
transaction is what would actually blank the palette).

Also ran the soft-delete / permissions / IPAM slices because of the
`db.py` change: 62 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)