### PR TITLE
feat(agents): last-known-good config revert + upward reporting (#882)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -671,10 +671,69 @@ suggestion, free-space treemap.
   zip's central directory is written last, so it needs a third-party
   writer — bounded by per-section + 48 MB caps instead) and a CLI
   fallback for a host that cannot serve HTTP.
-- ⬜ [**Agents never read the `previous.json` they write**](https://github.com/spatiumddi/spatiumddi/issues/882) —
-  both agents persist a last-known-good bundle and neither ever loads
-  it, so a bad config that passes validation but breaks the daemon has
-  no auto-revert. The file exists; the restore path does not.
+- ✅ [**Agents never read the `previous.json` they write**](https://github.com/spatiumddi/spatiumddi/issues/882)
+  — non-negotiable #5's cached config protects against a *dead* control
+  plane; this closes the other half, a *wrong* one. All three agents
+  (DNS / DHCP / looking-glass) gain `config_apply.py`: an `ApplyStatus`
+  reported on the heartbeat and a persisted `Quarantine` so a failed etag
+  is not re-applied every poll (the long-poll's 12 s wake tick + 2 s
+  fallback made a bad bundle a re-render *loop*, not one failure). The
+  agent parks on the failing etag — the long-poll then blocks on a 304,
+  costing nothing — and retries on a 60 s → 5 min → 15 min ladder so a
+  *transient* failure still self-heals.
+  **The rotation was the actual bug.** `previous.json` was written on
+  every *fetch*, so it meant "the bundle before this one", not "the last
+  one that worked" — identical only while every apply succeeds, which is
+  the case it does not exist for. Worse, it destroyed the fallback in two
+  poll cycles: a failing bundle leaves the etag unadvanced, so the next
+  poll re-fetches the *same* bundle and rotates it, now known-bad, over
+  the only good config on disk. `previous` is now written by an explicit
+  `commit_config` that **refuses to run if `current` is not the bundle
+  that applied**.
+  Apply is phased (render → validate → swap/reload) and the phase picks
+  the recovery: BIND validates into `rendered.new`, so a
+  `named-checkconf` failure never reached `named` and re-rendering would
+  bounce a healthy daemon to reach the state it is already in. Kea is the
+  mirror image — `config-test` rejects without touching the running
+  server, but the refused document is already at `kea_config_path`, which
+  is what Kea reads on its next start, so that one always rewrites the
+  files. Only Kea's *rejected* is a verdict about the config;
+  *socket-unreachable* is not, and reverting there would discard a good
+  bundle because Kea happened to be restarting.
+  **Four latent bugs found on the way, all of the "written, never read"
+  class the #899 audit named.** (1) `daemon` and `config` were declared
+  on the DNS + DHCP heartbeat request models and read by **neither
+  handler** — the degraded verdict agents already computed was discarded
+  at the door; the LG agent's `daemon_status` was set by its sync loop and
+  never even put on the wire. (2) A config **Kea refused** was reported as
+  a success: the loop advanced its etag, called `_record_success()`,
+  logged `dhcp_config_applied` and stamped the K8s readiness marker.
+  (3) `named-checkconf` writes its diagnostics — with the line number —
+  to **stdout**, and `validate()` read only stderr, so the error was
+  always the empty string `"named-checkconf failed: "`. Harmless while it
+  went nowhere; now it is the operator's only explanation. (4) The
+  supervisor audit the issue asked for: `maybe_fire_console_mode`
+  bypassed `_fire_host_config`, so the console-mode plane had none of
+  #387's protections — a failing `spatiumddi-verbose-boot-reload` left
+  the applied sidecar unchanged, the next heartbeat rewrote the trigger,
+  its rename re-fired the `.path` unit, and it repeated every ~30 s
+  forever with nothing said upward; that runner's three failure paths
+  also left the trigger in place (the #550 pattern, unfixed there).
+  Reporting matters more than it sounds: a reverted agent keeps serving
+  and keeps heartbeating, so `status`, the health check and `last_seen_at`
+  all read normal while the saved zone or scope is live nowhere. Verdict
+  → `{dns_server,dhcp_server,looking_glass_collector}.config_apply_*`
+  (migration `e9c2d47b1a63`, partial index on the failing states only),
+  a chip + detail banner, the default-**on** `agent_config_rejected` alert
+  rule (severity from the agent's own verdict — `reverted` is a warning,
+  `revert_failed` / `no_previous` critical), and 1 MCP tool
+  (`find_agents_with_config_failures`). NULL means UNKNOWN, never `ok` —
+  an agent too old to report is exactly where a silent revert would hide.
+  **Deferred:** the `tz-status` / `verbose-boot-status` sidecars carry a
+  failure *reason* nothing reads (`host_config_health` reports only that a
+  plane is unapplied); and `DNSServerOptions.allow_query` is interpolated
+  into `named.conf` unvalidated — a third instance of the #876/#899
+  class, used deliberately here as the E2E fault-injection lever.
 - ⬜ [**Config snapshots + rollback**](https://github.com/spatiumddi/spatiumddi/issues/883) — audit-log-driven revert
   of a single change plus scoped named snapshots. Distinct from #882,
   which is an agent-side safety net rather than an operator action.

--- a/agent/dhcp/spatium_dhcp_agent/cache.py
+++ b/agent/dhcp/spatium_dhcp_agent/cache.py
@@ -3,9 +3,11 @@
 Layout under /var/lib/spatium-dhcp-agent/:
     agent-id                        # UUID, 0600
     agent_token.jwt                 # current JWT, 0600
-    config/current.json             # last-known-good ConfigBundle
+    config/current.json             # last bundle FETCHED from the control plane
     config/current.etag
-    config/previous.json
+    config/previous.json            # last bundle that APPLIED cleanly (#882)
+    config/previous.etag
+    config/quarantine.json          # etag of a bundle that failed to apply (#882)
     rendered/kea-dhcp4.json         # rendered Kea config (last applied)
     leases/pending.jsonl            # lease events not yet posted to the control plane
 """
@@ -17,6 +19,10 @@ import os
 import uuid
 from pathlib import Path
 from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
 
 # Schema version for the cached ConfigBundle — see DHCP.md §6.
 CACHE_SCHEMA_VERSION = 1
@@ -82,20 +88,99 @@ def load_config(state_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
 
 
 def save_config(state_dir: Path, bundle: dict[str, Any], etag: str) -> None:
-    """Atomic replace — write new, move current→previous, rename tmp→current."""
+    """Persist the bundle we just FETCHED as ``current`` (atomic rename).
+
+    Deliberately does **not** touch ``previous.json`` (#882). It used to:
+    every fetch rotated current→previous before the apply had been
+    attempted, which made ``previous`` mean "the bundle before this one"
+    rather than "the last one that worked" — the same thing only while
+    every apply succeeds, which is exactly the case this cache is not for.
+
+    ``previous`` is now written by :func:`commit_config`, once Kea has
+    accepted the rendered config.
+    """
     cfg_dir = state_dir / "config"
     cfg_dir.mkdir(parents=True, exist_ok=True)
     current = cfg_dir / "current.json"
-    previous = cfg_dir / "previous.json"
     tmp = cfg_dir / "current.json.tmp"
     # Stamp the schema version so older/newer agents can detect incompatible caches.
     stamped = dict(bundle)
     stamped.setdefault("_schema_version", CACHE_SCHEMA_VERSION)
     tmp.write_text(json.dumps(stamped, indent=2, sort_keys=True))
-    if current.exists():
-        current.replace(previous)
     tmp.replace(current)
     (cfg_dir / "current.etag").write_text(etag)
+
+
+def commit_config(state_dir: Path, etag: str) -> None:
+    """Promote ``current`` to ``previous`` — the last-known-GOOD bundle (#882).
+
+    Called only after Kea has answered ``config-test`` + ``config-reload``
+    successfully, so whatever lands here is known to load.
+
+    Copies rather than renames: ``current`` stays in place because it is
+    what the agent re-applies on restart.
+    """
+    cfg_dir = state_dir / "config"
+    current = cfg_dir / "current.json"
+    etag_path = cfg_dir / "current.etag"
+    if not current.exists() or not etag_path.exists():
+        return
+    # Guard the precondition rather than assume it. Promoting ``current``
+    # is only correct while ``current`` IS the bundle that just applied;
+    # a caller that applied something else (a revert, a bundle read from
+    # elsewhere) would otherwise silently stamp the wrong config as
+    # last-known-good, which is the one thing this file must never hold.
+    if etag_path.read_text().strip() != etag:
+        log.warning(
+            "commit_config_etag_mismatch",
+            applied_etag=etag,
+            cached_etag=etag_path.read_text().strip(),
+        )
+        return
+    if (cfg_dir / "previous.etag").exists():
+        # Already committed — skip the copy. ``commit_config`` is called from
+        # more than one point in a successful poll (the structural-apply path
+        # and the end-of-poll confirmation), and this bundle can be tens of
+        # kilobytes.
+        try:
+            if (cfg_dir / "previous.etag").read_text().strip() == etag:
+                return
+        except OSError:
+            pass  # unreadable sidecar → fall through and rewrite it
+    tmp = cfg_dir / "previous.json.tmp"
+    # Copy the bytes rather than re-serialise the bundle: ``previous.json``
+    # has to be exactly what ``current.json`` was, because that is what the
+    # agent replays on a revert. Two independent serialisations could drift.
+    tmp.write_text(current.read_text())
+    tmp.replace(cfg_dir / "previous.json")
+    etag_tmp = cfg_dir / "previous.etag.tmp"
+    etag_tmp.write_text(etag_path.read_text())
+    etag_tmp.replace(cfg_dir / "previous.etag")
+
+
+def load_previous_config(state_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """The last bundle Kea accepted, for the revert path (#882).
+
+    ``(None, None)`` when there is nothing to fall back to — a new agent
+    whose first bundle is the broken one. The caller reports that case
+    distinctly (``no_previous``): there is no safe state to return to.
+
+    The etag may be absent even when the bundle is present: agents upgraded
+    in the field carry a ``previous.json`` written by the old rotating
+    :func:`save_config`, which never wrote ``previous.etag``. That bundle is
+    still a usable fallback, so a missing etag is not a rejection.
+    """
+    cfg_dir = state_dir / "config"
+    cfg_path = cfg_dir / "previous.json"
+    if not cfg_path.exists():
+        return None, None
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except json.JSONDecodeError:
+        return None, None
+    etag_path = cfg_dir / "previous.etag"
+    etag = etag_path.read_text().strip() if etag_path.exists() else None
+    return cfg, etag
 
 
 def save_rendered_kea(state_dir: Path, rendered: dict[str, Any]) -> Path:

--- a/agent/dhcp/spatium_dhcp_agent/config_apply.py
+++ b/agent/dhcp/spatium_dhcp_agent/config_apply.py
@@ -1,0 +1,257 @@
+"""Last-known-good revert + poison-pill quarantine for config applies (#882).
+
+Non-negotiable #5 says the agent caches its config and keeps serving from
+that cache when the control plane is unreachable. That covers a *missing*
+control plane. It does not cover a *wrong* one: a bundle that parses fine
+but renders config the daemon rejects used to overwrite the cache and leave
+the agent with nothing to fall back to.
+
+This module is the other half. Two pieces:
+
+:class:`ApplyStatus`
+    What the agent tells the control plane about its last apply. Without
+    it a revert is silent, which is arguably worse than the crash it
+    replaces — the operator sees a saved config and a healthy daemon and
+    has no way to learn the two do not correspond.
+
+:class:`Quarantine`
+    Remembers the etag that failed so the agent stops re-applying it.
+    The long-poll wakes on a 12 s tick and falls back to a 2 s poll, so
+    without this a bad bundle is not a single failure — it is a retry
+    loop for as long as it stays saved.
+
+    Quarantine is not permanent. An apply can fail for reasons that have
+    nothing to do with the bundle (a full disk during render, a daemon
+    still starting), and those clear on their own; refusing to ever retry
+    would strand the agent on old config after the real problem went away.
+    So a quarantined etag is retried on a bounded backoff, and any bundle
+    that applies cleanly clears the record.
+
+The three agents (DNS / DHCP / looking-glass) are separate Python packages
+with no shared import path, so this module exists three times. Keep the
+semantics identical; the file is deliberately small to make that cheap.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Outcome vocabulary, shared with the control plane's
+# ``*_server.config_apply_status`` column. Keep in sync with
+# ``backend/app/services/agents/config_apply.py``.
+STATUS_OK = "ok"
+"""The bundle applied. Steady state."""
+
+STATUS_REVERTED = "reverted"
+"""The bundle failed and the agent is running the previous good config.
+
+The daemon is healthy but is NOT serving what the operator saved.
+"""
+
+STATUS_REVERT_FAILED = "revert_failed"
+"""The bundle failed AND restoring the previous config also failed.
+
+The worst case: the daemon may be down or serving a half-applied config.
+"""
+
+STATUS_NO_PREVIOUS = "no_previous"
+"""The bundle failed and there was no known-good config to fall back to.
+
+A first-ever bundle that does not work. There is nothing to revert TO, so
+the daemon is unconfigured until the operator fixes the config.
+"""
+
+FAILED_STATUSES = frozenset({STATUS_REVERTED, STATUS_REVERT_FAILED, STATUS_NO_PREVIOUS})
+
+# Backoff before a quarantined etag is retried. Bounded at both ends: short
+# enough that a transient failure (disk pressure, a daemon mid-restart)
+# recovers without operator involvement, long enough that a genuinely bad
+# bundle costs one apply attempt every 15 minutes instead of one per poll.
+RETRY_BACKOFF_SECONDS: tuple[float, ...] = (60.0, 300.0, 900.0)
+
+# Truncate the daemon's error text before it goes on the wire. Kea and named
+# can both emit a long block, and this lands in a String/Text column that is
+# read in a UI chip tooltip — the first line or two is the diagnostic part.
+MAX_ERROR_LEN = 2000
+
+
+# ── Apply phases ──────────────────────────────────────────────────────────
+#
+# The boundary that matters is between VALIDATE and RELOAD. Everything up to
+# and including validation happens against a staging copy — BIND renders into
+# ``rendered.new`` and runs ``named-checkconf`` there; Kea is asked
+# ``config-test`` before ``config-reload`` — so the running daemon has not
+# been touched and there is nothing to undo. Only a failure at RELOAD means
+# the live config has already been replaced, and only then does recovering
+# require re-rendering the previous bundle.
+
+PHASE_RENDER = "render"
+PHASE_VALIDATE = "validate"
+PHASE_RELOAD = "reload"
+
+DAEMON_DISTURBING_PHASES = frozenset({PHASE_RELOAD})
+
+
+class ConfigApplyError(RuntimeError):
+    """An apply that failed, tagged with the phase it failed in (#882)."""
+
+    def __init__(self, phase: str, cause: BaseException):
+        super().__init__(f"{phase} failed: {cause}")
+        self.phase = phase
+        self.cause = cause
+
+    @property
+    def daemon_disturbed(self) -> bool:
+        return self.phase in DAEMON_DISTURBING_PHASES
+
+
+def truncate_error(text: str) -> str:
+    """Bound an error string for the heartbeat, marking that it was cut."""
+    text = " ".join(text.split())
+    if len(text) <= MAX_ERROR_LEN:
+        return text
+    return text[: MAX_ERROR_LEN - 1] + "…"
+
+
+@dataclass
+class ApplyStatus:
+    """The agent's verdict on its most recent config apply."""
+
+    status: str = STATUS_OK
+    #: etag of the bundle actually live right now. On a revert this is the
+    #: PREVIOUS bundle's etag, not the one the operator just saved — which
+    #: is the whole point: it is what lets the control plane show that the
+    #: server has not converged.
+    etag: str | None = None
+    #: etag of the bundle that was rejected. ``None`` while healthy.
+    failed_etag: str | None = None
+    #: Which step failed — ``render`` / ``validate`` / ``reload``. Tells the
+    #: operator whether the daemon was ever disturbed.
+    phase: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "etag": self.etag,
+            "failed_etag": self.failed_etag,
+            "phase": self.phase,
+            "error": self.error,
+        }
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == STATUS_OK
+
+
+class Quarantine:
+    """Persisted record of an etag whose apply failed.
+
+    Persisted rather than in-memory because the failure survives a restart:
+    the agent re-applies ``current.json`` at boot, so an in-memory record
+    would let a crash-looping container re-break itself on every start.
+    """
+
+    def __init__(self, state_dir: Path):
+        self._path = state_dir / "config" / "quarantine.json"
+        self.etag: str | None = None
+        self.reason: str | None = None
+        self.failures: int = 0
+        self.retry_at: float = 0.0
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError):
+            # A corrupt quarantine file must not stop the agent starting.
+            # Losing the record means at worst one extra apply attempt of a
+            # bad bundle, which is exactly what happens without this file.
+            log.warning("quarantine_unreadable_ignoring", path=str(self._path))
+            return
+        if not isinstance(data, dict):
+            return
+        self.etag = data.get("etag")
+        self.reason = data.get("reason")
+        self.failures = int(data.get("failures") or 0)
+        # ``retry_at`` is stored as a monotonic-independent wall clock so it
+        # survives a restart. A clock that jumps backwards would delay the
+        # retry; a clock that jumps forwards brings it early. Both are
+        # acceptable — this is a backoff, not a deadline.
+        self.retry_at = float(data.get("retry_at") or 0.0)
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(
+                    {
+                        "etag": self.etag,
+                        "reason": self.reason,
+                        "failures": self.failures,
+                        "retry_at": self.retry_at,
+                    },
+                    indent=2,
+                )
+            )
+            tmp.replace(self._path)
+        except OSError:
+            # Best-effort. An unwritable state dir is its own (louder)
+            # problem; failing the apply path over it would be worse.
+            log.warning("quarantine_write_failed", path=str(self._path))
+
+    def record(self, etag: str, reason: str) -> None:
+        """Mark ``etag`` as failed and schedule its retry."""
+        if etag != self.etag:
+            # A different bundle — restart the backoff ladder rather than
+            # inheriting the previous one's.
+            self.failures = 0
+        self.etag = etag
+        self.reason = reason
+        self.failures += 1
+        idx = min(self.failures - 1, len(RETRY_BACKOFF_SECONDS) - 1)
+        self.retry_at = time.time() + RETRY_BACKOFF_SECONDS[idx]
+        self._save()
+        log.warning(
+            "config_quarantined",
+            etag=etag,
+            failures=self.failures,
+            retry_in_seconds=RETRY_BACKOFF_SECONDS[idx],
+            reason=reason,
+        )
+
+    def clear(self) -> None:
+        if self.etag is None:
+            return
+        log.info("config_quarantine_cleared", etag=self.etag)
+        self.etag = None
+        self.reason = None
+        self.failures = 0
+        self.retry_at = 0.0
+        try:
+            self._path.unlink(missing_ok=True)
+        except OSError:
+            # Stale file on disk only costs one skipped apply after a
+            # restart, and the next successful apply rewrites it away.
+            log.warning("quarantine_unlink_failed", path=str(self._path))
+
+    def blocks(self, etag: str | None) -> bool:
+        """Should this etag be skipped rather than applied right now?"""
+        if etag is None or self.etag is None or etag != self.etag:
+            return False
+        return time.time() < self.retry_at
+
+    def retry_due(self) -> bool:
+        """Is a quarantined bundle due for another attempt?"""
+        return self.etag is not None and time.time() >= self.retry_at

--- a/agent/dhcp/spatium_dhcp_agent/heartbeat.py
+++ b/agent/dhcp/spatium_dhcp_agent/heartbeat.py
@@ -13,6 +13,7 @@ import structlog
 from . import __version__, kea_ctrl
 from .cache import save_token
 from .config import AgentConfig
+from .config_apply import ApplyStatus
 
 log = structlog.get_logger(__name__)
 
@@ -23,6 +24,12 @@ class HeartbeatClient:
         self.token_ref = token_ref
         self._stop = threading.Event()
         self.daemon_status: dict[str, Any] = {}
+        # #882 — set by SyncLoop (constructed after this object, assigns itself
+        # in). Rides the heartbeat's ``config`` field so the control plane can
+        # tell a Kea that is up but running a REVERTED config apart from one
+        # that converged. Defaults to a healthy ApplyStatus so a heartbeat sent
+        # before the first sync doesn't report a failure that hasn't happened.
+        self.config_apply: ApplyStatus = ApplyStatus()
         self.lease_count_since_start = 0
         self.pending_acks: list[dict] = []
         # #637 — cached Kea daemon version. See _kea_version(); immutable for the
@@ -66,6 +73,10 @@ class HeartbeatClient:
             "pid": os.getpid(),
             "status": self.daemon_status.get("status", "ok"),
             "daemon": self.daemon_status,
+            # #882 — last config-apply verdict. The server's request model has
+            # declared a ``config`` field since the beginning; until now the
+            # DHCP agent never sent one and the handler never read one.
+            "config": self.config_apply.as_dict(),
             "lease_count_since_start": self.lease_count_since_start,
             "ops_ack": ops_ack,
             # #637 — the running Kea daemon's version (e.g. "3.0.3"), read live

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -123,6 +123,13 @@ class SyncLoop:
         # Set by _reload_socket so the raised ConfigApplyError can carry
         # Kea's own words rather than a generic "rejected".
         self._last_reload_error: str | None = None
+        # #882 — did a Kea daemon actually ACCEPT the config we just wrote?
+        # An unreachable control socket is not a rejection (Kea may be
+        # restarting) so it must not revert — but it is not an acceptance
+        # either, and only an accepted bundle may be promoted to
+        # ``previous.json``. Without this the "last-known-GOOD" fallback can
+        # end up holding a document no daemon has ever loaded.
+        self._reload_confirmed = False
 
         # Preload cached bundle — offline-operation guarantee.
         #
@@ -166,11 +173,14 @@ class SyncLoop:
                     reload_kea=True,
                     reload_retry_timeout=_BOOTSTRAP_RELOAD_TIMEOUT,
                 )
-                if not booting_from_previous:
+                if not booting_from_previous and self._reload_confirmed:
                     # #882 — ``current`` demonstrably loads, so it becomes the
                     # bundle we fall back TO. Skipped when we booted from
                     # ``previous``: committing there would copy the still-bad
-                    # ``current.json`` over the only good config we have.
+                    # ``current.json`` over the only good config we have — and
+                    # skipped when no daemon confirmed the config (every
+                    # control socket unreachable), since an unverified bundle
+                    # is not a safe revert target.
                     commit_config(self.cfg.state_dir, etag or "")
                 # #296 A2 — warm-restart readiness. The hostPath cache carries
                 # the bundle we just successfully re-applied; the marker tells
@@ -191,9 +201,28 @@ class SyncLoop:
                 # #882 — the cached bundle no longer loads. Quarantine it and
                 # fall back rather than leave Kea on the baked image config.
                 log.exception("bootstrap_cache_apply_failed")
-                if etag:
-                    self._quarantine.record(etag, truncate_error(str(e)))
-                self._bootstrap_fallback(etag, e)
+                if booting_from_previous:
+                    # It was the last-known-GOOD bundle that just failed, not
+                    # ``current`` — ``etag`` was rebound to ``prev_etag`` above.
+                    # Do NOT quarantine it: that would overwrite the record
+                    # naming the bundle which actually broke us, un-quarantining
+                    # the poison pill so the next poll applies it again.
+                    self._set_status(
+                        ApplyStatus(
+                            status=STATUS_REVERT_FAILED,
+                            failed_etag=self._quarantine.etag,
+                            error=truncate_error(str(e)),
+                        )
+                    )
+                    log.error(
+                        "bootstrap_last_known_good_apply_failed",
+                        failed_etag=self._quarantine.etag,
+                        previous_etag=etag,
+                    )
+                else:
+                    if etag:
+                        self._quarantine.record(etag, truncate_error(str(e)))
+                    self._bootstrap_fallback(etag, e)
 
     def _set_status(self, status: ApplyStatus) -> None:
         self.apply_status = status
@@ -267,7 +296,14 @@ class SyncLoop:
             return False
 
         self._quarantine.clear()
-        commit_config(self.cfg.state_dir, etag)
+        if self._reload_confirmed:
+            commit_config(self.cfg.state_dir, etag)
+        else:
+            # Written, not confirmed — every control socket was unreachable,
+            # so nothing has validated this document. Keep the previous
+            # last-known-good rather than promoting a bundle Kea may refuse
+            # the moment it comes back.
+            log.info("config_not_committed_unconfirmed", etag=etag)
         self._set_status(ApplyStatus(status=STATUS_OK, etag=etag))
         return True
 
@@ -432,6 +468,8 @@ class SyncLoop:
         inner dict. Fall back to the envelope if ``bundle`` isn't
         there so cached v0 responses (pre-envelope) still render.
         """
+        # #882 — reset per apply; set below once a daemon accepts the doc.
+        self._reload_confirmed = False
         # Issue #258 — explicit narrowing. Pre-#258 the inline
         # ternary fell through to ``bundle`` for ANY non-dict value
         # of ``bundle["bundle"]`` (list, str, None, …) and the
@@ -509,6 +547,9 @@ class SyncLoop:
             r6 = self._reload_socket(
                 self.cfg.kea_control_socket_v6, dhcp6_doc, "dhcp6", reload_retry_timeout
             )
+            # At least one daemon ran config-test against this document and
+            # accepted it, which is what makes it a legitimate revert target.
+            self._reload_confirmed = RELOAD_OK in (r4, r6)
             if r4 == RELOAD_OK and r6 == RELOAD_OK:
                 self.heartbeat.daemon_status = {"status": "ok"}
             elif RELOAD_REJECTED in (r4, r6):

--- a/agent/dhcp/spatium_dhcp_agent/sync.py
+++ b/agent/dhcp/spatium_dhcp_agent/sync.py
@@ -30,8 +30,27 @@ from typing import Any
 import httpx
 import structlog
 
-from .cache import load_config, save_config, save_rendered_kea, save_token
+from .cache import (
+    commit_config,
+    load_config,
+    load_previous_config,
+    save_config,
+    save_rendered_kea,
+    save_token,
+)
 from .config import AgentConfig
+from .config_apply import (
+    PHASE_RELOAD,
+    PHASE_RENDER,
+    STATUS_NO_PREVIOUS,
+    STATUS_OK,
+    STATUS_REVERT_FAILED,
+    STATUS_REVERTED,
+    ApplyStatus,
+    ConfigApplyError,
+    Quarantine,
+    truncate_error,
+)
 from .kea_ctrl import KeaCtrlError, config_reload, config_test
 from .radvd_apply import apply_radvd
 from .render_kea import render as render_kea
@@ -70,6 +89,12 @@ _OFFLINE_RETRY_SECONDS = 60.0
 _BOOTSTRAP_RELOAD_TIMEOUT = 15.0
 _BOOTSTRAP_RELOAD_INTERVAL = 1.0
 
+# Outcomes of one daemon's reload attempt. Only REJECTED is a verdict about
+# the config itself; UNREACHABLE means we never got to ask (#882).
+RELOAD_OK = "ok"
+RELOAD_REJECTED = "rejected"
+RELOAD_UNREACHABLE = "unreachable"
+
 
 class SyncLoop:
     def __init__(
@@ -89,6 +114,15 @@ class SyncLoop:
         self._current_etag: str | None = None
         self._consecutive_failures = 0
         self._offline = False
+        # #882 — last-known-good revert. ``quarantine`` remembers an etag
+        # whose apply Kea refused so we stop re-applying it every poll;
+        # ``apply_status`` is what the heartbeat reports upward.
+        self._quarantine = Quarantine(self.cfg.state_dir)
+        self.apply_status = ApplyStatus()
+        self.heartbeat.config_apply = self.apply_status
+        # Set by _reload_socket so the raised ConfigApplyError can carry
+        # Kea's own words rather than a generic "rejected".
+        self._last_reload_error: str | None = None
 
         # Preload cached bundle — offline-operation guarantee.
         #
@@ -100,6 +134,30 @@ class SyncLoop:
         # on its baked config forever — in particular losing HA state on
         # any agent restart.
         bundle, etag = load_config(self.cfg.state_dir)
+        # #882 — a restart must not re-break Kea with the bundle that broke
+        # it. ``current.json`` is what the control plane last SENT, which is
+        # not necessarily what loaded; if that bundle is quarantined, boot
+        # from the last-known-good instead.
+        booting_from_previous = False
+        if bundle is not None and self._quarantine.blocks(etag):
+            prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+            if prev_bundle is not None:
+                log.warning(
+                    "bootstrap_skipping_quarantined_bundle",
+                    failed_etag=etag,
+                    booting_etag=prev_etag,
+                    reason=self._quarantine.reason,
+                )
+                self._set_status(
+                    ApplyStatus(
+                        status=STATUS_REVERTED,
+                        etag=prev_etag,
+                        failed_etag=etag,
+                        error=self._quarantine.reason,
+                    )
+                )
+                bundle, etag = prev_bundle, prev_etag
+                booting_from_previous = True
         if bundle is not None:
             self._current_etag = etag
             try:
@@ -108,6 +166,12 @@ class SyncLoop:
                     reload_kea=True,
                     reload_retry_timeout=_BOOTSTRAP_RELOAD_TIMEOUT,
                 )
+                if not booting_from_previous:
+                    # #882 — ``current`` demonstrably loads, so it becomes the
+                    # bundle we fall back TO. Skipped when we booted from
+                    # ``previous``: committing there would copy the still-bad
+                    # ``current.json`` over the only good config we have.
+                    commit_config(self.cfg.state_dir, etag or "")
                 # #296 A2 — warm-restart readiness. The hostPath cache carries
                 # the bundle we just successfully re-applied; the marker tells
                 # the K8s readinessProbe this pod is ready to serve without
@@ -123,8 +187,139 @@ class SyncLoop:
                 # longer write the trigger surface anyway; the
                 # supervisor's appliance-state module is the single
                 # producer of appliance-host trigger files now.
-            except Exception:
+            except Exception as e:
+                # #882 — the cached bundle no longer loads. Quarantine it and
+                # fall back rather than leave Kea on the baked image config.
                 log.exception("bootstrap_cache_apply_failed")
+                if etag:
+                    self._quarantine.record(etag, truncate_error(str(e)))
+                self._bootstrap_fallback(etag, e)
+
+    def _set_status(self, status: ApplyStatus) -> None:
+        self.apply_status = status
+        self.heartbeat.config_apply = status
+
+    def _bootstrap_fallback(self, failed_etag: str | None, exc: BaseException) -> None:
+        """Boot from the last-known-good bundle after ``current`` failed (#882)."""
+        prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+        if prev_bundle is None or prev_etag == failed_etag:
+            self._set_status(
+                ApplyStatus(
+                    status=STATUS_NO_PREVIOUS,
+                    failed_etag=failed_etag,
+                    error=truncate_error(str(exc)),
+                )
+            )
+            log.error("bootstrap_no_last_known_good", failed_etag=failed_etag)
+            return
+        try:
+            self._apply_bundle(
+                prev_bundle,
+                reload_kea=True,
+                reload_retry_timeout=_BOOTSTRAP_RELOAD_TIMEOUT,
+            )
+        except Exception as revert_exc:
+            self._set_status(
+                ApplyStatus(
+                    status=STATUS_REVERT_FAILED,
+                    failed_etag=failed_etag,
+                    error=truncate_error(f"{exc} (revert also failed: {revert_exc})"),
+                )
+            )
+            log.exception("bootstrap_last_known_good_apply_failed")
+            return
+        self._current_etag = prev_etag
+        self._set_status(
+            ApplyStatus(
+                status=STATUS_REVERTED,
+                etag=prev_etag,
+                failed_etag=failed_etag,
+                error=truncate_error(str(exc)),
+            )
+        )
+        _touch_ready_marker(self.cfg.state_dir)
+        log.warning(
+            "bootstrap_from_last_known_good",
+            failed_etag=failed_etag,
+            booted_etag=prev_etag,
+        )
+
+    def _apply_with_revert(self, bundle: dict[str, Any], etag: str) -> bool:
+        """Apply ``bundle``; on failure fall back to the last-known-good (#882).
+
+        Returns True when ``bundle`` is live, False when it was rejected.
+
+        Unlike the DNS agent, a revert here always rewrites the on-disk Kea
+        documents even when the running daemon was never disturbed. Kea's
+        ``config-test`` rejects without touching the running server, so the
+        daemon is fine — but ``_apply_bundle`` has already written the
+        refused document to ``kea_config_path``, and that file is what Kea
+        reads on its next start. Leaving it would turn a rejected apply into
+        a crash loop the next time the container restarts.
+        """
+        try:
+            self._apply_bundle(bundle, reload_kea=True)
+        except ConfigApplyError as e:
+            self._handle_apply_failure(etag, e.phase, e.cause)
+            return False
+        except Exception as e:
+            self._handle_apply_failure(etag, None, e)
+            return False
+
+        self._quarantine.clear()
+        commit_config(self.cfg.state_dir, etag)
+        self._set_status(ApplyStatus(status=STATUS_OK, etag=etag))
+        return True
+
+    def _handle_apply_failure(
+        self, etag: str, phase: str | None, cause: BaseException
+    ) -> None:
+        log.error("sync_apply_failed", etag=etag, phase=phase, error=str(cause))
+        self._quarantine.record(etag, truncate_error(f"{phase or 'apply'}: {cause}"))
+
+        prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+        if prev_bundle is None:
+            self._set_status(
+                ApplyStatus(
+                    status=STATUS_NO_PREVIOUS,
+                    failed_etag=etag,
+                    phase=phase,
+                    error=truncate_error(str(cause)),
+                )
+            )
+            log.error("sync_no_last_known_good", failed_etag=etag)
+            return
+
+        try:
+            self._apply_bundle(prev_bundle, reload_kea=True)
+        except Exception as revert_exc:
+            self._set_status(
+                ApplyStatus(
+                    status=STATUS_REVERT_FAILED,
+                    failed_etag=etag,
+                    phase=phase,
+                    error=truncate_error(f"{cause} (revert also failed: {revert_exc})"),
+                )
+            )
+            log.exception("sync_revert_failed", failed_etag=etag)
+            return
+
+        self._set_status(
+            ApplyStatus(
+                status=STATUS_REVERTED,
+                etag=prev_etag,
+                failed_etag=etag,
+                phase=phase,
+                error=truncate_error(str(cause)),
+            )
+        )
+        self.heartbeat.daemon_status = {
+            "status": "degraded",
+            "reason": f"config_apply_reverted: {truncate_error(str(cause))}",
+        }
+        log.warning(
+            "sync_reverted_to_last_known_good", failed_etag=etag, live_etag=prev_etag
+        )
 
     def stop(self) -> None:
         self._stop.set()
@@ -155,12 +350,17 @@ class SyncLoop:
         config_doc: dict[str, Any],
         daemon: str,
         reload_retry_timeout: float,
-    ) -> bool:
+    ) -> str:
         """Preflight (config-test) then reload one Kea daemon.
 
-        Returns ``True`` on a successful reload, ``False`` otherwise. Never
-        raises, so a v6 failure can't abort the v4 apply (and vice-versa). Two
-        failure modes are now distinguished (#477):
+        Returns ``RELOAD_OK`` / ``RELOAD_REJECTED`` / ``RELOAD_UNREACHABLE``.
+        Never raises, so a v6 failure can't abort the v4 apply (and
+        vice-versa). Two failure modes are distinguished (#477), and #882
+        makes that distinction load-bearing rather than only cosmetic: a
+        REJECTED config is known-bad and triggers a revert to the last
+        config Kea accepted, while an UNREACHABLE socket says nothing about
+        the config — reverting there would discard a perfectly good bundle
+        because Kea happened to be restarting.
 
         * **Config rejected** — config-test / reload answers with a non-zero
           result. Terminal (retrying won't fix a bad render), so surface Kea's
@@ -179,7 +379,7 @@ class SyncLoop:
                 # reason on rejection; only reload once it passes.
                 config_test(socket_path, config_doc)
                 config_reload(socket_path)
-                return True
+                return RELOAD_OK
             except (KeaCtrlError, OSError) as e:
                 # Retry BOTH classes through the deadline. An OSError is the
                 # control socket not being up yet; and during Kea's startup
@@ -208,13 +408,15 @@ class SyncLoop:
                 "status": "degraded",
                 "reason": f"{daemon}_config_rejected: {last_err}",
             }
-        else:
-            log.warning("kea_config_reload_failed", daemon=daemon, error=str(last_err))
-            self.heartbeat.daemon_status = {
-                "status": "degraded",
-                "reason": f"{daemon}_socket_unreachable: {last_err}",
-            }
-        return False
+            self._last_reload_error = f"{daemon}: {last_err}"
+            return RELOAD_REJECTED
+        log.warning("kea_config_reload_failed", daemon=daemon, error=str(last_err))
+        self.heartbeat.daemon_status = {
+            "status": "degraded",
+            "reason": f"{daemon}_socket_unreachable: {last_err}",
+        }
+        self._last_reload_error = f"{daemon}: {last_err}"
+        return RELOAD_UNREACHABLE
 
     def _apply_bundle(
         self,
@@ -255,13 +457,18 @@ class SyncLoop:
         # swapped (``kea-leases4.csv`` → ``kea-leases6.csv``) so the v6
         # daemon never writes the v4 lease store.
         lease_file_v6 = str(self.cfg.kea_lease_file).replace("leases4", "leases6")
-        rendered = render_kea(
-            inner,
-            control_socket=str(self.cfg.kea_control_socket),
-            lease_file=str(self.cfg.kea_lease_file),
-            control_socket_v6=str(self.cfg.kea_control_socket_v6),
-            lease_file_v6=lease_file_v6,
-        )
+        try:
+            rendered = render_kea(
+                inner,
+                control_socket=str(self.cfg.kea_control_socket),
+                lease_file=str(self.cfg.kea_lease_file),
+                control_socket_v6=str(self.cfg.kea_control_socket_v6),
+                lease_file_v6=lease_file_v6,
+            )
+        except Exception as e:
+            # #882 — tag the phase. A render failure never reached Kea, so
+            # the caller knows the running config is untouched.
+            raise ConfigApplyError(PHASE_RENDER, e) from e
         # Keep the HA poller aligned with whether Kea is about to load
         # the HA hook — when the bundle has no failover block the hook
         # won't be loaded, so we don't want the poller spamming
@@ -295,14 +502,31 @@ class SyncLoop:
             # not abort the v4 apply (and vice-versa) — each is wrapped in
             # the same retry / tolerate-missing-socket logic, and the
             # heartbeat daemon_status reflects the worst of the two.
-            ok4 = self._reload_socket(
+            self._last_reload_error = None
+            r4 = self._reload_socket(
                 self.cfg.kea_control_socket, dhcp4_doc, "dhcp4", reload_retry_timeout
             )
-            ok6 = self._reload_socket(
+            r6 = self._reload_socket(
                 self.cfg.kea_control_socket_v6, dhcp6_doc, "dhcp6", reload_retry_timeout
             )
-            if ok4 and ok6:
+            if r4 == RELOAD_OK and r6 == RELOAD_OK:
                 self.heartbeat.daemon_status = {"status": "ok"}
+            elif RELOAD_REJECTED in (r4, r6):
+                # #882 — Kea told us the config is wrong. Pre-#882 this fell
+                # through: the caller advanced ``_current_etag``, called
+                # ``_record_success()``, logged ``dhcp_config_applied`` and
+                # stamped the readiness marker, all for a config that had
+                # been refused. Worse, the refused document was left at
+                # ``kea_config_path``, so the next container restart booted
+                # Kea straight into it. Raise so the caller reverts the
+                # files as well as the verdict.
+                raise ConfigApplyError(
+                    PHASE_RELOAD,
+                    RuntimeError(self._last_reload_error or "Kea rejected the config"),
+                )
+            # An UNREACHABLE socket is NOT a verdict on the config — Kea may
+            # simply be starting. daemon_status already says degraded; leave
+            # the rendered files in place so the next reload picks them up.
         # IPv6 Router Advertisements (issue #524) — write + reload the
         # managed radvd.conf the control plane rendered. No-op unless
         # RADVD_MANAGED=1; best-effort so a radvd failure never disturbs
@@ -339,6 +563,18 @@ class SyncLoop:
 
     def _poll_once(self) -> None:
         headers = {"Authorization": f"Bearer {self.token_ref[0]}"}
+        # #882 — a quarantined bundle is parked on a 304 by the etag we sent
+        # last time, so the only way to give it another attempt is to stop
+        # sending that etag. Dropping If-None-Match makes the server answer
+        # 200 with whatever it holds now: the corrected bundle if the operator
+        # has saved one, otherwise the same bundle for one more try.
+        if self._quarantine.retry_due():
+            log.info(
+                "sync_quarantine_retry_due",
+                etag=self._quarantine.etag,
+                failures=self._quarantine.failures,
+            )
+            self._current_etag = None
         if self._current_etag:
             headers["If-None-Match"] = self._current_etag
         try:
@@ -391,6 +627,14 @@ class SyncLoop:
             self._record_success()
             return
 
+        # #882 — the quarantine names ONE bundle. If the control plane is no
+        # longer serving it, the operator has saved something else and the
+        # record is moot: drop it now rather than let ``retry_due`` keep
+        # forcing If-None-Match off on every poll for a bundle that no
+        # longer exists.
+        if self._quarantine.etag is not None and etag != self._quarantine.etag:
+            self._quarantine.clear()
+
         save_config(self.cfg.state_dir, bundle, etag)
 
         # #170 Wave C1 — fleet-upgrade / reboot / SNMP / NTP trigger
@@ -402,14 +646,21 @@ class SyncLoop:
         # appliance_state module is the only producer of appliance-
         # host trigger files now.
 
-        try:
-            self._apply_bundle(bundle, reload_kea=True)
-        except Exception as e:
-            log.exception("sync_apply_failed")
-            self.heartbeat.daemon_status = {
-                "status": "degraded",
-                "reason": f"config_apply_failed: {e}",
-            }
+        if self._quarantine.blocks(etag):
+            # Already known-bad. Park on this etag so the long-poll blocks
+            # instead of re-rendering the same refused config every second.
+            log.info("sync_skipping_quarantined_bundle", etag=etag)
+            self._current_etag = etag
+            self._record_success()
+            return
+
+        if not self._apply_with_revert(bundle, etag):
+            # The bundle was refused. ``_current_etag`` still advances so the
+            # loop parks on a 304 rather than spinning; the quarantine
+            # decides when to try again. Deliberately no ``_record_success``
+            # / readiness marker: the control plane is reachable, but this
+            # server has NOT converged and must not look like it has.
+            self._current_etag = etag
             return
 
         self._current_etag = etag

--- a/agent/dhcp/tests/test_cache.py
+++ b/agent/dhcp/tests/test_cache.py
@@ -6,9 +6,11 @@ import os
 
 from spatium_dhcp_agent.cache import (
     CACHE_SCHEMA_VERSION,
+    commit_config,
     ensure_layout,
     load_config,
     load_or_create_agent_id,
+    load_previous_config,
     load_token,
     save_config,
     save_rendered_kea,
@@ -31,12 +33,30 @@ def test_cache_roundtrip(tmp_state) -> None:
     assert loaded["subnets"] == bundle["subnets"]
 
 
-def test_cache_previous_on_second_write(tmp_state) -> None:
+def test_fetching_does_not_rotate_previous(tmp_state) -> None:
+    """``previous`` tracks the last bundle that APPLIED, not the last fetched.
+
+    This test asserted the opposite until #882. The old rotate-on-fetch made
+    ``previous`` useless as a fallback: a bundle Kea refuses leaves the etag
+    unadvanced, so the next poll re-fetches the same bundle and rotates the
+    bad config into ``previous``, destroying the only copy that worked.
+    """
     ensure_layout(tmp_state)
     save_config(tmp_state, {"v": 1}, "etag1")
     save_config(tmp_state, {"v": 2}, "etag2")
-    assert (tmp_state / "config" / "previous.json").exists()
+    assert not (tmp_state / "config" / "previous.json").exists()
     assert (tmp_state / "config" / "current.json").exists()
+
+
+def test_commit_config_promotes_current(tmp_state) -> None:
+    ensure_layout(tmp_state)
+    save_config(tmp_state, {"v": 1}, "etag1")
+    commit_config(tmp_state, "etag1")
+    save_config(tmp_state, {"v": 2}, "etag2")
+
+    bundle, etag = load_previous_config(tmp_state)
+    assert etag == "etag1"
+    assert bundle["v"] == 1
 
 
 def test_agent_id_stable(tmp_state) -> None:

--- a/agent/dhcp/tests/test_config_revert.py
+++ b/agent/dhcp/tests/test_config_revert.py
@@ -1,0 +1,235 @@
+"""Last-known-good revert + poison-pill quarantine for the DHCP agent (#882).
+
+Before this, ``previous.json`` was written on every fetch and read by
+nothing, and a config Kea *refused* still counted as a success: the loop
+advanced its etag, called ``_record_success()``, logged
+``dhcp_config_applied`` and stamped the K8s readiness marker. The refused
+document was also left at ``kea_config_path``, so the next container start
+booted Kea straight into it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from spatium_dhcp_agent import sync as sync_mod
+from spatium_dhcp_agent.cache import (
+    commit_config,
+    ensure_layout,
+    load_previous_config,
+    save_config,
+)
+from spatium_dhcp_agent.config import AgentConfig
+from spatium_dhcp_agent.config_apply import (
+    STATUS_NO_PREVIOUS,
+    STATUS_OK,
+    STATUS_REVERT_FAILED,
+    STATUS_REVERTED,
+    ApplyStatus,
+    Quarantine,
+)
+from spatium_dhcp_agent.kea_ctrl import KeaCtrlError
+from spatium_dhcp_agent.sync import SyncLoop
+
+
+class _FakeHeartbeat:
+    def __init__(self) -> None:
+        self.daemon_status: dict[str, Any] = {}
+        self.pending_acks: list[dict[str, Any]] = []
+        self.config_apply = ApplyStatus()
+
+
+def _bundle(tag: str, subnet: str = "192.0.2.0/24") -> dict[str, Any]:
+    return {
+        "etag": tag,
+        "scopes": [
+            {
+                "subnet_cidr": subnet,
+                "lease_time": 3600,
+                "address_family": "ipv4",
+                "pools": [],
+                "statics": [],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def loop(agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch) -> SyncLoop:
+    """A SyncLoop whose Kea control socket always answers happily."""
+    monkeypatch.setattr(sync_mod, "config_test", lambda s, d: {"result": 0})
+    monkeypatch.setattr(sync_mod, "config_reload", lambda s: {"result": 0})
+    ensure_layout(agent_cfg.state_dir)
+    return SyncLoop(agent_cfg, token_ref=[""], heartbeat=_FakeHeartbeat())
+
+
+def _apply(loop: SyncLoop, tag: str, subnet: str = "192.0.2.0/24") -> bool:
+    """Apply a bundle the way ``_poll_once`` does — cache it, then apply."""
+    bundle = _bundle(tag, subnet)
+    save_config(loop.cfg.state_dir, bundle, tag)
+    return loop._apply_with_revert(bundle, tag)
+
+
+def _reject(monkeypatch: pytest.MonkeyPatch, message: str) -> None:
+    """Kea refuses every config from here on — including a revert's."""
+
+    def bad(sock, doc):  # type: ignore[no-untyped-def]
+        raise KeaCtrlError(message)
+
+    monkeypatch.setattr(sync_mod, "config_test", bad)
+
+
+def _reject_containing(monkeypatch: pytest.MonkeyPatch, marker: str, message: str) -> None:
+    """Kea refuses only documents mentioning ``marker``.
+
+    The realistic shape: one bad scope is rejected while the previous
+    config still loads, which is what makes a revert possible at all.
+    """
+
+    def selective(sock, doc):  # type: ignore[no-untyped-def]
+        if marker in json.dumps(doc):
+            raise KeaCtrlError(message)
+        return {"result": 0}
+
+    monkeypatch.setattr(sync_mod, "config_test", selective)
+
+
+def test_rejected_config_reverts_the_files_on_disk(
+    loop: SyncLoop, agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The crash-loop-on-restart bug.
+
+    Kea's ``config-test`` rejects without disturbing the running server, so
+    the daemon is fine either way — but ``_apply_bundle`` has already written
+    the refused document to ``kea_config_path``, and THAT is what Kea reads
+    on its next start. The revert has to rewrite the files, not just the
+    status.
+    """
+    assert _apply(loop, "good", "10.0.0.0/24") is True
+    good_doc = json.loads(agent_cfg.kea_config_path.read_text())
+
+    _reject_containing(
+        monkeypatch, "10.9.9.0/24", "config-test failed: pool not in subnet"
+    )
+    assert _apply(loop, "bad", "10.9.9.0/24") is False
+
+    # Not merely "status says reverted" — the file Kea would boot from is the
+    # good one again.
+    assert json.loads(agent_cfg.kea_config_path.read_text()) == good_doc
+    assert loop.apply_status.status == STATUS_REVERTED
+    assert loop.apply_status.failed_etag == "bad"
+    assert loop.apply_status.etag == "good"
+
+
+def test_unreachable_socket_does_not_revert(
+    loop: SyncLoop, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unreachable control socket says nothing about the config.
+
+    Kea may simply be restarting. Reverting here would throw away a
+    perfectly good bundle because of a timing accident, which is why
+    ``_reload_socket`` distinguishes REJECTED from UNREACHABLE.
+    """
+    assert _apply(loop, "good") is True
+
+    def unreachable(sock, doc):  # type: ignore[no-untyped-def]
+        raise OSError("no such control socket")
+
+    monkeypatch.setattr(sync_mod, "config_test", unreachable)
+    assert _apply(loop, "next") is True
+
+    assert loop.apply_status.status == STATUS_OK
+    assert loop._quarantine.etag is None
+
+
+def test_rejection_quarantines_the_etag(
+    loop: SyncLoop, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert _apply(loop, "good") is True
+    _reject(monkeypatch, "boom")
+    _apply(loop, "bad")
+
+    assert loop._quarantine.blocks("bad")
+    assert not loop._quarantine.blocks("good")
+
+
+def test_success_commits_the_last_known_good(loop: SyncLoop, agent_cfg: AgentConfig) -> None:
+    save_config(agent_cfg.state_dir, _bundle("one"), "one")
+    assert _apply(loop, "one") is True
+    bundle, etag = load_previous_config(agent_cfg.state_dir)
+    assert etag == "one"
+    assert bundle is not None
+
+
+def test_failure_with_no_previous_is_reported_distinctly(
+    loop: SyncLoop, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _reject(monkeypatch, "boom")
+    assert _apply(loop, "bad") is False
+    assert loop.apply_status.status == STATUS_NO_PREVIOUS
+    assert loop.apply_status.etag is None
+
+
+def test_revert_failure_is_reported_distinctly(
+    loop: SyncLoop, agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert _apply(loop, "good") is True
+    # Every config-test from here on fails, including the revert's.
+    _reject(monkeypatch, "boom")
+    assert _apply(loop, "bad") is False
+    assert loop.apply_status.status == STATUS_REVERT_FAILED
+    assert "revert also failed" in (loop.apply_status.error or "")
+
+
+def test_render_failure_is_tagged_as_such(
+    loop: SyncLoop, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert _apply(loop, "good") is True
+
+    real_render = sync_mod.render_kea
+
+    def boom(bundle, **kw):  # type: ignore[no-untyped-def]
+        if any(s.get("subnet_cidr") == "10.9.9.0/24" for s in bundle.get("scopes") or []):
+            raise ValueError("unrenderable scope")
+        return real_render(bundle, **kw)
+
+    monkeypatch.setattr(sync_mod, "render_kea", boom)
+    assert _apply(loop, "bad", "10.9.9.0/24") is False
+    assert loop.apply_status.phase == sync_mod.PHASE_RENDER
+    assert loop.apply_status.status == STATUS_REVERTED
+
+
+def test_bootstrap_skips_a_quarantined_bundle(
+    agent_cfg: AgentConfig, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A restart must not boot Kea into the config it already refused."""
+    monkeypatch.setattr(sync_mod, "config_test", lambda s, d: {"result": 0})
+    monkeypatch.setattr(sync_mod, "config_reload", lambda s: {"result": 0})
+    ensure_layout(agent_cfg.state_dir)
+
+    save_config(agent_cfg.state_dir, _bundle("good", "10.0.0.0/24"), "good")
+    commit_config(agent_cfg.state_dir, "good")
+    save_config(agent_cfg.state_dir, _bundle("bad", "10.9.9.0/24"), "bad")
+    Quarantine(agent_cfg.state_dir).record("bad", "pool not in subnet")
+
+    loop = SyncLoop(agent_cfg, token_ref=[""], heartbeat=_FakeHeartbeat())
+
+    live = json.loads(agent_cfg.kea_config_path.read_text())
+    assert "10.0.0.0/24" in json.dumps(live)
+    assert loop.apply_status.status == STATUS_REVERTED
+    assert loop.apply_status.failed_etag == "bad"
+
+
+def test_quarantine_clears_when_the_server_moves_on(loop: SyncLoop) -> None:
+    """The quarantine names one bundle; a different etag makes it moot.
+
+    Without this the agent would keep dropping If-None-Match on every poll
+    for a bundle the control plane no longer serves.
+    """
+    loop._quarantine.record("bad", "boom")
+    assert _apply(loop, "fixed") is True
+    assert loop._quarantine.etag is None

--- a/agent/dhcp/tests/test_config_revert.py
+++ b/agent/dhcp/tests/test_config_revert.py
@@ -11,7 +11,6 @@ booted Kea straight into it.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
 import pytest

--- a/agent/dhcp/tests/test_config_test_preflight.py
+++ b/agent/dhcp/tests/test_config_test_preflight.py
@@ -89,8 +89,10 @@ def test_reload_socket_rejection_surfaces_reason_and_skips_reload(
     monkeypatch.setattr(sync_mod, "config_test", bad_test)
     monkeypatch.setattr(sync_mod, "config_reload", lambda s: reloaded.append(s))
 
-    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
-    assert ok is False
+    result = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
+    # #882 — the exact value matters now: REJECTED is a verdict on the
+    # config and triggers a revert; UNREACHABLE is not.
+    assert result == sync_mod.RELOAD_REJECTED
     assert reloaded == []  # never reload a config Kea rejects
     assert loop.heartbeat.daemon_status["status"] == "degraded"
     assert "pool not in subnet" in loop.heartbeat.daemon_status["reason"]
@@ -104,8 +106,8 @@ def test_reload_socket_happy_path_tests_then_reloads(
     monkeypatch.setattr(sync_mod, "config_test", lambda s, d: calls.append("test"))
     monkeypatch.setattr(sync_mod, "config_reload", lambda s: calls.append("reload"))
 
-    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
-    assert ok is True
+    result = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
+    assert result == sync_mod.RELOAD_OK
     assert calls == ["test", "reload"]  # preflight BEFORE reload
 
 
@@ -121,8 +123,8 @@ def test_reload_socket_socket_not_ready_retries_then_reports(
     monkeypatch.setattr(sync_mod, "config_reload", lambda s: None)
 
     # timeout 0 → the OSError branch breaks immediately (no real wait).
-    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
-    assert ok is False
+    result = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 0.0)
+    assert result == sync_mod.RELOAD_UNREACHABLE
     assert "socket_unreachable" in loop.heartbeat.daemon_status["reason"]
 
 
@@ -146,7 +148,7 @@ def test_reload_socket_transient_kea_error_retries_then_succeeds(
     monkeypatch.setattr(sync_mod, "config_test", flaky_test)
     monkeypatch.setattr(sync_mod, "config_reload", lambda s: reloaded.append(s))
 
-    ok = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 5.0)
-    assert ok is True
+    result = loop._reload_socket(agent_cfg.kea_control_socket, {"Dhcp4": {}}, "dhcp4", 5.0)
+    assert result == sync_mod.RELOAD_OK
     assert calls["test"] == 2  # retried past the transient KeaCtrlError
     assert reloaded  # reloaded once config-test passed

--- a/agent/dns/spatium_dns_agent/cache.py
+++ b/agent/dns/spatium_dns_agent/cache.py
@@ -3,9 +3,11 @@
 Layout under /var/lib/spatium-dns-agent/:
     agent-id                       # UUID, 0600
     agent_token.jwt                # current JWT, 0600
-    config/current.json
+    config/current.json            # last bundle FETCHED from the control plane
     config/current.etag
-    config/previous.json
+    config/previous.json           # last bundle that APPLIED cleanly (#882)
+    config/previous.etag
+    config/quarantine.json         # etag of a bundle that failed to apply (#882)
     rendered/                      # managed by driver
     ops/{inflight,failed}/
 """
@@ -17,6 +19,10 @@ import os
 import uuid
 from pathlib import Path
 from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
 
 
 def ensure_layout(state_dir: Path) -> None:
@@ -64,14 +70,102 @@ def load_config(state_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
 
 
 def save_config(state_dir: Path, bundle: dict[str, Any], etag: str) -> None:
-    """Atomic replace — write new, move current→previous, rename tmp→current."""
+    """Persist the bundle we just FETCHED as ``current`` (atomic rename).
+
+    Deliberately does **not** touch ``previous.json`` (#882). It used to:
+    every fetch did ``current.replace(previous)`` before the apply had been
+    attempted, which made ``previous`` mean "the bundle before this one"
+    rather than "the last one that worked". Those are the same thing only
+    while every apply succeeds — and the case this cache exists for is the
+    one where an apply does not.
+
+    Concretely, the old rotation destroyed the fallback in two poll cycles:
+    a bundle that fails to apply leaves ``_current_etag`` unadvanced, so the
+    next poll re-fetches the SAME bad bundle and rotates it — now bad — into
+    ``previous``, overwriting the last config known to work.
+
+    ``previous`` is now written by :func:`commit_config`, which the sync loop
+    calls only after the driver has accepted the bundle.
+    """
     cfg_dir = state_dir / "config"
     cfg_dir.mkdir(parents=True, exist_ok=True)
     current = cfg_dir / "current.json"
-    previous = cfg_dir / "previous.json"
     tmp = cfg_dir / "current.json.tmp"
     tmp.write_text(json.dumps(bundle, indent=2, sort_keys=True))
-    if current.exists():
-        current.replace(previous)
     tmp.replace(current)
     (cfg_dir / "current.etag").write_text(etag)
+
+
+def commit_config(state_dir: Path, etag: str) -> None:
+    """Promote ``current`` to ``previous`` — the last-known-GOOD bundle (#882).
+
+    Call this only once the driver has rendered, validated and reloaded the
+    bundle successfully. ``previous.json`` is what
+    :func:`load_previous_config` hands back when a later bundle has to be
+    reverted, so anything that lands here must be known to work.
+
+    Copies rather than renames: ``current`` has to stay in place, because it
+    is what the agent re-applies on restart.
+    """
+    cfg_dir = state_dir / "config"
+    current = cfg_dir / "current.json"
+    etag_path = cfg_dir / "current.etag"
+    if not current.exists() or not etag_path.exists():
+        return
+    # Guard the precondition rather than assume it. Promoting ``current``
+    # is only correct while ``current`` IS the bundle that just applied;
+    # a caller that applied something else (a revert, a bundle read from
+    # elsewhere) would otherwise silently stamp the wrong config as
+    # last-known-good, which is the one thing this file must never hold.
+    if etag_path.read_text().strip() != etag:
+        log.warning(
+            "commit_config_etag_mismatch",
+            applied_etag=etag,
+            cached_etag=etag_path.read_text().strip(),
+        )
+        return
+    if (cfg_dir / "previous.etag").exists():
+        # Already committed — skip the copy. ``commit_config`` is called from
+        # more than one point in a successful poll (the structural-apply path
+        # and the end-of-poll confirmation), and this bundle can be tens of
+        # kilobytes.
+        try:
+            if (cfg_dir / "previous.etag").read_text().strip() == etag:
+                return
+        except OSError:
+            pass  # unreadable sidecar → fall through and rewrite it
+    tmp = cfg_dir / "previous.json.tmp"
+    # Copy the bytes rather than re-serialise the bundle: ``previous.json``
+    # has to be exactly what ``current.json`` was, because that is what the
+    # agent replays on a revert. Two independent serialisations could drift.
+    tmp.write_text(current.read_text())
+    tmp.replace(cfg_dir / "previous.json")
+    etag_tmp = cfg_dir / "previous.etag.tmp"
+    etag_tmp.write_text(etag_path.read_text())
+    etag_tmp.replace(cfg_dir / "previous.etag")
+
+
+def load_previous_config(state_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """The last bundle that applied cleanly, for the revert path (#882).
+
+    ``(None, None)`` when there is nothing to fall back to — a brand-new
+    agent whose very first bundle is the broken one. The caller has to
+    report that case distinctly (``no_previous``): there is no safe state to
+    return to, so the operator has to fix the config rather than wait.
+
+    Note the etag may be absent even when the bundle is present: agents
+    upgraded in the field carry a ``previous.json`` written by the old
+    rotating :func:`save_config`, which never wrote ``previous.etag``. The
+    bundle is still a usable fallback, so a missing etag is not a rejection.
+    """
+    cfg_dir = state_dir / "config"
+    cfg_path = cfg_dir / "previous.json"
+    if not cfg_path.exists():
+        return None, None
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except json.JSONDecodeError:
+        return None, None
+    etag_path = cfg_dir / "previous.etag"
+    etag = etag_path.read_text().strip() if etag_path.exists() else None
+    return cfg, etag

--- a/agent/dns/spatium_dns_agent/config_apply.py
+++ b/agent/dns/spatium_dns_agent/config_apply.py
@@ -1,0 +1,257 @@
+"""Last-known-good revert + poison-pill quarantine for config applies (#882).
+
+Non-negotiable #5 says the agent caches its config and keeps serving from
+that cache when the control plane is unreachable. That covers a *missing*
+control plane. It does not cover a *wrong* one: a bundle that parses fine
+but renders config the daemon rejects used to overwrite the cache and leave
+the agent with nothing to fall back to.
+
+This module is the other half. Two pieces:
+
+:class:`ApplyStatus`
+    What the agent tells the control plane about its last apply. Without
+    it a revert is silent, which is arguably worse than the crash it
+    replaces — the operator sees a saved config and a healthy daemon and
+    has no way to learn the two do not correspond.
+
+:class:`Quarantine`
+    Remembers the etag that failed so the agent stops re-applying it.
+    The long-poll wakes on a 12 s tick and falls back to a 2 s poll, so
+    without this a bad bundle is not a single failure — it is a retry
+    loop for as long as it stays saved.
+
+    Quarantine is not permanent. An apply can fail for reasons that have
+    nothing to do with the bundle (a full disk during render, a daemon
+    still starting), and those clear on their own; refusing to ever retry
+    would strand the agent on old config after the real problem went away.
+    So a quarantined etag is retried on a bounded backoff, and any bundle
+    that applies cleanly clears the record.
+
+The three agents (DNS / DHCP / looking-glass) are separate Python packages
+with no shared import path, so this module exists three times. Keep the
+semantics identical; the file is deliberately small to make that cheap.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Outcome vocabulary, shared with the control plane's
+# ``*_server.config_apply_status`` column. Keep in sync with
+# ``backend/app/services/agents/config_apply.py``.
+STATUS_OK = "ok"
+"""The bundle applied. Steady state."""
+
+STATUS_REVERTED = "reverted"
+"""The bundle failed and the agent is running the previous good config.
+
+The daemon is healthy but is NOT serving what the operator saved.
+"""
+
+STATUS_REVERT_FAILED = "revert_failed"
+"""The bundle failed AND restoring the previous config also failed.
+
+The worst case: the daemon may be down or serving a half-applied config.
+"""
+
+STATUS_NO_PREVIOUS = "no_previous"
+"""The bundle failed and there was no known-good config to fall back to.
+
+A first-ever bundle that does not work. There is nothing to revert TO, so
+the daemon is unconfigured until the operator fixes the config.
+"""
+
+FAILED_STATUSES = frozenset({STATUS_REVERTED, STATUS_REVERT_FAILED, STATUS_NO_PREVIOUS})
+
+# Backoff before a quarantined etag is retried. Bounded at both ends: short
+# enough that a transient failure (disk pressure, a daemon mid-restart)
+# recovers without operator involvement, long enough that a genuinely bad
+# bundle costs one apply attempt every 15 minutes instead of one per poll.
+RETRY_BACKOFF_SECONDS: tuple[float, ...] = (60.0, 300.0, 900.0)
+
+# Truncate the daemon's error text before it goes on the wire. Kea and named
+# can both emit a long block, and this lands in a String/Text column that is
+# read in a UI chip tooltip — the first line or two is the diagnostic part.
+MAX_ERROR_LEN = 2000
+
+
+# ── Apply phases ──────────────────────────────────────────────────────────
+#
+# The boundary that matters is between VALIDATE and RELOAD. Everything up to
+# and including validation happens against a staging copy — BIND renders into
+# ``rendered.new`` and runs ``named-checkconf`` there; Kea is asked
+# ``config-test`` before ``config-reload`` — so the running daemon has not
+# been touched and there is nothing to undo. Only a failure at RELOAD means
+# the live config has already been replaced, and only then does recovering
+# require re-rendering the previous bundle.
+
+PHASE_RENDER = "render"
+PHASE_VALIDATE = "validate"
+PHASE_RELOAD = "reload"
+
+DAEMON_DISTURBING_PHASES = frozenset({PHASE_RELOAD})
+
+
+class ConfigApplyError(RuntimeError):
+    """An apply that failed, tagged with the phase it failed in (#882)."""
+
+    def __init__(self, phase: str, cause: BaseException):
+        super().__init__(f"{phase} failed: {cause}")
+        self.phase = phase
+        self.cause = cause
+
+    @property
+    def daemon_disturbed(self) -> bool:
+        return self.phase in DAEMON_DISTURBING_PHASES
+
+
+def truncate_error(text: str) -> str:
+    """Bound an error string for the heartbeat, marking that it was cut."""
+    text = " ".join(text.split())
+    if len(text) <= MAX_ERROR_LEN:
+        return text
+    return text[: MAX_ERROR_LEN - 1] + "…"
+
+
+@dataclass
+class ApplyStatus:
+    """The agent's verdict on its most recent config apply."""
+
+    status: str = STATUS_OK
+    #: etag of the bundle actually live right now. On a revert this is the
+    #: PREVIOUS bundle's etag, not the one the operator just saved — which
+    #: is the whole point: it is what lets the control plane show that the
+    #: server has not converged.
+    etag: str | None = None
+    #: etag of the bundle that was rejected. ``None`` while healthy.
+    failed_etag: str | None = None
+    #: Which step failed — ``render`` / ``validate`` / ``reload``. Tells the
+    #: operator whether the daemon was ever disturbed.
+    phase: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "etag": self.etag,
+            "failed_etag": self.failed_etag,
+            "phase": self.phase,
+            "error": self.error,
+        }
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == STATUS_OK
+
+
+class Quarantine:
+    """Persisted record of an etag whose apply failed.
+
+    Persisted rather than in-memory because the failure survives a restart:
+    the agent re-applies ``current.json`` at boot, so an in-memory record
+    would let a crash-looping container re-break itself on every start.
+    """
+
+    def __init__(self, state_dir: Path):
+        self._path = state_dir / "config" / "quarantine.json"
+        self.etag: str | None = None
+        self.reason: str | None = None
+        self.failures: int = 0
+        self.retry_at: float = 0.0
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError):
+            # A corrupt quarantine file must not stop the agent starting.
+            # Losing the record means at worst one extra apply attempt of a
+            # bad bundle, which is exactly what happens without this file.
+            log.warning("quarantine_unreadable_ignoring", path=str(self._path))
+            return
+        if not isinstance(data, dict):
+            return
+        self.etag = data.get("etag")
+        self.reason = data.get("reason")
+        self.failures = int(data.get("failures") or 0)
+        # ``retry_at`` is stored as a monotonic-independent wall clock so it
+        # survives a restart. A clock that jumps backwards would delay the
+        # retry; a clock that jumps forwards brings it early. Both are
+        # acceptable — this is a backoff, not a deadline.
+        self.retry_at = float(data.get("retry_at") or 0.0)
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(
+                    {
+                        "etag": self.etag,
+                        "reason": self.reason,
+                        "failures": self.failures,
+                        "retry_at": self.retry_at,
+                    },
+                    indent=2,
+                )
+            )
+            tmp.replace(self._path)
+        except OSError:
+            # Best-effort. An unwritable state dir is its own (louder)
+            # problem; failing the apply path over it would be worse.
+            log.warning("quarantine_write_failed", path=str(self._path))
+
+    def record(self, etag: str, reason: str) -> None:
+        """Mark ``etag`` as failed and schedule its retry."""
+        if etag != self.etag:
+            # A different bundle — restart the backoff ladder rather than
+            # inheriting the previous one's.
+            self.failures = 0
+        self.etag = etag
+        self.reason = reason
+        self.failures += 1
+        idx = min(self.failures - 1, len(RETRY_BACKOFF_SECONDS) - 1)
+        self.retry_at = time.time() + RETRY_BACKOFF_SECONDS[idx]
+        self._save()
+        log.warning(
+            "config_quarantined",
+            etag=etag,
+            failures=self.failures,
+            retry_in_seconds=RETRY_BACKOFF_SECONDS[idx],
+            reason=reason,
+        )
+
+    def clear(self) -> None:
+        if self.etag is None:
+            return
+        log.info("config_quarantine_cleared", etag=self.etag)
+        self.etag = None
+        self.reason = None
+        self.failures = 0
+        self.retry_at = 0.0
+        try:
+            self._path.unlink(missing_ok=True)
+        except OSError:
+            # Stale file on disk only costs one skipped apply after a
+            # restart, and the next successful apply rewrites it away.
+            log.warning("quarantine_unlink_failed", path=str(self._path))
+
+    def blocks(self, etag: str | None) -> bool:
+        """Should this etag be skipped rather than applied right now?"""
+        if etag is None or self.etag is None or etag != self.etag:
+            return False
+        return time.time() < self.retry_at
+
+    def retry_due(self) -> bool:
+        """Is a quarantined bundle due for another attempt?"""
+        return self.etag is not None and time.time() >= self.retry_at

--- a/agent/dns/spatium_dns_agent/drivers/base.py
+++ b/agent/dns/spatium_dns_agent/drivers/base.py
@@ -11,6 +11,13 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
+from ..config_apply import (
+    PHASE_RELOAD,
+    PHASE_RENDER,
+    PHASE_VALIDATE,
+    ConfigApplyError,
+)
+
 # Record-op kinds that describe an RRset, and so can carry the complete
 # desired ``record["rrset"]`` the control plane stamps on them (#773).
 # Everything else on the queue is zone-level (the ``dnssec_*`` ops) and
@@ -72,7 +79,22 @@ class DriverBase(ABC):
         return None
 
     def apply_config(self, bundle: dict[str, Any]) -> None:
-        """Default orchestration: render → validate → swap+reload."""
-        self.render(bundle)
-        self.validate()
-        self.swap_and_reload()
+        """Default orchestration: render → validate → swap+reload.
+
+        Every failure is re-raised as :class:`ConfigApplyError` carrying the
+        phase it happened in. The caller needs that to choose a recovery: a
+        render or validate failure never reached the daemon, so nothing has
+        to be undone beyond the staging tree, whereas a swap/reload failure
+        means the live config directory has already been replaced and the
+        previous bundle has to be re-rendered to get back to a known state
+        (#882).
+        """
+        for phase, step in (
+            (PHASE_RENDER, lambda: self.render(bundle)),
+            (PHASE_VALIDATE, self.validate),
+            (PHASE_RELOAD, self.swap_and_reload),
+        ):
+            try:
+                step()
+            except Exception as e:
+                raise ConfigApplyError(phase, e) from e

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -1310,10 +1310,25 @@ class Bind9Driver(DriverBase):
             log.warning("named_checkconf_missing_skipping")
             return
         res = subprocess.run(
-            ["named-checkconf", str(conf)], capture_output=True, text=True, check=False
+            ["named-checkconf", str(conf)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
         )
         if res.returncode != 0:
-            raise RuntimeError(f"named-checkconf failed: {res.stderr.strip()}")
+            # #882 — read stdout FIRST. ``named-checkconf`` writes its
+            # diagnostics ("named.conf:20: undefined ACL 'trusted'", with the
+            # line number) to stdout and leaves stderr empty, so reading only
+            # stderr produced the message "named-checkconf failed: " with
+            # nothing after the colon. That was survivable while the text went
+            # nowhere; now it is the operator-facing explanation of why their
+            # config did not go live, and an empty one makes the whole revert
+            # report useless. Mirrors the PowerDNS driver's
+            # ``res.stderr or res.stdout``, inverted because these two tools
+            # disagree about which stream diagnostics belong on.
+            detail = (res.stdout or "").strip() or (res.stderr or "").strip()
+            raise RuntimeError(f"named-checkconf failed: {detail or 'no output'}")
 
     def swap_and_reload(self) -> None:
         new_dir = self.state_dir / "rendered.new"

--- a/agent/dns/spatium_dns_agent/heartbeat.py
+++ b/agent/dns/spatium_dns_agent/heartbeat.py
@@ -12,6 +12,7 @@ import structlog
 from . import __version__
 from .cache import save_token
 from .config import AgentConfig
+from .config_apply import ApplyStatus
 from .drivers.base import DriverBase
 
 log = structlog.get_logger(__name__)
@@ -30,6 +31,13 @@ class HeartbeatClient:
         self._stop = threading.Event()
         self.pending_acks: list[dict[str, Any]] = []
         self.daemon_status: dict[str, Any] = {}
+        # #882 — set by SyncLoop (which is constructed after this object and
+        # assigns itself in). Its ``as_dict()`` rides the heartbeat's
+        # ``config`` field so the control plane can tell a server that is up
+        # but running a REVERTED config apart from one that converged.
+        # Defaults to a healthy ApplyStatus so a heartbeat sent before the
+        # first sync doesn't report a failure that hasn't happened.
+        self.config_apply: ApplyStatus = ApplyStatus()
         self.failed_ops_count = 0
         # #638 — the driver is only used to probe the DNS daemon's version.
         # Optional so tests (and any caller that just wants liveness) can build
@@ -96,7 +104,10 @@ class HeartbeatClient:
             # plane must treat that as "unknown", never as a specific version.
             "daemon_version": self._daemon_version(),
             "daemon": self.daemon_status,
-            "config": {},
+            # #882 — last config-apply verdict. Before #882 this field was
+            # sent as a literal ``{}``: declared on the server's request
+            # model, accepted, and read by nothing.
+            "config": self.config_apply.as_dict(),
             "ops_ack": self.pending_acks,
             "failed_ops_count": self.failed_ops_count,
         }

--- a/agent/dns/spatium_dns_agent/sync.py
+++ b/agent/dns/spatium_dns_agent/sync.py
@@ -141,9 +141,28 @@ class SyncLoop:
                 # it and fall back, rather than leaving the daemon on whatever
                 # half-state the failed apply produced.
                 log.exception("bootstrap_cache_apply_failed")
-                if etag:
-                    self._quarantine.record(etag, truncate_error(str(e)))
-                self._bootstrap_fallback(etag, e)
+                if booting_from_previous:
+                    # It was the last-known-GOOD bundle that just failed, not
+                    # ``current`` — ``etag`` was rebound to ``prev_etag`` above.
+                    # Do NOT quarantine it: that would overwrite the record
+                    # naming the bundle which actually broke us, un-quarantining
+                    # the poison pill so the next poll applies it again.
+                    self.apply_status = ApplyStatus(
+                        status=STATUS_REVERT_FAILED,
+                        etag=None,
+                        failed_etag=self._quarantine.etag,
+                        error=truncate_error(str(e)),
+                    )
+                    self.heartbeat.config_apply = self.apply_status
+                    log.error(
+                        "bootstrap_last_known_good_apply_failed",
+                        failed_etag=self._quarantine.etag,
+                        previous_etag=etag,
+                    )
+                else:
+                    if etag:
+                        self._quarantine.record(etag, truncate_error(str(e)))
+                    self._bootstrap_fallback(etag, e)
 
     def _bootstrap_fallback(self, failed_etag: str | None, exc: BaseException) -> None:
         """Boot from the last-known-good bundle after ``current`` failed (#882).
@@ -406,12 +425,12 @@ class SyncLoop:
         try:
             self.driver.apply_config(bundle)
         except ConfigApplyError as e:
-            self._handle_apply_failure(bundle, etag, e.phase, e.cause, e.daemon_disturbed)
+            self._handle_apply_failure(etag, e.phase, e.cause, e.daemon_disturbed)
             return False
         except Exception as e:
             # A driver that raised outside the phased wrapper. Unknown phase,
             # so assume the worst and treat the daemon as disturbed.
-            self._handle_apply_failure(bundle, etag, None, e, True)
+            self._handle_apply_failure(etag, None, e, True)
             return False
 
         self._quarantine.clear()
@@ -426,7 +445,6 @@ class SyncLoop:
 
     def _handle_apply_failure(
         self,
-        bundle: dict[str, Any],
         etag: str,
         phase: str | None,
         cause: BaseException,
@@ -443,6 +461,15 @@ class SyncLoop:
 
         prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
         if prev_bundle is None:
+            if daemon_disturbed:
+                # The live config directory was already replaced and we have
+                # nothing to put back, so we no longer know what ``named`` is
+                # running. Forget the structural fingerprint: leaving it would
+                # let a LATER bundle whose structural etag happens to match it
+                # (the operator undoing the change that broke this one) skip
+                # the apply entirely, and the agent would then report ``ok``
+                # for a daemon still sitting on the half-applied config.
+                self._current_structural_etag = None
             status = ApplyStatus(
                 status=STATUS_NO_PREVIOUS,
                 etag=None,
@@ -472,6 +499,11 @@ class SyncLoop:
             try:
                 self.driver.apply_config(prev_bundle)
             except Exception as revert_exc:
+                # Same reasoning as the no-previous branch above: the revert
+                # did not land either, so the running config is unknown and
+                # the structural fingerprint must not be trusted to skip the
+                # next apply.
+                self._current_structural_etag = None
                 status = ApplyStatus(
                     status=STATUS_REVERT_FAILED,
                     etag=None,

--- a/agent/dns/spatium_dns_agent/sync.py
+++ b/agent/dns/spatium_dns_agent/sync.py
@@ -16,8 +16,18 @@ import httpx
 import structlog
 
 from .admin_pusher import push_rendered_config
-from .cache import load_config, save_config
+from .cache import commit_config, load_config, load_previous_config, save_config
 from .config import AgentConfig
+from .config_apply import (
+    STATUS_NO_PREVIOUS,
+    STATUS_OK,
+    STATUS_REVERT_FAILED,
+    STATUS_REVERTED,
+    ApplyStatus,
+    ConfigApplyError,
+    Quarantine,
+    truncate_error,
+)
 from .drivers.base import DriverBase
 
 log = structlog.get_logger(__name__)
@@ -59,14 +69,49 @@ class SyncLoop:
         # but leave structural_etag alone — the agent then drains record ops
         # via RFC 2136 over loopback without bouncing the daemon.
         self._current_structural_etag: str | None = None
+        # #882 — last-known-good revert. ``quarantine`` remembers an etag
+        # whose apply failed so we stop re-applying it every poll;
+        # ``apply_status`` is what the heartbeat reports upward.
+        self._quarantine = Quarantine(self.cfg.state_dir)
+        self.apply_status = ApplyStatus()
+        self.heartbeat.config_apply = self.apply_status
 
         # Preload cached bundle (offline-operation guarantee)
         bundle, etag = load_config(self.cfg.state_dir)
+        # #882 — a restart must not re-break the daemon with the same bundle
+        # that failed before it. ``current.json`` is what the control plane
+        # last SENT, which is not necessarily what worked; if that bundle is
+        # quarantined, boot from the last-known-good instead.
+        booting_from_previous = False
+        if bundle is not None and self._quarantine.blocks(etag):
+            prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+            if prev_bundle is not None:
+                log.warning(
+                    "bootstrap_skipping_quarantined_bundle",
+                    failed_etag=etag,
+                    booting_etag=prev_etag,
+                    reason=self._quarantine.reason,
+                )
+                self.apply_status = ApplyStatus(
+                    status=STATUS_REVERTED,
+                    etag=prev_etag,
+                    failed_etag=etag,
+                    error=self._quarantine.reason,
+                )
+                self.heartbeat.config_apply = self.apply_status
+                bundle, etag = prev_bundle, prev_etag
+                booting_from_previous = True
         if bundle is not None:
             self._current_etag = etag
             try:
                 self.driver.apply_config(bundle)
                 self._current_structural_etag = bundle.get("structural_etag")
+                if not booting_from_previous:
+                    # #882 — ``current`` demonstrably works, so it becomes the
+                    # bundle we fall back TO. Skipped when we booted from
+                    # ``previous``: committing there would copy the still-bad
+                    # ``current.json`` over the only good config we have.
+                    commit_config(self.cfg.state_dir, etag or "")
                 # #296 A2 — warm-restart readiness. The hostPath cache carries
                 # the bundle we just successfully re-applied; the marker tells
                 # the K8s readinessProbe this pod is ready to serve without
@@ -91,8 +136,60 @@ class SyncLoop:
                     push_rendered_config(self.cfg, self.token_ref[0])
                 except Exception:
                     log.exception("rendered_config_bootstrap_push_failed")
-            except Exception:
+            except Exception as e:
+                # #882 — the cached bundle itself no longer applies. Quarantine
+                # it and fall back, rather than leaving the daemon on whatever
+                # half-state the failed apply produced.
                 log.exception("bootstrap_cache_apply_failed")
+                if etag:
+                    self._quarantine.record(etag, truncate_error(str(e)))
+                self._bootstrap_fallback(etag, e)
+
+    def _bootstrap_fallback(self, failed_etag: str | None, exc: BaseException) -> None:
+        """Boot from the last-known-good bundle after ``current`` failed (#882).
+
+        Only reached at startup, where there is no running daemon to protect
+        — so unlike the steady-state revert this is about getting the server
+        answering at all, on the newest config that is known to work.
+        """
+        prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+        if prev_bundle is None or prev_etag == failed_etag:
+            self.apply_status = ApplyStatus(
+                status=STATUS_NO_PREVIOUS,
+                etag=None,
+                failed_etag=failed_etag,
+                error=truncate_error(str(exc)),
+            )
+            self.heartbeat.config_apply = self.apply_status
+            log.error("bootstrap_no_last_known_good", failed_etag=failed_etag)
+            return
+        try:
+            self.driver.apply_config(prev_bundle)
+        except Exception as revert_exc:
+            self.apply_status = ApplyStatus(
+                status=STATUS_REVERT_FAILED,
+                etag=None,
+                failed_etag=failed_etag,
+                error=truncate_error(f"{exc} (revert also failed: {revert_exc})"),
+            )
+            self.heartbeat.config_apply = self.apply_status
+            log.exception("bootstrap_last_known_good_apply_failed")
+            return
+        self._current_etag = prev_etag
+        self._current_structural_etag = prev_bundle.get("structural_etag")
+        self.apply_status = ApplyStatus(
+            status=STATUS_REVERTED,
+            etag=prev_etag,
+            failed_etag=failed_etag,
+            error=truncate_error(str(exc)),
+        )
+        self.heartbeat.config_apply = self.apply_status
+        _touch_ready_marker(self.cfg.state_dir)
+        log.warning(
+            "bootstrap_from_last_known_good",
+            failed_etag=failed_etag,
+            booted_etag=prev_etag,
+        )
 
     def stop(self) -> None:
         self._stop.set()
@@ -110,6 +207,18 @@ class SyncLoop:
 
     def _poll_once(self) -> None:
         headers = {"Authorization": f"Bearer {self.token_ref[0]}"}
+        # #882 — a quarantined bundle is parked on a 304 by the etag we sent
+        # last time, so the only way to give it another attempt is to stop
+        # sending that etag. Dropping If-None-Match makes the server answer
+        # 200 with whatever it holds now: the corrected bundle if the operator
+        # has saved one, otherwise the same bundle for one more try.
+        if self._quarantine.retry_due():
+            log.info(
+                "sync_quarantine_retry_due",
+                etag=self._quarantine.etag,
+                failures=self._quarantine.failures,
+            )
+            self._current_etag = None
         if self._current_etag:
             headers["If-None-Match"] = self._current_etag
         try:
@@ -153,6 +262,14 @@ class SyncLoop:
             log.warning("sync_bundle_missing_etag")
             return
 
+        # #882 — the quarantine names ONE bundle. If the control plane is no
+        # longer serving it, the operator has saved something else and the
+        # record is moot: drop it now rather than let ``retry_due`` keep
+        # forcing If-None-Match off on every poll for a bundle that no
+        # longer exists.
+        if self._quarantine.etag is not None and etag != self._quarantine.etag:
+            self._quarantine.clear()
+
         # Atomic-swap cache always (cache is the source of truth for restarts)
         save_config(self.cfg.state_dir, bundle, etag)
 
@@ -170,15 +287,17 @@ class SyncLoop:
         # daemon stays running and ops are applied incrementally below.
         new_structural = bundle.get("structural_etag")
         if new_structural != self._current_structural_etag:
-            try:
-                self.driver.apply_config(bundle)
-            except Exception as e:
-                log.exception("sync_apply_failed")
-                self.heartbeat.daemon_status = {
-                    **self.heartbeat.daemon_status,
-                    "status": "degraded",
-                    "reason": f"config_validation_failed: {e}",
-                }
+            # #882 — a bundle that already failed is not retried on every
+            # poll. Advancing ``_current_etag`` parks the long-poll on a 304
+            # until either the operator saves something different or the
+            # quarantine backoff expires, instead of re-rendering the same
+            # broken config as fast as the wake tick fires.
+            if self._quarantine.blocks(etag):
+                log.info("sync_skipping_quarantined_bundle", etag=etag)
+                self._current_etag = etag
+                return
+            if not self._apply_with_revert(bundle, etag):
+                self._current_etag = etag
                 return
             self._current_structural_etag = new_structural
             log.info("structural_reload_applied", structural_etag=new_structural)
@@ -238,6 +357,29 @@ class SyncLoop:
         if dnssec_states:
             self._report_dnssec_state(dnssec_states)
 
+        # #882 — we got here with nothing quarantined and nothing to
+        # re-render, so whatever the control plane is serving is what we are
+        # running. Clear a stale ``reverted`` verdict: the operator's fix has
+        # landed and leaving the chip up would report a divergence that no
+        # longer exists.
+        if self._quarantine.etag is None and not self.apply_status.healthy:
+            self.apply_status = ApplyStatus(status=STATUS_OK, etag=etag)
+            self.heartbeat.config_apply = self.apply_status
+            log.info("config_apply_recovered", etag=etag)
+
+        # #882 — a poll that got all the way here had no apply failure, so
+        # whatever is cached as ``current`` is known to work and becomes the
+        # bundle we fall back TO.
+        #
+        # This is NOT redundant with the commit inside ``_apply_with_revert``.
+        # A structural etag that is unchanged skips the apply entirely — which
+        # is exactly what happens when an operator UNDOES the change that
+        # broke the config: the rendered result is byte-identical to what is
+        # already running, so nothing re-renders and the commit inside the
+        # apply path never fires. Without this, ``previous`` would keep
+        # pointing at an older etag indefinitely.
+        commit_config(self.cfg.state_dir, etag)
+
         # #296 A2 — stamp readiness marker AFTER the bundle was fetched,
         # persisted to the hostPath cache, and the driver-apply path
         # completed (either structural reload, record-op dispatch, or
@@ -245,6 +387,121 @@ class SyncLoop:
         # confirmed-in-sync state). A failed apply returns early above
         # so we never reach this point on error.
         _touch_ready_marker(self.cfg.state_dir)
+
+    def _apply_with_revert(self, bundle: dict[str, Any], etag: str) -> bool:
+        """Apply ``bundle``; on failure fall back to the last-known-good (#882).
+
+        Returns True when ``bundle`` is live, False when it was rejected —
+        in which case the daemon is either untouched (the failure happened
+        while rendering or validating into the staging tree) or has been
+        put back onto the previous bundle.
+
+        The phase distinction is what keeps the revert honest. BIND renders
+        and validates into ``rendered.new``, so a ``named-checkconf`` failure
+        never reached ``named``: re-rendering the previous bundle there would
+        bounce a healthy daemon to reach a state it is already in. Only a
+        failure at swap/reload — where the live directory has been replaced —
+        needs the previous config put back on disk.
+        """
+        try:
+            self.driver.apply_config(bundle)
+        except ConfigApplyError as e:
+            self._handle_apply_failure(bundle, etag, e.phase, e.cause, e.daemon_disturbed)
+            return False
+        except Exception as e:
+            # A driver that raised outside the phased wrapper. Unknown phase,
+            # so assume the worst and treat the daemon as disturbed.
+            self._handle_apply_failure(bundle, etag, None, e, True)
+            return False
+
+        self._quarantine.clear()
+        commit_config(self.cfg.state_dir, etag)
+        self.apply_status = ApplyStatus(status=STATUS_OK, etag=etag)
+        self.heartbeat.config_apply = self.apply_status
+        if self.heartbeat.daemon_status.get("status") == "degraded":
+            # Clear a degraded verdict this loop set on a previous cycle;
+            # leaving it would make a recovered server look broken forever.
+            self.heartbeat.daemon_status = {"status": "ok"}
+        return True
+
+    def _handle_apply_failure(
+        self,
+        bundle: dict[str, Any],
+        etag: str,
+        phase: str | None,
+        cause: BaseException,
+        daemon_disturbed: bool,
+    ) -> None:
+        log.error(
+            "sync_apply_failed",
+            etag=etag,
+            phase=phase,
+            error=str(cause),
+            daemon_disturbed=daemon_disturbed,
+        )
+        self._quarantine.record(etag, truncate_error(f"{phase or 'apply'}: {cause}"))
+
+        prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+        if prev_bundle is None:
+            status = ApplyStatus(
+                status=STATUS_NO_PREVIOUS,
+                etag=None,
+                failed_etag=etag,
+                phase=phase,
+                error=truncate_error(str(cause)),
+            )
+            log.error("sync_no_last_known_good", failed_etag=etag)
+        elif not daemon_disturbed:
+            # The staging tree failed; the daemon is still serving the config
+            # it was already serving, which IS the previous bundle. Nothing to
+            # re-render — record what is live and leave the daemon alone.
+            status = ApplyStatus(
+                status=STATUS_REVERTED,
+                etag=prev_etag,
+                failed_etag=etag,
+                phase=phase,
+                error=truncate_error(str(cause)),
+            )
+            log.warning(
+                "sync_reverted_without_reload",
+                failed_etag=etag,
+                live_etag=prev_etag,
+                phase=phase,
+            )
+        else:
+            try:
+                self.driver.apply_config(prev_bundle)
+            except Exception as revert_exc:
+                status = ApplyStatus(
+                    status=STATUS_REVERT_FAILED,
+                    etag=None,
+                    failed_etag=etag,
+                    phase=phase,
+                    error=truncate_error(f"{cause} (revert also failed: {revert_exc})"),
+                )
+                log.exception("sync_revert_failed", failed_etag=etag)
+            else:
+                self._current_structural_etag = prev_bundle.get("structural_etag")
+                status = ApplyStatus(
+                    status=STATUS_REVERTED,
+                    etag=prev_etag,
+                    failed_etag=etag,
+                    phase=phase,
+                    error=truncate_error(str(cause)),
+                )
+                log.warning(
+                    "sync_reverted_to_last_known_good",
+                    failed_etag=etag,
+                    live_etag=prev_etag,
+                )
+
+        self.apply_status = status
+        self.heartbeat.config_apply = status
+        self.heartbeat.daemon_status = {
+            **self.heartbeat.daemon_status,
+            "status": "degraded",
+            "reason": f"config_apply_{status.status}: {status.error}",
+        }
 
     def _report_zone_state(self, bundle: dict[str, Any]) -> None:
         """POST ``{zones: [{zone_name, serial}, ...]}`` after a successful apply.

--- a/agent/dns/tests/test_config_revert.py
+++ b/agent/dns/tests/test_config_revert.py
@@ -1,0 +1,446 @@
+"""Last-known-good revert + poison-pill quarantine (issue #882).
+
+Before this, ``previous.json`` was written on every fetch and read by
+nothing, so a bundle that rendered config ``named`` rejects overwrote the
+only copy of the config that worked and then re-applied itself on every
+poll. These tests pin the three properties that fixes:
+
+* ``previous`` tracks the last bundle that APPLIED, not the last one fetched;
+* a failed bundle is not retried until the backoff expires;
+* the daemon is only re-rendered when the failure actually disturbed it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from spatium_dns_agent.cache import (
+    commit_config,
+    ensure_layout,
+    load_config,
+    load_previous_config,
+    save_config,
+)
+from spatium_dns_agent.config_apply import (
+    PHASE_RELOAD,
+    PHASE_VALIDATE,
+    STATUS_NO_PREVIOUS,
+    STATUS_OK,
+    STATUS_REVERT_FAILED,
+    STATUS_REVERTED,
+    ApplyStatus,
+    ConfigApplyError,
+    Quarantine,
+    truncate_error,
+)
+from spatium_dns_agent.drivers.base import DriverBase
+from spatium_dns_agent.sync import SyncLoop
+
+
+# ── cache: previous == last GOOD, not last fetched ────────────────────────
+
+
+def _bundle(tag: str) -> dict[str, Any]:
+    return {"etag": tag, "structural_etag": f"s-{tag}", "zones": []}
+
+
+def test_save_config_does_not_rotate_previous(tmp_path: Path) -> None:
+    """The regression that destroyed the fallback.
+
+    Pre-#882 ``save_config`` rotated current→previous on every FETCH. A bad
+    bundle left ``_current_etag`` unadvanced, so the next poll re-fetched the
+    same bundle and rotated the bad config into ``previous`` — after two
+    cycles there was no good config left anywhere on disk.
+    """
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+
+    # Two fetches of the same bad bundle, as the old retry loop produced.
+    save_config(tmp_path, _bundle("bad"), "bad")
+    save_config(tmp_path, _bundle("bad"), "bad")
+
+    prev, prev_etag = load_previous_config(tmp_path)
+    assert prev_etag == "good"
+    assert prev == _bundle("good")
+
+
+def test_commit_config_promotes_current(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("one"), "one")
+    commit_config(tmp_path, "one")
+    save_config(tmp_path, _bundle("two"), "two")
+    commit_config(tmp_path, "two")
+
+    assert load_previous_config(tmp_path) == (_bundle("two"), "two")
+    assert load_config(tmp_path) == (_bundle("two"), "two")
+
+
+def test_no_previous_when_nothing_ever_applied(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("first"), "first")
+    assert load_previous_config(tmp_path) == (None, None)
+
+
+def test_previous_without_etag_is_still_usable(tmp_path: Path) -> None:
+    """A field agent upgraded across #882 has a ``previous.json`` written by
+    the old rotating save_config, and no ``previous.etag`` beside it. The
+    bundle is still a valid fallback."""
+    ensure_layout(tmp_path)
+    (tmp_path / "config" / "previous.json").write_text(json.dumps(_bundle("legacy")))
+    bundle, etag = load_previous_config(tmp_path)
+    assert bundle == _bundle("legacy")
+    assert etag is None
+
+
+# ── quarantine ────────────────────────────────────────────────────────────
+
+
+def test_quarantine_blocks_then_retries(tmp_path: Path, monkeypatch) -> None:
+    ensure_layout(tmp_path)
+    now = [1000.0]
+    monkeypatch.setattr("spatium_dns_agent.config_apply.time.time", lambda: now[0])
+
+    q = Quarantine(tmp_path)
+    q.record("bad", "named-checkconf failed")
+    assert q.blocks("bad")
+    assert not q.blocks("other")
+    assert not q.retry_due()
+
+    now[0] += 61.0
+    assert not q.blocks("bad")
+    assert q.retry_due()
+
+
+def test_quarantine_backoff_grows_per_failure(tmp_path: Path, monkeypatch) -> None:
+    ensure_layout(tmp_path)
+    now = [0.0]
+    monkeypatch.setattr("spatium_dns_agent.config_apply.time.time", lambda: now[0])
+    q = Quarantine(tmp_path)
+    q.record("bad", "x")
+    first = q.retry_at
+    q.record("bad", "x")
+    second = q.retry_at
+    q.record("bad", "x")
+    third = q.retry_at
+    assert first < second < third
+    # And it stops growing at the cap rather than running away.
+    q.record("bad", "x")
+    assert q.retry_at == third
+
+
+def test_quarantine_resets_ladder_for_a_different_bundle(tmp_path: Path, monkeypatch) -> None:
+    ensure_layout(tmp_path)
+    now = [0.0]
+    monkeypatch.setattr("spatium_dns_agent.config_apply.time.time", lambda: now[0])
+    q = Quarantine(tmp_path)
+    q.record("bad-1", "x")
+    q.record("bad-1", "x")
+    q.record("bad-2", "y")
+    assert q.failures == 1
+
+
+def test_quarantine_survives_restart(tmp_path: Path) -> None:
+    """Persisted, not in-memory: a crash-looping container must not re-break
+    itself with the same bundle on every start."""
+    ensure_layout(tmp_path)
+    Quarantine(tmp_path).record("bad", "boom")
+    reloaded = Quarantine(tmp_path)
+    assert reloaded.etag == "bad"
+    assert reloaded.blocks("bad")
+
+
+def test_quarantine_clear_removes_the_file(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    q = Quarantine(tmp_path)
+    q.record("bad", "boom")
+    q.clear()
+    assert not (tmp_path / "config" / "quarantine.json").exists()
+    assert not Quarantine(tmp_path).blocks("bad")
+
+
+def test_corrupt_quarantine_file_does_not_raise(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    (tmp_path / "config" / "quarantine.json").write_text("{not json")
+    q = Quarantine(tmp_path)
+    assert q.etag is None
+
+
+def test_truncate_error_marks_the_cut(tmp_path: Path) -> None:
+    assert truncate_error("a\n  b   c") == "a b c"
+    long = truncate_error("x" * 5000)
+    assert len(long) <= 2000
+    assert long.endswith("…")
+
+
+# ── phased apply ──────────────────────────────────────────────────────────
+
+
+class _Driver(DriverBase):
+    """Driver whose phases can be made to fail on demand."""
+
+    def __init__(self, state_dir: Path):
+        super().__init__(state_dir)
+        self.fail_on: str | None = None
+        self.applied: list[str] = []
+
+    def render(self, bundle: dict[str, Any]) -> None:
+        if self.fail_on == "render":
+            raise RuntimeError("render boom")
+
+    def validate(self) -> None:
+        if self.fail_on == "validate":
+            raise RuntimeError("named-checkconf failed: bad acl")
+
+    def swap_and_reload(self) -> None:
+        if self.fail_on == "reload":
+            raise RuntimeError("rndc reconfig failed")
+
+    def apply_config(self, bundle: dict[str, Any]) -> None:
+        super().apply_config(bundle)
+        self.applied.append(str(bundle.get("etag")))
+
+    def apply_record_op(self, op: dict[str, Any]) -> dict[str, Any] | None:
+        return None
+
+    def start_daemon(self) -> None:
+        return None
+
+    def daemon_running(self) -> bool:
+        return True
+
+
+def test_apply_config_tags_the_failing_phase(tmp_path: Path) -> None:
+    d = _Driver(tmp_path)
+    d.fail_on = "validate"
+    with pytest.raises(ConfigApplyError) as ei:
+        d.apply_config({})
+    assert ei.value.phase == PHASE_VALIDATE
+    # Validation runs against the staging tree, so the daemon is untouched.
+    assert not ei.value.daemon_disturbed
+
+
+def test_reload_failure_is_daemon_disturbing(tmp_path: Path) -> None:
+    d = _Driver(tmp_path)
+    d.fail_on = "reload"
+    with pytest.raises(ConfigApplyError) as ei:
+        d.apply_config({})
+    assert ei.value.phase == PHASE_RELOAD
+    assert ei.value.daemon_disturbed
+
+
+# ── SyncLoop revert behaviour ─────────────────────────────────────────────
+
+
+class _Heartbeat:
+    def __init__(self) -> None:
+        self.daemon_status: dict[str, Any] = {}
+        self.pending_acks: list[dict[str, Any]] = []
+        self.failed_ops_count = 0
+        self.config_apply = ApplyStatus()
+
+
+class _Cfg:
+    def __init__(self, state_dir: Path):
+        self.state_dir = state_dir
+        self.control_plane_url = "http://cp.invalid"
+        self.insecure_skip_tls_verify = False
+        self.tls_ca_path = None
+
+
+def _loop(tmp_path: Path, driver: _Driver) -> SyncLoop:
+    return SyncLoop(_Cfg(tmp_path), ["tok"], driver, _Heartbeat())
+
+
+def test_validate_failure_leaves_daemon_alone(tmp_path: Path) -> None:
+    """A staging-tree failure must not bounce a healthy daemon.
+
+    ``named`` renders and validates into ``rendered.new``; a checkconf
+    failure never reached it. Re-rendering the previous bundle there would
+    reload a daemon to reach the state it is already in.
+    """
+    ensure_layout(tmp_path)
+    driver = _Driver(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+    loop = _loop(tmp_path, driver)
+    driver.applied.clear()
+
+    driver.fail_on = "validate"
+    assert loop._apply_with_revert(_bundle("bad"), "bad") is False
+
+    assert driver.applied == []  # no revert re-render
+    assert loop.apply_status.status == STATUS_REVERTED
+    assert loop.apply_status.failed_etag == "bad"
+    assert loop.apply_status.etag == "good"
+
+
+def test_reload_failure_re_renders_the_previous_bundle(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    driver = _Driver(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+    loop = _loop(tmp_path, driver)
+    driver.applied.clear()
+
+    calls = {"n": 0}
+    original_swap = driver.swap_and_reload
+
+    def swap() -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("rndc reconfig failed")
+        original_swap()
+
+    driver.swap_and_reload = swap  # type: ignore[method-assign]
+    assert loop._apply_with_revert(_bundle("bad"), "bad") is False
+
+    assert driver.applied == ["good"]  # the previous bundle was put back
+    assert loop.apply_status.status == STATUS_REVERTED
+    assert loop.apply_status.etag == "good"
+
+
+def test_failure_with_no_previous_is_reported_distinctly(tmp_path: Path) -> None:
+    """Nothing to revert TO. The operator has to fix the config — telling
+    them 'reverted' would imply a safe state that does not exist."""
+    ensure_layout(tmp_path)
+    driver = _Driver(tmp_path)
+    loop = _loop(tmp_path, driver)
+
+    driver.fail_on = "validate"
+    assert loop._apply_with_revert(_bundle("bad"), "bad") is False
+    assert loop.apply_status.status == STATUS_NO_PREVIOUS
+    assert loop.apply_status.etag is None
+
+
+def test_revert_failure_is_reported_distinctly(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    driver = _Driver(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+    loop = _loop(tmp_path, driver)
+
+    driver.fail_on = "reload"  # fails for the bad bundle AND for the revert
+    assert loop._apply_with_revert(_bundle("bad"), "bad") is False
+    assert loop.apply_status.status == STATUS_REVERT_FAILED
+    assert "revert also failed" in (loop.apply_status.error or "")
+
+
+def test_success_commits_and_clears_quarantine(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    driver = _Driver(tmp_path)
+    loop = _loop(tmp_path, driver)
+    loop._quarantine.record("bad", "boom")
+
+    save_config(tmp_path, _bundle("new"), "new")
+    assert loop._apply_with_revert(_bundle("new"), "new") is True
+
+    assert loop.apply_status.status == STATUS_OK
+    assert loop._quarantine.etag is None
+    assert load_previous_config(tmp_path) == (_bundle("new"), "new")
+
+
+def test_bootstrap_skips_a_quarantined_bundle(tmp_path: Path) -> None:
+    """A restart must not re-break the daemon with the bundle that broke it."""
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+    save_config(tmp_path, _bundle("bad"), "bad")
+    Quarantine(tmp_path).record("bad", "named-checkconf failed")
+
+    driver = _Driver(tmp_path)
+    loop = _loop(tmp_path, driver)
+
+    assert driver.applied == ["good"]
+    assert loop.apply_status.status == STATUS_REVERTED
+    assert loop.apply_status.failed_etag == "bad"
+
+
+def test_bootstrap_falls_back_when_cached_bundle_fails(tmp_path: Path) -> None:
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+    save_config(tmp_path, _bundle("bad"), "bad")
+
+    driver = _Driver(tmp_path)
+    calls = {"n": 0}
+    real_validate = driver.validate
+
+    def validate() -> None:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("named-checkconf failed")
+        real_validate()
+
+    driver.validate = validate  # type: ignore[method-assign]
+    loop = _loop(tmp_path, driver)
+
+    assert driver.applied == ["good"]
+    assert loop.apply_status.status == STATUS_REVERTED
+    assert loop._current_etag == "good"
+    # And the bad bundle is quarantined so the next poll doesn't retry it.
+    assert loop._quarantine.blocks("bad")
+
+
+# ── named-checkconf diagnostics land on stdout ────────────────────────────
+
+
+def test_bind9_validate_reads_checkconf_stdout(tmp_path: Path, monkeypatch) -> None:
+    """``named-checkconf`` writes its diagnostics to STDOUT, not stderr.
+
+    Reading only stderr produced ``"named-checkconf failed: "`` — an empty
+    reason. That was survivable while the text went nowhere; #882 makes it
+    the operator-facing explanation of why a config did not go live, so an
+    empty one defeats the point of reporting at all.
+    """
+    import subprocess
+
+    from spatium_dns_agent.drivers.bind9 import Bind9Driver
+
+    (tmp_path / "rendered.new").mkdir(parents=True)
+    (tmp_path / "rendered.new" / "named.conf").write_text("options {};\n")
+
+    monkeypatch.setattr("spatium_dns_agent.drivers.bind9.shutil.which", lambda _: "/x")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *a, **kw: subprocess.CompletedProcess(
+            a[0],
+            1,
+            stdout="named.conf:20: undefined ACL 'trusted'\n",
+            stderr="",
+        ),
+    )
+    driver = Bind9Driver(tmp_path)
+    with pytest.raises(RuntimeError) as ei:
+        driver.validate()
+    assert "undefined ACL 'trusted'" in str(ei.value)
+    assert "named.conf:20" in str(ei.value)
+
+
+def test_commit_is_skipped_when_previous_already_matches(tmp_path: Path) -> None:
+    """``commit_config`` is called from two points in a successful poll; the
+    second must not re-copy a bundle that can be tens of kilobytes."""
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("one"), "one")
+    commit_config(tmp_path, "one")
+    first = (tmp_path / "config" / "previous.json").stat().st_mtime_ns
+    commit_config(tmp_path, "one")
+    assert (tmp_path / "config" / "previous.json").stat().st_mtime_ns == first
+
+
+def test_commit_refuses_when_current_is_not_what_applied(tmp_path: Path) -> None:
+    """The guard that stops a caller stamping the WRONG bundle as
+    last-known-good — the one thing this file must never hold."""
+    ensure_layout(tmp_path)
+    save_config(tmp_path, _bundle("good"), "good")
+    commit_config(tmp_path, "good")
+    save_config(tmp_path, _bundle("bad"), "bad")
+    # A caller that applied something other than ``current`` (a revert, say)
+    # must not promote ``current``.
+    commit_config(tmp_path, "good")
+    assert load_previous_config(tmp_path) == (_bundle("good"), "good")

--- a/agent/looking-glass/spatium_lg_agent/cache.py
+++ b/agent/looking-glass/spatium_lg_agent/cache.py
@@ -3,9 +3,11 @@
 Layout under /var/lib/spatium-lg-agent/:
     agent-id                       # UUID, 0600
     agent_token.jwt                # current JWT, 0600
-    config/current.json            # last-known-good peer-config ConfigBundle
+    config/current.json            # last peer-config bundle FETCHED
     config/current.etag
-    config/previous.json
+    config/previous.json           # last bundle that APPLIED cleanly (#882)
+    config/previous.etag
+    config/quarantine.json         # etag of a bundle that failed to apply (#882)
     rendered/gobgpd.json           # last rendered gobgpd config (for audit/debug)
     .ready                         # stamped after the first successful RIB poll+apply
 
@@ -23,6 +25,10 @@ import os
 import uuid
 from pathlib import Path
 from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
 
 # Schema version for the cached ConfigBundle.
 CACHE_SCHEMA_VERSION = 1
@@ -104,11 +110,22 @@ def _chmod_600(path: Path) -> None:
 
 
 def save_config(state_dir: Path, bundle: dict[str, Any], etag: str) -> None:
-    """Atomic replace — write new, move current→previous, rename tmp→current."""
+    """Persist the bundle we just FETCHED as ``current`` (atomic rename).
+
+    Deliberately does **not** touch ``previous.json`` (#882). It used to:
+    every fetch rotated current→previous before the apply had been
+    attempted, so ``previous`` meant "the bundle before this one" rather
+    than "the last one that worked". This loop makes that worse than the
+    other two agents: it deliberately leaves ``_current_etag`` unadvanced on
+    an apply failure in order to retry, so the same bad bundle was re-fetched
+    and rotated into ``previous`` on the very next attempt.
+
+    ``previous`` is now written by :func:`commit_config`, after gobgpd has
+    been reconfigured successfully.
+    """
     cfg_dir = state_dir / "config"
     cfg_dir.mkdir(parents=True, exist_ok=True)
     current = cfg_dir / "current.json"
-    previous = cfg_dir / "previous.json"
     tmp = cfg_dir / "current.json.tmp"
     stamped = dict(bundle)
     stamped.setdefault("_schema_version", CACHE_SCHEMA_VERSION)
@@ -116,10 +133,76 @@ def save_config(state_dir: Path, bundle: dict[str, Any], etag: str) -> None:
     # chmod the tmp file BEFORE the rename so the secret is never briefly
     # world-readable at the final path (matches save_token's pattern).
     _chmod_600(tmp)
-    if current.exists():
-        current.replace(previous)
     tmp.replace(current)
     (cfg_dir / "current.etag").write_text(etag)
+
+
+def commit_config(state_dir: Path, etag: str) -> None:
+    """Promote ``current`` to ``previous`` — the last-known-GOOD bundle (#882).
+
+    Called only once :func:`spatium_lg_agent.gobgp.apply_config` has
+    rendered, written and reloaded the bundle without raising.
+
+    Copies rather than renames: ``current`` stays in place because it is
+    what the agent re-applies on restart. The copy is 0600'd for the same
+    reason ``current`` is — the rendered neighbor block embeds the plaintext
+    TCP-MD5 peer password.
+    """
+    cfg_dir = state_dir / "config"
+    current = cfg_dir / "current.json"
+    etag_path = cfg_dir / "current.etag"
+    if not current.exists() or not etag_path.exists():
+        return
+    # Guard the precondition rather than assume it: promoting ``current`` is
+    # only correct while ``current`` IS the bundle that just applied.
+    if etag_path.read_text().strip() != etag:
+        log.warning(
+            "commit_config_etag_mismatch",
+            applied_etag=etag,
+            cached_etag=etag_path.read_text().strip(),
+        )
+        return
+    if (cfg_dir / "previous.etag").exists():
+        # Already committed — skip the copy. ``commit_config`` is called from
+        # more than one point in a successful poll (the structural-apply path
+        # and the end-of-poll confirmation), and this bundle can be tens of
+        # kilobytes.
+        try:
+            if (cfg_dir / "previous.etag").read_text().strip() == etag:
+                return
+        except OSError:
+            pass  # unreadable sidecar → fall through and rewrite it
+    tmp = cfg_dir / "previous.json.tmp"
+    # Copy the bytes rather than re-serialise: ``previous.json`` has to be
+    # exactly what ``current.json`` was, because that is what a revert
+    # replays. Two independent serialisations could drift.
+    tmp.write_text(current.read_text())
+    _chmod_600(tmp)
+    tmp.replace(cfg_dir / "previous.json")
+    etag_tmp = cfg_dir / "previous.etag.tmp"
+    etag_tmp.write_text(etag_path.read_text())
+    etag_tmp.replace(cfg_dir / "previous.etag")
+
+
+def load_previous_config(state_dir: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """The last bundle gobgpd accepted, for the revert path (#882).
+
+    ``(None, None)`` when there is nothing to fall back to. The etag may be
+    absent even when the bundle is present: agents upgraded in the field
+    carry a ``previous.json`` written by the old rotating
+    :func:`save_config`, which never wrote ``previous.etag``.
+    """
+    cfg_dir = state_dir / "config"
+    cfg_path = cfg_dir / "previous.json"
+    if not cfg_path.exists():
+        return None, None
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except json.JSONDecodeError:
+        return None, None
+    etag_path = cfg_dir / "previous.etag"
+    etag = etag_path.read_text().strip() if etag_path.exists() else None
+    return cfg, etag
 
 
 def save_rendered_gobgpd(state_dir: Path, rendered: dict[str, Any]) -> Path:

--- a/agent/looking-glass/spatium_lg_agent/config_apply.py
+++ b/agent/looking-glass/spatium_lg_agent/config_apply.py
@@ -1,0 +1,257 @@
+"""Last-known-good revert + poison-pill quarantine for config applies (#882).
+
+Non-negotiable #5 says the agent caches its config and keeps serving from
+that cache when the control plane is unreachable. That covers a *missing*
+control plane. It does not cover a *wrong* one: a bundle that parses fine
+but renders config the daemon rejects used to overwrite the cache and leave
+the agent with nothing to fall back to.
+
+This module is the other half. Two pieces:
+
+:class:`ApplyStatus`
+    What the agent tells the control plane about its last apply. Without
+    it a revert is silent, which is arguably worse than the crash it
+    replaces — the operator sees a saved config and a healthy daemon and
+    has no way to learn the two do not correspond.
+
+:class:`Quarantine`
+    Remembers the etag that failed so the agent stops re-applying it.
+    The long-poll wakes on a 12 s tick and falls back to a 2 s poll, so
+    without this a bad bundle is not a single failure — it is a retry
+    loop for as long as it stays saved.
+
+    Quarantine is not permanent. An apply can fail for reasons that have
+    nothing to do with the bundle (a full disk during render, a daemon
+    still starting), and those clear on their own; refusing to ever retry
+    would strand the agent on old config after the real problem went away.
+    So a quarantined etag is retried on a bounded backoff, and any bundle
+    that applies cleanly clears the record.
+
+The three agents (DNS / DHCP / looking-glass) are separate Python packages
+with no shared import path, so this module exists three times. Keep the
+semantics identical; the file is deliberately small to make that cheap.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+log = structlog.get_logger(__name__)
+
+# Outcome vocabulary, shared with the control plane's
+# ``*_server.config_apply_status`` column. Keep in sync with
+# ``backend/app/services/agents/config_apply.py``.
+STATUS_OK = "ok"
+"""The bundle applied. Steady state."""
+
+STATUS_REVERTED = "reverted"
+"""The bundle failed and the agent is running the previous good config.
+
+The daemon is healthy but is NOT serving what the operator saved.
+"""
+
+STATUS_REVERT_FAILED = "revert_failed"
+"""The bundle failed AND restoring the previous config also failed.
+
+The worst case: the daemon may be down or serving a half-applied config.
+"""
+
+STATUS_NO_PREVIOUS = "no_previous"
+"""The bundle failed and there was no known-good config to fall back to.
+
+A first-ever bundle that does not work. There is nothing to revert TO, so
+the daemon is unconfigured until the operator fixes the config.
+"""
+
+FAILED_STATUSES = frozenset({STATUS_REVERTED, STATUS_REVERT_FAILED, STATUS_NO_PREVIOUS})
+
+# Backoff before a quarantined etag is retried. Bounded at both ends: short
+# enough that a transient failure (disk pressure, a daemon mid-restart)
+# recovers without operator involvement, long enough that a genuinely bad
+# bundle costs one apply attempt every 15 minutes instead of one per poll.
+RETRY_BACKOFF_SECONDS: tuple[float, ...] = (60.0, 300.0, 900.0)
+
+# Truncate the daemon's error text before it goes on the wire. Kea and named
+# can both emit a long block, and this lands in a String/Text column that is
+# read in a UI chip tooltip — the first line or two is the diagnostic part.
+MAX_ERROR_LEN = 2000
+
+
+# ── Apply phases ──────────────────────────────────────────────────────────
+#
+# The boundary that matters is between VALIDATE and RELOAD. Everything up to
+# and including validation happens against a staging copy — BIND renders into
+# ``rendered.new`` and runs ``named-checkconf`` there; Kea is asked
+# ``config-test`` before ``config-reload`` — so the running daemon has not
+# been touched and there is nothing to undo. Only a failure at RELOAD means
+# the live config has already been replaced, and only then does recovering
+# require re-rendering the previous bundle.
+
+PHASE_RENDER = "render"
+PHASE_VALIDATE = "validate"
+PHASE_RELOAD = "reload"
+
+DAEMON_DISTURBING_PHASES = frozenset({PHASE_RELOAD})
+
+
+class ConfigApplyError(RuntimeError):
+    """An apply that failed, tagged with the phase it failed in (#882)."""
+
+    def __init__(self, phase: str, cause: BaseException):
+        super().__init__(f"{phase} failed: {cause}")
+        self.phase = phase
+        self.cause = cause
+
+    @property
+    def daemon_disturbed(self) -> bool:
+        return self.phase in DAEMON_DISTURBING_PHASES
+
+
+def truncate_error(text: str) -> str:
+    """Bound an error string for the heartbeat, marking that it was cut."""
+    text = " ".join(text.split())
+    if len(text) <= MAX_ERROR_LEN:
+        return text
+    return text[: MAX_ERROR_LEN - 1] + "…"
+
+
+@dataclass
+class ApplyStatus:
+    """The agent's verdict on its most recent config apply."""
+
+    status: str = STATUS_OK
+    #: etag of the bundle actually live right now. On a revert this is the
+    #: PREVIOUS bundle's etag, not the one the operator just saved — which
+    #: is the whole point: it is what lets the control plane show that the
+    #: server has not converged.
+    etag: str | None = None
+    #: etag of the bundle that was rejected. ``None`` while healthy.
+    failed_etag: str | None = None
+    #: Which step failed — ``render`` / ``validate`` / ``reload``. Tells the
+    #: operator whether the daemon was ever disturbed.
+    phase: str | None = None
+    error: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "etag": self.etag,
+            "failed_etag": self.failed_etag,
+            "phase": self.phase,
+            "error": self.error,
+        }
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == STATUS_OK
+
+
+class Quarantine:
+    """Persisted record of an etag whose apply failed.
+
+    Persisted rather than in-memory because the failure survives a restart:
+    the agent re-applies ``current.json`` at boot, so an in-memory record
+    would let a crash-looping container re-break itself on every start.
+    """
+
+    def __init__(self, state_dir: Path):
+        self._path = state_dir / "config" / "quarantine.json"
+        self.etag: str | None = None
+        self.reason: str | None = None
+        self.failures: int = 0
+        self.retry_at: float = 0.0
+        self._load()
+
+    def _load(self) -> None:
+        if not self._path.exists():
+            return
+        try:
+            data = json.loads(self._path.read_text())
+        except (OSError, json.JSONDecodeError):
+            # A corrupt quarantine file must not stop the agent starting.
+            # Losing the record means at worst one extra apply attempt of a
+            # bad bundle, which is exactly what happens without this file.
+            log.warning("quarantine_unreadable_ignoring", path=str(self._path))
+            return
+        if not isinstance(data, dict):
+            return
+        self.etag = data.get("etag")
+        self.reason = data.get("reason")
+        self.failures = int(data.get("failures") or 0)
+        # ``retry_at`` is stored as a monotonic-independent wall clock so it
+        # survives a restart. A clock that jumps backwards would delay the
+        # retry; a clock that jumps forwards brings it early. Both are
+        # acceptable — this is a backoff, not a deadline.
+        self.retry_at = float(data.get("retry_at") or 0.0)
+
+    def _save(self) -> None:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".json.tmp")
+            tmp.write_text(
+                json.dumps(
+                    {
+                        "etag": self.etag,
+                        "reason": self.reason,
+                        "failures": self.failures,
+                        "retry_at": self.retry_at,
+                    },
+                    indent=2,
+                )
+            )
+            tmp.replace(self._path)
+        except OSError:
+            # Best-effort. An unwritable state dir is its own (louder)
+            # problem; failing the apply path over it would be worse.
+            log.warning("quarantine_write_failed", path=str(self._path))
+
+    def record(self, etag: str, reason: str) -> None:
+        """Mark ``etag`` as failed and schedule its retry."""
+        if etag != self.etag:
+            # A different bundle — restart the backoff ladder rather than
+            # inheriting the previous one's.
+            self.failures = 0
+        self.etag = etag
+        self.reason = reason
+        self.failures += 1
+        idx = min(self.failures - 1, len(RETRY_BACKOFF_SECONDS) - 1)
+        self.retry_at = time.time() + RETRY_BACKOFF_SECONDS[idx]
+        self._save()
+        log.warning(
+            "config_quarantined",
+            etag=etag,
+            failures=self.failures,
+            retry_in_seconds=RETRY_BACKOFF_SECONDS[idx],
+            reason=reason,
+        )
+
+    def clear(self) -> None:
+        if self.etag is None:
+            return
+        log.info("config_quarantine_cleared", etag=self.etag)
+        self.etag = None
+        self.reason = None
+        self.failures = 0
+        self.retry_at = 0.0
+        try:
+            self._path.unlink(missing_ok=True)
+        except OSError:
+            # Stale file on disk only costs one skipped apply after a
+            # restart, and the next successful apply rewrites it away.
+            log.warning("quarantine_unlink_failed", path=str(self._path))
+
+    def blocks(self, etag: str | None) -> bool:
+        """Should this etag be skipped rather than applied right now?"""
+        if etag is None or self.etag is None or etag != self.etag:
+            return False
+        return time.time() < self.retry_at
+
+    def retry_due(self) -> bool:
+        """Is a quarantined bundle due for another attempt?"""
+        return self.etag is not None and time.time() >= self.retry_at

--- a/agent/looking-glass/spatium_lg_agent/gobgp.py
+++ b/agent/looking-glass/spatium_lg_agent/gobgp.py
@@ -338,24 +338,18 @@ def _assert_receive_only(rendered: dict[str, Any]) -> None:
             )
 
 
-def write_config(cfg: AgentConfig, bundle: dict[str, Any]) -> dict[str, Any]:
-    """Render + atomically write the gobgpd config file.
+def _write_rendered(cfg: AgentConfig, rendered: dict[str, Any]) -> None:
+    """Atomically swap the rendered document into gobgpd's config path.
 
     Also stashes a copy under the agent state dir's ``rendered/`` for
     audit/debug (mirrors the DHCP agent's ``rendered/kea-dhcp4.json``
     convention).
-    """
-    rendered = render_config(bundle)
-    _write_rendered(cfg, rendered)
-    return rendered
 
-
-def _write_rendered(cfg: AgentConfig, rendered: dict[str, Any]) -> None:
-    """Atomically swap the rendered document into gobgpd's config path.
-
-    Split out of :func:`write_config` so :func:`apply_config` can tell a
-    render failure (config file untouched) from a write failure (it may not
-    be) — see that function's docstring.
+    Kept separate from :func:`render_config` so :func:`apply_config` can tell
+    a render failure (config file untouched) from a write failure (it may not
+    be) — see that function's docstring. That split is why the old
+    ``write_config`` wrapper, which did both in one call, no longer exists:
+    it had no callers left and could only reintroduce the conflation.
     """
     target = cfg.gobgpd_config_path
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/agent/looking-glass/spatium_lg_agent/gobgp.py
+++ b/agent/looking-glass/spatium_lg_agent/gobgp.py
@@ -73,6 +73,7 @@ import structlog
 
 from .cache import save_rendered_gobgpd
 from .config import AgentConfig
+from .config_apply import PHASE_RELOAD, PHASE_RENDER, ConfigApplyError
 
 log = structlog.get_logger(__name__)
 
@@ -345,13 +346,23 @@ def write_config(cfg: AgentConfig, bundle: dict[str, Any]) -> dict[str, Any]:
     convention).
     """
     rendered = render_config(bundle)
+    _write_rendered(cfg, rendered)
+    return rendered
+
+
+def _write_rendered(cfg: AgentConfig, rendered: dict[str, Any]) -> None:
+    """Atomically swap the rendered document into gobgpd's config path.
+
+    Split out of :func:`write_config` so :func:`apply_config` can tell a
+    render failure (config file untouched) from a write failure (it may not
+    be) — see that function's docstring.
+    """
     target = cfg.gobgpd_config_path
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp = target.with_suffix(target.suffix + ".tmp")
     tmp.write_text(json.dumps(rendered, indent=2, sort_keys=True))
     tmp.replace(target)
     save_rendered_gobgpd(cfg.state_dir, rendered)
-    return rendered
 
 
 def start_daemon(cfg: AgentConfig) -> subprocess.Popen[bytes]:
@@ -457,10 +468,25 @@ def apply_config(
     ``proc`` may be ``None`` when applying the cache before gobgpd has
     even been started yet (the config file write still happens — the
     daemon picks it up on its own first read).
+
+    Failures are re-raised as :class:`ConfigApplyError` tagged with the
+    phase (#882). The split is at the file swap, not at the reload: gobgpd
+    has no dry-run mode and :func:`reload` is a best-effort SIGHUP that
+    never raises, so "did the daemon accept it" is not knowable here. What
+    IS knowable is whether the config file on disk still holds the previous
+    bundle — and that file is what gobgpd reads on its next start. A render
+    failure leaves it untouched; anything after does not.
     """
-    rendered = write_config(cfg, bundle)
-    if proc is not None:
-        reload(proc)
+    try:
+        rendered = render_config(bundle)
+    except Exception as e:
+        raise ConfigApplyError(PHASE_RENDER, e) from e
+    try:
+        _write_rendered(cfg, rendered)
+        if proc is not None:
+            reload(proc)
+    except Exception as e:
+        raise ConfigApplyError(PHASE_RELOAD, e) from e
     return rendered
 
 

--- a/agent/looking-glass/spatium_lg_agent/heartbeat.py
+++ b/agent/looking-glass/spatium_lg_agent/heartbeat.py
@@ -11,9 +11,11 @@ Body shape matches
 ``AgentHeartbeatRequest``/``PeerStateReport`` EXACTLY — both carry
 ``model_config = ConfigDict(extra="forbid")``, so anything not in the
 allowed field set (a stray top-level ``pid``/``status``, say) 422s the
-*entire* heartbeat, not just the extra field. Only ``agent_version`` +
-``peers[]`` travel at the top level; each peer entry is restricted to
-``_PEER_STATE_FIELDS`` before being sent.
+*entire* heartbeat, not just the extra field. ``agent_version``, ``peers[]``
+and ``config`` (the #882 config-apply verdict) travel at the top level; each
+peer entry is restricted to ``_PEER_STATE_FIELDS`` before being sent. A new
+top-level field therefore has to be added to ``AgentHeartbeatRequest`` in
+the SAME change, or every heartbeat 422s.
 
 Note: ``rpki_invalid_count`` is never populated here even though
 ``PeerStateReport`` accepts it — RPKI validation is computed server-side
@@ -35,6 +37,7 @@ import structlog
 from . import __version__
 from .cache import save_token
 from .config import AgentConfig
+from .config_apply import ApplyStatus
 
 log = structlog.get_logger(__name__)
 
@@ -58,10 +61,15 @@ class HeartbeatClient:
         self.cfg = cfg
         self.token_ref = token_ref
         self._stop = threading.Event()
-        # Internal-only degraded-state note (e.g. set by SyncLoop on a
-        # render failure) — logged locally, NOT sent upstream (the real
-        # heartbeat schema has no room for it; see module docstring).
+        # Free-form degraded-state note (set by SyncLoop) — logged locally
+        # and not sent upstream; the structured half of the same signal now
+        # IS sent, as ``config_apply`` below (#882).
         self.daemon_status: dict[str, Any] = {}
+        # #882 — last config-apply verdict, assigned by SyncLoop (constructed
+        # after this object). Defaults to a healthy ApplyStatus so a
+        # heartbeat sent before the first sync doesn't report a failure that
+        # hasn't happened.
+        self.config_apply: ApplyStatus = ApplyStatus()
         # peer_id -> {session_state, uptime_started_at, prefixes_received,
         #             prefixes_accepted, last_state_change, last_flap_at}.
         # Written by RibPoller.
@@ -89,6 +97,11 @@ class HeartbeatClient:
         body: dict[str, Any] = {
             "agent_version": __version__,
             "peers": peers,
+            # #882 — whether the collector is running the peer set the
+            # operator saved, or a reverted one. Without this a revert is
+            # silent: the collector looks healthy while quietly peering on
+            # a config the control plane no longer believes is live.
+            "config": self.config_apply.as_dict(),
         }
         try:
             with self._client() as c:

--- a/agent/looking-glass/spatium_lg_agent/sync.py
+++ b/agent/looking-glass/spatium_lg_agent/sync.py
@@ -132,9 +132,28 @@ class SyncLoop:
                 log.info("lg_agent_bootstrap_from_cache", etag=etag)
             except Exception as e:
                 log.exception("lg_bootstrap_cache_apply_failed")
-                if etag:
-                    self._quarantine.record(etag, truncate_error(str(e)))
-                self._bootstrap_fallback(etag, e)
+                if booting_from_previous:
+                    # It was the last-known-GOOD bundle that just failed, not
+                    # ``current`` — ``etag`` was rebound to ``prev_etag`` above.
+                    # Do NOT quarantine it: that would overwrite the record
+                    # naming the bundle which actually broke us, un-quarantining
+                    # the poison pill so the next poll applies it again.
+                    self._set_status(
+                        ApplyStatus(
+                            status=STATUS_REVERT_FAILED,
+                            failed_etag=self._quarantine.etag,
+                            error=truncate_error(str(e)),
+                        )
+                    )
+                    log.error(
+                        "lg_bootstrap_last_known_good_apply_failed",
+                        failed_etag=self._quarantine.etag,
+                        previous_etag=etag,
+                    )
+                else:
+                    if etag:
+                        self._quarantine.record(etag, truncate_error(str(e)))
+                    self._bootstrap_fallback(etag, e)
 
     def _set_status(self, status: ApplyStatus) -> None:
         self.apply_status = status

--- a/agent/looking-glass/spatium_lg_agent/sync.py
+++ b/agent/looking-glass/spatium_lg_agent/sync.py
@@ -27,7 +27,6 @@ docstring.
 
 from __future__ import annotations
 
-import random
 import subprocess
 import threading
 import time
@@ -37,17 +36,34 @@ import httpx
 import structlog
 
 from . import gobgp
-from .cache import load_config, save_config, save_token
+from .cache import (
+    commit_config,
+    load_config,
+    load_previous_config,
+    save_config,
+    save_token,
+)
 from .config import AgentConfig
+from .config_apply import (
+    STATUS_NO_PREVIOUS,
+    STATUS_OK,
+    STATUS_REVERT_FAILED,
+    STATUS_REVERTED,
+    ApplyStatus,
+    ConfigApplyError,
+    Quarantine,
+    truncate_error,
+)
 
 log = structlog.get_logger(__name__)
 
-# Jittered exponential backoff for a persistently-failing bundle apply
-# (mirrors bootstrap.py's register loop). Bounded so a bad bundle can't
-# hammer the /config long-poll or peg the CPU, but small enough that a
-# transient failure recovers within a poll or two.
-_APPLY_BACKOFF_BASE = 2.0
-_APPLY_BACKOFF_CAP = 45.0
+# NOTE: the jittered ``_APPLY_BACKOFF_BASE`` / ``_APPLY_BACKOFF_CAP`` sleep
+# that used to live here is gone (#882). It kept a persistently-bad bundle
+# from pegging the CPU, but it also kept RETRYING that bundle forever at a
+# 45 s cap, with the collector stuck on a peer set that does not render and
+# nothing said upward. ``Quarantine`` replaces it: park on the etag so the
+# long-poll blocks properly, retry on a longer ladder, and report the
+# failure on the heartbeat.
 
 
 class SyncLoop:
@@ -66,14 +82,39 @@ class SyncLoop:
         self.gobgpd_proc = gobgpd_proc
         self._stop = threading.Event()
         self._current_etag: str | None = None
-        # Grows on consecutive apply failures, resets to base on success.
-        self._apply_backoff = _APPLY_BACKOFF_BASE
+        # #882 — last-known-good revert. ``quarantine`` remembers an etag
+        # whose apply failed so we stop re-rendering it; ``apply_status`` is
+        # what the heartbeat reports upward.
+        self._quarantine = Quarantine(self.cfg.state_dir)
+        self.apply_status = ApplyStatus()
+        self.heartbeat.config_apply = self.apply_status
 
         # Preload cached bundle (non-negotiable #5 — offline-operation
         # guarantee). Applying it BEFORE the first network poll is what
         # keeps already-configured BGP sessions up if the control plane
         # is unreachable at container start.
         bundle, etag = load_config(self.cfg.state_dir)
+        # #882 — a restart must not re-apply the bundle that already failed.
+        booting_from_previous = False
+        if bundle is not None and self._quarantine.blocks(etag):
+            prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+            if prev_bundle is not None:
+                log.warning(
+                    "lg_bootstrap_skipping_quarantined_bundle",
+                    failed_etag=etag,
+                    booting_etag=prev_etag,
+                    reason=self._quarantine.reason,
+                )
+                self._set_status(
+                    ApplyStatus(
+                        status=STATUS_REVERTED,
+                        etag=prev_etag,
+                        failed_etag=etag,
+                        error=self._quarantine.reason,
+                    )
+                )
+                bundle, etag = prev_bundle, prev_etag
+                booting_from_previous = True
         if bundle is not None:
             self._current_etag = etag
             try:
@@ -82,9 +123,66 @@ class SyncLoop:
                     gobgp.peer_address_map(bundle),
                     gobgp.peer_import_scopes(bundle),
                 )
+                if not booting_from_previous:
+                    # #882 — ``current`` demonstrably renders, so it becomes
+                    # the bundle we fall back TO. Skipped when we booted from
+                    # ``previous``: committing there would copy the still-bad
+                    # ``current.json`` over the only good config we have.
+                    commit_config(self.cfg.state_dir, etag or "")
                 log.info("lg_agent_bootstrap_from_cache", etag=etag)
-            except Exception:
+            except Exception as e:
                 log.exception("lg_bootstrap_cache_apply_failed")
+                if etag:
+                    self._quarantine.record(etag, truncate_error(str(e)))
+                self._bootstrap_fallback(etag, e)
+
+    def _set_status(self, status: ApplyStatus) -> None:
+        self.apply_status = status
+        self.heartbeat.config_apply = status
+
+    def _bootstrap_fallback(self, failed_etag: str | None, exc: BaseException) -> None:
+        """Boot from the last-known-good bundle after ``current`` failed (#882)."""
+        prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+        if prev_bundle is None or prev_etag == failed_etag:
+            self._set_status(
+                ApplyStatus(
+                    status=STATUS_NO_PREVIOUS,
+                    failed_etag=failed_etag,
+                    error=truncate_error(str(exc)),
+                )
+            )
+            log.error("lg_bootstrap_no_last_known_good", failed_etag=failed_etag)
+            return
+        try:
+            gobgp.apply_config(self.cfg, prev_bundle, self.gobgpd_proc)
+            self.rib.set_peers(
+                gobgp.peer_address_map(prev_bundle),
+                gobgp.peer_import_scopes(prev_bundle),
+            )
+        except Exception as revert_exc:
+            self._set_status(
+                ApplyStatus(
+                    status=STATUS_REVERT_FAILED,
+                    failed_etag=failed_etag,
+                    error=truncate_error(f"{exc} (revert also failed: {revert_exc})"),
+                )
+            )
+            log.exception("lg_bootstrap_last_known_good_apply_failed")
+            return
+        self._current_etag = prev_etag
+        self._set_status(
+            ApplyStatus(
+                status=STATUS_REVERTED,
+                etag=prev_etag,
+                failed_etag=failed_etag,
+                error=truncate_error(str(exc)),
+            )
+        )
+        log.warning(
+            "lg_bootstrap_from_last_known_good",
+            failed_etag=failed_etag,
+            booted_etag=prev_etag,
+        )
 
     def stop(self) -> None:
         self._stop.set()
@@ -101,6 +199,16 @@ class SyncLoop:
 
     def _poll_once(self) -> None:
         headers = {"Authorization": f"Bearer {self.token_ref[0]}"}
+        # #882 — a quarantined bundle is parked on a 304 by the etag we sent
+        # last time, so the only way to give it another attempt is to stop
+        # sending that etag.
+        if self._quarantine.retry_due():
+            log.info(
+                "lg_sync_quarantine_retry_due",
+                etag=self._quarantine.etag,
+                failures=self._quarantine.failures,
+            )
+            self._current_etag = None
         if self._current_etag:
             headers["If-None-Match"] = self._current_etag
         try:
@@ -146,36 +254,28 @@ class SyncLoop:
         # restarts, even before we know the apply below succeeds. We cache
         # the unwrapped inner bundle (matches what the constructor's
         # ``load_config`` preload path expects to hand to ``gobgp.py``).
+        # #882 — the quarantine names ONE bundle. If the control plane is no
+        # longer serving it, the operator has saved something else and the
+        # record is moot.
+        if self._quarantine.etag is not None and etag != self._quarantine.etag:
+            self._quarantine.clear()
+
         save_config(self.cfg.state_dir, inner_bundle, etag)
 
-        try:
-            gobgp.apply_config(self.cfg, inner_bundle, self.gobgpd_proc)
-        except Exception as e:
-            log.exception("lg_sync_apply_failed")
-            self.heartbeat.daemon_status = {
-                **self.heartbeat.daemon_status,
-                "status": "degraded",
-                "reason": f"config_render_failed: {e}",
-            }
-            # Bounded backoff so a persistently-bad bundle (e.g. a
-            # ReceiveOnlyViolation, a malformed peer set) can't spin the
-            # bare ``run()`` loop: we deliberately DON'T advance
-            # ``_current_etag``, so the next poll re-fetches the SAME
-            # bundle to retry the apply — but only after sleeping, instead
-            # of immediately re-hitting /config with the stale
-            # If-None-Match and pegging the CPU. ``_stop.wait`` so a
-            # shutdown signal interrupts the sleep promptly.
-            sleep_for = min(
-                self._apply_backoff + random.uniform(0, 2), _APPLY_BACKOFF_CAP
-            )
-            log.warning("lg_sync_apply_backoff", seconds=round(sleep_for, 1))
-            self._stop.wait(sleep_for)
-            self._apply_backoff = min(self._apply_backoff * 2, _APPLY_BACKOFF_CAP)
+        if self._quarantine.blocks(etag):
+            # #882 — already known-bad. Park on this etag so the long-poll
+            # blocks on a 304 instead of re-rendering the same broken peer
+            # set; the quarantine backoff decides when to try again. This
+            # replaces the pre-#882 sleep-and-retry, which held the bundle
+            # forever at a 45 s cap with no upward signal.
+            log.info("lg_sync_skipping_quarantined_bundle", etag=etag)
+            self._current_etag = etag
             return
 
-        # Apply succeeded — reset the backoff so the next failure (if any)
-        # starts from the base again.
-        self._apply_backoff = _APPLY_BACKOFF_BASE
+        if not self._apply_with_revert(inner_bundle, etag):
+            self._current_etag = etag
+            return
+
         self.rib.set_peers(
             gobgp.peer_address_map(inner_bundle),
             gobgp.peer_import_scopes(inner_bundle),
@@ -186,6 +286,111 @@ class SyncLoop:
             etag=etag,
             peer_count=len(inner_bundle.get("peers") or []),
         )
+
+    def _apply_with_revert(self, bundle: dict[str, Any], etag: str) -> bool:
+        """Apply ``bundle``; on failure fall back to the last-known-good (#882).
+
+        Returns True when ``bundle`` is live, False when it was rejected.
+
+        gobgpd has no dry-run and :func:`gobgp.reload` is a best-effort
+        SIGHUP that never raises, so the only failures observable here are
+        render and file-write. That is still worth reverting for: the
+        rendered document is what gobgpd reads on its next start, so a
+        half-written or stale-but-wrong file turns one bad bundle into a
+        collector that comes back up with the wrong peer set.
+        """
+        try:
+            gobgp.apply_config(self.cfg, bundle, self.gobgpd_proc)
+        except ConfigApplyError as e:
+            self._handle_apply_failure(etag, e.phase, e.cause, e.daemon_disturbed)
+            return False
+        except Exception as e:
+            self._handle_apply_failure(etag, None, e, True)
+            return False
+
+        self._quarantine.clear()
+        commit_config(self.cfg.state_dir, etag)
+        self._set_status(ApplyStatus(status=STATUS_OK, etag=etag))
+        if self.heartbeat.daemon_status.get("status") == "degraded":
+            self.heartbeat.daemon_status = {"status": "ok"}
+        return True
+
+    def _handle_apply_failure(
+        self,
+        etag: str,
+        phase: str | None,
+        cause: BaseException,
+        daemon_disturbed: bool,
+    ) -> None:
+        log.error(
+            "lg_sync_apply_failed",
+            etag=etag,
+            phase=phase,
+            error=str(cause),
+            daemon_disturbed=daemon_disturbed,
+        )
+        self._quarantine.record(etag, truncate_error(f"{phase or 'apply'}: {cause}"))
+
+        prev_bundle, prev_etag = load_previous_config(self.cfg.state_dir)
+        if prev_bundle is None:
+            status = ApplyStatus(
+                status=STATUS_NO_PREVIOUS,
+                failed_etag=etag,
+                phase=phase,
+                error=truncate_error(str(cause)),
+            )
+            log.error("lg_sync_no_last_known_good", failed_etag=etag)
+        elif not daemon_disturbed:
+            # Rendering failed, so gobgpd's config file was never replaced —
+            # it still holds the previous bundle, which is the state a revert
+            # would produce. Rewriting it would be busywork.
+            status = ApplyStatus(
+                status=STATUS_REVERTED,
+                etag=prev_etag,
+                failed_etag=etag,
+                phase=phase,
+                error=truncate_error(str(cause)),
+            )
+            log.warning(
+                "lg_sync_reverted_without_rewrite",
+                failed_etag=etag,
+                live_etag=prev_etag,
+            )
+        else:
+            try:
+                gobgp.apply_config(self.cfg, prev_bundle, self.gobgpd_proc)
+                self.rib.set_peers(
+                    gobgp.peer_address_map(prev_bundle),
+                    gobgp.peer_import_scopes(prev_bundle),
+                )
+            except Exception as revert_exc:
+                status = ApplyStatus(
+                    status=STATUS_REVERT_FAILED,
+                    failed_etag=etag,
+                    phase=phase,
+                    error=truncate_error(f"{cause} (revert also failed: {revert_exc})"),
+                )
+                log.exception("lg_sync_revert_failed", failed_etag=etag)
+            else:
+                status = ApplyStatus(
+                    status=STATUS_REVERTED,
+                    etag=prev_etag,
+                    failed_etag=etag,
+                    phase=phase,
+                    error=truncate_error(str(cause)),
+                )
+                log.warning(
+                    "lg_sync_reverted_to_last_known_good",
+                    failed_etag=etag,
+                    live_etag=prev_etag,
+                )
+
+        self._set_status(status)
+        self.heartbeat.daemon_status = {
+            **self.heartbeat.daemon_status,
+            "status": "degraded",
+            "reason": f"config_apply_{status.status}: {status.error}",
+        }
 
     def run(self) -> None:
         while not self._stop.is_set():

--- a/agent/supervisor/spatium_supervisor/appliance_state.py
+++ b/agent/supervisor/spatium_supervisor/appliance_state.py
@@ -465,7 +465,9 @@ _TZ_TRIGGER_FILE = Path("/var/lib/spatiumddi-host/release-state/tz-pending")
 _TZ_APPLIED_HASH_FILE = Path("/var/lib/spatiumddi-host/release-state/tz-hash")
 # Verbose-boot console toggle. The runner flips a grubenv variable
 # (spatium_verbose) the grub.cfg menuentries read; trigger body is a single
-# "1" (standard Linux console) or "0" (quiet boot + dashboard).
+# "0" (quiet boot + dashboard), "1" (verbose boot + plain getty, no dashboard)
+# or "2" (verbose boot output, then the dashboard) — see
+# ``_CONSOLE_MODE_TO_GRUBENV``. It was binary until #393 added mode 2.
 _VERBOSE_TRIGGER_FILE = Path(
     "/var/lib/spatiumddi-host/release-state/verbose-boot-pending"
 )
@@ -960,6 +962,9 @@ _HOST_CONFIG_PLANES: list[tuple[str, Path, Path]] = [
     ("resolver", _RESOLVER_TRIGGER_FILE, _RESOLVER_HASH_SIDECAR),
     ("firewall", _FIREWALL_TRIGGER_FILE, _FIREWALL_APPLIED_HASH_SIDECAR),
     ("timezone", _TZ_TRIGGER_FILE, _TZ_APPLIED_HASH_FILE),
+    # #882 audit — was absent, so a console-mode apply that kept failing
+    # was invisible on the heartbeat while re-firing every tick.
+    ("console_mode", _VERBOSE_TRIGGER_FILE, _VERBOSE_APPLIED_FILE),
 ]
 
 
@@ -1353,20 +1358,36 @@ def maybe_fire_console_mode(desired_console_mode: str | None) -> bool:
     if detect_deployment_kind() != "appliance":
         return False
     desired = _CONSOLE_MODE_TO_GRUBENV.get(desired_console_mode or "dashboard", "0")
+    # #882 audit — fire through the shared bounded-retry guard, like every
+    # other host-config plane. This used to write the trigger directly, which
+    # meant it had none of the #387 protections: no trigger-presence check, no
+    # backoff, and no entry in ``_HOST_CONFIG_PLANES``. A runner that could not
+    # apply (no grubenv found, ``grub-editenv`` failing) left ``applied``
+    # unchanged, so the very next heartbeat rewrote the trigger, the .path unit
+    # fired on the rename, and the failure repeated every ~30 s indefinitely
+    # with nothing said upward — the silent re-fire flood the guard exists to
+    # prevent, on the one plane that never got it.
+    #
+    # The applied grubenv numeric plays the role of the applied-hash, exactly
+    # as ``maybe_fire_timezone`` uses the applied IANA name.
+    #
+    # The "already applied" test stays HERE rather than being left to
+    # ``_fire_host_config``: a missing sidecar means a fresh box, and a fresh
+    # box IS on mode 0 because the installer seeds
+    # ``grub-editenv … spatium_verbose=0``. ``_fire_host_config`` reads a
+    # missing sidecar as the empty string, which would never equal "0" — so
+    # delegating this check would make every fresh appliance fire a
+    # console-mode trigger on its first heartbeat to set the value it already
+    # has.
     try:
         applied = _VERBOSE_APPLIED_FILE.read_text(encoding="utf-8").strip()
     except OSError:
-        applied = "0"  # install seeds grubenv spatium_verbose=0 — default is live
+        applied = "0"
     if applied == desired:
         return False
-    try:
-        _VERBOSE_TRIGGER_FILE.parent.mkdir(parents=True, exist_ok=True)
-        tmp = _VERBOSE_TRIGGER_FILE.with_suffix(".new")
-        tmp.write_text(desired + "\n", encoding="utf-8")
-        tmp.replace(_VERBOSE_TRIGGER_FILE)
-        return True
-    except OSError:
-        return False
+    return _fire_host_config(
+        _VERBOSE_TRIGGER_FILE, _VERBOSE_APPLIED_FILE, desired, desired + "\n"
+    )
 
 
 def read_slot_versions() -> tuple[str | None, str | None]:

--- a/agent/supervisor/tests/test_console_mode_triggers.py
+++ b/agent/supervisor/tests/test_console_mode_triggers.py
@@ -72,3 +72,65 @@ def test_non_appliance_no_op(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     )
     assert appliance_state.maybe_fire_console_mode("text_console") is False
     assert not (tmp_path / "verbose-boot-pending").exists()
+
+
+# ── #882 audit: the plane now rides the shared bounded-retry guard ────────
+#
+# Pre-#882 this writer bypassed ``_fire_host_config`` entirely, so it had
+# none of the #387 protections. A runner that could not apply left the
+# applied sidecar unchanged, and the next heartbeat rewrote the trigger —
+# whose rename re-fires the .path unit — so a failing console-mode apply
+# repeated every ~30 s forever, with nothing reported upward.
+
+
+@pytest.fixture
+def guarded(cm_paths: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """``cm_paths`` plus the plane registered for health reporting."""
+    monkeypatch.setattr(
+        appliance_state,
+        "_HOST_CONFIG_PLANES",
+        [
+            (
+                "console_mode",
+                cm_paths / "verbose-boot-pending",
+                cm_paths / "verbose-boot-applied",
+            )
+        ],
+    )
+    return cm_paths
+
+
+def test_does_not_stack_a_second_trigger(guarded: Path) -> None:
+    """An unconsumed trigger means the runner has not run yet."""
+    assert appliance_state.maybe_fire_console_mode("text_console") is True
+    # The trigger is still sitting there — do not rewrite it. The rewrite is
+    # what re-fired the .path unit on every heartbeat.
+    assert appliance_state.maybe_fire_console_mode("text_console") is False
+
+
+def test_failing_apply_backs_off_instead_of_flooding(guarded: Path) -> None:
+    """Simulate the runner failing: it consumes the trigger but never
+    updates the applied sidecar."""
+    fires = 0
+    for _ in range(10):
+        if appliance_state.maybe_fire_console_mode("text_console"):
+            fires += 1
+            (guarded / "verbose-boot-pending").unlink()  # runner consumed it
+    # Without the guard this fired 10/10. With it, the backoff window means
+    # only the first attempt goes out within the same instant.
+    assert fires == 1
+
+
+def test_failing_apply_is_reported_on_the_heartbeat(guarded: Path) -> None:
+    assert appliance_state.maybe_fire_console_mode("text_console") is True
+    (guarded / "verbose-boot-pending").unlink()  # runner ran and failed
+    health = appliance_state.read_host_config_health()
+    assert "console_mode" in health
+    assert health["console_mode"]["state"] in ("retrying", "failing")
+
+
+def test_successful_apply_clears_the_health_entry(guarded: Path) -> None:
+    assert appliance_state.maybe_fire_console_mode("text_console") is True
+    (guarded / "verbose-boot-pending").unlink()
+    (guarded / "verbose-boot-applied").write_text("1\n")  # runner succeeded
+    assert appliance_state.read_host_config_health() == {}

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-verbose-boot-reload
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-verbose-boot-reload
@@ -48,6 +48,20 @@ mkdir -p "$LOG_DIR" "$(dirname "$APPLIED_SIDECAR")"
 
 log() { printf '%s spatiumddi-verbose-boot-reload: %s\n' "$(date -u +%FT%TZ)" "$*" | tee -a "$LOG"; }
 
+# #882 audit — on any failure path, move the trigger aside before exiting.
+# Every sibling runner does this (#550) and this one did not: the supervisor's
+# _fire_host_config bails while the trigger exists, so an exit 1 that leaves it
+# in place wedges the plane until someone SSHes in and deletes the file by
+# hand. Renaming it lets the next corrected heartbeat re-fire; the copy stays
+# for forensics.
+fail_release() {
+    printf 'state=failed\nreason=%s\nrequested=%s\napplied_at=%s\n' \
+        "$1" "${2:-}" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
+    [ -f "$TRIGGER" ] \
+        && mv -f "$TRIGGER" "${TRIGGER}.failed.$(date +%s)" 2>/dev/null
+    exit 1
+}
+
 exec 9>"$LOCK"
 if ! flock -n 9; then
     log "another instance is running — exiting"
@@ -67,9 +81,7 @@ case "$val" in
     0 | 1 | 2) ;;
     *)
         log "REJECT: trigger value '$val' is not 0, 1 or 2"
-        printf 'state=failed\nreason=invalid_value\nrequested=%s\napplied_at=%s\n' \
-            "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
-        exit 1
+        fail_release invalid_value "$val"
         ;;
 esac
 
@@ -82,17 +94,13 @@ for cand in /boot/efi/grub/grubenv /boot/grub/grubenv /boot/grub2/grubenv; do
 done
 if [ -z "$GRUBENV" ]; then
     log "ERROR: no grubenv found (looked in /boot/efi/grub, /boot/grub, /boot/grub2)"
-    printf 'state=failed\nreason=grubenv_not_found\nrequested=%s\napplied_at=%s\n' \
-        "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
-    exit 1
+    fail_release grubenv_not_found "$val"
 fi
 
 log "apply: spatium_verbose=$val into $GRUBENV"
 if ! grub-editenv "$GRUBENV" set spatium_verbose="$val" 2>&1 | tee -a "$LOG"; then
     log "ERROR: grub-editenv failed"
-    printf 'state=failed\nreason=grub_editenv_failed\nrequested=%s\napplied_at=%s\n' \
-        "$val" "$(date -u +%FT%TZ)" > "$STATUS_SIDECAR"
-    exit 1
+    fail_release grub_editenv_failed "$val"
 fi
 
 # Apply landed. Record it so the supervisor short-circuits the next heartbeat's

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -675,6 +675,10 @@ backend/alembic/versions/e7f94b21c8d5_dns_zone_dnssec_ds_records.py:drop_column:
 backend/alembic/versions/e8c3f1b9a724_appliance_revoked_at.py:drop_column:65
 backend/alembic/versions/e8c3f1b9a724_appliance_revoked_at.py:drop_column:72
 backend/alembic/versions/e93b41ad7c5f_ai_daily_digest_setting.py:drop_column:39
+backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:66
+backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:67
+backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:68
+backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:69
 backend/alembic/versions/e9c47a1f3b28_wake_scheduler.py:drop_table:235
 backend/alembic/versions/e9c47a1f3b28_wake_scheduler.py:drop_table:237
 backend/alembic/versions/e9c47a1f3b28_wake_scheduler.py:drop_table:239

--- a/backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py
+++ b/backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py
@@ -1,0 +1,70 @@
+"""Agent config-apply status on DNS / DHCP / looking-glass server rows.
+
+Issue #882 — agents cache a last-known-good bundle and now revert to it
+when a new one fails to apply. A revert has to be visible: without these
+columns the control plane cannot tell a server that converged from one
+that is healthy, reachable, answering queries, and running a config the
+operator never approved.
+
+The agents already reported this — the DNS and DHCP heartbeat request
+models have declared a ``config: dict`` field since they were written, and
+both handlers ignored it. This migration is the storage that makes the
+field mean something.
+
+Revision ID: e9c2d47b1a63
+Revises: f4b91d38a70c
+Create Date: 2026-08-22
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e9c2d47b1a63"
+down_revision = "f4b91d38a70c"
+branch_labels = None
+depends_on = None
+
+
+# Same four columns on each agent-managed server table. NULLable throughout:
+# NULL means "this agent has never reported", which covers both a pre-#882
+# agent in the field and an agentless driver (Windows DNS, the cloud DNS
+# providers, ``technitium_api``) that has no apply loop to report from. The
+# read side must treat NULL as UNKNOWN and never as ``ok`` — an agent too old
+# to send a verdict is exactly the case where a silent revert could hide.
+_TABLES = ("dns_server", "dhcp_server", "looking_glass_collector")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.add_column(table, sa.Column("config_apply_status", sa.String(20), nullable=True))
+        op.add_column(table, sa.Column("config_apply_error", sa.Text(), nullable=True))
+        op.add_column(table, sa.Column("config_failed_etag", sa.String(128), nullable=True))
+        op.add_column(
+            table,
+            sa.Column("config_apply_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        # Partial index over the failing states only. The alert sweep and the
+        # server-list chip both ask "which servers have NOT converged", and on
+        # a healthy fleet that matches ~nothing — indexing the whole column
+        # would be almost entirely 'ok' rows nobody queries for.
+        op.create_index(
+            f"ix_{table}_config_apply_failed",
+            table,
+            ["config_apply_status"],
+            unique=False,
+            postgresql_where=sa.text(
+                "config_apply_status IS NOT NULL AND config_apply_status <> 'ok'"
+            ),
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.drop_index(f"ix_{table}_config_apply_failed", table_name=table)
+        op.drop_column(table, "config_apply_at")
+        op.drop_column(table, "config_failed_etag")
+        op.drop_column(table, "config_apply_error")
+        op.drop_column(table, "config_apply_status")

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -39,6 +39,7 @@ from app.models.dhcp import (
 from app.models.logs import DHCPLogEntry
 from app.models.metrics import DHCPMetricSample
 from app.models.settings import PlatformSettings
+from app.services.agents.config_apply import apply_reported_status
 from app.services.appliance.lldp import lldp_bundle
 from app.services.appliance.ntp import ntp_bundle
 from app.services.appliance.resolver import resolver_bundle
@@ -108,6 +109,9 @@ class AgentHeartbeatRequest(BaseModel):
     # heartbeat from a current agent.
     kea_version: str | None = None
     daemon: dict[str, Any] = {}
+    # #882 — the agent's last config-apply verdict:
+    # ``{status, etag, failed_etag, phase, error}``. See the DNS agent's
+    # AgentHeartbeatRequest for why this stays a loose dict.
     config: dict[str, Any] = {}
     # Bound the ACK list so a malformed / hostile heartbeat can't pin memory.
     ops_ack: list[dict[str, Any]] = Field(default_factory=list, max_length=5000)
@@ -845,6 +849,12 @@ async def agent_heartbeat(
         if elapsed > 15:
             server.reboot_requested = False
             server.reboot_requested_at = None
+
+    # #882 — the config-apply verdict. Pre-#882 a config Kea REFUSED still
+    # reached here as a healthy heartbeat: the agent advanced its etag,
+    # recorded success and stamped its readiness marker, so nothing on this
+    # side ever learned the scope changes were not live.
+    apply_reported_status(server, body.config, agent_kind="dhcp", server_id=str(server.id))
 
     for ack in body.ops_ack:
         op_id = ack.get("op_id")

--- a/backend/app/api/v1/dhcp/servers.py
+++ b/backend/app/api/v1/dhcp/servers.py
@@ -215,6 +215,14 @@ class ServerResponse(BaseModel):
     # Per-server maintenance mode (issue #182).
     maintenance_mode: bool = False
     maintenance_started_at: datetime | None = None
+    # #882 — last config-apply verdict reported by the agent.
+    # ``ok`` / ``reverted`` / ``revert_failed`` / ``no_previous``; NULL when
+    # the agent has never reported (a pre-#882 agent, or an agentless driver
+    # with no apply loop). NULL means UNKNOWN, never "fine".
+    config_apply_status: str | None = None
+    config_apply_error: str | None = None
+    config_failed_etag: str | None = None
+    config_apply_at: datetime | None = None
     maintenance_reason: str | None = None
     created_at: datetime
     modified_at: datetime
@@ -275,6 +283,10 @@ class ServerResponse(BaseModel):
             maintenance_mode=s.maintenance_mode,
             maintenance_started_at=s.maintenance_started_at,
             maintenance_reason=s.maintenance_reason,
+            config_apply_status=s.config_apply_status,
+            config_apply_error=s.config_apply_error,
+            config_failed_etag=s.config_failed_etag,
+            config_apply_at=s.config_apply_at,
             created_at=s.created_at,
             modified_at=s.modified_at,
         )

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -41,6 +41,7 @@ from app.models.dns import (
 from app.models.dns_rpz_hit import DNSRPZHit
 from app.models.logs import DNSQueryLogEntry
 from app.models.metrics import DNSMetricSample
+from app.services.agents.config_apply import apply_reported_status
 from app.services.dns.agent_config import build_config_bundle
 from app.services.dns.agent_token import (
     hash_token,
@@ -102,6 +103,11 @@ class AgentHeartbeatRequest(BaseModel):
     # 422 every heartbeat from a current agent.
     daemon_version: str | None = None
     daemon: dict[str, Any] = {}
+    # #882 — the agent's last config-apply verdict:
+    # ``{status, etag, failed_etag, phase, error}``. Kept as a loose dict
+    # rather than a strict model because a pre-#882 agent sends ``{}`` and
+    # a NEWER agent may send fields this control plane predates — both must
+    # keep heartbeating. ``apply_reported_status`` validates what it reads.
     config: dict[str, Any] = {}
     # Bound the ACK list so a malformed/hostile heartbeat can't pin memory.
     ops_ack: list[dict[str, Any]] = Field(default_factory=list, max_length=5000)
@@ -464,6 +470,11 @@ async def agent_heartbeat(
         if elapsed > 15:
             server.reboot_requested = False
             server.reboot_requested_at = None
+
+    # #882 — the config-apply verdict. ``body.config`` has been declared on
+    # this model since it was written and read by nothing; a server could be
+    # reachable, healthy and serving a config the operator never approved.
+    apply_reported_status(server, body.config, agent_kind="dns", server_id=str(server.id))
 
     # Process op ACKs
     for ack in body.ops_ack:

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -426,6 +426,14 @@ class ServerResponse(BaseModel):
     # Per-server maintenance mode (issue #182).
     maintenance_mode: bool = False
     maintenance_started_at: datetime | None = None
+    # #882 — last config-apply verdict reported by the agent.
+    # ``ok`` / ``reverted`` / ``revert_failed`` / ``no_previous``; NULL when
+    # the agent has never reported (a pre-#882 agent, or an agentless driver
+    # with no apply loop). NULL means UNKNOWN, never "fine".
+    config_apply_status: str | None = None
+    config_apply_error: str | None = None
+    config_failed_etag: str | None = None
+    config_apply_at: datetime | None = None
     maintenance_reason: str | None = None
     created_at: datetime
     modified_at: datetime
@@ -458,6 +466,10 @@ class ServerResponse(BaseModel):
             is_primary=s.is_primary,
             maintenance_mode=s.maintenance_mode,
             maintenance_started_at=s.maintenance_started_at,
+            config_apply_status=s.config_apply_status,
+            config_apply_error=s.config_apply_error,
+            config_failed_etag=s.config_failed_etag,
+            config_apply_at=s.config_apply_at,
             maintenance_reason=s.maintenance_reason,
             created_at=s.created_at,
             modified_at=s.modified_at,

--- a/backend/app/api/v1/looking_glass/agents.py
+++ b/backend/app/api/v1/looking_glass/agents.py
@@ -32,6 +32,7 @@ from app.core.agent_wake import (
 )
 from app.core.http_etag import etag_matches, format_etag
 from app.models.bgp_looking_glass import BGPLGPeer, LookingGlassCollector
+from app.services.agents.config_apply import apply_reported_status
 from app.services.looking_glass.agent_token import (
     hash_token,
     mint_agent_token,
@@ -100,6 +101,12 @@ class AgentHeartbeatRequest(BaseModel):
     # rejects at the field.
     agent_version: str | None = Field(default=None, max_length=64)
     peers: list[PeerStateReport] = Field(default_factory=list, max_length=5000)
+    # #882 — the agent's last config-apply verdict:
+    # ``{status, etag, failed_etag, phase, error}``. MUST be declared here:
+    # this model is extra="forbid", so an undeclared field would 422 every
+    # heartbeat from a current collector. Kept a loose dict for the same
+    # reason as the DNS/DHCP agents — see their AgentHeartbeatRequest.
+    config: dict[str, Any] = Field(default_factory=dict)
 
 
 class AgentHeartbeatResponse(BaseModel):
@@ -354,6 +361,13 @@ async def agent_heartbeat(
         collector.last_seen_ip = request.client.host
     if body.agent_version:
         collector.agent_version = body.agent_version
+
+    # #882 — the config-apply verdict. The collector's own SyncLoop has set a
+    # ``daemon_status`` since it was written and the heartbeat never carried
+    # it, so a peer set that failed to render was invisible from here.
+    apply_reported_status(
+        collector, body.config, agent_kind="looking_glass", server_id=str(collector.id)
+    )
 
     # Per-peer runtime state — only overwrite the columns the agent sent.
     for rep in body.peers:

--- a/backend/app/api/v1/looking_glass/schemas.py
+++ b/backend/app/api/v1/looking_glass/schemas.py
@@ -106,6 +106,13 @@ class CollectorRead(BaseModel):
     last_seen_ip: str | None
     last_seen_at: datetime | None
     last_health_check_at: datetime | None
+    # #882 — last config-apply verdict reported by the collector agent.
+    # ``ok`` / ``reverted`` / ``revert_failed`` / ``no_previous``; NULL when
+    # the agent has never reported. NULL means UNKNOWN, never "fine".
+    config_apply_status: str | None = None
+    config_apply_error: str | None = None
+    config_failed_etag: str | None = None
+    config_apply_at: datetime | None = None
     appliance_id: uuid.UUID | None
     created_at: datetime
     modified_at: datetime

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -489,6 +489,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         await seed_firewall_apply_stalled_alert_rule()
     except Exception as exc:  # noqa: BLE001
         logger.debug("firewall_apply_stalled_alert_rule_seed_skipped", reason=str(exc))
+    # Agent config-apply-rejected alert rule — singleton, ENABLED by default
+    # (issue #882). Fires when an agent reverts to its last-known-good config
+    # because the one we sent would not apply. Idempotent.
+    try:
+        from app.services.alerts import (  # noqa: PLC0415
+            seed_agent_config_rejected_alert_rule,
+        )
+
+        await seed_agent_config_rejected_alert_rule()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("agent_config_rejected_alert_rule_seed_skipped", reason=str(exc))
     # DNS query-anomaly alert rules — NXDOMAIN-spike + query-rate-spike,
     # singletons, DISABLED by default (issue #371). Discoverable in the
     # Alerts UI; fire only on agent-based BIND9 installs with metric data.

--- a/backend/app/models/bgp_looking_glass.py
+++ b/backend/app/models/bgp_looking_glass.py
@@ -107,6 +107,33 @@ class LookingGlassCollector(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         DateTime(timezone=True), nullable=True
     )
 
+    # ── #882 last config-apply verdict ────────────────────────────────────
+    #
+    # Reported by the agent on every heartbeat. Distinct from ``status`` /
+    # ``last_seen_at``, which only say whether the agent is TALKING to us:
+    # a server can be reachable, healthy and answering queries while running
+    # a config the operator never approved, because the one they saved was
+    # rejected and the agent reverted to its last-known-good.
+    #
+    # ``config_apply_status`` values, mirroring the agent's
+    # ``config_apply.py``:
+    #   ok            — converged; the live config is the saved one
+    #   reverted      — the saved bundle failed; running the previous one
+    #   revert_failed — the saved bundle failed AND the revert failed
+    #   no_previous   — failed with nothing to fall back to (first bundle)
+    #
+    # NULL means the agent has never reported (a pre-#882 agent, or an
+    # agentless driver that has no apply loop at all). Treat NULL as
+    # UNKNOWN, never as ``ok``.
+    config_apply_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # The daemon's own words about why it refused — ``named-checkconf``
+    # output, Kea's config-test text. Truncated agent-side to 2000 chars.
+    config_apply_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # etag of the bundle that was rejected, so the operator can tell whether
+    # the failure is still current or predates the config now saved.
+    config_failed_etag: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    config_apply_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     # Issue #197 shape — deleting the owning appliance sweeps its collector
     # rows via ON DELETE CASCADE. NULL for standalone / operator-registered
     # collectors (off-fleet box, manual register).

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -207,6 +207,33 @@ class DHCPServer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # older than 2.7, so upgrading an HA pair one node at a time breaks HA
     # mid-run. NULL = not reported yet (treat as UNKNOWN, never as "old").
     kea_version: Mapped[str | None] = mapped_column(String(32), nullable=True)
+
+    # ── #882 last config-apply verdict ────────────────────────────────────
+    #
+    # Reported by the agent on every heartbeat. Distinct from ``status`` /
+    # ``last_seen_at``, which only say whether the agent is TALKING to us:
+    # a server can be reachable, healthy and answering queries while running
+    # a config the operator never approved, because the one they saved was
+    # rejected and the agent reverted to its last-known-good.
+    #
+    # ``config_apply_status`` values, mirroring the agent's
+    # ``config_apply.py``:
+    #   ok            — converged; the live config is the saved one
+    #   reverted      — the saved bundle failed; running the previous one
+    #   revert_failed — the saved bundle failed AND the revert failed
+    #   no_previous   — failed with nothing to fall back to (first bundle)
+    #
+    # NULL means the agent has never reported (a pre-#882 agent, or an
+    # agentless driver that has no apply loop at all). Treat NULL as
+    # UNKNOWN, never as ``ok``.
+    config_apply_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # The daemon's own words about why it refused — ``named-checkconf``
+    # output, Kea's config-test text. Truncated agent-side to 2000 chars.
+    config_apply_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # etag of the bundle that was rejected, so the operator can tell whether
+    # the failure is still current or predates the config now saved.
+    config_failed_etag: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    config_apply_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     agent_approved: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     agent_fingerprint: Mapped[str | None] = mapped_column(String(128), nullable=True)
 

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -236,6 +236,33 @@ class DNSServer(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     # report one) and must be treated as UNKNOWN, never as "old".
     daemon_version: Mapped[str | None] = mapped_column(String(32), nullable=True)
 
+    # ── #882 last config-apply verdict ────────────────────────────────────
+    #
+    # Reported by the agent on every heartbeat. Distinct from ``status`` /
+    # ``last_seen_at``, which only say whether the agent is TALKING to us:
+    # a server can be reachable, healthy and answering queries while running
+    # a config the operator never approved, because the one they saved was
+    # rejected and the agent reverted to its last-known-good.
+    #
+    # ``config_apply_status`` values, mirroring the agent's
+    # ``config_apply.py``:
+    #   ok            — converged; the live config is the saved one
+    #   reverted      — the saved bundle failed; running the previous one
+    #   revert_failed — the saved bundle failed AND the revert failed
+    #   no_previous   — failed with nothing to fall back to (first bundle)
+    #
+    # NULL means the agent has never reported (a pre-#882 agent, or an
+    # agentless driver that has no apply loop at all). Treat NULL as
+    # UNKNOWN, never as ``ok``.
+    config_apply_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # The daemon's own words about why it refused — ``named-checkconf``
+    # output, Kea's config-test text. Truncated agent-side to 2000 chars.
+    config_apply_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # etag of the bundle that was rejected, so the operator can tell whether
+    # the failure is still current or predates the config now saved.
+    config_failed_etag: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    config_apply_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
     # Issue #197 — link back to the parent Application appliance
     # (when the row was registered through the supervisor's role-
     # assignment flow). ``ON DELETE CASCADE`` does the orphan-row

--- a/backend/app/services/agents/config_apply.py
+++ b/backend/app/services/agents/config_apply.py
@@ -1,0 +1,131 @@
+"""Ingest the config-apply verdict agents report on every heartbeat (#882).
+
+Three agents (DNS, DHCP, looking-glass) report the same structure on the
+same field, and three heartbeat handlers persist it onto three tables with
+the same four columns. One function so the semantics cannot drift apart —
+in particular the "only overwrite on a real report" rule, which is what
+stops a pre-#882 agent (which sends no ``config`` at all) from silently
+clearing a genuine failure recorded by a newer one.
+
+The counterpart lives in each agent's ``config_apply.py``; the status
+vocabulary is shared and must stay in sync.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+STATUS_OK = "ok"
+STATUS_REVERTED = "reverted"
+STATUS_REVERT_FAILED = "revert_failed"
+STATUS_NO_PREVIOUS = "no_previous"
+
+VALID_STATUSES = frozenset({STATUS_OK, STATUS_REVERTED, STATUS_REVERT_FAILED, STATUS_NO_PREVIOUS})
+
+#: Statuses meaning "this server is NOT running the config we hold". Every
+#: read surface — the alert rule, the server-list chip, the MCP tool —
+#: filters on this set rather than re-listing the strings.
+FAILED_STATUSES = frozenset({STATUS_REVERTED, STATUS_REVERT_FAILED, STATUS_NO_PREVIOUS})
+
+#: Severity per status. A revert is a warning: the daemon is healthy and
+#: serving, just not what was asked for. The other two are critical —
+#: ``revert_failed`` means the fallback ALSO failed, and ``no_previous``
+#: means there was never a working config to fall back to, so the service
+#: may not be answering at all.
+SEVERITY_BY_STATUS = {
+    STATUS_REVERTED: "warning",
+    STATUS_REVERT_FAILED: "critical",
+    STATUS_NO_PREVIOUS: "critical",
+}
+
+# Bounds mirroring the columns. The agent already truncates, but the
+# heartbeat is an authenticated-agent-supplied payload and a compromised or
+# simply buggy agent must not be able to write past the column width.
+_MAX_ERROR = 2000
+_MAX_ETAG = 128
+_MAX_STATUS = 20
+
+
+class _HasConfigApplyColumns(Protocol):
+    config_apply_status: str | None
+    config_apply_error: str | None
+    config_failed_etag: str | None
+    config_apply_at: datetime | None
+
+
+def _clip(value: Any, limit: int) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:limit]
+
+
+def apply_reported_status(
+    server: _HasConfigApplyColumns,
+    reported: dict[str, Any] | None,
+    *,
+    agent_kind: str,
+    server_id: str,
+) -> None:
+    """Persist ``reported`` onto ``server``'s config-apply columns.
+
+    ``reported`` is the heartbeat's ``config`` field. Three shapes matter
+    and are handled differently:
+
+    * **absent / empty** — a pre-#882 agent, which sends ``{}`` or nothing.
+      Leave every column untouched. Writing ``ok`` here would be a
+      fabrication, and NULLing the columns would erase a real failure that
+      a newer agent had reported before a downgrade.
+    * **an unrecognised status** — a newer agent than this control plane, or
+      a corrupt payload. Log and leave the columns alone, for the same
+      reason: guessing is worse than admitting we do not know.
+    * **a known status** — write all four columns together, so a stale
+      ``config_apply_error`` can never outlive the failure it described.
+    """
+    if not reported or not isinstance(reported, dict):
+        return
+
+    status = _clip(reported.get("status"), _MAX_STATUS)
+    if status is None:
+        return
+    if status not in VALID_STATUSES:
+        logger.warning(
+            "agent_config_apply_unknown_status",
+            agent_kind=agent_kind,
+            server_id=server_id,
+            status=status,
+        )
+        return
+
+    previous = server.config_apply_status
+    server.config_apply_status = status
+    # Cleared as a group on ``ok``: the error and the failed etag describe a
+    # failure that is over, and a chip tooltip showing last week's
+    # named-checkconf output next to a green status is worse than showing
+    # nothing.
+    if status == STATUS_OK:
+        server.config_apply_error = None
+        server.config_failed_etag = None
+    else:
+        server.config_apply_error = _clip(reported.get("error"), _MAX_ERROR)
+        server.config_failed_etag = _clip(reported.get("failed_etag"), _MAX_ETAG)
+    server.config_apply_at = datetime.now(UTC)
+
+    if status != previous:
+        log = logger.warning if status in FAILED_STATUSES else logger.info
+        log(
+            "agent_config_apply_status_changed",
+            agent_kind=agent_kind,
+            server_id=server_id,
+            status=status,
+            previous=previous,
+            failed_etag=server.config_failed_etag,
+            phase=_clip(reported.get("phase"), 32),
+        )

--- a/backend/app/services/ai/tools/observability.py
+++ b/backend/app/services/ai/tools/observability.py
@@ -442,3 +442,80 @@ async def global_search(
 # Silence the false-positive "imported but unused" — ``or_`` is part
 # of the standard import block we share with sibling tool modules.
 _ = or_
+
+
+# ── find_agents_with_config_failures ──────────────────────────────────
+
+
+class FindAgentConfigFailuresArgs(BaseModel):
+    include_unreported: bool = Field(
+        default=False,
+        description=(
+            "Also list agent-managed servers that have never reported a "
+            "config-apply verdict (a pre-#882 agent, or an agentless driver "
+            "with no apply loop). These are UNKNOWN, not healthy."
+        ),
+    )
+    limit: int = Field(default=200, ge=1, le=1000)
+
+
+@register_tool(
+    name="find_agents_with_config_failures",
+    description=(
+        "List DNS servers, DHCP servers and Looking Glass collectors whose "
+        "agent could NOT apply the configuration the control plane sent, and "
+        "has reverted to its last-known-good config (issue #882). Use this to "
+        "answer 'why isn't my zone/scope change live?' when the server looks "
+        "healthy: a reverted agent keeps serving and keeps heartbeating, so "
+        "status, health checks and last-seen all read normal while the saved "
+        "configuration is not running anywhere. Returns the rejected config's "
+        "etag and the daemon's own error text (named-checkconf output, Kea's "
+        "config-test message) — that text usually names the exact problem. A "
+        "status of 'reverted' means healthy-but-stale; 'revert_failed' and "
+        "'no_previous' mean the service may not be running at all."
+    ),
+    args_model=FindAgentConfigFailuresArgs,
+    category="ops",
+)
+async def find_agents_with_config_failures(
+    db: AsyncSession,
+    user: User,  # noqa: ARG001 — read-only fleet health, same gate as the other ops tools
+    args: FindAgentConfigFailuresArgs,
+) -> list[dict[str, Any]]:
+    from app.models.bgp_looking_glass import LookingGlassCollector  # noqa: PLC0415
+    from app.models.dhcp import DHCPServer  # noqa: PLC0415
+    from app.models.dns import DNSServer  # noqa: PLC0415
+    from app.services.agents.config_apply import FAILED_STATUSES  # noqa: PLC0415
+
+    out: list[dict[str, Any]] = []
+    for model, kind in (
+        (DNSServer, "dns_server"),
+        (DHCPServer, "dhcp_server"),
+        (LookingGlassCollector, "looking_glass_collector"),
+    ):
+        stmt = select(model)
+        if args.include_unreported:
+            stmt = stmt.where(
+                or_(
+                    model.config_apply_status.in_(sorted(FAILED_STATUSES)),
+                    model.config_apply_status.is_(None),
+                )
+            )
+        else:
+            stmt = stmt.where(model.config_apply_status.in_(sorted(FAILED_STATUSES)))
+        rows = (await db.execute(stmt.limit(args.limit))).scalars().all()
+        for r in rows:
+            out.append(
+                {
+                    "kind": kind,
+                    "id": str(r.id),
+                    "name": r.name,
+                    "config_apply_status": r.config_apply_status or "never_reported",
+                    "config_failed_etag": r.config_failed_etag,
+                    "config_apply_error": r.config_apply_error,
+                    "config_apply_at": (
+                        r.config_apply_at.isoformat() if r.config_apply_at else None
+                    ),
+                }
+            )
+    return out[: args.limit]

--- a/backend/app/services/alerts.py
+++ b/backend/app/services/alerts.py
@@ -183,6 +183,23 @@ RULE_TYPE_FIREWALL_APPLY_STALLED = "firewall.apply_stalled"
 # critical). Catches the "we forgot to rotate" 3am-page failure mode.
 RULE_TYPE_SECRET_EXPIRING = "secret_expiring"
 
+# Issue #882 — an agent reported that it could NOT apply the config we sent
+# and has reverted to its last-known-good (or has nothing to revert to).
+# Subject = the dns_server / dhcp_server / looking_glass_collector row.
+#
+# Deliberately NOT folded into ``server_unreachable``: that rule is about
+# an agent we cannot hear from, and this one fires on an agent that is
+# heartbeating perfectly, whose daemon is healthy, and whose answers are
+# simply not the ones the operator configured. Reachability alerting is
+# what makes such a divergence invisible — the server looks fine on every
+# other signal, which is exactly why a revert needs its own alarm rather
+# than a health check.
+#
+# Severity comes from the reported status, not from the rule: ``reverted``
+# is a warning (serving, wrong config), ``revert_failed`` / ``no_previous``
+# are critical (may not be serving at all).
+RULE_TYPE_AGENT_CONFIG_REJECTED = "agent_config_rejected"
+
 # Issue #46 — planned-decommission awareness. Subject = subnet. Fires
 # when a subnet's ``decom_date`` falls within ``threshold_days`` (default
 # 30). Same threshold-escalation shape as the other ``*_expiring`` rules
@@ -384,6 +401,7 @@ RULE_TYPES = frozenset(
         RULE_TYPE_DHCP_POOL_EXHAUSTION,
         RULE_TYPE_FIREWALL_APPLY_STALLED,
         RULE_TYPE_SECRET_EXPIRING,
+        RULE_TYPE_AGENT_CONFIG_REJECTED,
         RULE_TYPE_DECOM_EXPIRING,
         RULE_TYPE_DNS_NXDOMAIN_SPIKE,
         RULE_TYPE_DNS_QUERY_RATE_SPIKE,
@@ -2802,6 +2820,75 @@ async def _matching_secret_expiring_subjects(
     return matches
 
 
+async def _matching_agent_config_rejected_subjects(
+    db: AsyncSession,
+    rule: AlertRule,  # noqa: ARG001
+) -> list[tuple[str, str, str, str | None]]:
+    """``agent_config_rejected`` — every agent-managed server that reported a
+    failed config apply on its last heartbeat (#882).
+
+    Reads the ``config_apply_*`` columns the three heartbeat handlers write;
+    no probing, no extra round-trip. Auto-resolves through ``evaluate_all``'s
+    standard "subject no longer matches" diff the moment an agent reports
+    ``ok`` again.
+
+    NULL is deliberately not a match. It means the agent has never reported —
+    a pre-#882 agent, or one of the agentless drivers (Windows DNS, the cloud
+    DNS providers, ``technitium_api``) that has no apply loop at all. Firing
+    on those would alarm every install on upgrade day and say nothing true.
+    """
+    from app.models.bgp_looking_glass import LookingGlassCollector  # noqa: PLC0415
+    from app.models.dhcp import DHCPServer  # noqa: PLC0415
+    from app.models.dns import DNSServer  # noqa: PLC0415
+    from app.services.agents.config_apply import (  # noqa: PLC0415
+        FAILED_STATUSES,
+        SEVERITY_BY_STATUS,
+        STATUS_NO_PREVIOUS,
+        STATUS_REVERT_FAILED,
+    )
+
+    matches: list[tuple[str, str, str, str | None]] = []
+    failed = sorted(FAILED_STATUSES)
+    for model, kind in (
+        (DNSServer, "DNS"),
+        (DHCPServer, "DHCP"),
+        (LookingGlassCollector, "Looking Glass collector"),
+    ):
+        rows = (
+            (await db.execute(select(model).where(model.config_apply_status.in_(failed))))
+            .scalars()
+            .all()
+        )
+        for row in rows:
+            status = row.config_apply_status or ""
+            if status == STATUS_NO_PREVIOUS:
+                what = (
+                    "could not apply the configuration and had no previously-working "
+                    "configuration to fall back to, so it may not be serving at all"
+                )
+            elif status == STATUS_REVERT_FAILED:
+                what = (
+                    "could not apply the configuration AND failed to roll back to the "
+                    "previous one — its running state is unknown"
+                )
+            else:
+                what = (
+                    "rejected the configuration and rolled back to the last one that "
+                    "worked, so it is healthy but NOT serving what is saved here"
+                )
+            detail = (row.config_apply_error or "").strip()
+            message = (
+                f"{kind} server '{row.name}' {what}. "
+                f"Rejected config etag: {row.config_failed_etag or 'unknown'}."
+                + (f" Daemon reported: {detail}" if detail else "")
+            )
+            subject_id = f"{model.__tablename__}:{row.id}"
+            matches.append(
+                (subject_id, f"{row.name} ({kind})", message, SEVERITY_BY_STATUS.get(status))
+            )
+    return matches
+
+
 async def _matching_firewall_apply_stalled_subjects(
     db: AsyncSession,
     rule: AlertRule,
@@ -3557,6 +3644,58 @@ async def seed_firewall_apply_stalled_alert_rule() -> None:
                 rule_type=RULE_TYPE_FIREWALL_APPLY_STALLED,
                 severity="warning",
                 enabled=False,
+                notify_syslog=True,
+                notify_webhook=True,
+                notify_smtp=False,
+            )
+        )
+        await session.commit()
+
+
+_AGENT_CONFIG_REJECTED_RULE_NAME = "Agent config apply rejected"
+
+
+async def seed_agent_config_rejected_alert_rule() -> None:
+    """Seed the #882 rule, ENABLED by default.
+
+    Unlike the firewall-stalled and DNS-anomaly rules — which are seeded off
+    because they only make sense once an optional subsystem is switched on —
+    this one applies to every install that runs an agent, needs no
+    configuration, and cannot false-fire: it reads a verdict the agent itself
+    reported about its own apply. The failure it catches (a saved config that
+    silently never went live) is invisible on every other signal, so leaving
+    the alarm off by default would mean the operator has to already suspect
+    the problem in order to find out about it.
+
+    Keyed on ``name``; an operator who disables or renames it is never
+    overridden.
+    """
+    from app.db import AsyncSessionLocal  # noqa: PLC0415
+    from app.models.alerts import AlertRule  # noqa: PLC0415
+
+    async with AsyncSessionLocal() as session:
+        existing = await session.scalar(
+            select(AlertRule).where(AlertRule.name == _AGENT_CONFIG_REJECTED_RULE_NAME)
+        )
+        if existing is not None:
+            return
+        session.add(
+            AlertRule(
+                name=_AGENT_CONFIG_REJECTED_RULE_NAME,
+                description=(
+                    "Fires when a DNS, DHCP or Looking Glass agent reports that it "
+                    "could not apply the configuration the control plane sent it. "
+                    "The agent reverts to its last-known-good config and keeps "
+                    "serving, so the server stays reachable and healthy while NOT "
+                    "running what is saved here — a divergence no reachability or "
+                    "health check can see. Severity follows the agent's verdict: a "
+                    "rollback is a warning; a failed rollback, or a failure with no "
+                    "previous config to fall back to, is critical. Auto-resolves "
+                    "when the agent reports a successful apply."
+                ),
+                rule_type=RULE_TYPE_AGENT_CONFIG_REJECTED,
+                severity="warning",
+                enabled=True,
                 notify_syslog=True,
                 notify_webhook=True,
                 notify_smtp=False,
@@ -4699,6 +4838,15 @@ async def evaluate_all(db: AsyncSession) -> dict[str, int]:
                 expiring = await _matching_secret_expiring_subjects(db, rule, now)
                 matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in expiring]
                 subject_type = "secret"
+            elif rule.rule_type == RULE_TYPE_AGENT_CONFIG_REJECTED:
+                rejected = await _matching_agent_config_rejected_subjects(db, rule)
+                matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in rejected]
+                # One rule spans three tables, so the subject_type is the
+                # generic "agent" and the subject_id carries the source —
+                # same shape ``secret_expiring`` uses for its two credential
+                # tables. Without the prefix a dns_server and a dhcp_server
+                # sharing a UUID would collide into one event.
+                subject_type = "agent"
             elif rule.rule_type == RULE_TYPE_FIREWALL_APPLY_STALLED:
                 stalled = await _matching_firewall_apply_stalled_subjects(db, rule, now)
                 matches = [(sid, disp, msg, sev) for sid, disp, msg, sev in stalled]

--- a/backend/tests/test_agent_config_apply_status.py
+++ b/backend/tests/test_agent_config_apply_status.py
@@ -1,0 +1,197 @@
+"""Agent config-apply status ingest + the ``agent_config_rejected`` alert (#882).
+
+The failure this covers is specifically a *silent* one. When an agent cannot
+apply a bundle it reverts to its last-known-good and keeps serving, so the
+server's ``status`` stays ``active``, its health check passes and its
+heartbeat keeps arriving on time — while the zone or scope the operator saved
+is not live anywhere. These columns are the only place that divergence shows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPServer
+from app.models.dns import DNSServer, DNSServerGroup
+from app.services.agents.config_apply import (
+    FAILED_STATUSES,
+    SEVERITY_BY_STATUS,
+    STATUS_NO_PREVIOUS,
+    STATUS_OK,
+    STATUS_REVERT_FAILED,
+    STATUS_REVERTED,
+    apply_reported_status,
+)
+from app.services.alerts import _matching_agent_config_rejected_subjects
+
+_RULE = SimpleNamespace(severity="warning")
+
+
+def _row() -> SimpleNamespace:
+    return SimpleNamespace(
+        config_apply_status=None,
+        config_apply_error=None,
+        config_failed_etag=None,
+        config_apply_at=None,
+    )
+
+
+def _report(row: object, payload: dict | None) -> None:
+    apply_reported_status(row, payload, agent_kind="dns", server_id="s1")
+
+
+# ── ingest ────────────────────────────────────────────────────────────────
+
+
+def test_reverted_report_is_persisted() -> None:
+    row = _row()
+    _report(
+        row,
+        {
+            "status": STATUS_REVERTED,
+            "etag": "good",
+            "failed_etag": "bad",
+            "phase": "validate",
+            "error": "named-checkconf failed: undefined acl 'trusted'",
+        },
+    )
+    assert row.config_apply_status == STATUS_REVERTED
+    assert row.config_failed_etag == "bad"
+    assert "undefined acl" in row.config_apply_error
+    assert row.config_apply_at is not None
+
+
+def test_ok_clears_the_stale_failure_detail() -> None:
+    """A green status next to last week's checkconf output is worse than
+    nothing — the four columns move as a group."""
+    row = _row()
+    _report(row, {"status": STATUS_REVERTED, "failed_etag": "bad", "error": "boom"})
+    _report(row, {"status": STATUS_OK, "etag": "fixed"})
+    assert row.config_apply_status == STATUS_OK
+    assert row.config_apply_error is None
+    assert row.config_failed_etag is None
+
+
+def test_empty_report_leaves_a_recorded_failure_alone() -> None:
+    """A pre-#882 agent sends ``config: {}``.
+
+    Treating that as ``ok`` would fabricate a verdict; NULLing the columns
+    would erase a real failure recorded before a downgrade. Both are worse
+    than leaving the last known answer in place.
+    """
+    row = _row()
+    _report(row, {"status": STATUS_REVERTED, "failed_etag": "bad"})
+    _report(row, {})
+    _report(row, None)
+    assert row.config_apply_status == STATUS_REVERTED
+    assert row.config_failed_etag == "bad"
+
+
+def test_unknown_status_is_ignored_not_guessed() -> None:
+    """A newer agent than this control plane, or a corrupt payload."""
+    row = _row()
+    _report(row, {"status": STATUS_REVERTED, "failed_etag": "bad"})
+    _report(row, {"status": "something_new"})
+    assert row.config_apply_status == STATUS_REVERTED
+
+
+def test_oversized_fields_are_clipped_to_the_columns() -> None:
+    """The heartbeat is agent-supplied; the agent truncates, but a buggy or
+    compromised one must not be able to write past the column width."""
+    row = _row()
+    _report(
+        row,
+        {
+            "status": STATUS_REVERTED,
+            "error": "x" * 9000,
+            "failed_etag": "e" * 500,
+        },
+    )
+    assert len(row.config_apply_error) == 2000
+    assert len(row.config_failed_etag) == 128
+
+
+def test_blank_strings_are_normalised_to_null() -> None:
+    row = _row()
+    _report(row, {"status": STATUS_REVERTED, "error": "   ", "failed_etag": ""})
+    assert row.config_apply_error is None
+    assert row.config_failed_etag is None
+
+
+# ── alert matcher ─────────────────────────────────────────────────────────
+
+
+async def _dns_server(db: AsyncSession, name: str, **kw: object) -> DNSServer:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(group)
+    await db.flush()
+    s = DNSServer(group_id=group.id, name=name, driver="bind9", host="10.0.0.53", port=53, **kw)
+    db.add(s)
+    await db.flush()
+    return s
+
+
+async def test_matcher_fires_on_a_reverted_agent(db_session: AsyncSession) -> None:
+    await _dns_server(
+        db_session,
+        "ns-reverted",
+        config_apply_status=STATUS_REVERTED,
+        config_failed_etag="sha256:bad",
+        config_apply_error="named-checkconf failed",
+    )
+    matches = await _matching_agent_config_rejected_subjects(db_session, _RULE)
+    assert len(matches) == 1
+    subject_id, display, message, severity = matches[0]
+    # Subject ids are table-prefixed: one rule spans three tables and a
+    # dns_server sharing a UUID with a dhcp_server must not collide.
+    assert subject_id.startswith("dns_server:")
+    assert "ns-reverted" in display
+    assert "sha256:bad" in message
+    assert "named-checkconf failed" in message
+    assert severity == SEVERITY_BY_STATUS[STATUS_REVERTED]
+
+
+async def test_matcher_ignores_ok_and_never_reported(db_session: AsyncSession) -> None:
+    """NULL means the agent has never reported — a pre-#882 agent or an
+    agentless driver with no apply loop. Firing on those would alarm every
+    install on upgrade day and say nothing true."""
+    await _dns_server(db_session, "ns-ok", config_apply_status=STATUS_OK)
+    await _dns_server(db_session, "ns-silent")  # NULL
+    assert await _matching_agent_config_rejected_subjects(db_session, _RULE) == []
+
+
+async def test_severity_escalates_for_the_unrecoverable_states(
+    db_session: AsyncSession,
+) -> None:
+    """``reverted`` is a warning: the daemon is up and answering, just not
+    with the saved config. The other two mean it may not be answering."""
+    await _dns_server(db_session, "ns-a", config_apply_status=STATUS_REVERT_FAILED)
+    await _dns_server(db_session, "ns-b", config_apply_status=STATUS_NO_PREVIOUS)
+    matches = await _matching_agent_config_rejected_subjects(db_session, _RULE)
+    assert {m[3] for m in matches} == {"critical"}
+
+
+async def test_matcher_spans_dhcp_servers_too(db_session: AsyncSession) -> None:
+    db_session.add(
+        DHCPServer(
+            name="kea-1",
+            driver="kea",
+            host="10.0.0.67",
+            config_apply_status=STATUS_REVERTED,
+            config_failed_etag="sha256:bad",
+        )
+    )
+    await db_session.flush()
+    matches = await _matching_agent_config_rejected_subjects(db_session, _RULE)
+    assert len(matches) == 1
+    assert matches[0][0].startswith("dhcp_server:")
+
+
+def test_failed_statuses_excludes_ok() -> None:
+    """Every read surface filters on this set; ``ok`` leaking in would make
+    the alert fire on every healthy server in the fleet."""
+    assert STATUS_OK not in FAILED_STATUSES
+    assert FAILED_STATUSES == {STATUS_REVERTED, STATUS_REVERT_FAILED, STATUS_NO_PREVIOUS}

--- a/docs/deployment/DNS_AGENT.md
+++ b/docs/deployment/DNS_AGENT.md
@@ -201,9 +201,11 @@ agent-id                         # UUID, 0600
 agent_token.jwt                  # current JWT, 0600
 bootstrap.last                   # last-used PSK hash (for rotation detect)
 config/
-  current.json                   # last-applied AgentConfigBundle (ETag in header field)
+  current.json                   # last AgentConfigBundle FETCHED from the control plane
   current.etag
-  previous.json                  # rollback copy
+  previous.json                  # last bundle that APPLIED cleanly — the revert target
+  previous.etag
+  quarantine.json                # etag of a bundle that failed to apply, + its backoff
 rendered/
   zones/
     example.com.db
@@ -218,6 +220,54 @@ ops/
 ```
 
 **Offline operation**: if the control plane is unreachable on boot, the agent loads `config/current.json`, renders configs if not already rendered, starts the daemon, and continues serving DNS. It enters a retry loop and resumes sync when the control plane returns. No query path ever depends on control-plane reachability.
+
+### Last-known-good revert (issue #882)
+
+Offline operation covers a *missing* control plane. It does not cover a
+*wrong* one: a bundle that parses fine but renders config `named` rejects.
+Both agents wrote `previous.json` from the first release and **neither ever
+read it**, so a bad-but-parseable bundle overwrote the cache and left the
+agent with nothing to fall back to.
+
+Two properties make the fallback real:
+
+* **`previous` is the last bundle that APPLIED, not the last one fetched.**
+  It used to be rotated on every fetch, which destroyed the fallback in two
+  poll cycles: a failing bundle leaves the etag unadvanced, so the next poll
+  re-fetches the *same* bundle and rotates it — now known-bad — into
+  `previous`. It is now written by an explicit commit after the driver
+  accepts the bundle, and that commit refuses to run if `current` is not the
+  bundle that was applied.
+* **A failed etag is quarantined.** The long-poll wakes on a 12 s tick with a
+  2 s poll fallback, so without this a bad bundle is not one failure but a
+  re-render loop. The agent parks on the failing etag (the long-poll then
+  blocks on a 304, costing nothing) and retries on a 60 s → 5 min → 15 min
+  ladder, so a *transient* failure — a full disk mid-render, a daemon still
+  starting — still recovers on its own. Any bundle that applies clears the
+  record, as does the control plane simply serving a different etag.
+
+The apply is phased — render → validate → swap/reload — and the phase decides
+the recovery. BIND renders and validates into `rendered.new`, so a
+`named-checkconf` failure never reached `named`: the daemon is already in the
+state a revert would produce, and re-rendering the previous bundle there would
+bounce a healthy server for nothing. Only a swap/reload failure, where the
+live config directory has already been replaced, re-renders the previous
+bundle. Kea is the mirror image — `config-test` rejects without disturbing the
+running server, but the refused document has already been written to
+`kea_config_path`, and that file is what Kea reads on its next start, so a
+rejection there always rewrites the files even though the daemon is fine.
+
+On restart the agent checks the quarantine before re-applying `current.json`:
+a container that crash-loops must not re-break itself with the bundle that
+broke it.
+
+**A revert is reported, never silent.** That matters more than it sounds: a
+reverted agent keeps serving and keeps heartbeating, so `status`, the health
+check and `last_seen_at` all read normal while the zone the operator saved is
+live nowhere. The verdict rides the heartbeat's `config` field, lands on
+`dns_server.config_apply_*`, and drives a chip on the server row, a banner on
+the server detail, the `agent_config_rejected` alert rule and the
+`find_agents_with_config_failures` Copilot tool.
 
 
 ---
@@ -238,7 +288,13 @@ ops/
     "queries_per_sec_1m": 42.1,
     "cache_hit_ratio_5m": 0.87
   },
-  "config": { "etag": "sha256:...", "applied_at": "..." },
+  "config": {
+    "status": "ok",
+    "etag": "sha256:...",
+    "failed_etag": null,
+    "phase": null,
+    "error": null
+  },
   "ops_ack": [
     {"op_id": "...", "result": "ok"},
     {"op_id": "...", "result": "error", "message": "NXRRSET"}

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -619,6 +619,38 @@ The Kea daemon config file (JSON) is generated from this cache. On startup, the 
 - A manual "force resync" is available from the admin UI (`POST /api/v1/dhcp/servers/{id}/sync`)
 - Cache version is tracked; SpatiumDDI will reject applying a cache version older than the current DB version
 
+### Last-known-good revert (issue #882)
+
+The section above covers a control plane that is *unreachable*. It does not
+cover one that is *wrong* — a bundle that renders to a Kea config the daemon
+refuses.
+
+Two files back the fallback, under `config/` in the agent state dir:
+`previous.json` is the last bundle Kea **accepted** (not, as it used to be,
+whichever bundle came before this one — that rotation destroyed the fallback
+after two poll cycles), and `quarantine.json` records an etag whose apply
+failed so it is not re-rendered on every poll.
+
+Kea's `config-test` is what makes the distinction usable: a rejection is a
+verdict about the config, whereas an unreachable control socket says nothing
+about it — Kea may simply be restarting. Only a rejection reverts; reverting
+on an unreachable socket would discard a good bundle because of a timing
+accident.
+
+The revert rewrites the on-disk `kea-dhcp4.conf` / `kea-dhcp6.conf`, not just
+the agent's bookkeeping. `config-test` rejects *without* disturbing the
+running daemon, so Kea itself is fine either way — but the refused document
+has already been written to those paths, and that file is what Kea reads on
+its next start. Leaving it turns a rejected apply into a crash loop the next
+time the container restarts.
+
+Before #882 a refused config was reported as a **success**: the loop advanced
+its etag, called `_record_success()`, logged `dhcp_config_applied` and stamped
+the Kubernetes readiness marker. The agent now reports the verdict on its
+heartbeat (`config` field → `dhcp_server.config_apply_*`), which drives the
+server-row chip, the `agent_config_rejected` alert rule and the
+`find_agents_with_config_failures` Copilot tool.
+
 ---
 
 ## 7. DHCP ↔ IPAM Synchronization

--- a/frontend/src/components/ConfigApplyChip.tsx
+++ b/frontend/src/components/ConfigApplyChip.tsx
@@ -1,0 +1,123 @@
+import type { ConfigApplyFields, ConfigApplyStatus } from "@/lib/api";
+
+/**
+ * Chip surfacing an agent's last config-apply verdict (#882).
+ *
+ * This exists because every other signal on a server row lies in exactly one
+ * case. A DNS or DHCP agent that rejects a config reverts to its
+ * last-known-good and keeps serving, so `status` reads `active`, the health
+ * check passes, `last_seen_at` is seconds old — and the zone or scope the
+ * operator saved is not live anywhere. The chip is the only place that
+ * divergence is visible.
+ *
+ * Renders nothing on `ok` and nothing on `null`. `null` means the agent has
+ * never reported — a pre-#882 agent, or an agentless driver with no apply
+ * loop — and inventing a green "converged" badge for a server we have heard
+ * nothing from would be the same false reassurance the chip is here to fix.
+ */
+
+const LABEL: Record<ConfigApplyStatus, string> = {
+  ok: "Config applied",
+  reverted: "Config reverted",
+  revert_failed: "Rollback failed",
+  no_previous: "Config not applied",
+};
+
+const EXPLAIN: Record<ConfigApplyStatus, string> = {
+  ok: "Running the saved configuration.",
+  reverted:
+    "This agent could not apply the saved configuration and rolled back to the last one that worked. It is healthy and answering — but NOT with what is saved here.",
+  revert_failed:
+    "This agent could not apply the saved configuration AND could not roll back to the previous one. Its running state is unknown.",
+  no_previous:
+    "This agent could not apply the saved configuration and had no previously-working configuration to fall back to, so the service may not be running at all.",
+};
+
+// reverted is amber, not red: the daemon is up and serving. The other two are
+// rose because the service may be down or in an unknown state.
+const TONE: Record<ConfigApplyStatus, string> = {
+  ok: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400",
+  reverted: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  revert_failed: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+  no_previous: "bg-rose-500/15 text-rose-700 dark:text-rose-400",
+};
+
+export function ConfigApplyChip({
+  server,
+  className = "",
+}: {
+  server: Partial<ConfigApplyFields>;
+  className?: string;
+}) {
+  const status = server.config_apply_status;
+  if (!status || status === "ok") return null;
+
+  const when = server.config_apply_at
+    ? new Date(server.config_apply_at).toLocaleString()
+    : null;
+  const title = [
+    EXPLAIN[status],
+    server.config_apply_error
+      ? `\n\nAgent reported: ${server.config_apply_error}`
+      : "",
+    server.config_failed_etag
+      ? `\n\nRejected config: ${server.config_failed_etag}`
+      : "",
+    when ? `\n\nReported: ${when}` : "",
+  ].join("");
+
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-medium ${TONE[status]} ${className}`}
+      title={title}
+    >
+      {LABEL[status]}
+    </span>
+  );
+}
+
+/**
+ * Full-width version for a server-detail view, where there is room for the
+ * daemon's own error text.
+ *
+ * The chip's tooltip is fine for a list row but a tooltip is a poor place to
+ * put a multi-line `named-checkconf` failure — which is the one piece of
+ * information that actually tells the operator what to fix.
+ */
+export function ConfigApplyBanner({
+  server,
+}: {
+  server: Partial<ConfigApplyFields>;
+}) {
+  const status = server.config_apply_status;
+  if (!status || status === "ok") return null;
+
+  const tone =
+    status === "reverted"
+      ? "border-amber-600/40 bg-amber-500/10 text-amber-800 dark:text-amber-300"
+      : "border-rose-600/40 bg-rose-500/10 text-rose-800 dark:text-rose-300";
+
+  return (
+    <div className={`rounded border px-3 py-2 text-xs ${tone}`}>
+      <div className="font-medium">{LABEL[status]}</div>
+      <p className="mt-0.5 opacity-90">{EXPLAIN[status]}</p>
+      {server.config_apply_error && (
+        <pre className="mt-2 max-h-40 overflow-auto whitespace-pre-wrap break-all rounded bg-black/5 p-2 font-mono text-[11px] dark:bg-white/5">
+          {server.config_apply_error}
+        </pre>
+      )}
+      <div className="mt-1.5 flex flex-wrap gap-x-3 opacity-75">
+        {server.config_failed_etag && (
+          <span className="font-mono break-all">
+            rejected: {server.config_failed_etag}
+          </span>
+        )}
+        {server.config_apply_at && (
+          <span>
+            reported {new Date(server.config_apply_at).toLocaleString()}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4970,6 +4970,30 @@ export interface DNSPoolWrite {
   members?: DNSPoolMemberWrite[];
 }
 
+/**
+ * Last config-apply verdict an agent reported (#882).
+ *
+ * `null` means the agent has never reported one — a pre-#882 agent, or an
+ * agentless driver (Windows DNS, the cloud DNS providers, `technitium_api`)
+ * that has no apply loop at all. Render that as unknown, never as healthy.
+ */
+export type ConfigApplyStatus =
+  | "ok"
+  /** The saved config failed; the agent rolled back and is serving the previous one. */
+  | "reverted"
+  /** The saved config failed AND the rollback failed. Running state unknown. */
+  | "revert_failed"
+  /** Failed with no previously-working config to fall back to. */
+  | "no_previous";
+
+/** Config-apply fields shared by DNS servers, DHCP servers and LG collectors. */
+export interface ConfigApplyFields {
+  config_apply_status: ConfigApplyStatus | null;
+  config_apply_error: string | null;
+  config_failed_etag: string | null;
+  config_apply_at: string | null;
+}
+
 export interface DNSServer {
   id: string;
   group_id: string;
@@ -5001,6 +5025,10 @@ export interface DNSServer {
    *  to identify which host an agent is on (the operator-set ``host``
    *  is just a label; doesn't reflect NAT / distributed deployments). */
   last_seen_ip: string | null;
+  config_apply_status: ConfigApplyStatus | null;
+  config_apply_error: string | null;
+  config_failed_etag: string | null;
+  config_apply_at: string | null;
   last_config_etag: string | null;
   pending_approval: boolean;
   is_primary: boolean;
@@ -7606,6 +7634,10 @@ export interface DHCPServer {
    *  to identify which host an agent runs on (the operator-set ``host``
    *  is just a label; doesn't reflect NAT / distributed deployments). */
   last_seen_ip: string | null;
+  config_apply_status: ConfigApplyStatus | null;
+  config_apply_error: string | null;
+  config_failed_etag: string | null;
+  config_apply_at: string | null;
   agent_version: string | null;
   config_etag: string | null;
   config_pushed_at: string | null;
@@ -15306,6 +15338,10 @@ export interface BGPLGCollector {
   agent_registered: boolean;
   agent_version: string | null;
   last_seen_ip: string | null;
+  config_apply_status: ConfigApplyStatus | null;
+  config_apply_error: string | null;
+  config_failed_etag: string | null;
+  config_apply_at: string | null;
   last_seen_at: string | null;
   last_health_check_at: string | null;
   appliance_id: string | null;

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -55,6 +55,7 @@ import { CreateServerGroupModal } from "./CreateServerGroupModal";
 import { CreateServerModal } from "./CreateServerModal";
 import { ServerDetailModal } from "./ServerDetailModal";
 import { PauseServerModal } from "@/components/ui/pause-server-modal";
+import { ConfigApplyChip } from "@/components/ConfigApplyChip";
 import { CreateScopeModal } from "./CreateScopeModal";
 import { CreateClientClassModal } from "./CreateClientClassModal";
 import { CreateOptionTemplateModal } from "./CreateOptionTemplateModal";
@@ -1016,6 +1017,7 @@ function GroupServersList({
                           Maintenance
                         </span>
                       )}
+                      <ConfigApplyChip server={s} />
                     </div>
                     <p className="text-xs text-muted-foreground truncate">
                       <span className="font-mono">

--- a/frontend/src/pages/dhcp/ServerDetailModal.tsx
+++ b/frontend/src/pages/dhcp/ServerDetailModal.tsx
@@ -27,6 +27,7 @@ import {
 import { Modal } from "@/components/ui/modal";
 import { PauseServerModal } from "@/components/ui/pause-server-modal";
 import { formatBucket } from "@/lib/chart-time";
+import { ConfigApplyBanner } from "@/components/ConfigApplyChip";
 import {
   dhcpApi,
   logsApi,
@@ -250,6 +251,10 @@ function OverviewTab({ server }: { server: DHCPServer }) {
       : (server.last_sync_at ?? server.agent_last_seen);
   return (
     <div className="space-y-4">
+      {/* #882 — above the status grid on purpose: every field below reports
+          healthy while the agent is running a config the operator never
+          approved, so this has to be the first thing read. */}
+      <ConfigApplyBanner server={server} />
       <div className="grid grid-cols-2 gap-3">
         <InfoCard label="Status" value={server.status}>
           <StatusDot status={server.status} />

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -41,6 +41,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { ConfigApplyChip } from "@/components/ConfigApplyChip";
 import { TagFilterChips } from "@/components/TagFilterChips";
 import { PropagationCheckModal } from "./PropagationCheckModal";
 import { BlocklistCatalogModal } from "./BlocklistCatalogModal";
@@ -4527,6 +4528,7 @@ function ServersTab({ group }: { group: DNSServerGroup }) {
                       Maintenance
                     </span>
                   )}
+                  <ConfigApplyChip server={s} />
                 </div>
                 <p className="text-xs text-muted-foreground">
                   {s.host}:{s.port}

--- a/frontend/src/pages/dns/ServerDetailModal.tsx
+++ b/frontend/src/pages/dns/ServerDetailModal.tsx
@@ -31,6 +31,7 @@ import {
 import { Modal } from "@/components/ui/modal";
 import { formatBucket } from "@/lib/chart-time";
 import { PauseServerModal } from "@/components/ui/pause-server-modal";
+import { ConfigApplyBanner } from "@/components/ConfigApplyChip";
 import {
   dnsApi,
   logsApi,
@@ -262,6 +263,10 @@ function OverviewTab({
 }) {
   return (
     <div className="space-y-4">
+      {/* #882 — above the status grid on purpose: every field below reports
+          healthy while the agent is running a config the operator never
+          approved, so this has to be the first thing read. */}
+      <ConfigApplyBanner server={server} />
       <div className="grid grid-cols-2 gap-3">
         <OverviewInfo server={server} />
       </div>

--- a/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
+++ b/frontend/src/pages/network/looking-glass/LookingGlassPage.tsx
@@ -7,6 +7,7 @@ import { lookingGlassApi, type BGPLGPeer } from "@/lib/api";
 import { HeaderButton } from "@/components/ui/header-button";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { cn } from "@/lib/utils";
+import { ConfigApplyBanner } from "@/components/ConfigApplyChip";
 
 import { PeerFormModal, SessionsTab } from "./SessionsTab";
 import { RoutesTab } from "./RoutesTab";
@@ -183,6 +184,22 @@ export function LookingGlassPage() {
       </div>
 
       <div className="flex-1 overflow-auto p-6">
+        {/* #882 — a collector whose peer set failed to render keeps running on
+            the previous one, so its sessions look healthy while the peers the
+            operator added are simply absent. There is no collector list to
+            hang a per-row chip on, so surface it above the tab content. */}
+        {collectors
+          .filter(
+            (c) => c.config_apply_status && c.config_apply_status !== "ok",
+          )
+          .map((c) => (
+            <div key={c.id} className="mb-4">
+              <div className="mb-1 text-xs font-medium text-muted-foreground">
+                Collector “{c.name}”
+              </div>
+              <ConfigApplyBanner server={c} />
+            </div>
+          ))}
         {tab === "sessions" ? (
           <SessionsTab
             collectors={collectors}


### PR DESCRIPTION
Closes #882

Non-negotiable #5's on-disk cache protects against a **dead** control plane. This closes the other half: a **wrong** one — a bundle that parses fine but renders config the daemon rejects.

All three agents (DNS / DHCP / looking-glass) gain `config_apply.py`: an `ApplyStatus` reported on the heartbeat, and a persisted `Quarantine` so a failed etag is not re-applied on every poll. The long-poll's 12 s wake tick plus 2 s fallback made a bad bundle a re-render *loop* rather than one failure; the agent now parks on the failing etag (the long-poll then blocks on a 304, costing nothing) and retries on a 60 s → 5 min → 15 min ladder so a *transient* failure still self-heals.

## The rotation was the actual bug

`previous.json` was written on every **fetch**, so it meant "the bundle before this one" rather than "the last one that worked" — the same thing only while every apply succeeds, which is the case it does not exist for. It also destroyed the fallback in two poll cycles: a failing bundle leaves the etag unadvanced, so the next poll re-fetches the *same* bundle and rotates it, now known-bad, over the only good config on disk.

`previous` is now written by an explicit `commit_config` that **refuses to run if `current` is not the bundle that applied**.

## Phased apply

Apply is phased (render → validate → swap/reload) and the phase picks the recovery:

- **BIND** validates into `rendered.new`, so a `named-checkconf` failure never reached `named`. Re-rendering the previous bundle there would bounce a healthy daemon to reach the state it is already in.
- **Kea** is the mirror image: `config-test` rejects without touching the running server, but the refused document is already at `kea_config_path`, which is what Kea reads on its next start — so that path always rewrites the files.

Only Kea's `rejected` is a verdict about the config. `socket-unreachable` is not, and reverting there would discard a good bundle because Kea happened to be restarting.

## Four latent bugs found on the way

All of the "written, never read" class the #899 audit named:

1. **`daemon` and `config` were declared on the DNS + DHCP heartbeat request models and read by neither handler** — the degraded verdict the agents already computed was discarded at the door. The LG agent's `daemon_status` was set by its sync loop and never even put on the wire.
2. **A config Kea *refused* was reported as a success**: the loop advanced its etag, called `_record_success()`, logged `dhcp_config_applied` and stamped the Kubernetes readiness marker.
3. **`named-checkconf` writes its diagnostics — with the line number — to stdout**, and `validate()` read only stderr, so the message was always `"named-checkconf failed: "` with nothing after it. Harmless while the text went nowhere; it is now the operator's only explanation.
4. **Supervisor audit** (issue part 5): `maybe_fire_console_mode` bypassed `_fire_host_config`, so the console-mode plane had none of #387's protections. A failing `spatiumddi-verbose-boot-reload` left the applied sidecar unchanged, the next heartbeat rewrote the trigger, its rename re-fired the `.path` unit, and it repeated every ~30 s **forever** with nothing reported upward. That runner's three failure paths also left the trigger in place — the #550 pattern, unfixed there.

## Why reporting matters more than it sounds

A reverted agent keeps serving and keeps heartbeating, so `status`, the health check and `last_seen_at` all read normal while the saved zone or scope is live **nowhere**. The verdict lands on `{dns_server,dhcp_server,looking_glass_collector}.config_apply_*` (migration `e9c2d47b1a63`, partial index over the failing states only) and drives:

- a server-row chip + a detail-view banner
- the default-**on** `agent_config_rejected` alert rule — severity from the agent's own verdict (`reverted` warning; `revert_failed` / `no_previous` critical)
- 1 MCP tool, `find_agents_with_config_failures`

`NULL` means UNKNOWN, never `ok`: an agent too old to report is exactly where a silent revert would hide.

## Verification

End-to-end against the live BIND9 agent (fault injected via an undefined ACL in `allow_query`):

- rejected at `validate` with `daemon_disturbed: false`, quarantined, reverted — and `dig` confirmed BIND kept answering throughout
- reported as `named-checkconf failed: …/named.conf:20: undefined ACL 'another-undefined-acl-name'`
- a container restart logged `bootstrap_skipping_quarantined_bundle` and booted last-known-good instead of re-breaking itself
- restoring the config recovered to `ok` and cleared the error + failed etag

Suites: DNS agent 268 passed, DHCP agent 134, supervisor 304, backend `test_agent_config_apply_status.py` 11, plus a 109-test regression sweep over the touched areas. `make ci` green.

## Deferred

- The `tz-status` / `verbose-boot-status` sidecars carry a failure **reason** nothing reads; `host_config_health` reports only *that* a plane is unapplied.
- `DNSServerOptions.allow_query` is interpolated into `named.conf` unvalidated — a third instance of the #876/#899 class. Used deliberately here as the E2E fault-injection lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)