### PR TITLE
feat(dns): surface per-view blocklist scoping + full view CRUD (#876)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -546,12 +546,36 @@ suggestion, free-space treemap.
   1 MCP tool (`list_blocklist_templates`). BIND9-only,
   and [`docs/features/DNS.md` §8.1](docs/features/DNS.md) is explicit
   that DNS filtering is bypassable at all.
-- ⬜ [**Per-subnet DNS blocklist scoping — surface it in the UI**](https://github.com/spatiumddi/spatiumddi/issues/876)
-  — the backend already scopes a blocklist to a view *or* a server
-  group (`dns_blocklist_view_assoc`, honoured by the agent renderer
-  since #24); the UI exposes only the group half. Pairs with the #878
-  family filter, whose whole point is filtering one network and not
-  another.
+- ✅ [**Per-subnet DNS blocklist scoping — surface it in the UI**](https://github.com/spatiumddi/spatiumddi/issues/876)
+  — the backend has scoped a blocklist to a view *or* a server group
+  since #24 (`dns_blocklist_view_assoc`, rendered per-view by the agent);
+  the UI wrote only the group half, so the #878 family filter's whole
+  point — filtering one network and not another — was unreachable from
+  the product. Now: the **Views tab is full CRUD** (it was read-only, so
+  split-horizon was API-only to configure at all), with an *Add subnets…*
+  picker that turns IPAM prefixes into `match_clients`; a **scope modal**
+  on each blocking list writing group and view assignment in one PUT; and
+  per-view chips on both tabs. **The load-bearing addition is server-side
+  validation** (`app/services/dns/view_validation.py`): `match_clients`,
+  `match_destinations` and the view name are interpolated *verbatim* into
+  `named.conf`, and the name additionally becomes a directory on the
+  agent — so a malformed prefix, an undefined ACL name, a `;`-injection or
+  a `../` traversal are now 422s naming the offending element. That gate
+  matters because the agent runs `named-checkconf` before swapping config
+  in: an accepted-but-invalid value doesn't break one view, it stops the
+  whole group's config converging, silently. Also fixed: the Blocklists
+  tab classified a view-scoped list as "Available (not applied)" — i.e.
+  reported a list actively filtering a VLAN as doing nothing — and its
+  Apply/Detach toggle keyed off that section rather than the actual group
+  relationship, so "Detach" on a view-scoped list was a no-op that looked
+  broken. BIND9-only, and both surfaces say so when the group runs another
+  driver. **Found on the way:** the agent never renders `acl {}`
+  definitions at all — `DNSAcl` rows are stored and editable but the bundle
+  ships only `{id, name}` and the agent renderer ignores it, so naming an
+  ACL in a view would leave an undefined symbol and stop the group
+  converging. Named ACLs are therefore rejected in a view's match-list with
+  a 422 saying why; [#899](https://github.com/spatiumddi/spatiumddi/issues/899)
+  tracks making them real.
 - ✅ [**Blocklist feed wildcard semantics are per-list**](https://github.com/spatiumddi/spatiumddi/issues/894)
   — #878 made every feed row `is_wildcard=True`, right for all 19
   catalog sources but a global constant, and wrong for a host-specific

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -91,6 +91,11 @@ from app.services.dns.resolver_presets import (
     find_forwarder_conflict,
 )
 from app.services.dns.serial import bump_zone_serial
+from app.services.dns.view_validation import (
+    ViewValidationError,
+    validate_address_match_list,
+    validate_view_name,
+)
 from app.services.dns.zone_templates import (
     get_template,
     list_templates,
@@ -3337,20 +3342,83 @@ async def list_views(group_id: uuid.UUID, db: DB, _: CurrentUser) -> list[DNSVie
     return list(result.scalars().all())
 
 
+async def _validated_view_fields(
+    group_id: uuid.UUID, body: ViewCreate | ViewUpdate, db: DB
+) -> dict[str, Any]:
+    """Validate the free-text halves of a view before they reach named.conf.
+
+    ``name``, ``match_clients`` and ``match_destinations`` are interpolated
+    verbatim into the rendered config (and the name additionally becomes a
+    directory on the agent), so they are checked here rather than trusted.
+    Until #876 these fields were API-only and effectively unvalidated; now
+    that a form writes them, one typo would otherwise stop the whole
+    group's config converging when the agent's ``named-checkconf`` refuses
+    the bundle.
+
+    Returns only the fields present on ``body`` — an update leaves the rest
+    alone. Raises 422 naming the exact offending element.
+    """
+    changes: dict[str, Any] = {}
+    # Group-scoped ACLs only. Both bundle builders
+    # (``services/dns/{agent_config,config_bundle}.py``) select ACLs with
+    # ``group_id == server.group_id``, so a global (NULL-group) row is never
+    # rendered — accepting its name here would pass validation and then
+    # produce a named.conf referencing an ACL that isn't defined.
+    acl_names = frozenset(
+        (await db.execute(select(DNSAcl.name).where(DNSAcl.group_id == group_id))).scalars().all()
+    )
+    # TSIG key names the group ships to its agents: the operator-managed
+    # ``DNSTSIGKey`` rows plus the legacy auto-generated group key. Mirrors
+    # what ``agent_config`` puts in the bundle's ``tsig_keys`` block.
+    key_names = set(
+        (await db.execute(select(DNSTSIGKey.name).where(DNSTSIGKey.group_id == group_id)))
+        .scalars()
+        .all()
+    )
+    group = await db.get(DNSServerGroup, group_id)
+    if group is not None and group.tsig_key_name:
+        key_names.add(group.tsig_key_name)
+    known_keys = frozenset(key_names)
+    try:
+        name = getattr(body, "name", None)
+        if name is not None:
+            changes["name"] = validate_view_name(name)
+        # ``allow_query`` / ``allow_query_cache`` (#430) land in the same
+        # kind of address-match-list statement, so they get the same gate.
+        for attr in ("match_clients", "match_destinations", "allow_query", "allow_query_cache"):
+            value = getattr(body, attr, None)
+            if value is not None:
+                changes[attr] = validate_address_match_list(
+                    value, field=attr, known_acls=acl_names, known_keys=known_keys
+                )
+    except ViewValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"field": exc.field, "value": exc.value, "message": str(exc)},
+        ) from exc
+    return changes
+
+
 @router.post("/groups/{group_id}/views", response_model=ViewResponse, status_code=201)
 async def create_view(
     group_id: uuid.UUID, body: ViewCreate, db: DB, current_user: SuperAdmin
 ) -> DNSView:
     await _require_group(group_id, db)
+    payload = body.model_dump()
+    # Validate BEFORE the duplicate check: the validator strips the name, so
+    # checking ``body.name`` would let " guest" past a pre-check that "guest"
+    # would have caught, and the answer would come from the DB's unique
+    # violation as a generic 409 instead of the message naming the field.
+    payload.update(await _validated_view_fields(group_id, body, db))
     existing = await db.execute(
-        select(DNSView).where(DNSView.group_id == group_id, DNSView.name == body.name)
+        select(DNSView).where(DNSView.group_id == group_id, DNSView.name == payload["name"])
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
             status_code=409, detail="A view with that name already exists in this group"
         )
 
-    view = DNSView(group_id=group_id, **body.model_dump())
+    view = DNSView(group_id=group_id, **payload)
     db.add(view)
     db.add(
         AuditLog(
@@ -3380,6 +3448,7 @@ async def update_view(
 ) -> DNSView:
     view = await _require_view(group_id, view_id, db)
     changes = body.model_dump(exclude_none=True)
+    changes.update(await _validated_view_fields(group_id, body, db))
     for k, v in changes.items():
         setattr(view, k, v)
     db.add(

--- a/backend/app/services/dns/view_validation.py
+++ b/backend/app/services/dns/view_validation.py
@@ -1,0 +1,245 @@
+"""Validation for DNS view names and address-match-lists (issue #876).
+
+View scoping shipped with #24 but was only reachable through the API, so
+the values in ``DNSView.match_clients`` were whatever an operator's script
+put there. #876 puts a form in front of it, which makes validation
+load-bearing rather than nice-to-have — both fields are interpolated
+**verbatim** into ``named.conf``:
+
+    view "{{ view.name }}" {
+        match-clients { {% for c in view.match_clients %}{{ c }}; {% endfor %}};
+
+Two ways that goes wrong, and neither is hypothetical:
+
+* **A typo takes the group offline.** BIND rejects a malformed
+  ``match-clients`` element, and the agent runs ``named-checkconf`` before
+  swapping config in — so one bad CIDR doesn't corrupt one view, it stops
+  the whole group's config converging, silently, until somebody reads the
+  agent log. Same blast radius as the malformed-RPZ-zone bugs in #878.
+* **The view name is also a directory name.** The agent writes RPZ zone
+  files to ``/var/cache/bind/rpz/<view name>/`` and zone files to
+  ``zones/<view name>/``, so a name containing ``/`` or ``..`` is a path
+  traversal, and one containing a quote or brace escapes the ``view "…"``
+  statement it is embedded in.
+
+So this module is the gate. It rejects rather than sanitises: silently
+rewriting an operator's ACL into something that "works" would be worse
+than telling them it is wrong.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+
+__all__ = [
+    "BUILTIN_ACLS",
+    "RESERVED_VIEW_NAMES",
+    "ViewValidationError",
+    "validate_address_match_list",
+    "validate_view_name",
+]
+
+
+class ViewValidationError(ValueError):
+    """Carries the offending element so the caller can name it in the 422."""
+
+    def __init__(self, message: str, *, field: str, value: str | None = None) -> None:
+        super().__init__(message)
+        self.field = field
+        self.value = value
+
+
+# BIND's built-in address-match-list names. `none` and `any` are the two
+# an operator actually reaches for; `localhost` / `localnets` are the
+# server's own addresses and directly-attached networks.
+BUILTIN_ACLS = frozenset({"any", "none", "localhost", "localnets"})
+
+# ``_default`` is the view BIND uses when a client matches nothing and
+# ``_bind`` is the built-in CHAOS view — declaring either is an error at
+# config-parse time, which is exactly the failure this module exists to
+# catch before it reaches a server.
+RESERVED_VIEW_NAMES = frozenset({"_default", "_bind"})
+
+# The per-view RPZ zone the agent renders is named
+# ``spatium-blocklist-<view>.rpz.`` (see ``services/dns/agent_config.py``),
+# and the first label of that name is a DNS label — capped at 63 **octets**
+# by RFC 1035. ``spatium-blocklist-`` is 18 of them, so a view name longer
+# than 45 renders a zone BIND refuses to load ("label too long"), taking
+# the whole group's config down with it. That is the failure this module
+# exists to catch, so the cap is enforced here rather than discovered
+# later.
+_RPZ_ZONE_PREFIX = "spatium-blocklist-"
+MAX_VIEW_NAME_LEN = 63 - len(_RPZ_ZONE_PREFIX)
+
+# Conservative: letters, digits, and the three separators that are safe
+# both as a BIND identifier and as a single path segment. Deliberately no
+# dot — a dotted view name is legal to BIND but reads as a hostname in the
+# agent's ``zones/<view>/<zone>`` layout, and the ambiguity buys nothing.
+_VIEW_NAME_RE = re.compile(rf"^[A-Za-z0-9][A-Za-z0-9_-]{{0,{MAX_VIEW_NAME_LEN - 1}}}$")
+
+# An ACL name defined via `DNSAcl`. A dot is allowed here (unlike a view
+# name, which is also a path segment) because ``DNSAcl.name`` is free text
+# up to 255 chars and BIND takes a dotted unquoted string happily — a name
+# the operator has already created must not be rejected as "not a valid
+# ACL name" when the real objection would be that it isn't defined. The
+# character class stays injection-safe: no quote, brace, semicolon or
+# whitespace can reach the rendered ``match-clients { … };``.
+_ACL_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$")
+
+_KEY_RE = re.compile(r"^key\s+([A-Za-z0-9][A-Za-z0-9_.-]{0,127})$")
+
+
+def validate_view_name(name: str, *, field: str = "name") -> str:
+    """Return the name, or raise :class:`ViewValidationError`.
+
+    The name ends up in three places — the ``view "…"`` statement, a
+    directory under the agent's cache, and the per-view RPZ zone path — so
+    it is held to the strictest of the three.
+    """
+    candidate = (name or "").strip()
+    if not candidate:
+        raise ViewValidationError("View name is required.", field=field, value=name)
+    if candidate.lower() in RESERVED_VIEW_NAMES:
+        raise ViewValidationError(
+            f"'{candidate}' is reserved by BIND and cannot be used as a view name.",
+            field=field,
+            value=candidate,
+        )
+    if not _VIEW_NAME_RE.match(candidate):
+        raise ViewValidationError(
+            "A view name must start with a letter or digit and contain only "
+            f"letters, digits, hyphens and underscores (max {MAX_VIEW_NAME_LEN} "
+            "characters). It is used as a BIND view name, as a directory name "
+            "on the DNS agent, and as a label in the per-view blocking-list "
+            "zone name.",
+            field=field,
+            value=candidate,
+        )
+    return candidate
+
+
+def _validate_element(
+    element: str,
+    field: str,
+    known_acls: frozenset[str],
+    known_keys: frozenset[str],
+) -> None:
+    raw = (element or "").strip()
+    if not raw:
+        raise ViewValidationError(
+            "Empty entry — remove it or replace it with an address, CIDR or ACL name.",
+            field=field,
+            value=element,
+        )
+
+    # A leading '!' negates the element ("everything except this"). BIND
+    # allows whitespace after it; normalise before checking the rest.
+    body = raw[1:].strip() if raw.startswith("!") else raw
+    if not body:
+        raise ViewValidationError(
+            "'!' must be followed by an address, CIDR or ACL name.",
+            field=field,
+            value=element,
+        )
+
+    lowered = body.lower()
+    if lowered in BUILTIN_ACLS:
+        return
+
+    # ``key <name>`` matches queries signed with that TSIG key. The key has
+    # to be one the group actually ships to the agent — an undefined key
+    # name is an undefined symbol in named.conf, exactly as an undefined
+    # ACL name is, and fails the whole bundle rather than the one view.
+    key_match = _KEY_RE.match(body)
+    if key_match:
+        key_name = key_match.group(1)
+        if key_name not in known_keys:
+            known = ", ".join(sorted(known_keys)) if known_keys else "none defined"
+            raise ViewValidationError(
+                f"'{key_name}' is not a TSIG key defined in this server group "
+                f"(available: {known}). Define it on the TSIG keys tab first.",
+                field=field,
+                value=element,
+            )
+        return
+
+    # An address or prefix. ``strict=False`` so 10.0.0.5/24 is accepted the
+    # way BIND accepts it, rather than rejected for having host bits set.
+    if "/" in body:
+        try:
+            ipaddress.ip_network(body, strict=False)
+        except ValueError as exc:
+            raise ViewValidationError(
+                f"'{body}' is not a valid CIDR prefix ({exc}).", field=field, value=element
+            ) from exc
+        return
+    try:
+        ipaddress.ip_address(body)
+    except ValueError:
+        pass
+    else:
+        return
+
+    # Anything left would have to be a named ACL — and BIND9 config as
+    # actually shipped has none.
+    #
+    # A `DNSAcl` row is stored, listed and editable on the ACLs tab, and the
+    # bundle even carries an ``acls`` block — but only as ``{id, name}``,
+    # and the agent's BIND9 renderer never reads it or emits an ``acl {};``
+    # stanza. (The control-plane template that *does* render one has no
+    # production caller.) So ``match-clients { office; };`` reaches a server
+    # with ``office`` undefined, ``named-checkconf`` fails, and the agent
+    # declines the whole bundle — the group stops converging entirely, not
+    # just this view.
+    #
+    # Rejecting here is therefore not a restriction, it is the accurate
+    # answer: it converts a silent group-wide outage into a 422 that says
+    # what to type instead. Lift this the moment the agent renders ACL
+    # blocks — https://github.com/spatiumddi/spatiumddi/issues/899.
+    if _ACL_NAME_RE.match(body) and body in known_acls:
+        raise ViewValidationError(
+            f"'{body}' is a named ACL, and the DNS agent does not yet render "
+            f"ACL definitions into named.conf — a view referencing one would "
+            f"stop the whole server group's config from applying. Use the "
+            f"addresses or CIDR prefixes directly here instead.",
+            field=field,
+            value=element,
+        )
+    raise ViewValidationError(
+        f"'{body}' is not an IP address, a CIDR prefix, or one of "
+        f"{', '.join(sorted(BUILTIN_ACLS))}.",
+        field=field,
+        value=element,
+    )
+
+
+def validate_address_match_list(
+    elements: list[str] | None,
+    *,
+    field: str,
+    known_acls: frozenset[str] = frozenset(),
+    known_keys: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Validate every element of a BIND address-match-list.
+
+    ``known_keys`` is the set of TSIG key names the group ships to its
+    agents; a ``key <name>`` element naming one that doesn't exist renders a
+    ``named.conf`` BIND will not load, so it is rejected here rather than
+    discovered when the agent's ``named-checkconf`` refuses the bundle.
+
+    ``known_acls`` is used only to tell an operator who typed a *real* ACL
+    name why it isn't accepted — see :func:`_validate_element`. Named ACLs
+    are rejected outright today because the agent never renders ``acl {}``
+    definitions.
+
+    Returns the list with each element stripped, so trailing whitespace
+    from a paste doesn't reach the template.
+    """
+    if elements is None:
+        return []
+    cleaned: list[str] = []
+    for element in elements:
+        _validate_element(element, field, known_acls, known_keys)
+        cleaned.append((element or "").strip())
+    return cleaned

--- a/backend/tests/test_dns_view_validation.py
+++ b/backend/tests/test_dns_view_validation.py
@@ -1,0 +1,363 @@
+"""DNS view name + address-match-list validation (issue #876).
+
+View scoping shipped with #24 but was API-only, so these fields were
+effectively unvalidated. #876 puts a form in front of them, and both are
+interpolated **verbatim** into ``named.conf`` — the name additionally
+becomes a directory on the DNS agent. So the tests that matter here are
+the ones that prove a bad value is refused at the API rather than
+discovered when the agent's ``named-checkconf`` rejects the bundle and the
+whole group silently stops converging.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSAcl, DNSServerGroup
+from app.services import feature_modules
+from app.services.dns.view_validation import (
+    MAX_VIEW_NAME_LEN,
+    RESERVED_VIEW_NAMES,
+    ViewValidationError,
+    validate_address_match_list,
+    validate_view_name,
+)
+
+# No module-level ``pytest.mark.asyncio`` — ``asyncio_mode = "auto"`` in
+# pyproject already collects the async tests, and marking the sync ones
+# emits a PytestWarning per test.
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def _reset_module_cache():
+    feature_modules.invalidate_cache()
+    yield
+    feature_modules.invalidate_cache()
+
+
+async def _admin(db: AsyncSession) -> str:
+    tag = uuid.uuid4().hex[:8]
+    user = User(
+        username=f"a-{tag}",
+        email=f"{tag}@example.com",
+        display_name="A",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _group(db: AsyncSession) -> DNSServerGroup:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(group)
+    await db.flush()
+    return group
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ── view names ────────────────────────────────────────────────────────────
+
+
+def test_accepts_ordinary_view_names():
+    for name in ("guest", "internal", "dmz-2", "vlan_50", "a", "A1"):
+        assert validate_view_name(name) == name
+
+
+def test_rejects_bind_reserved_names():
+    for name in RESERVED_VIEW_NAMES:
+        with pytest.raises(ViewValidationError):
+            validate_view_name(name)
+    # Case-insensitively — BIND's parser is not case-sensitive here.
+    with pytest.raises(ViewValidationError):
+        validate_view_name("_DEFAULT")
+
+
+def test_rejects_names_that_would_escape_their_context():
+    """The name lands in ``view "…" {`` and in a filesystem path.
+
+    A quote or brace breaks out of the statement; a slash or ``..`` walks
+    out of ``/var/cache/bind/rpz/<view>/``.
+    """
+    for name in (
+        'guest"; };  //',
+        "../../etc/bind",
+        "a/b",
+        "with space",
+        "semi;colon",
+        "brace}",
+        "",
+        "   ",
+    ):
+        with pytest.raises(ViewValidationError):
+            validate_view_name(name)
+
+
+def test_rejects_over_long_names():
+    """The cap is the RPZ zone label, not the view statement.
+
+    The agent names the per-view blocking zone
+    ``spatium-blocklist-<view>.rpz.`` — an 18-character prefix on a label
+    RFC 1035 caps at 63 octets. A longer view name renders a zone BIND
+    refuses to load, which takes the whole group's config with it.
+    """
+    assert MAX_VIEW_NAME_LEN == 45
+    assert validate_view_name("v" * MAX_VIEW_NAME_LEN)
+    assert len(f"spatium-blocklist-{'v' * MAX_VIEW_NAME_LEN}") == 63
+    with pytest.raises(ViewValidationError):
+        validate_view_name("v" * (MAX_VIEW_NAME_LEN + 1))
+
+
+# ── address-match-lists ───────────────────────────────────────────────────
+
+
+def test_accepts_addresses_prefixes_and_builtins():
+    ok = [
+        "any",
+        "none",
+        "localhost",
+        "localnets",
+        "10.0.0.1",
+        "2001:db8::1",
+        "10.20.0.0/16",
+        "2001:db8::/32",
+        "!198.51.100.0/24",
+    ]
+    assert validate_address_match_list(ok, field="match_clients") == ok
+
+
+def test_host_bits_set_is_accepted_like_bind_accepts_it():
+    """``10.0.0.5/24`` is legal in an address-match-list."""
+    assert validate_address_match_list(["10.0.0.5/24"], field="match_clients")
+
+
+def test_rejects_a_malformed_prefix():
+    with pytest.raises(ViewValidationError) as exc:
+        validate_address_match_list(["10.0.0.0/33"], field="match_clients")
+    assert exc.value.field == "match_clients"
+    assert exc.value.value == "10.0.0.0/33"
+
+
+def test_rejects_an_octet_out_of_range():
+    with pytest.raises(ViewValidationError):
+        validate_address_match_list(["10.0.0.300"], field="match_clients")
+
+
+def test_rejects_config_injection():
+    """The element is interpolated straight into ``match-clients { … };``."""
+    with pytest.raises(ViewValidationError):
+        validate_address_match_list(['any; }; zone "evil" {'], field="match_clients")
+
+
+def test_rejects_an_empty_element():
+    with pytest.raises(ViewValidationError):
+        validate_address_match_list(["10.0.0.0/8", "  "], field="match_clients")
+
+
+def test_bare_negation_is_rejected():
+    with pytest.raises(ViewValidationError):
+        validate_address_match_list(["!"], field="match_clients")
+
+
+def test_an_undefined_name_is_rejected():
+    with pytest.raises(ViewValidationError) as exc:
+        validate_address_match_list(["office-clients"], field="match_clients")
+    assert "not an IP address" in str(exc.value)
+
+
+def test_a_real_acl_name_is_rejected_because_the_agent_cannot_render_it():
+    """The agent emits no ``acl {}`` definitions.
+
+    ``DNSAcl`` rows are stored and editable, and the bundle carries an
+    ``acls`` block — but only ``{id, name}``, and the agent's BIND9
+    renderer never reads it. So ``match-clients { office; };`` reaches a
+    server with ``office`` undefined, ``named-checkconf`` fails, and the
+    agent declines the entire bundle: the whole group stops converging,
+    not just this view.
+
+    Accepting the name would therefore be the bug. The message has to name
+    the real reason, because from the operator's side the ACL plainly
+    exists — they just created it on the tab next door.
+    """
+    with pytest.raises(ViewValidationError) as exc:
+        validate_address_match_list(
+            ["office"], field="match_clients", known_acls=frozenset({"office"})
+        )
+    assert "does not yet render ACL definitions" in str(exc.value)
+
+
+def test_unknown_tsig_key_is_rejected():
+    """``key <name>`` is an undefined symbol unless the group ships the key.
+
+    Same blast radius as an undefined ACL: named.conf fails to parse and the
+    whole group stops converging, not just this view.
+    """
+    with pytest.raises(ViewValidationError) as exc:
+        validate_address_match_list(["key transfer-key"], field="match_clients")
+    assert "not a TSIG key" in str(exc.value)
+
+
+def test_known_tsig_key_is_accepted():
+    assert validate_address_match_list(
+        ["key transfer-key", "!key other-key"],
+        field="match_clients",
+        known_keys=frozenset({"transfer-key", "other-key"}),
+    ) == ["key transfer-key", "!key other-key"]
+
+
+def test_elements_are_stripped():
+    assert validate_address_match_list(["  10.0.0.0/8  "], field="match_clients") == ["10.0.0.0/8"]
+
+
+# ── through the API ───────────────────────────────────────────────────────
+
+
+async def test_create_view_rejects_a_bad_cidr(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "guest", "match_clients": ["10.0.0.0/33"]},
+    )
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert detail["field"] == "match_clients"
+    assert detail["value"] == "10.0.0.0/33"
+
+
+async def test_create_view_rejects_a_traversing_name(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "../../etc/bind", "match_clients": ["any"]},
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["field"] == "name"
+
+
+async def test_create_view_rejects_an_acl_name_with_the_reason(client: AsyncClient, db_session):
+    """End-to-end: a view naming an ACL the operator really created is
+    still refused, and the 422 explains why rather than claiming it does
+    not exist."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    db_session.add(DNSAcl(group_id=group.id, name="office", description=""))
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "internal", "match_clients": ["office", "10.0.0.0/8"]},
+    )
+    assert r.status_code == 422, r.text
+    detail = r.json()["detail"]
+    assert detail["field"] == "match_clients"
+    assert "does not yet render ACL definitions" in detail["message"]
+
+
+async def test_create_view_accepts_the_prefixes_the_acl_would_have_held(
+    client: AsyncClient, db_session
+):
+    """The documented workaround has to actually work."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "internal", "match_clients": ["10.0.0.0/8", "192.168.0.0/16"]},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["match_clients"] == ["10.0.0.0/8", "192.168.0.0/16"]
+
+
+async def test_duplicate_name_is_caught_after_stripping(client: AsyncClient, db_session):
+    """The validator strips, so the duplicate check has to run on the
+
+    stripped name — otherwise ``" guest "`` sails past a pre-check that
+    ``"guest"`` would have caught and the answer comes from the DB's unique
+    violation instead of the handler's own message.
+    """
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    first = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "guest", "match_clients": ["any"]},
+    )
+    assert first.status_code == 201, first.text
+
+    dupe = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "  guest  ", "match_clients": ["any"]},
+    )
+    assert dupe.status_code == 409, dupe.text
+    assert "already exists" in dupe.json()["detail"]
+
+
+async def test_update_view_validates_too(client: AsyncClient, db_session):
+    """The update path is the one an operator uses most, and it applied
+    ``setattr`` straight from the body."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    created = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "guest", "match_clients": ["10.20.0.0/16"]},
+    )
+    assert created.status_code == 201
+    view_id = created.json()["id"]
+
+    r = await client.put(
+        f"/api/v1/dns/groups/{group.id}/views/{view_id}",
+        headers=_hdr(token),
+        json={"match_clients": ["not-an-address"]},
+    )
+    assert r.status_code == 422
+
+    # The stored value is untouched by the rejected write.
+    listed = await client.get(f"/api/v1/dns/groups/{group.id}/views", headers=_hdr(token))
+    assert listed.json()[0]["match_clients"] == ["10.20.0.0/16"]
+
+
+async def test_allow_query_overrides_are_validated(client: AsyncClient, db_session):
+    """#430's per-view query ACLs render into the same kind of statement."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={
+            "name": "guest",
+            "match_clients": ["any"],
+            "allow_query": ["10.0.0.0/8; }; //"],
+        },
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["field"] == "allow_query"

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -643,6 +643,89 @@ DNSBlockListException
 - Manual domain addition to block list
 - "Test a domain" — check if a domain would be blocked
 
+### Scoping — where a list applies (issue #876)
+
+A blocking list is applied through one of **two** independent
+relationships, and the difference is the whole point of the feature:
+
+| Scope | Relationship | Who it filters |
+|---|---|---|
+| Server group | `applied_group_ids` | every client the group answers |
+| View | `applied_view_ids` | only clients matching that view's `match-clients` |
+
+View scoping is what "the adult lists on the guest VLAN, threat lists
+everywhere" means in practice. It shipped with the split-horizon work in
+#24 and has been rendered end-to-end by the BIND9 agent since — but until
+#876 the UI wrote only the group half, so per-subnet filtering was
+unreachable from the product despite being fully implemented underneath.
+
+A **view** is a set of clients, identified by source address. `match_clients`
+is a BIND address-match-list: addresses, CIDR prefixes, or one of `any` /
+`none` / `localhost` / `localnets`, each optionally negated with a leading
+`!`. Views are evaluated in `order`
+(low first) and a client is served by the **first** view it matches, so
+the catch-all belongs last.
+
+#### Worked example — filter one VLAN
+
+The guest VLAN is `10.20.0.0/16`; everyone else should be unfiltered.
+
+1. **DNS → group → Views → New View.** Name `guest`, order `0`,
+   match clients `10.20.0.0/16`. *Add subnets…* fills that in from IPAM
+   rather than retyping the prefix.
+2. **New View** again: name `default`, order `10`, match clients `any`.
+   This is load-bearing — once any view exists BIND serves every client
+   from a view, so without a catch-all everyone outside the guest VLAN
+   matches nothing and gets no answer.
+3. **Blocklists tab** → the funnel icon on the adult/gambling list →
+   tick `guest`, leave *Whole group* unticked → **Save scope**.
+4. Threat lists stay on *Whole group*: they apply inside every view.
+
+The rendered config puts the RPZ inside the matching view only:
+
+```
+view "guest" {
+    match-clients { 10.20.0.0/16; };
+    response-policy { zone "spatium-blocklist-guest.rpz"; } break-dnssec yes;
+    ...
+};
+```
+
+#### Constraints worth knowing
+
+- **BIND9 only.** `render_rpz_zone` is a no-op on the Windows, PowerDNS
+  and cloud drivers, and Technitium blocks natively with no per-view
+  concept. The Views tab and the scope modal both say so when the group
+  runs a non-BIND9 server; scoping is stored but never applied there.
+- **Views are all-or-nothing for a group.** BIND forbids a top-level
+  `zone {}` alongside views, so once one view exists every zone is served
+  from inside a view. Zones with no view of their own render into all of
+  them.
+- **Named ACLs are not accepted in `match_clients` yet.** A `DNSAcl` row is
+  stored, listed and editable on the ACLs tab, and the config bundle even
+  carries an `acls` block — but only as `{id, name}`, and the DNS agent's
+  BIND9 renderer never reads it or emits an `acl {};` stanza. (The
+  control-plane template that does render one has no production caller.) A
+  view referencing an ACL by name would therefore reach a server with that
+  symbol undefined, `named-checkconf` would fail, and the agent would
+  decline the whole bundle — so the group stops converging entirely, not
+  just that view. The API rejects it with a 422 saying so. Use the
+  prefixes directly until the agent renders ACL definitions ([#899](https://github.com/spatiumddi/spatiumddi/issues/899)).
+- **`match_clients` and the view name are validated server-side**
+  (`app/services/dns/view_validation.py`). Both are interpolated verbatim
+  into `named.conf`, and the name additionally becomes a directory on the
+  agent, so a malformed prefix, an undefined ACL or TSIG key name, or a
+  name containing a path separator is rejected with a 422 naming the
+  offending element. It has to be: the agent runs `named-checkconf` before
+  swapping config in, so an accepted-but-invalid value would not corrupt
+  one view — it would stop the whole group's config converging, silently.
+  A view name is capped at **45 characters**, not 63: the per-view RPZ zone
+  is named `spatium-blocklist-<view>.rpz.`, and that 18-character prefix
+  has to fit inside the 63-octet DNS label limit with it.
+- **Deleting a view** leaves its zones in place (they fall back to being
+  served from the remaining views) but any list scoped *only* to it stops
+  applying anywhere.
+
 ### 8.1 Content filtering / family filter (issue #878)
 
 Two independent ways to filter adult content, and they compose:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -193,6 +193,17 @@ export function formatApiError(err: unknown, fallback = "Error"): string {
     if (parts.length) return parts.join("; ");
   }
   if (detail && typeof detail === "object") {
+    // A structured 422 that names the offending field, e.g. the DNS view
+    // address-match-list validator (#876):
+    //   {"field": "match_clients", "value": "10.0.0.300", "message": "…"}
+    // Without this the operator was shown the raw JSON, which buries the
+    // one sentence that tells them what to fix.
+    const rec = detail as { message?: unknown; field?: unknown };
+    if (typeof rec.message === "string" && rec.message.trim()) {
+      return typeof rec.field === "string" && rec.field
+        ? `${rec.field}: ${rec.message}`
+        : rec.message;
+    }
     // Unexpected shape — stringify defensively so we never render an object.
     try {
       return JSON.stringify(detail);

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/pages/network/CertificatesPage";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { Modal } from "@/components/ui/modal";
+import { ConfirmModal } from "@/components/ui/confirm-modal";
 import { HeaderButton } from "@/components/ui/header-button";
 import { Pager } from "@/components/ui/pager";
 import { AskAIButton } from "@/components/copilot/AskAIButton";
@@ -65,6 +66,7 @@ import {
   applianceTlsApi,
   dnsApi,
   dnsBlocklistApi,
+  ipamApi,
   domainsApi,
   formatApiError,
   tlsCertsApi,
@@ -73,6 +75,7 @@ import {
   type DNSZone,
   type ZoneServerState,
   type DNSView,
+  type DNSAcl,
   type DNSRecord,
   type DNSGroupRecord,
   type DNSImportPreview,
@@ -4691,48 +4694,549 @@ function SyncStat({
 
 // ── Views Tab ─────────────────────────────────────────────────────────────────
 
+/**
+ * Views tab (#876) — full CRUD.
+ *
+ * View storage, per-view zone rendering and per-view RPZ all shipped with
+ * #24, but the only way to define a view was the REST API, which meant
+ * split-horizon DNS and per-subnet blocklist scoping were both
+ * unreachable from the product. This tab is that missing surface.
+ *
+ * `match_clients` is the whole point: it is the address-match-list BIND
+ * tests a query's source address against, so "the adult lists on the
+ * guest VLAN only" is a view whose match_clients is the guest CIDRs plus
+ * a blocklist scoped to that view.
+ */
 function ViewsTab({ group }: { group: DNSServerGroup }) {
+  const qc = useQueryClient();
+  const [editing, setEditing] = useState<DNSView | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<DNSView | null>(null);
+  const [error, setError] = useState("");
+
   const { data: views = [] } = useQuery({
     queryKey: ["dns-views", group.id],
     queryFn: () => dnsApi.listViews(group.id),
   });
+  const { data: servers = [] } = useQuery({
+    queryKey: ["dns-servers", group.id],
+    queryFn: () => dnsApi.listServers(group.id),
+  });
+  const { data: blocklists = [] } = useQuery({
+    queryKey: ["dns-blocklists"],
+    queryFn: () => dnsBlocklistApi.list(),
+  });
+
+  // Per-view RPZ is rendered by the BIND9 driver only — render_rpz_zone is
+  // a no-op on Windows / PowerDNS / cloud, and Technitium blocks natively
+  // with no per-view concept. Saying so here beats an operator scoping a
+  // list to a view and waiting for filtering that will never arrive.
+  const nonBindDrivers = Array.from(
+    new Set(servers.filter((s) => s.driver !== "bind9").map((s) => s.driver)),
+  );
+  const hasBind = servers.some((s) => s.driver === "bind9");
+
+  const delMut = useMutation({
+    mutationFn: (id: string) => dnsApi.deleteView(group.id, id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dns-views", group.id] });
+      qc.invalidateQueries({ queryKey: ["dns-blocklists"] });
+      setConfirmDelete(null);
+    },
+    // Close the dialog on failure too — the error renders on the page
+    // behind it, so leaving the modal up hides the only explanation and
+    // reads as "Delete does nothing".
+    onError: (e: ApiError) => {
+      setError(formatApiError(e, "Delete failed"));
+      setConfirmDelete(null);
+    },
+  });
 
   return (
     <div>
-      {views.length === 0 ? (
-        <p className="text-sm text-muted-foreground italic">
-          No views defined. Views enable split-horizon DNS.
-        </p>
-      ) : (
-        <div className="space-y-2">
-          {views.map((v) => (
-            <div key={v.id} className="rounded-md border bg-card px-3 py-2.5">
-              <div className="flex items-center justify-between">
-                <span className="text-sm font-medium">{v.name}</span>
-                <span className="text-xs text-muted-foreground">
-                  order: {v.order}
-                </span>
-              </div>
-              {v.description && (
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {v.description}
-                </p>
-              )}
-              <div className="mt-1.5 flex flex-wrap gap-1">
-                {v.match_clients.map((c) => (
-                  <span
-                    key={c}
-                    className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-xs font-mono"
-                  >
-                    {c}
-                  </span>
-                ))}
-              </div>
-            </div>
-          ))}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          Views
+        </span>
+        <button
+          className="flex items-center gap-1 rounded-md border px-2 py-1 text-xs hover:bg-accent"
+          onClick={() => {
+            setError("");
+            setCreating(true);
+          }}
+        >
+          <Plus className="h-3 w-3" /> New View
+        </button>
+      </div>
+
+      {servers.length > 0 && !hasBind && (
+        <div className="mb-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-400">
+          <strong>This group runs no BIND9 server.</strong> Views and
+          view-scoped blocking lists are rendered by the BIND9 driver only — on{" "}
+          {nonBindDrivers.join(" / ")} they are stored but never applied.
         </div>
       )}
+
+      {views.length === 0 ? (
+        <div className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">No views defined.</p>
+          <p className="mt-1">
+            A view serves different answers to different clients, matched on the
+            query's source address. Use one to run split-horizon DNS, or to
+            apply a blocking list to just one VLAN.
+          </p>
+          <p className="mt-1">
+            Note that once any view exists, <em>every</em> zone in this group is
+            served from inside a view — zones with no view of their own are
+            rendered into all of them.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {views.map((v) => {
+            const scoped = blocklists.filter((b) =>
+              b.applied_view_ids?.includes(v.id),
+            );
+            return (
+              <div
+                key={v.id}
+                className="rounded-md border bg-card px-3 py-2.5 group"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <span className="text-sm font-medium font-mono">
+                      {v.name}
+                    </span>
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      order {v.order}
+                    </span>
+                    {!v.recursion && (
+                      <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium">
+                        no recursion
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1 opacity-0 group-hover:opacity-100">
+                    <button
+                      className="h-7 w-7 flex items-center justify-center rounded text-muted-foreground hover:text-foreground"
+                      title="Edit view"
+                      onClick={() => {
+                        setError("");
+                        setEditing(v);
+                      }}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      className="h-7 w-7 flex items-center justify-center rounded text-muted-foreground hover:text-destructive"
+                      title="Delete view"
+                      onClick={() => {
+                        setError("");
+                        setConfirmDelete(v);
+                      }}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+                {v.description && (
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    {v.description}
+                  </p>
+                )}
+                <div className="mt-1.5 flex flex-wrap items-center gap-1">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+                    clients
+                  </span>
+                  {v.match_clients.map((c) => (
+                    <span
+                      key={c}
+                      className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-xs font-mono"
+                    >
+                      {c}
+                    </span>
+                  ))}
+                </div>
+                {scoped.length > 0 && (
+                  <div className="mt-1.5 flex flex-wrap items-center gap-1">
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground/70">
+                      blocking
+                    </span>
+                    {scoped.map((b) => (
+                      <span
+                        key={b.id}
+                        className="inline-flex items-center rounded bg-rose-500/10 px-1.5 py-0.5 text-xs text-rose-600 dark:text-rose-400"
+                        title={`${b.entry_count.toLocaleString()} entries`}
+                      >
+                        {b.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+
+      {(creating || editing) && (
+        <ViewModal
+          groupId={group.id}
+          view={editing}
+          onClose={() => {
+            setCreating(false);
+            setEditing(null);
+          }}
+        />
+      )}
+
+      {confirmDelete && (
+        <ConfirmModal
+          open
+          title={`Delete view "${confirmDelete.name}"?`}
+          confirmLabel="Delete view"
+          tone="destructive"
+          loading={delMut.isPending}
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={() => delMut.mutate(confirmDelete.id)}
+          message={
+            <div className="space-y-2 text-sm">
+              <p>
+                Zones assigned to this view are not deleted — they fall back to
+                being served from every remaining view.
+              </p>
+              <p>
+                Any blocking list scoped only to this view stops being applied
+                anywhere.
+              </p>
+              {views.length === 1 && (
+                <p className="text-amber-700 dark:text-amber-400">
+                  This is the last view in the group. Removing it returns the
+                  group to serving one flat set of zones to every client.
+                </p>
+              )}
+            </div>
+          }
+        />
+      )}
     </div>
+  );
+}
+
+/** Create / edit a DNS view.
+ *
+ * `match_clients` is entered as one element per line, mirroring the ACL
+ * editor next door — an operator who has typed one has typed both. The
+ * "Add subnets…" picker exists because what people actually mean by
+ * "scope this to the guest VLAN" is the guest VLAN's CIDR, and retyping a
+ * prefix they already modelled in IPAM is how typos get in.
+ *
+ * Validation is server-side (`app/services/dns/view_validation.py`): these
+ * strings are interpolated verbatim into named.conf, so the client checks
+ * nothing it could be wrong about and simply renders the 422.
+ */
+function ViewModal({
+  groupId,
+  view,
+  onClose,
+}: {
+  groupId: string;
+  view: DNSView | null;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [name, setName] = useState(view?.name ?? "");
+  const [description, setDescription] = useState(view?.description ?? "");
+  const [order, setOrder] = useState(String(view?.order ?? 0));
+  const [recursion, setRecursion] = useState(view?.recursion ?? true);
+  const [matchClients, setMatchClients] = useState(
+    (view?.match_clients ?? ["any"]).join("\n"),
+  );
+  const [matchDestinations, setMatchDestinations] = useState(
+    (view?.match_destinations ?? []).join("\n"),
+  );
+  const [showSubnets, setShowSubnets] = useState(false);
+  const [error, setError] = useState("");
+
+  const lines = (s: string) =>
+    s
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean);
+
+  const saveMut = useMutation({
+    mutationFn: (payload: Partial<DNSView>) =>
+      view
+        ? dnsApi.updateView(groupId, view.id, payload)
+        : dnsApi.createView(groupId, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dns-views", groupId] });
+      qc.invalidateQueries({ queryKey: ["dns-blocklists"] });
+      onClose();
+    },
+    onError: (e: ApiError) => setError(formatApiError(e, "Save failed")),
+  });
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    const clients = lines(matchClients);
+    if (clients.length === 0) {
+      // BIND treats an empty match-clients as "match nothing", so a view
+      // saved this way silently answers no one. Refuse rather than let an
+      // operator ship a view that looks configured and serves nobody.
+      setError(
+        "Add at least one client match — an address, a CIDR prefix, an ACL name, or 'any'.",
+      );
+      return;
+    }
+    saveMut.mutate({
+      name: name.trim(),
+      description: description.trim(),
+      order: Number(order) || 0,
+      recursion,
+      match_clients: clients,
+      match_destinations: lines(matchDestinations),
+    });
+  }
+
+  return (
+    <Modal
+      title={view ? `Edit view "${view.name}"` : "New view"}
+      onClose={onClose}
+      wide
+    >
+      <form onSubmit={submit} className="space-y-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <Field label="Name">
+            <input
+              className={inputCls}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="guest"
+              required
+            />
+          </Field>
+          <Field label="Order">
+            <input
+              className={inputCls}
+              type="number"
+              value={order}
+              onChange={(e) => setOrder(e.target.value)}
+            />
+          </Field>
+          <Field label="Recursion">
+            <label className="flex h-[30px] items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={recursion}
+                onChange={(e) => setRecursion(e.target.checked)}
+              />
+              Answer recursive queries
+            </label>
+          </Field>
+        </div>
+        <p className="-mt-1 text-[11px] text-muted-foreground">
+          Views are evaluated low order first, and a client is served by the
+          first view it matches — so put the most specific view above the
+          catch-all.
+        </p>
+
+        <Field label="Description">
+          <input
+            className={inputCls}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Optional"
+          />
+        </Field>
+
+        <div>
+          <div className="mb-1 flex items-center justify-between">
+            <span className="text-xs font-medium text-muted-foreground">
+              Match clients (one per line; prefix ! to negate)
+            </span>
+            <button
+              type="button"
+              className="flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] hover:bg-accent"
+              onClick={() => setShowSubnets(true)}
+            >
+              <Plus className="h-3 w-3" /> Add subnets…
+            </button>
+          </div>
+          <textarea
+            value={matchClients}
+            onChange={(e) => setMatchClients(e.target.value)}
+            className="w-full rounded border bg-background px-2 py-1 font-mono text-xs resize-none h-24 focus:outline-none focus:ring-1 focus:ring-ring"
+            placeholder={"10.20.0.0/16\n192.168.50.0/24\nany"}
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            An address, a CIDR prefix, or one of{" "}
+            <span className="font-mono">any</span> /{" "}
+            <span className="font-mono">none</span> /{" "}
+            <span className="font-mono">localhost</span> /{" "}
+            <span className="font-mono">localnets</span>. Named ACLs from the
+            ACLs tab are not accepted here — the DNS agent doesn't render ACL
+            definitions into <span className="font-mono">named.conf</span> yet,
+            so a view referencing one would stop the whole group's config from
+            applying. Paste the prefixes instead.
+          </p>
+        </div>
+
+        <details className="rounded border bg-muted/20 px-2 py-1.5">
+          <summary className="cursor-pointer text-xs text-muted-foreground">
+            Match destinations (advanced)
+          </summary>
+          <div className="mt-2">
+            <textarea
+              value={matchDestinations}
+              onChange={(e) => setMatchDestinations(e.target.value)}
+              className="w-full rounded border bg-background px-2 py-1 font-mono text-xs resize-none h-16 focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="Leave empty unless the server listens on several addresses"
+            />
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Matches the address the query arrived <em>on</em>, not the client
+              it came from. Only useful on a multi-homed server.
+            </p>
+          </div>
+        </details>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2 border-t pt-3">
+          <button
+            type="button"
+            className="rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={saveMut.isPending}
+            className="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground disabled:opacity-50"
+          >
+            {saveMut.isPending ? "Saving…" : view ? "Save changes" : "Create"}
+          </button>
+        </div>
+      </form>
+
+      {showSubnets && (
+        <SubnetPickerModal
+          onClose={() => setShowSubnets(false)}
+          onPick={(cidrs) => {
+            setMatchClients((prev) => {
+              const existing = lines(prev);
+              const merged = [...existing];
+              for (const c of cidrs) if (!merged.includes(c)) merged.push(c);
+              return merged.join("\n");
+            });
+            setShowSubnets(false);
+          }}
+        />
+      )}
+    </Modal>
+  );
+}
+
+/** Pick IPAM subnets and return their CIDRs.
+ *
+ * Views are the mechanism, but subnets are what operators think in — this
+ * turns "the guest VLAN" into the prefix without a copy-paste round trip
+ * through the IPAM page.
+ */
+function SubnetPickerModal({
+  onClose,
+  onPick,
+}: {
+  onClose: () => void;
+  onPick: (cidrs: string[]) => void;
+}) {
+  const [filter, setFilter] = useState("");
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const { data: subnets = [], isLoading } = useQuery({
+    queryKey: ["ipam-subnets", "view-picker"],
+    queryFn: () => ipamApi.listSubnets(),
+  });
+
+  const q = filter.trim().toLowerCase();
+  const shown = q
+    ? subnets.filter(
+        (s) =>
+          s.network.toLowerCase().includes(q) ||
+          (s.name ?? "").toLowerCase().includes(q),
+      )
+    : subnets;
+
+  return (
+    <Modal title="Add subnets" onClose={onClose}>
+      <div className="space-y-3">
+        <input
+          className={inputCls}
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter by name or CIDR…"
+          autoFocus
+        />
+        <div className="max-h-72 overflow-y-auto rounded border">
+          {isLoading && (
+            <p className="p-3 text-xs text-muted-foreground">Loading…</p>
+          )}
+          {!isLoading && shown.length === 0 && (
+            <p className="p-3 text-xs text-muted-foreground italic">
+              No subnets match.
+            </p>
+          )}
+          {shown.map((s) => (
+            <label
+              key={s.id}
+              className="flex cursor-pointer items-center gap-2 border-b px-2 py-1.5 text-xs last:border-0 hover:bg-accent/50"
+            >
+              <input
+                type="checkbox"
+                checked={picked.has(s.network)}
+                onChange={() =>
+                  setPicked((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(s.network)) next.delete(s.network);
+                    else next.add(s.network);
+                    return next;
+                  })
+                }
+              />
+              <span className="font-mono">{s.network}</span>
+              {s.name && (
+                <span className="truncate text-muted-foreground">{s.name}</span>
+              )}
+            </label>
+          ))}
+        </div>
+        <div className="flex items-center justify-between border-t pt-3">
+          <span className="text-xs text-muted-foreground">
+            {picked.size} selected
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={picked.size === 0}
+              className="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground disabled:opacity-50"
+              onClick={() => onPick(Array.from(picked))}
+            >
+              Add {picked.size > 0 ? picked.size : ""}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
   );
 }
 
@@ -4741,6 +5245,11 @@ function ViewsTab({ group }: { group: DNSServerGroup }) {
 function AclsTab({ groupId }: { groupId: string }) {
   const qc = useQueryClient();
   const [showCreate, setShowCreate] = useState(false);
+  // ConfirmModal rather than window.confirm — a native dialog can't be
+  // styled, can't explain the blast radius, and is blocked outright in
+  // some embedded browsers. (Project convention; this was the last
+  // window.confirm on the DNS page.)
+  const [confirmDelete, setConfirmDelete] = useState<DNSAcl | null>(null);
   const [newName, setNewName] = useState("");
   const [newDesc, setNewDesc] = useState("");
   const [newEntries, setNewEntries] = useState("");
@@ -4870,10 +5379,7 @@ function AclsTab({ groupId }: { groupId: string }) {
               </div>
               <button
                 className="h-7 w-7 flex items-center justify-center rounded opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive"
-                onClick={() => {
-                  if (confirm(`Delete ACL "${acl.name}"?`))
-                    delMut.mutate(acl.id);
-                }}
+                onClick={() => setConfirmDelete(acl)}
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </button>
@@ -4894,6 +5400,27 @@ function AclsTab({ groupId }: { groupId: string }) {
           </div>
         ))}
       </div>
+      {confirmDelete && (
+        <ConfirmModal
+          open
+          title={`Delete ACL "${confirmDelete.name}"?`}
+          confirmLabel="Delete ACL"
+          tone="destructive"
+          onClose={() => setConfirmDelete(null)}
+          onConfirm={() => {
+            delMut.mutate(confirmDelete.id);
+            setConfirmDelete(null);
+          }}
+          message={
+            <p className="text-sm">
+              Any view or zone referencing{" "}
+              <span className="font-mono">{confirmDelete.name}</span> by name
+              will stop resolving it — check the Views tab before removing an
+              ACL that is in use.
+            </p>
+          }
+        />
+      )}
     </div>
   );
 }
@@ -7508,6 +8035,199 @@ function ZonesTab({
 
 // ── Blocklists Tab ────────────────────────────────────────────────────────────
 
+/**
+ * Choose where a blocking list applies (#876).
+ *
+ * The backend has carried two independent relationships since #24 —
+ * ``server_groups`` (every client of the group) and ``views`` (only
+ * clients matching that view's address list) — but the UI only ever wrote
+ * the first, so per-subnet filtering was unreachable from the product
+ * despite being fully rendered by the agent.
+ *
+ * Both are written in one PUT so the two halves can't diverge, and so the
+ * de-assigned groups get woken too (the endpoint unions old and new
+ * affected groups before publishing the config wake).
+ */
+function BlocklistScopeModal({
+  list,
+  group,
+  views,
+  onClose,
+}: {
+  list: DNSBlockList;
+  group: DNSServerGroup;
+  views: DNSView[];
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [wholeGroup, setWholeGroup] = useState(
+    list.applied_group_ids.includes(group.id),
+  );
+  // Only THIS group's views — the checkbox list below renders no others, so
+  // seeding from the raw ``applied_view_ids`` would park an un-unpickable
+  // id in the state that the footer then counts ("Applies to 1 view" about a
+  // view of some other group) and that ships duplicated in the PUT alongside
+  // ``otherViews``.
+  const [picked, setPicked] = useState<Set<string>>(() => {
+    const thisGroups = new Set(views.map((v) => v.id));
+    return new Set(
+      (list.applied_view_ids ?? []).filter((v) => thisGroups.has(v)),
+    );
+  });
+  const [error, setError] = useState("");
+
+  const { data: servers = [] } = useQuery({
+    queryKey: ["dns-servers", group.id],
+    queryFn: () => dnsApi.listServers(group.id),
+  });
+  const nonBind = Array.from(
+    new Set(servers.filter((s) => s.driver !== "bind9").map((s) => s.driver)),
+  );
+
+  const saveMut = useMutation({
+    mutationFn: () => {
+      // Preserve assignments to OTHER groups and to views of other groups —
+      // this modal only speaks for the group it was opened from, and the
+      // endpoint replaces each list wholesale.
+      const otherGroups = list.applied_group_ids.filter((g) => g !== group.id);
+      const thisGroupsViews = new Set(views.map((v) => v.id));
+      const otherViews = (list.applied_view_ids ?? []).filter(
+        (v) => !thisGroupsViews.has(v),
+      );
+      return dnsBlocklistApi.updateAssignments(list.id, {
+        server_group_ids: wholeGroup ? [...otherGroups, group.id] : otherGroups,
+        view_ids: [...otherViews, ...Array.from(picked)],
+      });
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["dns-blocklists"] });
+      onClose();
+    },
+    onError: (e: ApiError) => setError(formatApiError(e, "Save failed")),
+  });
+
+  const nothingSelected = !wholeGroup && picked.size === 0;
+
+  return (
+    <Modal title={`Scope "${list.name}"`} onClose={onClose} wide>
+      <div className="space-y-3">
+        {nonBind.length > 0 && (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs text-amber-700 dark:text-amber-400">
+            This group also runs {nonBind.join(" / ")}, which
+            {nonBind.length === 1 ? " does" : " do"} not render RPZ blocking.
+            Scoping affects the BIND9 servers only.
+          </div>
+        )}
+
+        <label className="flex cursor-pointer items-start gap-2 rounded-md border p-2.5 hover:bg-accent/30">
+          <input
+            type="checkbox"
+            className="mt-0.5"
+            checked={wholeGroup}
+            onChange={(e) => setWholeGroup(e.target.checked)}
+          />
+          <span className="text-sm">
+            <span className="font-medium">Whole group</span>
+            <span className="block text-xs text-muted-foreground">
+              Every client {group.name} answers, including clients of every
+              view.
+            </span>
+          </span>
+        </label>
+
+        <div>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">
+            Specific views
+          </p>
+          {views.length === 0 ? (
+            <p className="rounded-md border border-dashed p-3 text-xs text-muted-foreground">
+              No views defined in this group. Create one on the Views tab to
+              apply a list to a subset of clients — that is how "adult lists on
+              the guest VLAN only" is expressed.
+            </p>
+          ) : (
+            <div className="space-y-1">
+              {views.map((v) => (
+                <label
+                  key={v.id}
+                  className={cn(
+                    "flex cursor-pointer items-start gap-2 rounded-md border p-2 hover:bg-accent/30",
+                    wholeGroup && "opacity-50",
+                  )}
+                >
+                  <input
+                    type="checkbox"
+                    className="mt-0.5"
+                    checked={picked.has(v.id)}
+                    onChange={() =>
+                      setPicked((prev) => {
+                        const next = new Set(prev);
+                        if (next.has(v.id)) next.delete(v.id);
+                        else next.add(v.id);
+                        return next;
+                      })
+                    }
+                  />
+                  <span className="min-w-0 text-sm">
+                    <span className="font-mono">{v.name}</span>
+                    <span className="mt-0.5 flex flex-wrap gap-1">
+                      {v.match_clients.map((c) => (
+                        <span
+                          key={c}
+                          className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-[11px] font-mono"
+                        >
+                          {c}
+                        </span>
+                      ))}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+          {wholeGroup && picked.size > 0 && (
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              The group-wide assignment already covers every view, so these
+              per-view selections add nothing while it is on. They are kept so
+              unchecking "Whole group" narrows the list rather than removing it
+              everywhere.
+            </p>
+          )}
+        </div>
+
+        {error && <p className="text-xs text-destructive">{error}</p>}
+
+        <div className="flex items-center justify-between border-t pt-3">
+          <span className="text-xs text-muted-foreground">
+            {nothingSelected
+              ? "Not applied anywhere in this group."
+              : wholeGroup
+                ? "Applies to every client of this group."
+                : `Applies to ${picked.size} view${picked.size === 1 ? "" : "s"}.`}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded-md border px-3 py-1.5 text-xs hover:bg-accent"
+              onClick={onClose}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={saveMut.isPending}
+              className="rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground disabled:opacity-50"
+              onClick={() => saveMut.mutate()}
+            >
+              {saveMut.isPending ? "Saving…" : "Save scope"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
 function BlocklistsTab({ group }: { group: DNSServerGroup }) {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<DNSBlockList | null>(null);
@@ -7515,6 +8235,10 @@ function BlocklistsTab({ group }: { group: DNSServerGroup }) {
   const [showCatalog, setShowCatalog] = useState(false);
   const [editList, setEditList] = useState<DNSBlockList | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<DNSBlockList | null>(null);
+  // #876 — per-view scoping. Editing which views a list applies to is a
+  // separate action from the group-wide Apply/Detach toggle, because they
+  // write two different relationships.
+  const [scopeList, setScopeList] = useState<DNSBlockList | null>(null);
   // Bulk-select state. Keyed by blocklist id; spans both sections so the
   // operator can apply / detach / refresh / delete a mixed selection.
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
@@ -7556,9 +8280,32 @@ function BlocklistsTab({ group }: { group: DNSServerGroup }) {
     });
   }, [lists, refreshing]);
 
-  // Filter by lists applied to this group (or not yet applied anywhere)
-  const applied = lists.filter((l) => l.applied_group_ids.includes(group.id));
-  const other = lists.filter((l) => !l.applied_group_ids.includes(group.id));
+  const { data: views = [] } = useQuery({
+    queryKey: ["dns-views", group.id],
+    queryFn: () => dnsApi.listViews(group.id),
+  });
+  const viewIds = useMemo(() => new Set(views.map((v) => v.id)), [views]);
+  const viewName = useMemo(
+    () => new Map(views.map((v) => [v.id, v.name])),
+    [views],
+  );
+
+  /** Views of THIS group that ``l`` is scoped to. */
+  const scopedViews = (l: DNSBlockList) =>
+    (l.applied_view_ids ?? []).filter((id) => viewIds.has(id));
+
+  // A list scoped to a view of this group IS applied here — the bundle
+  // renders it inside that view's ``response-policy``. Classifying purely
+  // on ``applied_group_ids`` (as this did before #876 surfaced view
+  // scoping) filed those lists under "Available (not applied)", which
+  // reads as "this list is doing nothing" about a list that is actively
+  // filtering a VLAN.
+  const groupAssigned = (l: DNSBlockList) =>
+    l.applied_group_ids.includes(group.id);
+  const appliesHere = (l: DNSBlockList) =>
+    l.applied_group_ids.includes(group.id) || scopedViews(l).length > 0;
+  const applied = lists.filter(appliesHere);
+  const other = lists.filter((l) => !appliesHere(l));
 
   // Selection helpers — both per-row and per-section.
   function toggleOne(id: string) {
@@ -7827,9 +8574,12 @@ function BlocklistsTab({ group }: { group: DNSServerGroup }) {
         <p className="text-sm text-muted-foreground">Loading…</p>
       )}
 
+      {/* No ``assigned`` flag on the section any more: since #876 a row can
+          sit in the applied section purely because a VIEW of this group
+          scopes it, so per-row controls key off ``groupAssigned(l)``. */}
       {[
-        { label: "Applied to this group", rows: applied, assigned: true },
-        { label: "Available (not applied)", rows: other, assigned: false },
+        { label: "Applied to this group or one of its views", rows: applied },
+        { label: "Available (not applied)", rows: other },
       ].map((section) => {
         const sectionIds = section.rows.map((r) => r.id);
         const sectionAllSel =
@@ -7895,6 +8645,15 @@ function BlocklistsTab({ group }: { group: DNSServerGroup }) {
                         disabled
                       </span>
                     )}
+                    {scopedViews(l).map((id) => (
+                      <span
+                        key={id}
+                        className="inline-flex items-center rounded bg-violet-500/15 px-1.5 py-0.5 text-xs text-violet-600 dark:text-violet-400"
+                        title="Applied to this view only"
+                      >
+                        view: {viewName.get(id)}
+                      </span>
+                    ))}
                     <span className="ml-auto text-xs text-muted-foreground">
                       {l.entry_count} entries
                     </span>
@@ -7902,22 +8661,42 @@ function BlocklistsTab({ group }: { group: DNSServerGroup }) {
                       className="flex items-center gap-1"
                       onClick={(e) => e.stopPropagation()}
                     >
-                      <button
-                        title={
-                          section.assigned
-                            ? "Detach from this group"
-                            : "Apply to this group"
-                        }
-                        className={`rounded border px-2 py-0.5 text-xs ${section.assigned ? "text-amber-600 border-amber-400" : "text-emerald-600 border-emerald-400"}`}
-                        onClick={() =>
-                          toggleAssignment.mutate({
-                            list: l,
-                            assign: !section.assigned,
-                          })
-                        }
-                      >
-                        {section.assigned ? "Detach" : "Apply"}
-                      </button>
+                      {/* Group-wide toggle. Keyed off the actual group
+                          relationship rather than the section, because a
+                          list can sit in the "applied" section purely
+                          because a VIEW of this group scopes it — and
+                          "Detach" would then rewrite a group list it was
+                          never in, doing nothing while looking broken. */}
+                      {groupAssigned(l) ? (
+                        <button
+                          title="Detach from this group"
+                          className="rounded border border-amber-400 px-2 py-0.5 text-xs text-amber-600"
+                          onClick={() =>
+                            toggleAssignment.mutate({ list: l, assign: false })
+                          }
+                        >
+                          Detach
+                        </button>
+                      ) : (
+                        <button
+                          title="Apply to every client of this group"
+                          className="rounded border border-emerald-400 px-2 py-0.5 text-xs text-emerald-600"
+                          onClick={() =>
+                            toggleAssignment.mutate({ list: l, assign: true })
+                          }
+                        >
+                          Apply
+                        </button>
+                      )}
+                      {views.length > 0 && (
+                        <button
+                          title="Scope to specific views"
+                          className="h-6 w-6 flex items-center justify-center rounded text-muted-foreground hover:text-foreground"
+                          onClick={() => setScopeList(l)}
+                        >
+                          <Filter className="h-3 w-3" />
+                        </button>
+                      )}
                       {l.source_type === "url" && l.feed_url && (
                         <button
                           title={
@@ -7957,6 +8736,15 @@ function BlocklistsTab({ group }: { group: DNSServerGroup }) {
           </div>
         );
       })}
+
+      {scopeList && (
+        <BlocklistScopeModal
+          list={scopeList}
+          group={group}
+          views={views}
+          onClose={() => setScopeList(null)}
+        />
+      )}
 
       {showCreate && <BlocklistModal onClose={() => setShowCreate(false)} />}
       {editList && (


### PR DESCRIPTION
Closes #876

The issue's read was right: the backend has scoped a blocking list to a
view *or* a server group since #24 (`dns_blocklist_view_assoc`, rendered
per-view by the agent), and only the UI was missing. It wrote the group
half only, so the #878 family filter's whole point — filtering one network
and not another — was unreachable from the product despite being fully
implemented underneath.

## What landed

| Gap | Fix |
|---|---|
| Frontend never sent `view_ids` | Scope modal on each list, writing group + view assignment in one PUT |
| Views tab read-only | Full CRUD, so split-horizon DNS is configurable from the product at all |
| Docs covered group scoping only | `DNS.md` §8 gains a scoping section + a worked kids-VLAN example |
| "Scope to subnets…" (stretch) | *Add subnets…* picker in the view editor, filling `match_clients` from IPAM |

The subnet picker exists because "scope this to the guest VLAN" means that
VLAN's CIDR, and retyping a prefix already modelled in IPAM is how typos
get in. Both surfaces badge a group that runs a non-BIND9 driver, since
`render_rpz_zone` is a no-op there.

## The part that wasn't surface

`match_clients`, `match_destinations` and the view name had **no
server-side validation**, and all three are interpolated verbatim into
`named.conf`:

```
view "{{ view.name }}" {
    match-clients { {% for c in view.match_clients %}{{ c }}; {% endfor %}};
```

The name additionally becomes a directory on the agent
(`/var/cache/bind/rpz/<view>/`) and a DNS label in
`spatium-blocklist-<view>.rpz`. So `app/services/dns/view_validation.py`
now rejects, with a 422 naming the offending element: malformed prefixes,
`;`-injection, `../` traversal, names over 45 chars (the RPZ label would
overflow 63 octets), BIND's reserved `_default` / `_bind`, and `key
<name>` naming a TSIG key the group doesn't ship.

That gate matters more than it looks. The agent runs `named-checkconf`
before swapping config in, so an accepted-but-invalid value doesn't break
one view — it stops the **whole group's** config converging, silently,
until someone reads the agent log. Same blast radius as the malformed-RPZ
bugs in #878.

## Two pre-existing UI bugs that view scoping exposed

- The Blocklists tab classified a view-scoped list as "Available (not
  applied)" — reporting a list actively filtering a VLAN as doing nothing.
- Its Apply/Detach toggle keyed off which *section* the row was in rather
  than the actual group relationship, so "Detach" on a view-scoped list
  rewrote a group list it was never in: a no-op that looked broken.

## Found on the way: named ACLs are inert config

The DNS agent **never renders `acl {}` definitions at all**. `DNSAcl` rows
are stored, listed and editable on the ACLs tab, and the bundle carries an
`acls` block — but only as `{id, name}`, and the agent's BIND9 renderer
never reads it. The one template that does emit `acl {}` is reached only
through `BIND9Driver.render_server_config`, which has no production caller.

So naming an ACL in a view would leave an undefined symbol in `named.conf`,
`named-checkconf` would fail, and the agent would decline the entire
bundle. My first draft of both the UI help text and DNS.md told operators
to do exactly that. Named ACLs are now rejected with a 422 explaining the
real reason rather than claiming the ACL doesn't exist, and
**#899** tracks making them work. Rejecting is not a restriction here — it
converts a silent group-wide outage into a message that says what to type
instead.

Worth knowing this is the same shape as `allow_transfer` (settable,
persisted, never rendered) until #734 fixed it.

## Verified on a live agent

Not just in tests — creating a view and scoping a list to it renders:

```
view "guest" {
    match-clients { 10.20.0.0/16; };
    response-policy { zone "spatium-blocklist-guest.rpz"; } break-dnssec yes;
```

and `named-checkconf` accepts it (exit 0, 8 zones still rendered).

## Tests

23 new in `backend/tests/test_dns_view_validation.py` — the injection and
traversal cases, the 45-char RPZ-label cap, the TSIG-key gate, the ACL
rejection *with its reason*, and that the documented workaround (paste the
prefixes) actually works. 37 passing with the existing blocklist suite.

Drive-by: replaced the last `window.confirm` on the DNS page (ACL delete)
with `ConfirmModal`, per project convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)