### PR TITLE
feat(dns): render named ACLs into named.conf (#899)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -556,7 +556,7 @@ suggestion, free-space treemap.
   picker that turns IPAM prefixes into `match_clients`; a **scope modal**
   on each blocking list writing group and view assignment in one PUT; and
   per-view chips on both tabs. **The load-bearing addition is server-side
-  validation** (`app/services/dns/view_validation.py`): `match_clients`,
+  validation** (`app/services/dns/named_conf_validation.py`): `match_clients`,
   `match_destinations` and the view name are interpolated *verbatim* into
   `named.conf`, and the name additionally becomes a directory on the
   agent — so a malformed prefix, an undefined ACL name, a `;`-injection or
@@ -573,9 +573,9 @@ suggestion, free-space treemap.
   definitions at all — `DNSAcl` rows are stored and editable but the bundle
   ships only `{id, name}` and the agent renderer ignores it, so naming an
   ACL in a view would leave an undefined symbol and stop the group
-  converging. Named ACLs are therefore rejected in a view's match-list with
-  a 422 saying why; [#899](https://github.com/spatiumddi/spatiumddi/issues/899)
-  tracks making them real.
+  converging. Named ACLs were therefore rejected in a view's match-list
+  with a 422 saying why, until
+  [#899](https://github.com/spatiumddi/spatiumddi/issues/899) made them real.
 - ✅ [**Blocklist feed wildcard semantics are per-list**](https://github.com/spatiumddi/spatiumddi/issues/894)
   — #878 made every feed row `is_wildcard=True`, right for all 19
   catalog sources but a global constant, and wrong for a host-specific
@@ -591,6 +591,35 @@ suggestion, free-space treemap.
   arrived `*.`-prefixed, so an apex-only list fed a wildcard-syntax
   feed logs that it is overriding the feed's stated intent instead of
   doing it silently.
+
+- ✅ [**DNS agent never renders `acl {}` definitions**](https://github.com/spatiumddi/spatiumddi/issues/899)
+  — `DNSAcl` rows were stored, listed and editable on the ACLs tab and
+  applied to **nothing**: the bundle carried `{id, name}` with no entries
+  and the agent's BIND9 renderer emitted no `acl {}` stanza at all (the
+  control-plane template that does render one has no production caller).
+  Citing an ACL anywhere that reached `named.conf` therefore left an
+  undefined symbol — `named-checkconf` fails, the agent declines the
+  *whole* bundle, and the group stops converging rather than just that
+  statement, which is why #876 had to reject ACL names outright. Now the
+  bundle ships entries and the agent renders `acl "<name>" { … };` **above
+  `options`** — placement is the correctness property, since BIND resolves
+  an `acl` where it is written and a definition below its first use is an
+  error, not a forward declaration. The list is emitted
+  dependency-ordered (`order_acls_for_render`, a DFS topological sort) so
+  a nested reference resolves, and **cycles are refused at the commit**
+  with a graph check: `a → b → a` has two individually-legal edges, so
+  per-field validation cannot see it. Entry values now go through the same
+  gate as a view's `match_clients`, and an entry-less ACL is skipped at
+  render because BIND rejects `acl "x" { };`. Global ACLs (`group_id IS
+  NULL`) are documented unsupported — nothing creates one and the bundle
+  is per-group. **The audit the issue asked for found a second instance of
+  the same bug class:** `DNSServerOptions.forward_policy` was settable,
+  persisted and shipped, and no `forward` statement was ever rendered — so
+  `only` silently behaved as BIND's default `first`, letting queries leak
+  past a filtering upstream that an operator had deliberately forced
+  everything through. Third field in this class after `allow_transfer`
+  (#734); the lesson recorded in `DNS.md` §8.2 is to assert on the
+  *rendered config*, not the stored row.
 
 #### DHCP-specific
 

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -42,7 +42,7 @@ from .base import RRSET_OP_KINDS, DriverBase
 log = structlog.get_logger(__name__)
 
 NAMED_CONF_SKELETON = """\
-{tls_statements}options {{
+{acl_statements}{tls_statements}options {{
     directory "/var/cache/bind";
     listen-on {{ any; }};
     listen-on-v6 {{ any; }};
@@ -344,7 +344,50 @@ def _forward_over_tls(opts: dict[str, Any]) -> bool:
     return (opts.get("forward_transport") or "do53") == "tls"
 
 
-def _render_tls_statements(opts: dict[str, Any], state_dir: Path, has_cert: bool) -> str:
+def _render_acl_statements(acls: list[dict[str, Any]] | None) -> str:
+    """``acl "name" { … };`` blocks for the group's named ACLs (issue #899).
+
+    These come FIRST in named.conf, ahead of ``options``, because BIND
+    resolves an ``acl`` statement where it is written: a reference to one
+    declared later in the file is an error, not a forward declaration. The
+    control plane already emits the list dependency-ordered (an ACL may
+    reference another), so this renders it as given.
+
+    Until #899 the bundle carried ``{id, name}`` with no entries and this
+    function did not exist — an ACL an operator created on the ACLs tab was
+    stored, listed, editable, and applied to nothing. Worse, naming one
+    anywhere that reached named.conf left an undefined symbol, so
+    ``named-checkconf`` failed and the whole bundle was declined.
+
+    An ACL with no usable entries renders as ``{ none; }`` rather than
+    being skipped. Skipping looks tidier and is wrong: the name may already
+    be cited by a view or another ACL, and dropping the definition
+    re-creates the undefined-symbol outage this whole change exists to
+    remove. ``none`` is also the honest meaning of an empty address-match
+    list — it matches nothing.
+    """
+    out = []
+    for acl in acls or []:
+        name = str(acl.get("name") or "").strip()
+        if not name:
+            continue
+        items = ""
+        for e in acl.get("entries") or []:
+            value = str(e.get("value", "")).strip()
+            if not value:
+                continue
+            # The control plane stores negation as a flag, but an operator
+            # pasting "!10.0.0.0/8" into the entry value is equally valid.
+            # Rendering both would emit "!!10.0.0.0/8", which BIND rejects.
+            negated = bool(e.get("negate")) or value.startswith("!")
+            items += f"{'!' if negated else ''}{value.lstrip('!').strip()}; "
+        out.append(f'acl "{name}" {{ {items or "none; "}}};\n')
+    return "".join(out)
+
+
+def _render_tls_statements(
+    opts: dict[str, Any], state_dir: Path, has_cert: bool
+) -> str:
     """Top-level ``tls`` / ``http`` statements for the encrypted transports.
 
     Returns "" when nothing is enabled so an install that never opted in
@@ -371,7 +414,9 @@ def _render_tls_statements(opts: dict[str, Any], state_dir: Path, has_cert: bool
 
     if _doh_listener_active(opts, has_cert):
         path = (opts.get("doh_path") or "/dns-query").strip()
-        blocks.append(f"http {_LOCAL_HTTP_ID} {{\n    endpoints {{ \"{path}\"; }};\n}};\n")
+        blocks.append(
+            f'http {_LOCAL_HTTP_ID} {{\n    endpoints {{ "{path}"; }};\n}};\n'
+        )
 
     if _forward_over_tls(opts):
         lines = [f"tls {_UPSTREAM_TLS_ID} {{"]
@@ -497,7 +542,12 @@ def _wire_value(rtype: str, value: str, fields: dict[str, Any]) -> str:
         pri = fields.get("priority")
         wt = fields.get("weight")
         prt = fields.get("port")
-        if pri is not None and wt is not None and prt is not None and len(value.split()) < 4:
+        if (
+            pri is not None
+            and wt is not None
+            and prt is not None
+            and len(value.split()) < 4
+        ):
             return f"{pri} {wt} {prt} {value}"
     return value
 
@@ -602,7 +652,6 @@ def _render_dnssec_policies(policies: list[dict[str, Any]]) -> str:
     return out
 
 
-
 class Bind9Driver(DriverBase):
     rendered_dir_name = "rendered"
     daemon_pid: int | None = None
@@ -632,7 +681,9 @@ class Bind9Driver(DriverBase):
         # the operator's intent flag — see _render_tls_statements.
         tls_cert = bundle.get("tls_cert") or None
         has_cert = bool(
-            isinstance(tls_cert, dict) and tls_cert.get("cert_pem") and tls_cert.get("key_pem")
+            isinstance(tls_cert, dict)
+            and tls_cert.get("cert_pem")
+            and tls_cert.get("key_pem")
         )
         if (opts.get("dot_enabled") or opts.get("doh_enabled")) and not has_cert:
             log.warning(
@@ -646,6 +697,22 @@ class Bind9Driver(DriverBase):
             fwd_block = "    forwarders {{ {fs}; }};\n".format(
                 fs="; ".join(_format_forwarder(str(f), opts) for f in forwarders)
             )
+            # ``forward only`` means "never fall back to recursing yourself".
+            # It was settable, persisted and shipped in the bundle, but no
+            # ``forward`` statement was ever rendered — so BIND used its own
+            # default (``first``) and an operator who chose ``only`` silently
+            # got the opposite. That matters beyond tidiness: ``only`` is how
+            # you force every query through a filtering upstream, and
+            # ``first`` lets queries leak straight past it on any upstream
+            # hiccup.
+            #
+            # Emitted only for ``only``, because ``first`` IS BIND's default
+            # — rendering it explicitly would change named.conf on every
+            # install that has forwarders and reload BIND for no behaviour
+            # change. Found by the #899 audit for stored-but-never-rendered
+            # fields, same class as allow-transfer (#734) and named ACLs.
+            if str(opts.get("forward_policy", "first")).lower() == "only":
+                fwd_block += "    forward only;\n"
 
         tsig_keys = bundle.get("tsig_keys") or []
         tsig_key_name = tsig_keys[0]["name"] if tsig_keys else None
@@ -658,7 +725,9 @@ class Bind9Driver(DriverBase):
         # own ``allow_transfer`` override emits its own clause below, which
         # BIND lets shadow this one entirely.
         key_grants = _transfer_key_grants(tsig_keys)
-        allow_transfer_opt = _render_allow_transfer(opts.get("allow_transfer"), key_grants)
+        allow_transfer_opt = _render_allow_transfer(
+            opts.get("allow_transfer"), key_grants
+        )
 
         # Split-horizon (issue #24): when the group defines views, every
         # zone — and every RPZ/response-policy — lives INSIDE a
@@ -696,6 +765,7 @@ class Bind9Driver(DriverBase):
             rate_limit=_render_rate_limit_block(opts),
             logging_block=logging_block,
             tsig_include=tsig_include,
+            acl_statements=_render_acl_statements(bundle.get("acls")),
             tls_statements=_render_tls_statements(opts, self.state_dir, has_cert),
             encrypted_listeners=_render_encrypted_listeners(opts, has_cert),
         )
@@ -741,7 +811,9 @@ class Bind9Driver(DriverBase):
             # fall back to plaintext for its zone-scoped upstreams.
             if zone_type == "forward":
                 fwds = [
-                    _format_forwarder(str(f), opts) for f in (zone.get("forwarders") or []) if f
+                    _format_forwarder(str(f), opts)
+                    for f in (zone.get("forwarders") or [])
+                    if f
                 ]
                 if not fwds:
                     return ""
@@ -1141,7 +1213,9 @@ class Bind9Driver(DriverBase):
         # Exceptions are emitted as passthru below, so an entry for the
         # same name must not also be emitted. Matches the control-plane
         # renderer, which already skips excluded domains.
-        excluded = {str(x).rstrip(".").lower() for x in (bl.get("exceptions") or []) if x}
+        excluded = {
+            str(x).rstrip(".").lower() for x in (bl.get("exceptions") or []) if x
+        }
         # First writer of an owner name wins. The choice between two
         # disagreeing lists is arbitrary — what is NOT arbitrary is that
         # the zone must load, since the alternative is enforcing nothing

--- a/agent/dns/tests/test_acl_render.py
+++ b/agent/dns/tests/test_acl_render.py
@@ -1,0 +1,178 @@
+"""Named ACLs render into named.conf (issue #899).
+
+Before this the agent never emitted an ``acl {}`` stanza at all — the
+bundle carried ``{id, name}`` with no entries, so an ACL an operator
+created was stored, listed, editable, and applied to nothing. Referencing
+one from a view or from ``options`` therefore left an undefined symbol:
+``named-checkconf`` fails and the agent declines the *whole* bundle, so
+the group stops converging rather than just that statement.
+
+The load-bearing assertion here is **placement**. An ``acl`` in BIND is
+resolved where it is written, so a definition below its first use is an
+error, not a forward declaration.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from spatium_dns_agent.drivers.bind9 import Bind9Driver, _render_acl_statements
+
+
+def _bundle(acls: list[dict], views: list[dict] | None = None) -> dict:
+    return {
+        "server": {"name": "s1", "driver": "bind9"},
+        "options": {},
+        "acls": acls,
+        "views": views or [],
+        "zones": [],
+        "blocklists": [],
+        "tsig_keys": [],
+        "pending_ops": [],
+    }
+
+
+def _acl(name: str, *values: str) -> dict:
+    return {
+        "id": name,
+        "name": name,
+        "entries": [
+            {"value": v.lstrip("!"), "negate": v.startswith("!")} for v in values
+        ],
+    }
+
+
+# ── the helper ────────────────────────────────────────────────────────────
+
+
+def test_renders_entries_with_negation() -> None:
+    out = _render_acl_statements([_acl("office", "10.0.0.0/8", "!192.168.0.0/16")])
+    assert out == 'acl "office" { 10.0.0.0/8; !192.168.0.0/16; };\n'
+
+
+def test_an_empty_acl_renders_as_none_not_skipped() -> None:
+    """BIND rejects ``acl "x" { };`` — but omitting the definition is worse.
+
+    The name may already be cited by a view or another ACL, and dropping it
+    re-creates the undefined-symbol outage this whole change removes.
+    ``none`` is also the honest meaning of an empty address-match list.
+    """
+    assert (
+        _render_acl_statements([{"name": "empty", "entries": []}])
+        == 'acl "empty" { none; };\n'
+    )
+    assert (
+        _render_acl_statements([{"name": "blank", "entries": [{"value": "  "}]}])
+        == 'acl "blank" { none; };\n'
+    )
+    # A nameless ACL has nothing to render or cite.
+    assert _render_acl_statements([{"name": "", "entries": [{"value": "any"}]}]) == ""
+    assert _render_acl_statements([]) == ""
+    assert _render_acl_statements(None) == ""
+
+
+def test_negation_is_not_doubled() -> None:
+    """Negation is a flag on the row, but an operator can equally paste
+    ``!10.0.0.0/8`` into the value. Rendering both gives ``!!…``, which
+    BIND rejects."""
+    assert _render_acl_statements(
+        [{"name": "a", "entries": [{"value": "!10.0.0.0/8", "negate": True}]}]
+    ) == 'acl "a" { !10.0.0.0/8; };\n'
+    assert _render_acl_statements(
+        [{"name": "a", "entries": [{"value": "!10.0.0.0/8", "negate": False}]}]
+    ) == 'acl "a" { !10.0.0.0/8; };\n'
+
+
+
+# ── through the real renderer ─────────────────────────────────────────────
+
+
+def test_acls_are_written_above_options(tmp_path: Path) -> None:
+    """``options`` cites ACLs in allow-query / allow-transfer, so the
+    definitions have to precede it — this is the whole correctness
+    property, and it is invisible in a diff of the helper alone."""
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(_bundle([_acl("office", "10.0.0.0/8")]))
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+
+    assert 'acl "office" { 10.0.0.0/8; };' in conf
+    assert conf.index('acl "office"') < conf.index("options {")
+
+
+def test_acls_precede_the_views_that_reference_them(tmp_path: Path) -> None:
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(
+        _bundle(
+            [_acl("office", "10.0.0.0/8")],
+            views=[
+                {
+                    "name": "internal",
+                    "match_clients": ["office"],
+                    "match_destinations": [],
+                    "recursion": True,
+                    "order": 0,
+                }
+            ],
+        )
+    )
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert "match-clients { office; };" in conf
+    assert conf.index('acl "office"') < conf.index('view "internal"')
+
+
+def test_a_bundle_with_no_acls_renders_unchanged(tmp_path: Path) -> None:
+    """Every existing install has zero ACLs. Their named.conf must not
+    move — a changed byte churns the config hash and reloads BIND for
+    nothing."""
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(_bundle([]))
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert "acl " not in conf
+    assert conf.lstrip().startswith("options {")
+
+
+# ── forward policy ────────────────────────────────────────────────────────
+#
+# Not an ACL, but the same class of bug and found by the #899 audit:
+# ``DNSServerOptions.forward_policy`` was settable, persisted and shipped
+# in the bundle, and no ``forward`` statement was ever rendered.
+
+
+def _forwarder_bundle(policy: str) -> dict:
+    b = _bundle([])
+    # The agent reads forwarders from ``options``, not the bundle root.
+    b["options"] = {"forwarders": ["9.9.9.9"], "forward_policy": policy}
+    return b
+
+
+def test_forward_only_is_rendered(tmp_path: Path) -> None:
+    """``only`` means "never fall back to recursing yourself" — it is how an
+    operator forces every query through a filtering upstream. Rendering
+    nothing left BIND on its default (``first``), which lets queries leak
+    straight past that filter."""
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(_forwarder_bundle("only"))
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert "forwarders { 9.9.9.9; };" in conf
+    assert "forward only;" in conf
+
+
+def test_forward_first_renders_nothing_extra(tmp_path: Path) -> None:
+    """``first`` IS BIND's default, so emitting it would change named.conf
+    on every install that has forwarders and reload BIND for no behaviour
+    change."""
+    drv = Bind9Driver(state_dir=tmp_path)
+    drv.render(_forwarder_bundle("first"))
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert "forwarders { 9.9.9.9; };" in conf
+    assert "forward " not in conf
+
+
+def test_no_forward_statement_without_forwarders(tmp_path: Path) -> None:
+    """``forward only;`` with no forwarders is a BIND config error."""
+    drv = Bind9Driver(state_dir=tmp_path)
+    b = _bundle([])
+    b["options"] = {"forward_policy": "only"}
+    drv.render(b)
+    conf = (tmp_path / "rendered.new" / "named.conf").read_text()
+    assert "forward only;" not in conf

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -19,7 +19,13 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
-from app.api.pagination import DEFAULT_PAGE_SIZE, MAX_PAGE, MAX_PAGE_SIZE, Page, paginate
+from app.api.pagination import (
+    DEFAULT_PAGE_SIZE,
+    MAX_PAGE,
+    MAX_PAGE_SIZE,
+    Page,
+    paginate,
+)
 from app.config import settings
 from app.core.agent_wake import (
     appliance_channel,
@@ -76,6 +82,16 @@ from app.services.dns.delegation import (
     find_parent_zone,
     preview_to_dict,
 )
+from app.services.dns.named_conf_validation import (
+    AclCycleError,
+    ViewValidationError,
+    is_name_reference,
+    order_acls_for_render,
+    validate_acl_entries,
+    validate_acl_name,
+    validate_address_match_list,
+    validate_view_name,
+)
 from app.services.dns.record_ops import (
     clear_dnssec_key_state,
     enqueue_dnssec_op,
@@ -91,11 +107,6 @@ from app.services.dns.resolver_presets import (
     find_forwarder_conflict,
 )
 from app.services.dns.serial import bump_zone_serial
-from app.services.dns.view_validation import (
-    ViewValidationError,
-    validate_address_match_list,
-    validate_view_name,
-)
 from app.services.dns.zone_templates import (
     get_template,
     list_templates,
@@ -2930,6 +2941,146 @@ async def _load_acl(group_id: uuid.UUID, acl_id: uuid.UUID, db: DB) -> DNSAcl | 
     return result.scalar_one_or_none()
 
 
+async def _group_symbol_names(
+    group_id: uuid.UUID, db: DB, *, exclude_acl_id: uuid.UUID | None = None
+) -> tuple[frozenset[str], frozenset[str]]:
+    """(ACL names, TSIG key names) an address-match-list in this group may cite.
+
+    Both are symbols in the rendered ``named.conf``; citing one that isn't
+    defined makes BIND refuse the file, which fails the entire bundle rather
+    than the one statement. ``exclude_acl_id`` drops the ACL currently being
+    edited, so a self-reference is reported as an undefined name at the field
+    the operator is looking at rather than surfacing later as a cycle.
+    """
+    acl_stmt = select(DNSAcl.name).where(DNSAcl.group_id == group_id)
+    if exclude_acl_id is not None:
+        acl_stmt = acl_stmt.where(DNSAcl.id != exclude_acl_id)
+    acl_names = frozenset((await db.execute(acl_stmt)).scalars().all())
+
+    key_names = set(
+        (await db.execute(select(DNSTSIGKey.name).where(DNSTSIGKey.group_id == group_id)))
+        .scalars()
+        .all()
+    )
+    # The group's legacy auto-generated loopback key is a real ``key {}`` in
+    # the rendered config too, so it is citable like any other.
+    group = await db.get(DNSServerGroup, group_id)
+    if group is not None and group.tsig_key_name:
+        key_names.add(group.tsig_key_name)
+    return acl_names, frozenset(key_names)
+
+
+async def _assert_acl_graph_is_acyclic(group_id: uuid.UUID, db: DB) -> None:
+    """Refuse a commit that would leave the group's ACLs circular.
+
+    Per-field validation catches a *self*-reference, but not A→B→A: each
+    edge is individually legal and only the pair is not. The bundle builder
+    orders ACLs by dependency and raises on a cycle, so without this check
+    an operator could save a config that makes every later bundle build
+    fail — breaking the group long after the edit that caused it.
+    """
+    # ``populate_existing`` is load-bearing, not defensive. The ACL being
+    # edited is already in the identity map with the entry collection it had
+    # on load, and a plain SELECT hands that cached object back — so the
+    # graph check would run against the PRE-edit entries and wave through
+    # the very cycle the edit just created. Caught by
+    # ``test_a_two_acl_cycle_is_refused_at_the_commit``.
+    rows = (
+        (
+            await db.execute(
+                select(DNSAcl)
+                .where(DNSAcl.group_id == group_id)
+                .options(selectinload(DNSAcl.entries))
+                .execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    try:
+        order_acls_for_render(
+            [
+                {
+                    "name": a.name,
+                    "entries": [{"value": e.value, "negate": e.negate} for e in a.entries],
+                }
+                for a in rows
+            ]
+        )
+    except AclCycleError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"field": exc.field, "value": exc.value, "message": str(exc)},
+        ) from exc
+
+
+async def _assert_acl_is_unreferenced(
+    group_id: uuid.UUID, acl: DNSAcl, db: DB, *, action: str
+) -> None:
+    """Refuse to delete or rename an ACL that something still cites.
+
+    Write-time validation stops an operator *creating* a dangling
+    reference. It does nothing about removing the target of one that
+    already resolves — and the consequence is identical: ``named.conf``
+    carries an undefined symbol, ``named-checkconf`` fails, and the agent
+    declines the whole bundle, so the group stops converging rather than
+    losing one statement.
+
+    Checks both directions a name can be cited: another ACL's entries, and
+    any view's ``match_clients`` / ``match_destinations`` /
+    ``allow_query`` / ``allow_query_cache``.
+    """
+    citing_acls = [
+        a.name
+        for a in (
+            await db.execute(
+                select(DNSAcl)
+                .where(DNSAcl.group_id == group_id, DNSAcl.id != acl.id)
+                .options(selectinload(DNSAcl.entries))
+                .execution_options(populate_existing=True)
+            )
+        )
+        .scalars()
+        .all()
+        if any(is_name_reference(e.value) == acl.name for e in a.entries)
+    ]
+    citing_views = [
+        v.name
+        for v in (await db.execute(select(DNSView).where(DNSView.group_id == group_id)))
+        .scalars()
+        .all()
+        if any(
+            is_name_reference(el) == acl.name
+            for el in (
+                (v.match_clients or [])
+                + (v.match_destinations or [])
+                + (v.allow_query or [])
+                + (v.allow_query_cache or [])
+            )
+        )
+    ]
+    if not citing_acls and not citing_views:
+        return
+    cited_by = ", ".join(
+        [
+            *(f"ACL '{n}'" for n in sorted(citing_acls)),
+            *(f"view '{n}'" for n in sorted(citing_views)),
+        ]
+    )
+    raise HTTPException(
+        status_code=409,
+        detail={
+            "field": "name",
+            "value": acl.name,
+            "message": (
+                f"Cannot {action} ACL '{acl.name}' — it is still referenced by "
+                f"{cited_by}. BIND would refuse the whole server group's config "
+                f"with that name undefined. Remove the references first."
+            ),
+        },
+    )
+
+
 @router.get("/groups/{group_id}/acls", response_model=list[AclResponse])
 async def list_acls(group_id: uuid.UUID, db: DB, _: CurrentUser) -> list[DNSAcl]:
     await _require_group(group_id, db)
@@ -2942,20 +3093,37 @@ async def create_acl(
     group_id: uuid.UUID, body: AclCreate, db: DB, current_user: SuperAdmin
 ) -> DNSAcl:
     await _require_group(group_id, db)
+
+    acl_names, key_names = await _group_symbol_names(group_id, db)
+    try:
+        name = validate_acl_name(body.name)
+        values = validate_acl_entries(
+            [e.value for e in body.entries], known_acls=acl_names, known_keys=key_names
+        )
+    except ViewValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"field": exc.field, "value": exc.value, "message": str(exc)},
+        ) from exc
+
     existing = await db.execute(
-        select(DNSAcl).where(DNSAcl.group_id == group_id, DNSAcl.name == body.name)
+        select(DNSAcl).where(DNSAcl.group_id == group_id, DNSAcl.name == name)
     )
     if existing.scalar_one_or_none():
         raise HTTPException(
             status_code=409, detail="An ACL with that name already exists in this group"
         )
 
-    acl = DNSAcl(group_id=group_id, name=body.name, description=body.description)
+    acl = DNSAcl(group_id=group_id, name=name, description=body.description)
     db.add(acl)
     await db.flush()
 
-    for e in body.entries:
-        db.add(DNSAclEntry(acl_id=acl.id, **e.model_dump()))
+    for e, value in zip(body.entries, values, strict=True):
+        payload = e.model_dump()
+        payload["value"] = value
+        db.add(DNSAclEntry(acl_id=acl.id, **payload))
+    await db.flush()
+    await _assert_acl_graph_is_acyclic(group_id, db)
 
     db.add(
         AuditLog(
@@ -2983,7 +3151,32 @@ async def update_acl(
     current_user: SuperAdmin,
 ) -> DNSAcl:
     acl = await _require_acl(group_id, acl_id, db)
+    # Exclude this ACL from the citable set: an entry naming its own ACL is
+    # a self-reference, and reporting it as an undefined name points at the
+    # field the operator is editing.
+    acl_names, key_names = await _group_symbol_names(group_id, db, exclude_acl_id=acl_id)
     changes = body.model_dump(exclude_none=True, exclude={"entries"})
+    try:
+        if body.name is not None:
+            changes["name"] = validate_acl_name(body.name)
+        values = (
+            validate_acl_entries(
+                [e.value for e in body.entries],
+                known_acls=acl_names,
+                known_keys=key_names,
+            )
+            if body.entries is not None
+            else []
+        )
+    except ViewValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={"field": exc.field, "value": exc.value, "message": str(exc)},
+        ) from exc
+    if "name" in changes and changes["name"] != acl.name:
+        # A rename orphans every reference to the OLD name, exactly as a
+        # delete would.
+        await _assert_acl_is_unreferenced(group_id, acl, db, action="rename")
     for k, v in changes.items():
         setattr(acl, k, v)
 
@@ -2992,8 +3185,12 @@ async def update_acl(
         for entry in result.scalars().all():
             await db.delete(entry)
         await db.flush()
-        for e in body.entries:
-            db.add(DNSAclEntry(acl_id=acl.id, **e.model_dump()))
+        for e, value in zip(body.entries, values, strict=True):
+            payload = e.model_dump()
+            payload["value"] = value
+            db.add(DNSAclEntry(acl_id=acl.id, **payload))
+        await db.flush()
+        await _assert_acl_graph_is_acyclic(group_id, db)
 
     db.add(
         AuditLog(
@@ -3017,6 +3214,7 @@ async def delete_acl(
     group_id: uuid.UUID, acl_id: uuid.UUID, db: DB, current_user: SuperAdmin
 ) -> None:
     acl = await _require_acl(group_id, acl_id, db)
+    await _assert_acl_is_unreferenced(group_id, acl, db, action="delete")
     db.add(
         AuditLog(
             user_id=current_user.id,
@@ -3364,28 +3562,21 @@ async def _validated_view_fields(
     # ``group_id == server.group_id``, so a global (NULL-group) row is never
     # rendered — accepting its name here would pass validation and then
     # produce a named.conf referencing an ACL that isn't defined.
-    acl_names = frozenset(
-        (await db.execute(select(DNSAcl.name).where(DNSAcl.group_id == group_id))).scalars().all()
-    )
-    # TSIG key names the group ships to its agents: the operator-managed
-    # ``DNSTSIGKey`` rows plus the legacy auto-generated group key. Mirrors
-    # what ``agent_config`` puts in the bundle's ``tsig_keys`` block.
-    key_names = set(
-        (await db.execute(select(DNSTSIGKey.name).where(DNSTSIGKey.group_id == group_id)))
-        .scalars()
-        .all()
-    )
-    group = await db.get(DNSServerGroup, group_id)
-    if group is not None and group.tsig_key_name:
-        key_names.add(group.tsig_key_name)
-    known_keys = frozenset(key_names)
+    # Shared with the ACL endpoints — one definition of "what symbols exist
+    # in this group's rendered config", so the two cannot drift.
+    acl_names, known_keys = await _group_symbol_names(group_id, db)
     try:
         name = getattr(body, "name", None)
         if name is not None:
             changes["name"] = validate_view_name(name)
         # ``allow_query`` / ``allow_query_cache`` (#430) land in the same
         # kind of address-match-list statement, so they get the same gate.
-        for attr in ("match_clients", "match_destinations", "allow_query", "allow_query_cache"):
+        for attr in (
+            "match_clients",
+            "match_destinations",
+            "allow_query",
+            "allow_query_cache",
+        ):
             value = getattr(body, attr, None)
             if value is not None:
                 changes[attr] = validate_address_match_list(

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, TypedDict
 
+import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -37,6 +39,14 @@ from app.models.dns import (
 from app.models.settings import PlatformSettings
 from app.services.appliance.ntp import ntp_bundle
 from app.services.appliance.snmp import snmp_bundle
+from app.services.dns.named_conf_validation import (
+    AclCycleError,
+    ViewValidationError,
+    is_name_reference,
+    order_acls_for_render,
+    validate_acl_name,
+    validate_address_match_list,
+)
 from app.services.dns.pool_geo import (
     build_geo_steering,
     build_view_descriptors,
@@ -83,10 +93,88 @@ if TYPE_CHECKING:
     pass
 
 
+logger = structlog.get_logger(__name__)
+
+
 def _compute_etag(payload: dict[str, Any]) -> str:
     """SHA-256 of the canonicalized payload (sorted keys)."""
     blob = json.dumps(payload, sort_keys=True, default=str).encode()
     return "sha256:" + hashlib.sha256(blob).hexdigest()
+
+
+def _safe_acls_block(acls: Sequence[Any]) -> list[dict[str, Any]]:
+    """Assemble the bundle's ``acls`` block so that it always renders.
+
+    Validation on the ACL endpoints (#899) guards what an operator types
+    *from now on*. It cannot guard what is already in the table: ACL names
+    and entry values were completely unvalidated before this change, and
+    the moment the agent started rendering them a legacy row holding a bad
+    CIDR — or a quote, or the name ``any`` — would break ``named.conf`` on
+    upgrade with nobody having touched anything.
+
+    So the bundle drops what it cannot render, loudly, rather than shipping
+    a config the agent will refuse:
+
+    * an ACL whose name is not a legal identifier is skipped entirely;
+    * an individual entry that is not a legal address-match element is
+      dropped, leaving the rest of the ACL intact;
+    * an ACL left with no entries still renders (as ``{ none; }`` on the
+      agent) because its name may already be cited;
+    * a cyclic reference falls back to alphabetical order with the cycle
+      broken, instead of raising.
+
+    That last point matters most: this runs inside the agent's ``/config``
+    long-poll. An exception here is not a failed edit, it is every agent in
+    the group getting a 500 on every poll, forever, with no way to fix it
+    from the UI — strictly worse than the inert-config bug being fixed.
+    """
+    prepared: list[dict[str, Any]] = []
+    for acl in acls:
+        try:
+            name = validate_acl_name(acl.name)
+        except ViewValidationError as exc:
+            logger.warning("dns_acl_skipped_unrenderable_name", acl=str(acl.name), error=str(exc))
+            continue
+        entries: list[dict[str, Any]] = []
+        for e in sorted(acl.entries, key=lambda e: (e.order, e.value)):
+            try:
+                # Syntax only — whether a bare name actually resolves is
+                # decided by the known-set sweep below.
+                validate_address_match_list([e.value], field="entries", allow_unknown_names=True)
+            except ViewValidationError as exc:
+                logger.warning(
+                    "dns_acl_entry_dropped_unrenderable",
+                    acl=name,
+                    value=e.value,
+                    error=str(exc),
+                )
+                continue
+            entries.append({"value": e.value, "negate": e.negate})
+        prepared.append({"id": str(acl.id), "name": name, "entries": entries})
+
+    # A reference to an ACL that was just skipped would be an undefined
+    # symbol, so drop those entries too.
+    known = {a["name"] for a in prepared}
+    for a in prepared:
+        kept = []
+        for e in a["entries"]:
+            target = is_name_reference(str(e["value"]))
+            if target is not None and target not in known:
+                logger.warning(
+                    "dns_acl_entry_dropped_dangling_reference", acl=a["name"], value=target
+                )
+                continue
+            kept.append(e)
+        a["entries"] = kept
+
+    try:
+        # Dependency-ordered because BIND resolves ``acl`` statements
+        # top-down — a reference to one declared later in the file is an
+        # error, not a forward declaration.
+        return order_acls_for_render(prepared)
+    except AclCycleError as exc:
+        logger.error("dns_acl_cycle_in_bundle", error=str(exc))
+        return sorted(prepared, key=lambda a: a["name"])
 
 
 async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBundle:
@@ -474,7 +562,11 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         }
         for vd in view_descs
     ]
-    acls_block = [{"id": str(a.id), "name": a.name} for a in acls]
+    # #899 — ship the entries, not just the name. The agent renders these
+    # into ``acl "<name>" { … };`` stanzas; before this the block carried
+    # ``{id, name}`` only, so an ACL was inert config and any reference to
+    # one was an undefined symbol that failed the entire bundle.
+    acls_block = _safe_acls_block(acls)
 
     # Blocklists: one RPZ zone per view (if any) + one group-level zone.
     # Each assembled list has its entries resolved against view/group scope

--- a/backend/app/services/dns/named_conf_validation.py
+++ b/backend/app/services/dns/named_conf_validation.py
@@ -1,4 +1,9 @@
-"""Validation for DNS view names and address-match-lists (issue #876).
+"""Validation for the free-text that reaches ``named.conf``.
+
+Views and their address-match-lists came first (#876); named ACLs joined
+when the agent learned to render them (#899). Both are operator-supplied
+strings interpolated **verbatim** into the config an agent applies, so
+they share one gate.
 
 View scoping shipped with #24 but was only reachable through the API, so
 the values in ``DNSView.match_clients`` were whatever an operator's script
@@ -35,7 +40,11 @@ import re
 __all__ = [
     "BUILTIN_ACLS",
     "RESERVED_VIEW_NAMES",
+    "AclCycleError",
     "ViewValidationError",
+    "is_name_reference",
+    "order_acls_for_render",
+    "validate_acl_name",
     "validate_address_match_list",
     "validate_view_name",
 ]
@@ -124,6 +133,7 @@ def _validate_element(
     field: str,
     known_acls: frozenset[str],
     known_keys: frozenset[str],
+    allow_unknown_names: bool = False,
 ) -> None:
     raw = (element or "").strip()
     if not raw:
@@ -154,7 +164,7 @@ def _validate_element(
     key_match = _KEY_RE.match(body)
     if key_match:
         key_name = key_match.group(1)
-        if key_name not in known_keys:
+        if not allow_unknown_names and key_name not in known_keys:
             known = ", ".join(sorted(known_keys)) if known_keys else "none defined"
             raise ViewValidationError(
                 f"'{key_name}' is not a TSIG key defined in this server group "
@@ -171,7 +181,9 @@ def _validate_element(
             ipaddress.ip_network(body, strict=False)
         except ValueError as exc:
             raise ViewValidationError(
-                f"'{body}' is not a valid CIDR prefix ({exc}).", field=field, value=element
+                f"'{body}' is not a valid CIDR prefix ({exc}).",
+                field=field,
+                value=element,
             ) from exc
         return
     try:
@@ -181,37 +193,32 @@ def _validate_element(
     else:
         return
 
-    # Anything left would have to be a named ACL — and BIND9 config as
-    # actually shipped has none.
+    # A named ACL. It has to be one this group actually defines, because
+    # the rendered ``match-clients { office; };`` is an undefined symbol
+    # otherwise — ``named-checkconf`` fails, the agent declines the whole
+    # bundle, and the group stops converging entirely rather than just this
+    # one statement.
     #
-    # A `DNSAcl` row is stored, listed and editable on the ACLs tab, and the
-    # bundle even carries an ``acls`` block — but only as ``{id, name}``,
-    # and the agent's BIND9 renderer never reads it or emits an ``acl {};``
-    # stanza. (The control-plane template that *does* render one has no
-    # production caller.) So ``match-clients { office; };`` reaches a server
-    # with ``office`` undefined, ``named-checkconf`` fails, and the agent
-    # declines the whole bundle — the group stops converging entirely, not
-    # just this view.
-    #
-    # Rejecting here is therefore not a restriction, it is the accurate
-    # answer: it converts a silent group-wide outage into a 422 that says
-    # what to type instead. Lift this the moment the agent renders ACL
-    # blocks — https://github.com/spatiumddi/spatiumddi/issues/899.
-    if _ACL_NAME_RE.match(body) and body in known_acls:
+    # Before #899 this branch rejected every ACL name, because the agent
+    # emitted no ``acl {}`` definitions at all and so a reference could
+    # never resolve. Now that it does, an ACL the operator defined is a
+    # first-class element here.
+    if not _ACL_NAME_RE.match(body):
         raise ViewValidationError(
-            f"'{body}' is a named ACL, and the DNS agent does not yet render "
-            f"ACL definitions into named.conf — a view referencing one would "
-            f"stop the whole server group's config from applying. Use the "
-            f"addresses or CIDR prefixes directly here instead.",
+            f"'{body}' is not an IP address, a CIDR prefix, an ACL name, or "
+            f"one of {', '.join(sorted(BUILTIN_ACLS))}.",
             field=field,
             value=element,
         )
-    raise ViewValidationError(
-        f"'{body}' is not an IP address, a CIDR prefix, or one of "
-        f"{', '.join(sorted(BUILTIN_ACLS))}.",
-        field=field,
-        value=element,
-    )
+    if not allow_unknown_names and body not in known_acls:
+        known = ", ".join(sorted(known_acls)) if known_acls else "none defined"
+        raise ViewValidationError(
+            f"'{body}' is not an ACL defined in this server group "
+            f"(available: {known}). Create it on the ACLs tab first, or use "
+            f"an address or CIDR prefix here.",
+            field=field,
+            value=element,
+        )
 
 
 def validate_address_match_list(
@@ -220,18 +227,23 @@ def validate_address_match_list(
     field: str,
     known_acls: frozenset[str] = frozenset(),
     known_keys: frozenset[str] = frozenset(),
+    allow_unknown_names: bool = False,
 ) -> list[str]:
     """Validate every element of a BIND address-match-list.
+
+    ``allow_unknown_names`` checks syntax only, accepting a bare name
+    without asking whether it resolves. The bundle builder uses it to
+    decide whether a legacy row is *renderable*; resolution is a separate
+    question it answers with its own known-set.
 
     ``known_keys`` is the set of TSIG key names the group ships to its
     agents; a ``key <name>`` element naming one that doesn't exist renders a
     ``named.conf`` BIND will not load, so it is rejected here rather than
     discovered when the agent's ``named-checkconf`` refuses the bundle.
 
-    ``known_acls`` is used only to tell an operator who typed a *real* ACL
-    name why it isn't accepted — see :func:`_validate_element`. Named ACLs
-    are rejected outright today because the agent never renders ``acl {}``
-    definitions.
+    ``known_acls`` is the set of ``DNSAcl`` names defined on the group. A
+    name outside it is the same undefined-symbol failure, so it is rejected
+    here too.
 
     Returns the list with each element stripped, so trailing whitespace
     from a paste doesn't reach the template.
@@ -240,6 +252,154 @@ def validate_address_match_list(
         return []
     cleaned: list[str] = []
     for element in elements:
-        _validate_element(element, field, known_acls, known_keys)
+        _validate_element(element, field, known_acls, known_keys, allow_unknown_names)
         cleaned.append((element or "").strip())
     return cleaned
+
+
+# ── named ACLs (issue #899) ───────────────────────────────────────────────
+
+
+class AclCycleError(ViewValidationError):
+    """An ACL references itself, directly or through other ACLs.
+
+    BIND has no way to resolve that, so it is a config error — and since a
+    config error fails the whole bundle, catching it at write time is the
+    difference between a 422 and a server group that stops converging.
+    """
+
+
+def validate_acl_name(name: str, *, field: str = "name") -> str:
+    """Return the ACL name, or raise.
+
+    Looser than a view name: an ACL is never a directory or a DNS label, so
+    it only has to be a safe BIND identifier. Dots are allowed because
+    ``guest.wifi`` is a name operators reach for and BIND takes it unquoted.
+    """
+    candidate = (name or "").strip()
+    if not candidate:
+        raise ViewValidationError("ACL name is required.", field=field, value=name)
+    if candidate.lower() in BUILTIN_ACLS:
+        raise ViewValidationError(
+            f"'{candidate}' is a built-in BIND address-match-list name and "
+            f"cannot be redefined as an ACL.",
+            field=field,
+            value=candidate,
+        )
+    if not _ACL_NAME_RE.match(candidate):
+        raise ViewValidationError(
+            "An ACL name must start with a letter or digit and contain only "
+            "letters, digits, dots, hyphens and underscores (max 255 "
+            "characters). It is rendered into named.conf as "
+            'acl "<name>" { … };',
+            field=field,
+            value=candidate,
+        )
+    return candidate
+
+
+def validate_acl_entries(
+    entries: list[str] | None,
+    *,
+    field: str = "entries",
+    known_acls: frozenset[str] = frozenset(),
+    known_keys: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Validate the values of one ACL's entries.
+
+    An ACL body is an address-match-list like any other, so this is the
+    same gate a view's ``match_clients`` goes through — including the
+    ability to reference another ACL by name, which BIND supports and the
+    model has always documented.
+
+    Note ``known_acls`` should NOT contain the ACL being edited: a
+    self-reference is a cycle, and :func:`order_acls_for_render` would
+    refuse to order it anyway. Rejecting it here names the problem while
+    the operator is still looking at the form.
+    """
+    return validate_address_match_list(
+        entries, field=field, known_acls=known_acls, known_keys=known_keys
+    )
+
+
+def is_name_reference(value: str) -> str | None:
+    """The ACL name an address-match element refers to, or ``None``.
+
+    Only a bare identifier is a reference — an address, a CIDR prefix, a
+    built-in (``any`` / ``none`` / …) or a ``key <name>`` never is. Shared
+    by the ordering pass and the bundle builder so the two cannot disagree
+    about what counts as an edge.
+    """
+    body = (value or "").strip()
+    if body.startswith("!"):
+        body = body[1:].strip()
+    if not body or body.lower() in BUILTIN_ACLS or _KEY_RE.match(body):
+        return None
+    if "/" in body:
+        return None
+    try:
+        ipaddress.ip_address(body)
+    except ValueError:
+        pass
+    else:
+        return None
+    return body if _ACL_NAME_RE.match(body) else None
+
+
+def order_acls_for_render(acls: list[dict]) -> list[dict]:
+    """Order ACLs so every definition precedes its first reference.
+
+    BIND resolves ``acl`` statements top-down: referencing one that is
+    declared later in the file is an error, not a forward declaration. The
+    operator's own ordering carries no such guarantee — the ACLs tab sorts
+    by name — so the bundle emits them sorted by dependency instead, and
+    the agent renders the list as given.
+
+    ``acls`` is a list of ``{"name": str, "entries": [{"value", "negate"}]}``
+    dicts. Returns the same dicts, reordered.
+
+    Raises :class:`AclCycleError` if the references form a loop. That check
+    lives here rather than only at write time because an ACL can also be
+    orphaned into a cycle by *deleting* a different one, and a bundle that
+    cannot be ordered must fail loudly rather than ship a config the agent
+    will reject.
+    """
+    by_name = {a["name"]: a for a in acls}
+
+    def refs(acl: dict) -> list[str]:
+        out = []
+        for entry in acl.get("entries") or []:
+            target = is_name_reference(str(entry.get("value", "")))
+            if target in by_name:
+                out.append(str(target))
+        return out
+
+    ordered: list[dict] = []
+    # 0 = unvisited, 1 = on the current DFS path, 2 = emitted.
+    state: dict[str, int] = {}
+
+    def visit(name: str, path: list[str]) -> None:
+        mark = state.get(name, 0)
+        if mark == 2:
+            return
+        if mark == 1:
+            loop = " → ".join([*path[path.index(name) :], name])
+            raise AclCycleError(
+                f"ACL '{name}' references itself through {loop}. BIND cannot "
+                f"resolve a circular ACL, and the whole server group's config "
+                f"would be refused.",
+                field="entries",
+                value=name,
+            )
+        state[name] = 1
+        for dep in refs(by_name[name]):
+            visit(dep, [*path, name])
+        state[name] = 2
+        ordered.append(by_name[name])
+
+    # Sorted for determinism: the same set of ACLs must render byte-identical
+    # every time, or the bundle's sha256 ETag churns and every agent re-pulls
+    # a config that did not change.
+    for name in sorted(by_name):
+        visit(name, [])
+    return ordered

--- a/backend/tests/test_dns_acl_rendering.py
+++ b/backend/tests/test_dns_acl_rendering.py
@@ -1,0 +1,408 @@
+"""Named ACLs reach the agent, ordered and cycle-free (issue #899).
+
+The agent-side rendering of these into ``acl {}`` stanzas is covered by
+``agent/dns/tests/test_acl_render.py`` — the agent is a separate package
+with its own test job, so it cannot be imported from here.
+
+Before this, `DNSAcl` rows were stored, listed and editable on the ACLs
+tab and applied to nothing: the bundle carried `{id, name}` with no
+entries, and the agent's BIND9 renderer never emitted an `acl {}` stanza.
+Naming one anywhere that reached `named.conf` left an undefined symbol —
+`named-checkconf` fails, the agent declines the *whole* bundle, and the
+group stops converging rather than just that statement.
+
+So the assertions that matter are: the entries reach the bundle, they come
+out in an order BIND can resolve, and a cycle is refused rather than
+shipped.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSAcl, DNSAclEntry, DNSServerGroup
+from app.services.dns.named_conf_validation import AclCycleError, order_acls_for_render
+
+
+async def _admin(db: AsyncSession) -> str:
+    tag = uuid.uuid4().hex[:8]
+    user = User(
+        username=f"a-{tag}",
+        email=f"{tag}@example.com",
+        display_name="A",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _group(db: AsyncSession) -> DNSServerGroup:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(group)
+    await db.flush()
+    return group
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _acl(name: str, *values: str) -> dict:
+    return {"name": name, "entries": [{"value": v, "negate": False} for v in values]}
+
+
+# ── dependency ordering ───────────────────────────────────────────────────
+
+
+def test_a_referenced_acl_is_emitted_before_its_referrer():
+    """BIND resolves ``acl`` statements where they are written.
+
+    A reference to one declared later in the file is an error, not a
+    forward declaration — so the order is load-bearing, not cosmetic.
+    """
+    ordered = order_acls_for_render(
+        [_acl("outer", "inner", "10.0.0.0/8"), _acl("inner", "192.168.0.0/16")]
+    )
+    names = [a["name"] for a in ordered]
+    assert names.index("inner") < names.index("outer")
+
+
+def test_ordering_is_deterministic():
+    """The bundle is hashed into a sha256 ETag. A set-iteration order would
+    churn it and make every agent re-pull a config that did not change."""
+    acls = [_acl("c"), _acl("a"), _acl("b")]
+    assert [a["name"] for a in order_acls_for_render(acls)] == ["a", "b", "c"]
+    assert [a["name"] for a in order_acls_for_render(list(reversed(acls)))] == [
+        "a",
+        "b",
+        "c",
+    ]
+
+
+def test_a_negated_reference_still_counts_as_a_dependency():
+    """``!inner`` cites ``inner`` just as much as ``inner`` does."""
+    ordered = order_acls_for_render([_acl("outer", "!inner"), _acl("inner", "10.0.0.0/8")])
+    names = [a["name"] for a in ordered]
+    assert names.index("inner") < names.index("outer")
+
+
+def test_a_transitive_chain_orders_correctly():
+    ordered = order_acls_for_render([_acl("a", "b"), _acl("b", "c"), _acl("c", "10.0.0.0/8")])
+    assert [x["name"] for x in ordered] == ["c", "b", "a"]
+
+
+def test_a_direct_cycle_is_refused():
+    with pytest.raises(AclCycleError):
+        order_acls_for_render([_acl("a", "a")])
+
+
+def test_an_indirect_cycle_is_refused():
+    """A→B→A. Each edge is individually legal; only the pair is not, which
+    is why per-field validation cannot catch this on its own."""
+    with pytest.raises(AclCycleError) as exc:
+        order_acls_for_render([_acl("a", "b"), _acl("b", "a")])
+    assert "references itself" in str(exc.value)
+
+
+def test_an_address_that_looks_like_a_name_is_not_a_dependency():
+    """Only a bare name matching another ACL is a reference — an address,
+    a prefix or a built-in never is."""
+    ordered = order_acls_for_render([_acl("a", "any", "10.0.0.0/8", "key k")])
+    assert [x["name"] for x in ordered] == ["a"]
+
+
+# ── through the API ───────────────────────────────────────────────────────
+
+
+async def test_acl_entries_are_validated(client: AsyncClient, db_session):
+    """The values are interpolated verbatim into named.conf now, so they
+    get the same gate a view's match_clients does."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": "office", "entries": [{"value": "10.0.0.0/33"}]},
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"]["field"] == "entries"
+
+
+async def test_acl_name_is_validated(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": 'evil"; }; //', "entries": [{"value": "10.0.0.0/8"}]},
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["field"] == "name"
+
+
+async def test_acl_cannot_shadow_a_builtin(client: AsyncClient, db_session):
+    """``acl "any" { … };`` is a redefinition BIND refuses."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    r = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": "any", "entries": [{"value": "10.0.0.0/8"}]},
+    )
+    assert r.status_code == 422
+
+
+async def test_acl_may_reference_another_acl(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    inner = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": "inner", "entries": [{"value": "10.0.0.0/8"}]},
+    )
+    assert inner.status_code == 201, inner.text
+
+    outer = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={
+            "name": "outer",
+            "entries": [{"value": "inner"}, {"value": "172.16.0.0/12"}],
+        },
+    )
+    assert outer.status_code == 201, outer.text
+
+
+async def test_acl_self_reference_is_refused(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    created = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": "loop", "entries": [{"value": "10.0.0.0/8"}]},
+    )
+    acl_id = created.json()["id"]
+
+    r = await client.put(
+        f"/api/v1/dns/groups/{group.id}/acls/{acl_id}",
+        headers=_hdr(token),
+        json={"entries": [{"value": "loop"}]},
+    )
+    assert r.status_code == 422, r.text
+
+
+async def test_a_two_acl_cycle_is_refused_at_the_commit(client: AsyncClient, db_session):
+    """A→B is legal, then B→A closes the loop. Per-field validation sees
+    only one legal edge at a time; the graph check is what catches it."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    a = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": "a", "entries": [{"value": "10.0.0.0/8"}]},
+    )
+    b = await client.post(
+        f"/api/v1/dns/groups/{group.id}/acls",
+        headers=_hdr(token),
+        json={"name": "b", "entries": [{"value": "a"}]},
+    )
+    assert b.status_code == 201, b.text
+
+    r = await client.put(
+        f"/api/v1/dns/groups/{group.id}/acls/{a.json()['id']}",
+        headers=_hdr(token),
+        json={"entries": [{"value": "b"}]},
+    )
+    assert r.status_code == 422, r.text
+    assert "references itself" in r.json()["detail"]["message"]
+
+
+async def test_bundle_carries_acl_entries(client: AsyncClient, db_session):
+    """The regression that started it all: entries reaching the agent."""
+    from sqlalchemy import select
+
+    from app.models.dns import DNSServer
+    from app.services.dns.agent_config import build_config_bundle
+
+    group = await _group(db_session)
+    acl = DNSAcl(group_id=group.id, name="office", description="")
+    db_session.add(acl)
+    await db_session.flush()
+    db_session.add(DNSAclEntry(acl_id=acl.id, value="10.0.0.0/8", negate=False, order=0))
+    server = DNSServer(group_id=group.id, name="s1", driver="bind9", host="127.0.0.1", port=53)
+    db_session.add(server)
+    await db_session.flush()
+
+    loaded = (
+        await db_session.execute(select(DNSServer).where(DNSServer.id == server.id))
+    ).scalar_one()
+    bundle = await build_config_bundle(db_session, loaded)
+
+    acls = bundle["acls"]
+    assert [a["name"] for a in acls] == ["office"]
+    assert acls[0]["entries"] == [{"value": "10.0.0.0/8", "negate": False}]
+
+
+# ── referential integrity (review follow-up) ──────────────────────────────
+#
+# Write-time validation stops an operator CREATING a dangling reference. It
+# does nothing about removing the target of one that already resolves — and
+# the consequence is identical: named.conf carries an undefined symbol, so
+# the group stops converging.
+
+
+async def _create_acl(client: AsyncClient, token: str, group_id, name: str, *values: str) -> str:
+    r = await client.post(
+        f"/api/v1/dns/groups/{group_id}/acls",
+        headers=_hdr(token),
+        json={"name": name, "entries": [{"value": v, "order": i} for i, v in enumerate(values)]},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def test_deleting_an_acl_cited_by_another_acl_is_refused(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    inner = await _create_acl(client, token, group.id, "inner", "10.0.0.0/8")
+    await _create_acl(client, token, group.id, "outer", "inner")
+
+    r = await client.delete(f"/api/v1/dns/groups/{group.id}/acls/{inner}", headers=_hdr(token))
+    assert r.status_code == 409, r.text
+    assert "outer" in r.json()["detail"]["message"]
+
+
+async def test_deleting_an_acl_cited_by_a_view_is_refused(client: AsyncClient, db_session):
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    acl_id = await _create_acl(client, token, group.id, "office", "10.0.0.0/8")
+    v = await client.post(
+        f"/api/v1/dns/groups/{group.id}/views",
+        headers=_hdr(token),
+        json={"name": "corp", "match_clients": ["office"]},
+    )
+    assert v.status_code == 201, v.text
+
+    r = await client.delete(f"/api/v1/dns/groups/{group.id}/acls/{acl_id}", headers=_hdr(token))
+    assert r.status_code == 409
+    assert "corp" in r.json()["detail"]["message"]
+
+
+async def test_renaming_a_cited_acl_is_refused(client: AsyncClient, db_session):
+    """A rename orphans every reference to the OLD name, exactly as a
+    delete would — and is the easier mistake to make."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    inner = await _create_acl(client, token, group.id, "inner", "10.0.0.0/8")
+    await _create_acl(client, token, group.id, "outer", "inner")
+
+    r = await client.put(
+        f"/api/v1/dns/groups/{group.id}/acls/{inner}",
+        headers=_hdr(token),
+        json={"name": "renamed"},
+    )
+    assert r.status_code == 409, r.text
+
+
+async def test_an_uncited_acl_deletes_normally(client: AsyncClient, db_session):
+    """The guard must not make ordinary cleanup impossible."""
+    token = await _admin(db_session)
+    group = await _group(db_session)
+    await db_session.flush()
+
+    acl_id = await _create_acl(client, token, group.id, "spare", "10.0.0.0/8")
+    r = await client.delete(f"/api/v1/dns/groups/{group.id}/acls/{acl_id}", headers=_hdr(token))
+    assert r.status_code == 204, r.text
+
+
+# ── legacy rows the old, unvalidated endpoints allowed ────────────────────
+
+
+async def test_bundle_drops_an_unrenderable_legacy_entry(client: AsyncClient, db_session):
+    """Rows predating #899 were stored with no validation at all.
+
+    The moment the agent started rendering them, a legacy bad CIDR would
+    break named.conf on upgrade with nobody having touched anything — so
+    the bundle drops what it cannot render rather than shipping it.
+    """
+    from sqlalchemy import select
+
+    from app.models.dns import DNSServer
+    from app.services.dns.agent_config import build_config_bundle
+
+    group = await _group(db_session)
+    acl = DNSAcl(group_id=group.id, name="legacy", description="")
+    db_session.add(acl)
+    await db_session.flush()
+    # Written straight to the table, bypassing the API — exactly how these
+    # rows exist today.
+    db_session.add(DNSAclEntry(acl_id=acl.id, value="10.0.0.0/8", negate=False, order=0))
+    db_session.add(DNSAclEntry(acl_id=acl.id, value="not-a-prefix/99", negate=False, order=1))
+    server = DNSServer(group_id=group.id, name="s1", driver="bind9", host="127.0.0.1", port=53)
+    db_session.add(server)
+    await db_session.flush()
+
+    loaded = (
+        await db_session.execute(select(DNSServer).where(DNSServer.id == server.id))
+    ).scalar_one()
+    bundle = await build_config_bundle(db_session, loaded)
+
+    entries = bundle["acls"][0]["entries"]
+    assert [e["value"] for e in entries] == ["10.0.0.0/8"]
+
+
+async def test_bundle_survives_a_legacy_cycle(client: AsyncClient, db_session):
+    """A cyclic pair can only exist from before the graph check.
+
+    ``build_config_bundle`` runs inside the agent's /config long-poll, so
+    raising here is not a failed edit — it is every agent in the group
+    getting a 500 on every poll, forever, with no way to fix it from the
+    UI. Strictly worse than the bug being fixed.
+    """
+    from sqlalchemy import select
+
+    from app.models.dns import DNSServer
+    from app.services.dns.agent_config import build_config_bundle
+
+    group = await _group(db_session)
+    a = DNSAcl(group_id=group.id, name="a", description="")
+    b = DNSAcl(group_id=group.id, name="b", description="")
+    db_session.add_all([a, b])
+    await db_session.flush()
+    db_session.add(DNSAclEntry(acl_id=a.id, value="b", negate=False, order=0))
+    db_session.add(DNSAclEntry(acl_id=b.id, value="a", negate=False, order=0))
+    server = DNSServer(group_id=group.id, name="s1", driver="bind9", host="127.0.0.1", port=53)
+    db_session.add(server)
+    await db_session.flush()
+
+    loaded = (
+        await db_session.execute(select(DNSServer).where(DNSServer.id == server.id))
+    ).scalar_one()
+    bundle = await build_config_bundle(db_session, loaded)
+    assert sorted(x["name"] for x in bundle["acls"]) == ["a", "b"]

--- a/backend/tests/test_dns_named_conf_validation.py
+++ b/backend/tests/test_dns_named_conf_validation.py
@@ -1,4 +1,4 @@
-"""DNS view name + address-match-list validation (issue #876).
+"""Validation for the free-text that reaches ``named.conf`` (#876, #899).
 
 View scoping shipped with #24 but was API-only, so these fields were
 effectively unvalidated. #876 puts a form in front of them, and both are
@@ -22,7 +22,7 @@ from app.core.security import create_access_token, hash_password
 from app.models.auth import User
 from app.models.dns import DNSAcl, DNSServerGroup
 from app.services import feature_modules
-from app.services.dns.view_validation import (
+from app.services.dns.named_conf_validation import (
     MAX_VIEW_NAME_LEN,
     RESERVED_VIEW_NAMES,
     ViewValidationError,
@@ -173,28 +173,29 @@ def test_bare_negation_is_rejected():
 def test_an_undefined_name_is_rejected():
     with pytest.raises(ViewValidationError) as exc:
         validate_address_match_list(["office-clients"], field="match_clients")
-    assert "not an IP address" in str(exc.value)
+    assert "not an ACL defined" in str(exc.value)
 
 
-def test_a_real_acl_name_is_rejected_because_the_agent_cannot_render_it():
-    """The agent emits no ``acl {}`` definitions.
+def test_a_defined_acl_name_is_accepted():
+    """#899 — the agent now renders ``acl {}``, so a reference resolves.
 
-    ``DNSAcl`` rows are stored and editable, and the bundle carries an
-    ``acls`` block — but only ``{id, name}``, and the agent's BIND9
-    renderer never reads it. So ``match-clients { office; };`` reaches a
-    server with ``office`` undefined, ``named-checkconf`` fails, and the
-    agent declines the entire bundle: the whole group stops converging,
-    not just this view.
-
-    Accepting the name would therefore be the bug. The message has to name
-    the real reason, because from the operator's side the ACL plainly
-    exists — they just created it on the tab next door.
+    #876 rejected every ACL name because none of them could ever resolve;
+    that was the accurate answer then and the wrong one now.
     """
+    assert validate_address_match_list(
+        ["office", "10.0.0.0/8"],
+        field="match_clients",
+        known_acls=frozenset({"office"}),
+    ) == ["office", "10.0.0.0/8"]
+
+
+def test_an_undefined_acl_name_is_still_rejected():
+    """An undefined symbol fails the whole bundle, not just this view."""
     with pytest.raises(ViewValidationError) as exc:
         validate_address_match_list(
-            ["office"], field="match_clients", known_acls=frozenset({"office"})
+            ["marketing"], field="match_clients", known_acls=frozenset({"office"})
         )
-    assert "does not yet render ACL definitions" in str(exc.value)
+    assert "not an ACL defined in this server group" in str(exc.value)
 
 
 def test_unknown_tsig_key_is_rejected():
@@ -253,10 +254,8 @@ async def test_create_view_rejects_a_traversing_name(client: AsyncClient, db_ses
     assert r.json()["detail"]["field"] == "name"
 
 
-async def test_create_view_rejects_an_acl_name_with_the_reason(client: AsyncClient, db_session):
-    """End-to-end: a view naming an ACL the operator really created is
-    still refused, and the 422 explains why rather than claiming it does
-    not exist."""
+async def test_create_view_accepts_a_defined_acl_by_name(client: AsyncClient, db_session):
+    """#899 — the whole point. A view may cite an ACL the group defines."""
     token = await _admin(db_session)
     group = await _group(db_session)
     db_session.add(DNSAcl(group_id=group.id, name="office", description=""))
@@ -267,27 +266,26 @@ async def test_create_view_rejects_an_acl_name_with_the_reason(client: AsyncClie
         headers=_hdr(token),
         json={"name": "internal", "match_clients": ["office", "10.0.0.0/8"]},
     )
-    assert r.status_code == 422, r.text
-    detail = r.json()["detail"]
-    assert detail["field"] == "match_clients"
-    assert "does not yet render ACL definitions" in detail["message"]
+    assert r.status_code == 201, r.text
+    assert r.json()["match_clients"] == ["office", "10.0.0.0/8"]
 
 
-async def test_create_view_accepts_the_prefixes_the_acl_would_have_held(
-    client: AsyncClient, db_session
-):
-    """The documented workaround has to actually work."""
+async def test_create_view_rejects_an_acl_from_another_group(client: AsyncClient, db_session):
+    """ACL names are per-group, so one group's ACL is undefined in another —
+    and the bundle is built per group, so it would never be rendered."""
     token = await _admin(db_session)
-    group = await _group(db_session)
+    owner = await _group(db_session)
+    other = await _group(db_session)
+    db_session.add(DNSAcl(group_id=owner.id, name="office", description=""))
     await db_session.flush()
 
     r = await client.post(
-        f"/api/v1/dns/groups/{group.id}/views",
+        f"/api/v1/dns/groups/{other.id}/views",
         headers=_hdr(token),
-        json={"name": "internal", "match_clients": ["10.0.0.0/8", "192.168.0.0/16"]},
+        json={"name": "internal", "match_clients": ["office"]},
     )
-    assert r.status_code == 201, r.text
-    assert r.json()["match_clients"] == ["10.0.0.0/8", "192.168.0.0/16"]
+    assert r.status_code == 422
+    assert r.json()["detail"]["field"] == "match_clients"
 
 
 async def test_duplicate_name_is_caught_after_stripping(client: AsyncClient, db_session):

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -660,9 +660,9 @@ everywhere" means in practice. It shipped with the split-horizon work in
 unreachable from the product despite being fully implemented underneath.
 
 A **view** is a set of clients, identified by source address. `match_clients`
-is a BIND address-match-list: addresses, CIDR prefixes, or one of `any` /
-`none` / `localhost` / `localnets`, each optionally negated with a leading
-`!`. Views are evaluated in `order`
+is a BIND address-match-list: addresses, CIDR prefixes, a named ACL from
+the ACLs tab, or one of `any` / `none` / `localhost` / `localnets`, each
+optionally negated with a leading `!`. Views are evaluated in `order`
 (low first) and a client is served by the **first** view it matches, so
 the catch-all belongs last.
 
@@ -701,18 +701,14 @@ view "guest" {
   `zone {}` alongside views, so once one view exists every zone is served
   from inside a view. Zones with no view of their own render into all of
   them.
-- **Named ACLs are not accepted in `match_clients` yet.** A `DNSAcl` row is
-  stored, listed and editable on the ACLs tab, and the config bundle even
-  carries an `acls` block — but only as `{id, name}`, and the DNS agent's
-  BIND9 renderer never reads it or emits an `acl {};` stanza. (The
-  control-plane template that does render one has no production caller.) A
-  view referencing an ACL by name would therefore reach a server with that
-  symbol undefined, `named-checkconf` would fail, and the agent would
-  decline the whole bundle — so the group stops converging entirely, not
-  just that view. The API rejects it with a 422 saying so. Use the
-  prefixes directly until the agent renders ACL definitions ([#899](https://github.com/spatiumddi/spatiumddi/issues/899)).
+- **Named ACLs work in `match_clients`** as of
+  [#899](https://github.com/spatiumddi/spatiumddi/issues/899). Before that
+  a `DNSAcl` row was stored, listed and editable and applied to nothing —
+  the bundle carried `{id, name}` with no entries and the agent emitted no
+  `acl {}` stanza — so a view citing one left an undefined symbol and the
+  group stopped converging. See §8.2.
 - **`match_clients` and the view name are validated server-side**
-  (`app/services/dns/view_validation.py`). Both are interpolated verbatim
+  (`app/services/dns/named_conf_validation.py`). Both are interpolated verbatim
   into `named.conf`, and the name additionally becomes a directory on the
   agent, so a malformed prefix, an undefined ACL or TSIG key name, or a
   name containing a path separator is rejected with a 422 naming the
@@ -878,6 +874,50 @@ entire zone — so the renderer picks one rather than enforcing nothing.
 Reconcile the lists if you see that warning.
 
 ---
+
+### 8.2 Named ACLs (issue #899)
+
+An ACL is a reusable address-match-list: define `office` once on the group's
+**ACLs tab**, then cite it by name from a view's `match_clients`, from
+`allow-query`, or from another ACL.
+
+They render as `acl "<name>" { … };` at the **top** of `named.conf`, above
+`options`. Placement is the correctness property, not tidiness: BIND
+resolves an `acl` statement where it is written, so a definition below its
+first use is an error rather than a forward declaration. The control plane
+emits the list dependency-ordered for the same reason — an ACL may
+reference another, so `inner` has to precede `outer`.
+
+Constraints, all enforced server-side with a 422 naming the offending
+element:
+
+- **Entry values get the same gate as a view's `match_clients`** — they end
+  up in the same kind of statement. Addresses, CIDR prefixes, `key <name>`
+  for a TSIG key the group ships, another ACL's name, or one of the
+  built-ins, each optionally negated with `!`.
+- **Cycles are refused.** `a → b → a` is rejected at the commit, not
+  discovered when the next bundle build fails. Each edge is individually
+  legal, so this needs a graph check rather than per-field validation.
+- **Built-in names cannot be redefined** — `acl "any" { … };` is an error.
+- **An ACL with no entries renders as `{ none; }`**, not skipped. BIND
+  rejects `acl "x" { };`, but omitting the definition would be worse — the
+  name may already be cited by a view, and dropping it re-creates the
+  undefined-symbol outage. `none` is also the honest meaning of an empty
+  address-match list.
+- **Deleting or renaming an ACL something still cites is refused** (409).
+  Write-time validation stops you *creating* a dangling reference; removing
+  the target of one that already resolves breaks the group identically.
+- **ACL names are per-group.** `DNSAcl.group_id` is nullable, but nothing
+  creates a global ACL and the bundle is built per group, so a NULL-group
+  row would be invisible to every agent. Treat global ACLs as unsupported.
+
+> **History worth knowing.** ACLs were the third field found stored,
+> persisted, editable and never rendered — after `allow_transfer` (#734)
+> and alongside `forward_policy`, which #899's audit also caught: `forward
+> only` was silently behaving as `forward first`, so an operator forcing
+> every query through a filtering upstream was getting fall-through
+> recursion instead. If you add a field an agent is supposed to act on,
+> assert on the rendered config, not just on the stored row.
 
 ## 9. DNS UI Features
 

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -4933,7 +4933,7 @@ function ViewsTab({ group }: { group: DNSServerGroup }) {
  * "scope this to the guest VLAN" is the guest VLAN's CIDR, and retyping a
  * prefix they already modelled in IPAM is how typos get in.
  *
- * Validation is server-side (`app/services/dns/view_validation.py`): these
+ * Validation is server-side (`app/services/dns/named_conf_validation.py`): these
  * strings are interpolated verbatim into named.conf, so the client checks
  * nothing it could be wrong about and simply renders the 422.
  */
@@ -5073,15 +5073,11 @@ function ViewModal({
             placeholder={"10.20.0.0/16\n192.168.50.0/24\nany"}
           />
           <p className="mt-1 text-[11px] text-muted-foreground">
-            An address, a CIDR prefix, or one of{" "}
+            An address, a CIDR prefix, a named ACL from the ACLs tab, or one of{" "}
             <span className="font-mono">any</span> /{" "}
             <span className="font-mono">none</span> /{" "}
             <span className="font-mono">localhost</span> /{" "}
-            <span className="font-mono">localnets</span>. Named ACLs from the
-            ACLs tab are not accepted here — the DNS agent doesn't render ACL
-            definitions into <span className="font-mono">named.conf</span> yet,
-            so a view referencing one would stop the whole group's config from
-            applying. Paste the prefixes instead.
+            <span className="font-mono">localnets</span>.
           </p>
         </div>
 


### PR DESCRIPTION
Closes #899

`DNSAcl` rows were stored, listed and editable on the ACLs tab and applied
to **nothing**. The bundle carried `{id, name}` with no entries; the
agent's BIND9 renderer emitted no `acl {}` stanza at all. The only
template that does render one is reached through
`BIND9Driver.render_server_config`, which has no production caller.

Worse than inert: citing an ACL anywhere that reached `named.conf` left an
**undefined symbol**, so `named-checkconf` failed and the agent declined
the whole bundle — the group stopped converging rather than losing one
statement. That is why #876 had to reject ACL names in a view's
match-list outright.

## What landed

The bundle ships entries; the agent renders `acl "<name>" { … };` **above
`options`**. Placement is the correctness property, not tidiness: BIND
resolves an `acl` where it is written, so a definition below its first use
is an error rather than a forward declaration.

Nested references work — the list is emitted dependency-ordered by a DFS
topological sort — and **cycles are refused at the commit** with a graph
check, because `a → b → a` has two individually-legal edges that per-field
validation cannot see.

The #876 rejection is lifted, and the view editor + `DNS.md` §8 point at
ACLs again. `view_validation.py` → `named_conf_validation.py`, since it
now gates two kinds of operator text reaching the same file. Entry values
and ACL names get the same gate a view's `match_clients` does — they end
up in the same statement, and both were previously unvalidated entirely.

## Guarding everything that can dangle a reference

Write-time validation stops an operator *creating* a bad reference. It
does nothing about removing the target of one that already resolves, and
the consequence is identical. So:

| Path | Behaviour |
|---|---|
| Delete a cited ACL | 409 naming the citers — other ACLs *and* views |
| Rename a cited ACL | 409 (a rename orphans the old name exactly as a delete does) |
| ACL with no entries | renders `{ none; }`, **not** skipped |
| Legacy unrenderable entry | dropped at bundle build, logged |
| Legacy cycle | falls back to alphabetical order, logged |

Two of those deserve their reasoning spelled out:

**Empty ACLs render `{ none; }`.** Skipping looks tidier and is wrong —
the name may already be cited, so omitting the definition re-creates the
undefined-symbol outage this change removes. `none` is also the honest
meaning of an empty address-match list.

**The bundle drops what it cannot render rather than raising.**
`build_config_bundle` runs inside the agent's `/config` long-poll. An
exception there is not a failed edit; it is every agent in the group
getting a 500 on every poll, forever, with no way to fix it from the UI —
strictly worse than the bug being fixed. Rows predating this change were
stored with *no* validation, so a legacy bad CIDR would otherwise have
broken `named.conf` on upgrade with nobody having touched anything.

## The audit found a second one

`DNSServerOptions.forward_policy` was settable, persisted and shipped in
the bundle, and **no `forward` statement was ever rendered** — so `only`
silently behaved as BIND's default `first`.

Not cosmetic: `only` is how an operator forces every query through a
filtering upstream, and `first` lets queries leak straight past it on any
hiccup. Directly relevant to the #878 family-filter work. Emitted only for
`only`, so existing configs stay byte-identical and nothing reloads for a
no-op.

That is the third field found stored-but-never-rendered, after
`allow_transfer` (#734). `DNS.md` §8.2 records the lesson: assert on the
*rendered config*, not the stored row.

## Global ACLs

`DNSAcl.group_id` is nullable, but nothing creates a global ACL (the only
constructor is group-scoped) and the bundle is built per group. Documented
as unsupported rather than given shadowing machinery for a case with zero
rows and no creation path.

## Verified on a live agent

```
acl "office-core" { 10.1.0.0/24; };
acl "office-all" { office-core; 10.1.1.0/24; };
...
    match-clients { office-all; };
```

`named-checkconf` → VALID. The inner ACL precedes the outer one that
references it; an empty ACL renders `{ none; }` and still validates; and a
live cycle attempt returns the loop by name:

> ACL 'office-all' references itself through office-all → office-core → office-all.

## Tests

44 backend + 245 agent (the full agent suite, confirming the new `acl`
block doesn't disturb existing view/RPZ output). Includes an explicit
"a bundle with no ACLs renders unchanged" guard, since every existing
install has zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)