### PR TITLE
feat(auth): enrolment QR code when minting an API token (#906)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,15 @@ jobs:
       - name: TypeScript check
         run: npm run typecheck
 
+      # #906 — the frontend had no test runner at all. Added with the
+      # enrolment QR because that code is verified by DECODING what it
+      # renders: a transposed row/column or an inverted polarity produces a
+      # QR that looks perfectly normal and scans as nothing, which no amount
+      # of review or type-checking catches. Lives in this job rather than a
+      # new one so it reuses the install above — the suite is <1 s.
+      - name: Vitest
+        run: npm test
+
   frontend-build:
     name: Frontend — Build
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -830,6 +830,42 @@ suggestion, free-space treemap.
   already complete enough to build against. The app itself now lives in its
   own repo, **[spatiumddi/spatiumddi-mobile](https://github.com/spatiumddi/spatiumddi-mobile)**;
   what remains here is the server side of that split. **Still open:** the app.
+  - ✅ [**Enrolment QR code when minting an API token**](https://github.com/spatiumddi/spatiumddi/issues/906)
+    — the reveal-token modal renders a QR in two shapes: the bare token, or
+    `spatiumddi://enrol?host=…&port=…&scheme=…&token=…&fingerprint=…`, both
+    of which the mobile client already parses (so the URI is a **contract
+    with another repo**, not a local convention). Typing a token across
+    devices was the worst step in mobile sign-in, and worse than annoying:
+    an operator who cannot paste cleanly emails it to themselves.
+    **The fingerprint is the point.** A self-hosted control plane presents a
+    private-CA or self-signed cert, so the client must ask the operator to
+    confirm it — and comparing 64 hex characters by eye on a phone is
+    exactly the check people skim. Scanned from inside an authenticated
+    session, the comparison becomes machine-checked.
+    `GET /api/v1/api-tokens/enrolment-context` answers **only** when
+    SpatiumDDI owns TLS termination (an active `ApplianceCertificate`);
+    on Compose / plain-k8s an external proxy holds a cert this process has
+    never seen, so it returns `null` with a reason rather than guessing — a
+    fingerprint disagreeing with the wire would make the client report a
+    mismatch on a *correct* setup, training operators to click through the
+    one warning the feature exists to make meaningful. **The connection
+    comes from `window.location`, not the server**, which behind a proxy or
+    split DNS does not know its own external address; the operator can
+    correct it, since a laptop on a VPN and a handset on wifi disagree
+    routinely. QR hidden behind an explicit reveal and not mounted until
+    then — it makes the credential *camera-readable*, which the masked
+    string is not. **No new MCP tool**: `find_certificates` already returns
+    `fingerprint_sha256`, so a second surface would be redundant (explicit
+    decision per non-negotiable #13); no feature module, since this extends
+    an existing resource rather than adding a top-level family.
+    **This is also where the frontend got its first test runner.** vitest
+    was added because the QR is verified by *decoding what it renders* (via
+    `jsqr`, dev-only): a transposed row/column or inverted polarity yields a
+    code that looks perfectly normal and scans as nothing, which neither
+    review nor `tsc` can catch. Cross-checked once against ZXing and segno
+    during development. 25 frontend + 7 backend tests; `npm test` runs in
+    the existing Frontend Lint CI job. Ships `qrcode-generator` (MIT, zero
+    deps, +10 kB gzip).
   - ✅ [**Publish `openapi.json` as a release asset**](https://github.com/spatiumddi/spatiumddi/issues/903)
     — with the app out of this repo the schema stops being a file a client
     reads off the working tree and becomes the contract *between two repos*,

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ ci-backend-lint:
 
 ci-frontend-lint:
 	@echo "→ Frontend — Lint & Type Check"
-	cd $(FRONTEND_DIR) && npm run lint && npm run format:check && npm run typecheck
+	cd $(FRONTEND_DIR) && npm run lint && npm run format:check && npm run typecheck && npm test
 
 ci-frontend-build:
 	@echo "→ Frontend — Build"

--- a/NOTICE
+++ b/NOTICE
@@ -154,6 +154,7 @@ Where the two disagree about a license, THIS file is authoritative.
 - react-markdown / remark-gfm — MIT — https://github.com/remarkjs/react-markdown
 - dnd-kit — MIT — https://dndkit.com
 - clsx / tailwind-merge — MIT — https://github.com/lukeed/clsx
+- qrcode-generator (device-enrolment QR codes) — MIT — https://github.com/kazuhikoarase/qrcode-generator
 - nginx (frontend static serving + agent landing) — BSD 2-Clause — https://nginx.org
 
 This list covers the major bundled / shipped components; it is not an

--- a/backend/app/api/v1/api_tokens/router.py
+++ b/backend/app/api/v1/api_tokens/router.py
@@ -34,6 +34,7 @@ from sqlalchemy import delete, select
 from app.api.deps import DB, CurrentUser
 from app.core.permissions import is_effective_superadmin, user_has_permission
 from app.core.security import generate_api_token
+from app.models.appliance import ApplianceCertificate
 from app.models.audit import AuditLog
 from app.models.auth import APIToken
 from app.models.dns import DNSZone
@@ -186,6 +187,30 @@ def _resolve_expiry(body: ApiTokenCreate) -> datetime | None:
     return None
 
 
+class EnrolmentContext(BaseModel):
+    """What the web UI needs to build a device-enrolment QR code (#906).
+
+    Only the certificate fingerprint. The connection itself (host / port /
+    scheme) deliberately does NOT come from here: behind a reverse proxy,
+    split DNS or NAT the server does not know its own externally-reachable
+    address, and it would guess wrong on exactly the deployments this feature
+    is most useful for. The browser knows the address the operator actually
+    reached it on, so the UI starts from ``window.location`` and lets the
+    operator correct it — a laptop on a VPN and a handset on wifi routinely
+    disagree about how to reach the same server.
+    """
+
+    #: SHA-256 of the leaf certificate SpatiumDDI serves, bare lower-case hex,
+    #: or ``None`` when the server does not know what it presents.
+    tls_fingerprint_sha256: str | None
+    #: Where the fingerprint came from, so the UI can say so rather than
+    #: asserting a provenance it cannot support. ``None`` when there is none.
+    fingerprint_source: str | None
+    #: Why there is no fingerprint, for the UI to explain the absence instead
+    #: of silently dropping the strongest half of the enrolment code.
+    fingerprint_unavailable_reason: str | None
+
+
 # ── Endpoints ──────────────────────────────────────────────────────────────
 
 
@@ -263,6 +288,72 @@ async def create_token(
         "created_at": token.created_at,
         "token": raw,
     }
+
+
+@router.get("/enrolment-context", response_model=EnrolmentContext)
+async def enrolment_context(db: DB, current_user: CurrentUser) -> EnrolmentContext:
+    """Certificate fingerprint for the enrolment QR code (#906).
+
+    Gated on ``CurrentUser`` only, matching ``create_token`` — anyone who can
+    mint a token for themselves can build a code for it. That is not a
+    weakening: a TLS fingerprint is not a secret, it is what the server hands
+    to every client that connects, and anyone able to reach the port can
+    compute it without asking.
+
+    **Why the fingerprint is worth carrying.** A self-hosted control plane
+    generally presents a certificate from a private CA or the appliance's own
+    root, so the client has to ask the operator to confirm it. Comparing 64
+    hex characters by eye on a phone is precisely the check people skim. Put
+    the fingerprint in the code the operator scans from inside an
+    authenticated session and the comparison becomes machine-checked.
+
+    Reported ONLY when SpatiumDDI actually owns the TLS termination — i.e.
+    there is an active ``ApplianceCertificate``, which is the row deployed to
+    the TLS secret the frontend serves. On a Compose or plain-Kubernetes
+    install an external proxy or ingress terminates TLS with a certificate
+    this process has never seen, and there is no row: the honest answer is
+    ``None``, not a guess. A fingerprint that does not match the wire would
+    make the client report a mismatch on a correct setup, which trains
+    operators to click through the one warning this exists to make meaningful.
+    """
+    # Route ordering: this is declared BEFORE ``GET /{token_id}`` on purpose.
+    # FastAPI matches in registration order, so a later declaration would be
+    # shadowed by the UUID path param and 422 on the literal segment.
+    del current_user  # auth-only dependency; the answer is not per-user
+
+    row = (
+        (
+            await db.execute(
+                select(ApplianceCertificate)
+                .where(ApplianceCertificate.is_active.is_(True))
+                .limit(1)
+            )
+        )
+        .scalars()
+        .first()
+    )
+
+    if row is None or not row.fingerprint_sha256:
+        return EnrolmentContext(
+            tls_fingerprint_sha256=None,
+            fingerprint_source=None,
+            fingerprint_unavailable_reason=(
+                "SpatiumDDI does not manage the TLS certificate for this "
+                "deployment, so it cannot state what clients are served. "
+                "Verify the fingerprint out of band."
+            ),
+        )
+
+    # Normalise to bare lower-case hex. The stored value has carried colons
+    # historically depending on which path wrote it, and the enrolment format
+    # specifies hex with colons optional — emitting one canonical form keeps
+    # the client's comparison a string equality.
+    fingerprint = row.fingerprint_sha256.replace(":", "").strip().lower()
+    return EnrolmentContext(
+        tls_fingerprint_sha256=fingerprint,
+        fingerprint_source=row.source,
+        fingerprint_unavailable_reason=None,
+    )
 
 
 @router.get("/{token_id}", response_model=ApiTokenResponse)

--- a/backend/tests/test_api_token_enrolment_context.py
+++ b/backend/tests/test_api_token_enrolment_context.py
@@ -1,0 +1,144 @@
+"""Enrolment context for the device QR code (#906).
+
+The QR carries the control plane's own TLS fingerprint so the mobile client
+can machine-check the certificate it is offered, instead of asking the
+operator to compare 64 hex characters by eye on a phone — the check people
+skim.
+
+That only works if the fingerprint is right. The interesting behaviour is
+therefore the REFUSAL: on a deployment where an external proxy or ingress
+terminates TLS with a certificate this process has never seen, the honest
+answer is "I don't know", not a guess. A wrong fingerprint would make the
+client report a mismatch on a correct setup, which teaches operators to click
+through the one warning this feature exists to make meaningful.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.appliance import ApplianceCertificate
+from app.models.auth import User
+
+_URL = "/api/v1/api-tokens/enrolment-context"
+
+
+async def _user(db: AsyncSession) -> tuple[User, dict[str, str]]:
+    user = User(
+        username=f"enrol-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.test",
+        display_name="Enrolment User",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db.add(user)
+    await db.flush()
+    return user, {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+
+
+async def _cert(db: AsyncSession, *, fingerprint: str | None, active: bool = True) -> None:
+    db.add(
+        ApplianceCertificate(
+            name=f"c-{uuid.uuid4().hex[:6]}",
+            source="self-signed",
+            key_encrypted=b"\x00",
+            is_active=active,
+            subject_cn="ddi.test",
+            sans_json=[],
+            fingerprint_sha256=fingerprint,
+        )
+    )
+    await db.flush()
+
+
+async def test_reports_nothing_when_spatiumddi_does_not_manage_tls(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The Compose / plain-Kubernetes case: no managed certificate exists.
+
+    Must say so rather than guess — see the module docstring.
+    """
+    _, headers = await _user(db_session)
+    body = (await client.get(_URL, headers=headers)).json()
+    assert body["tls_fingerprint_sha256"] is None
+    assert body["fingerprint_source"] is None
+    assert body["fingerprint_unavailable_reason"]
+
+
+async def test_reports_the_active_certificate_fingerprint(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    _, headers = await _user(db_session)
+    await _cert(db_session, fingerprint="AB" * 32)
+
+    body = (await client.get(_URL, headers=headers)).json()
+    assert body["tls_fingerprint_sha256"] == "ab" * 32
+    assert body["fingerprint_source"] == "self-signed"
+    assert body["fingerprint_unavailable_reason"] is None
+
+
+async def test_normalises_the_stored_colon_form_to_bare_lower_hex(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Stored fingerprints have carried colons or not depending on which path
+    wrote them. The enrolment format specifies hex with colons optional, so
+    emitting one canonical form keeps the client's comparison a string
+    equality rather than a parse."""
+    _, headers = await _user(db_session)
+    await _cert(db_session, fingerprint=":".join(["AB"] * 32))
+
+    body = (await client.get(_URL, headers=headers)).json()
+    assert body["tls_fingerprint_sha256"] == "ab" * 32
+
+
+async def test_ignores_an_inactive_certificate(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Only the ACTIVE row is deployed to the TLS secret the frontend serves,
+    so an old or superseded certificate must not be advertised as what
+    clients will be offered."""
+    _, headers = await _user(db_session)
+    await _cert(db_session, fingerprint="CD" * 32, active=False)
+
+    body = (await client.get(_URL, headers=headers)).json()
+    assert body["tls_fingerprint_sha256"] is None
+
+
+async def test_ignores_a_pending_csr_row_with_no_fingerprint(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A CSR awaiting the operator's signed certificate is active-but-unusable:
+    its cert-derived fields are null."""
+    _, headers = await _user(db_session)
+    await _cert(db_session, fingerprint=None)
+
+    body = (await client.get(_URL, headers=headers)).json()
+    assert body["tls_fingerprint_sha256"] is None
+    assert body["fingerprint_unavailable_reason"]
+
+
+async def test_requires_authentication(client: AsyncClient) -> None:
+    assert (await client.get(_URL)).status_code == 401
+
+
+async def test_does_not_shadow_the_token_by_id_route(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``/enrolment-context`` is a literal segment sharing a prefix with
+    ``GET /{token_id}``. FastAPI matches in registration order, so declaring
+    it second would make the UUID param swallow it and 422 the literal."""
+    _, headers = await _user(db_session)
+    created = await client.post(
+        "/api/v1/api-tokens", headers=headers, json={"name": "enrol-route-test"}
+    )
+    assert created.status_code == 201
+    token_id = created.json()["id"]
+
+    assert (await client.get(_URL, headers=headers)).status_code == 200
+    by_id = await client.get(f"/api/v1/api-tokens/{token_id}", headers=headers)
+    assert by_id.status_code == 200
+    assert by_id.json()["id"] == token_id

--- a/docs/features/AUTH.md
+++ b/docs/features/AUTH.md
@@ -411,6 +411,73 @@ list without leaking entropy to an observer.
 The raw value is returned exactly once from `POST /api/v1/api-tokens`
 and never again — losing it means creating a new token.
 
+### Device enrolment QR code (issue #906)
+
+The only way to get a token onto a phone used to be typing or pasting
+it between devices. That is the worst step in the mobile sign-in flow,
+and worse than merely annoying: an operator who cannot paste cleanly
+emails the token to themselves or reads it aloud, and the credential
+ends up somewhere it should never have been.
+
+The reveal-token modal therefore offers a QR code in two shapes:
+
+| Shape | Payload |
+|---|---|
+| **Token only** | the bare token string — no format needed |
+| **Server + token** | `spatiumddi://enrol?host=…&port=…&scheme=…&token=…&fingerprint=…` |
+
+The enrolment URI is a **contract with the mobile client**
+([spatiumddi-mobile](https://github.com/spatiumddi/spatiumddi-mobile)),
+which already parses both shapes. `port` is omitted when it is the
+scheme default, and `scheme` only appears when it is `http` — being
+explicit about the insecure case is the right way round, since a code
+that silently downgrades is the failure worth preventing. IPv6 hosts
+are bracketed so the client cannot reparse them as `host:port`. The
+builder lives in `frontend/src/lib/enrolment.ts`.
+
+**The connection comes from the browser, not the server.** Behind a
+reverse proxy, split DNS or NAT the control plane does not know its own
+externally-reachable address, and would guess wrong on exactly the
+deployments this is most useful for. The UI starts from
+`window.location` and lets the operator correct it — a laptop on a VPN
+and a handset on wifi routinely disagree about how to reach one server.
+
+**Why the fingerprint is the interesting part.** A self-hosted control
+plane usually presents a certificate from a private CA or the
+appliance's own root, so the client has to ask the operator to confirm
+it rather than blanket-trusting an unknown certificate. Comparing 64
+hex characters by eye on a phone is precisely the check people skim.
+Putting the fingerprint in a code the operator scans from inside an
+authenticated session makes that comparison machine-checked — the
+weakest step in the trust flow becomes the strongest, for one query
+parameter.
+
+`GET /api/v1/api-tokens/enrolment-context` supplies it, gated on
+authentication only (matching token creation — a TLS fingerprint is not
+a secret; it is what the server hands every client that connects).
+It answers **only** when SpatiumDDI actually owns the TLS termination,
+i.e. there is an active `ApplianceCertificate` — the row deployed to
+the TLS secret the frontend serves. On a Compose or plain-Kubernetes
+install an external proxy terminates TLS with a certificate this
+process has never seen, and the honest answer is `null` with a reason,
+not a guess: a fingerprint that disagrees with the wire would make the
+client report a mismatch on a *correct* setup, training operators to
+click through the one warning this exists to make meaningful. The UI
+also lets the operator untick certificate pinning for the case where
+something in front of SpatiumDDI re-terminates TLS.
+
+**Exposure.** The QR is hidden behind an explicit reveal, like the
+token text beside it, and is not rendered into the DOM until then. That
+is not decoration: a QR makes the credential *camera-readable*, so it
+is strictly easier to capture over a shoulder — or from a screen-share
+— than the masked string. The code carries no exposure the displayed
+token does not, but it is easier to capture at a distance.
+
+Short-lived enrolment codes would be better still: if minting ever
+moves to a device-token grant, the QR could carry a single-use code and
+the token would never leave the server. The URI format above does not
+preclude that.
+
 **Validation path.** `app/api/deps.py:get_current_user` checks for the
 `sddi_` prefix first; if present it hashes the bearer, looks the row
 up by hash, enforces `is_active` and `expires_at`, then loads the

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^1.19.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
+        "qrcode-generator": "^2.0.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -35,12 +36,14 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
         "globals": "^15.12.0",
+        "jsqr": "^1.4.0",
         "postcss": "^8.5.26",
         "prettier": "^3.4.2",
         "tailwindcss": "^3.4.16",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.15.0",
-        "vite": "^8.2.1"
+        "vite": "^8.2.1",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1294,6 +1297,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -1355,6 +1368,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1728,6 +1747,112 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "dev": true,
@@ -1822,6 +1947,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -2023,6 +2157,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "dev": true,
@@ -2159,6 +2302,12 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "1.1.1",
@@ -2430,6 +2579,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -2637,6 +2792,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -2649,6 +2813,15 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3200,6 +3373,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "dev": true
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
@@ -3528,6 +3707,15 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-table": {
@@ -4459,6 +4647,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -4556,6 +4757,12 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4774,6 +4981,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/qrcode-generator": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-2.0.4.tgz",
+      "integrity": "sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g=="
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5224,6 +5436,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
@@ -5239,6 +5457,18 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
     },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
@@ -5393,6 +5623,21 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -5432,6 +5677,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -5844,6 +6098,107 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -5856,6 +6211,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",
@@ -21,6 +23,7 @@
     "axios": "^1.19.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
+    "qrcode-generator": "^2.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
@@ -41,11 +44,13 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
     "globals": "^15.12.0",
+    "jsqr": "^1.4.0",
     "postcss": "^8.5.26",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.15.0",
-    "vite": "^8.2.1"
+    "vite": "^8.2.1",
+    "vitest": "^4.1.11"
   }
 }

--- a/frontend/src/components/QrCode.tsx
+++ b/frontend/src/components/QrCode.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import { buildQrMatrix, type QrLevel } from "@/lib/qr";
+import { cn } from "@/lib/utils";
 
 /**
  * QR code rendered as inline SVG (issue #906).
@@ -35,7 +36,40 @@ export function QrCode({
   className,
   title = "QR code",
 }: QrCodeProps) {
-  const matrix = useMemo(() => buildQrMatrix(value, level), [value, level]);
+  // `buildQrMatrix` throws when the payload exceeds what a QR code can hold
+  // (qrcode-generator: "code length overflow"). Letting that escape a render
+  // unwinds to the app-level ErrorBoundary and takes the whole page with it —
+  // and this component's one caller is the reveal-once token modal, so a
+  // crash there loses a credential that can never be shown again.
+  const result = useMemo(() => {
+    try {
+      return { matrix: buildQrMatrix(value, level) };
+    } catch (err) {
+      return {
+        error:
+          err instanceof Error && err.message
+            ? err.message
+            : "This value is too long to encode as a QR code.",
+      };
+    }
+  }, [value, level]);
+
+  if (!result.matrix) {
+    return (
+      <div
+        role="img"
+        aria-label={title}
+        className={cn(
+          "flex items-center justify-center rounded-md border border-dashed p-3 text-center text-xs text-muted-foreground",
+          className,
+        )}
+        style={{ width: size, height: size }}
+      >
+        {result.error}
+      </div>
+    );
+  }
+  const matrix = result.matrix;
 
   return (
     <svg

--- a/frontend/src/components/QrCode.tsx
+++ b/frontend/src/components/QrCode.tsx
@@ -1,0 +1,61 @@
+import { useMemo } from "react";
+
+import { buildQrMatrix, type QrLevel } from "@/lib/qr";
+
+/**
+ * QR code rendered as inline SVG (issue #906).
+ *
+ * SVG rather than a canvas or a data-URI `<img>`: it stays sharp at any size
+ * and on any DPI, which matters because the thing reading it is a handheld
+ * camera at an arbitrary distance and angle. It also needs no `img-src data:`
+ * in the CSP.
+ *
+ * The matrix construction lives in `@/lib/qr` so it can be tested.
+ */
+
+export interface QrCodeProps {
+  value: string;
+  /** Rendered edge length in px. The matrix scales to fit. */
+  size?: number;
+  /**
+   * Error-correction level. `M` (~15% recoverable) is the default because
+   * these are read off a screen rather than a scuffed sticker, and a higher
+   * level costs modules — which makes an already-long enrolment URI denser
+   * and *harder* to scan, the opposite of the intent.
+   */
+  level?: QrLevel;
+  className?: string;
+  title?: string;
+}
+
+export function QrCode({
+  value,
+  size = 224,
+  level = "M",
+  className,
+  title = "QR code",
+}: QrCodeProps) {
+  const matrix = useMemo(() => buildQrMatrix(value, level), [value, level]);
+
+  return (
+    <svg
+      // The viewBox is in MODULE units with the quiet zone inside it, so the
+      // margin scales with the code rather than being a CSS afterthought a
+      // parent's padding could eat.
+      viewBox={`0 0 ${matrix.extent} ${matrix.extent}`}
+      width={size}
+      height={size}
+      className={className}
+      role="img"
+      aria-label={title}
+      shapeRendering="crispEdges"
+    >
+      <title>{title}</title>
+      {/* Explicit white ground. A QR code inheriting a dark-mode background
+          is unscannable, so these render light-on-white whatever theme the
+          operator is using. */}
+      <rect width={matrix.extent} height={matrix.extent} fill="#ffffff" />
+      <path d={matrix.d} fill="#000000" />
+    </svg>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9361,8 +9361,26 @@ export interface ApiTokenUpdate {
   scopes?: ApiTokenScope[];
 }
 
+/**
+ * What the enrolment QR code needs that only the server can answer (#906).
+ *
+ * Just the certificate fingerprint — the connection itself comes from
+ * `window.location`, because behind a proxy or split DNS the server does not
+ * know its own externally-reachable address.
+ */
+export interface EnrolmentContext {
+  /** Bare lower-case hex, or null when the server does not manage its TLS. */
+  tls_fingerprint_sha256: string | null;
+  fingerprint_source: string | null;
+  fingerprint_unavailable_reason: string | null;
+}
+
 export const apiTokensApi = {
   list: () => api.get<ApiToken[]>("/api-tokens").then((r) => r.data),
+  enrolmentContext: () =>
+    api
+      .get<EnrolmentContext>("/api-tokens/enrolment-context")
+      .then((r) => r.data),
   create: (body: ApiTokenCreate) =>
     api.post<ApiTokenCreated>("/api-tokens", body).then((r) => r.data),
   update: (id: string, body: ApiTokenUpdate) =>

--- a/frontend/src/lib/enrolment.test.ts
+++ b/frontend/src/lib/enrolment.test.ts
@@ -13,6 +13,7 @@ import {
   displayFingerprint,
   formatHost,
   isDefaultPort,
+  isValidPort,
   normaliseFingerprint,
 } from "./enrolment";
 
@@ -115,6 +116,22 @@ describe("buildEnrolmentUri", () => {
     });
     expect(uri).not.toContain("#");
     expect(params(uri).get("token")).toBe(token);
+  });
+
+  it("refuses a port that is not a real port number", () => {
+    // The port arrives from a free-text field via `Number(...)`, which answers
+    // NaN for anything unparseable. Emitting it would put a literal
+    // ``port=NaN`` in the code, which fails on the phone — where the operator
+    // has no way to see what went wrong.
+    for (const port of [NaN, 0, -1, 70000, 8443.5]) {
+      expect(() =>
+        buildEnrolmentUri({ host: "h", port, scheme: "https" }),
+      ).toThrow();
+    }
+    expect(isValidPort(1)).toBe(true);
+    expect(isValidPort(65535)).toBe(true);
+    expect(isValidPort(65536)).toBe(false);
+    expect(isValidPort(NaN)).toBe(false);
   });
 
   it("refuses to build without a host", () => {

--- a/frontend/src/lib/enrolment.test.ts
+++ b/frontend/src/lib/enrolment.test.ts
@@ -1,0 +1,220 @@
+/**
+ * The enrolment URI is parsed by a shipped client in another repo
+ * (spatiumddi-mobile), so these tests pin a CONTRACT rather than an
+ * implementation detail. A change that breaks one of them breaks scanning
+ * on a device nobody in this repo can see.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEnrolmentUri,
+  connectionFromLocation,
+  displayFingerprint,
+  formatHost,
+  isDefaultPort,
+  normaliseFingerprint,
+} from "./enrolment";
+
+const FP = "a".repeat(64);
+
+function params(uri: string): URLSearchParams {
+  expect(uri.startsWith("spatiumddi://enrol?")).toBe(true);
+  return new URLSearchParams(uri.slice("spatiumddi://enrol?".length));
+}
+
+describe("buildEnrolmentUri", () => {
+  it("carries host, token and fingerprint", () => {
+    const p = params(
+      buildEnrolmentUri({
+        host: "ddi.internal.example",
+        port: 8443,
+        scheme: "https",
+        token: "sddi_abc123",
+        fingerprint: FP,
+      }),
+    );
+    expect(p.get("host")).toBe("ddi.internal.example");
+    expect(p.get("port")).toBe("8443");
+    expect(p.get("token")).toBe("sddi_abc123");
+    expect(p.get("fingerprint")).toBe(FP);
+  });
+
+  it("omits the port when it is the scheme default", () => {
+    expect(
+      params(buildEnrolmentUri({ host: "h", port: 443, scheme: "https" })).has(
+        "port",
+      ),
+    ).toBe(false);
+    expect(
+      params(buildEnrolmentUri({ host: "h", port: 80, scheme: "http" })).has(
+        "port",
+      ),
+    ).toBe(false);
+    // …but a non-default port on either scheme is carried.
+    expect(
+      params(buildEnrolmentUri({ host: "h", port: 80, scheme: "https" })).get(
+        "port",
+      ),
+    ).toBe("80");
+  });
+
+  it("states the scheme only when it is http", () => {
+    // https is the assumed default; being explicit about the INSECURE case is
+    // the right way round, since a code that silently downgrades is the
+    // failure worth preventing.
+    expect(
+      params(buildEnrolmentUri({ host: "h", port: null, scheme: "https" })).has(
+        "scheme",
+      ),
+    ).toBe(false);
+    expect(
+      params(buildEnrolmentUri({ host: "h", port: null, scheme: "http" })).get(
+        "scheme",
+      ),
+    ).toBe("http");
+  });
+
+  it("omits token and fingerprint when absent — a server-only code", () => {
+    const p = params(
+      buildEnrolmentUri({ host: "h", port: null, scheme: "https" }),
+    );
+    expect(p.has("token")).toBe(false);
+    expect(p.has("fingerprint")).toBe(false);
+  });
+
+  it("brackets an IPv6 literal so it cannot be reparsed as host:port", () => {
+    const p = params(
+      buildEnrolmentUri({ host: "2001:db8::1", port: 8443, scheme: "https" }),
+    );
+    expect(p.get("host")).toBe("[2001:db8::1]");
+    expect(p.get("port")).toBe("8443");
+  });
+
+  it("does not double-bracket an already-bracketed literal", () => {
+    expect(
+      params(
+        buildEnrolmentUri({
+          host: "[2001:db8::1]",
+          port: null,
+          scheme: "https",
+        }),
+      ).get("host"),
+    ).toBe("[2001:db8::1]");
+  });
+
+  it("escapes reserved characters rather than truncating the URI", () => {
+    // A token is opaque; if one ever contained '&' or '#', naive
+    // concatenation would silently drop everything after it.
+    const token = "sddi_a&b#c d";
+    const uri = buildEnrolmentUri({
+      host: "h",
+      port: null,
+      scheme: "https",
+      token,
+    });
+    expect(uri).not.toContain("#");
+    expect(params(uri).get("token")).toBe(token);
+  });
+
+  it("refuses to build without a host", () => {
+    expect(() =>
+      buildEnrolmentUri({ host: "  ", port: null, scheme: "https" }),
+    ).toThrow();
+  });
+});
+
+describe("normaliseFingerprint", () => {
+  it("accepts bare hex and the colon form, normalising to bare lower-case", () => {
+    const colons = displayFingerprint(FP);
+    expect(normaliseFingerprint(colons)).toBe(FP);
+    expect(normaliseFingerprint(FP.toUpperCase())).toBe(FP);
+    expect(normaliseFingerprint(`  ${FP}  `)).toBe(FP);
+  });
+
+  it("rejects anything that is not 32 hex bytes", () => {
+    // Rejecting matters more than it looks: a malformed fingerprint would
+    // make the client report a mismatch against a certificate that is in
+    // fact correct, training the operator to click through the one warning
+    // this feature exists to make meaningful.
+    expect(normaliseFingerprint("")).toBeNull();
+    expect(normaliseFingerprint(null)).toBeNull();
+    expect(normaliseFingerprint("a".repeat(63))).toBeNull();
+    expect(normaliseFingerprint("a".repeat(65))).toBeNull();
+    expect(normaliseFingerprint("z".repeat(64))).toBeNull();
+    expect(normaliseFingerprint("sha256:" + FP)).toBeNull();
+  });
+
+  it("keeps a malformed fingerprint out of the URI entirely", () => {
+    const p = params(
+      buildEnrolmentUri({
+        host: "h",
+        port: null,
+        scheme: "https",
+        fingerprint: "nonsense",
+      }),
+    );
+    expect(p.has("fingerprint")).toBe(false);
+  });
+});
+
+describe("connectionFromLocation", () => {
+  it("reads scheme, host and explicit port from the browser's own URL", () => {
+    expect(
+      connectionFromLocation({
+        protocol: "https:",
+        hostname: "ddi.example",
+        port: "8443",
+      } as Location),
+    ).toEqual({ scheme: "https", host: "ddi.example", port: 8443 });
+  });
+
+  it("reports a scheme-default port as null, not as an empty string", () => {
+    expect(
+      connectionFromLocation({
+        protocol: "https:",
+        hostname: "h",
+        port: "",
+      } as Location),
+    ).toEqual({ scheme: "https", host: "h", port: null });
+  });
+
+  it("treats anything that is not http: as https", () => {
+    expect(
+      connectionFromLocation({
+        protocol: "http:",
+        hostname: "h",
+        port: "",
+      } as Location).scheme,
+    ).toBe("http");
+    expect(
+      connectionFromLocation({
+        protocol: "https:",
+        hostname: "h",
+        port: "",
+      } as Location).scheme,
+    ).toBe("https");
+  });
+});
+
+describe("helpers", () => {
+  it("formatHost leaves hostnames and IPv4 untouched", () => {
+    expect(formatHost("ddi.example")).toBe("ddi.example");
+    expect(formatHost("192.0.2.10")).toBe("192.0.2.10");
+    expect(formatHost(" ddi.example ")).toBe("ddi.example");
+  });
+
+  it("isDefaultPort treats null as the default", () => {
+    expect(isDefaultPort("https", null)).toBe(true);
+    expect(isDefaultPort("https", 443)).toBe(true);
+    expect(isDefaultPort("https", 8443)).toBe(false);
+    expect(isDefaultPort("http", 80)).toBe(true);
+  });
+
+  it("displayFingerprint groups into colon-separated upper-case bytes", () => {
+    const shown = displayFingerprint(FP);
+    expect(shown).toBe(Array(32).fill("AA").join(":"));
+    // …and round-trips back to the wire form.
+    expect(normaliseFingerprint(shown)).toBe(FP);
+  });
+});

--- a/frontend/src/lib/enrolment.ts
+++ b/frontend/src/lib/enrolment.ts
@@ -1,0 +1,156 @@
+/**
+ * Enrolment URI for the native client (issue #906).
+ *
+ * The mobile client (spatiumddi-mobile) already parses this format, so the
+ * shape below is a CONTRACT, not a local convention — see #906 for the
+ * canonical table. Changing a parameter name here breaks a shipped parser in
+ * another repo.
+ *
+ *   spatiumddi://enrol?host=…&port=…&scheme=…&token=…&fingerprint=…
+ *
+ * | param       | required | notes                                        |
+ * |-------------|----------|----------------------------------------------|
+ * | host        | yes      | hostname or IP literal (v4 or v6)            |
+ * | port        | no       | omitted when it is the scheme default        |
+ * | scheme      | no       | https assumed; http must be explicit         |
+ * | token       | no       | omit for a code that only configures a server|
+ * | fingerprint | no       | SHA-256 of the leaf cert, hex, colons optional|
+ *
+ * Everything here is pure so it can be tested without a DOM; the connection
+ * details come from the browser (see `connectionFromLocation`) because the
+ * address the operator actually reached the server on is the only thing
+ * either side reliably knows. The server behind a proxy does not know its
+ * own external URL, and would guess wrong on exactly the split-DNS and NAT
+ * deployments this is most useful for.
+ */
+
+export type EnrolmentScheme = "https" | "http";
+
+export interface EnrolmentConnection {
+  host: string;
+  /** `null` means "the scheme default", which is what gets omitted. */
+  port: number | null;
+  scheme: EnrolmentScheme;
+}
+
+export interface EnrolmentPayload extends EnrolmentConnection {
+  token?: string | null;
+  fingerprint?: string | null;
+}
+
+export const ENROLMENT_SCHEME = "spatiumddi";
+export const ENROLMENT_ACTION = "enrol";
+
+const DEFAULT_PORTS: Record<EnrolmentScheme, number> = {
+  https: 443,
+  http: 80,
+};
+
+/** A SHA-256 hex digest, with or without the conventional colon separators. */
+const FINGERPRINT_RE = /^[0-9a-f]{2}(:?[0-9a-f]{2}){31}$/i;
+
+/**
+ * Strip separators and lower-case a SHA-256 fingerprint.
+ *
+ * Returns `null` for anything that is not 32 hex bytes. Rejecting rather than
+ * passing the value through matters: a malformed fingerprint in the QR would
+ * make the client report a mismatch against a certificate that is in fact
+ * correct, and an operator taught to click through that warning is worse off
+ * than one who was never offered the check.
+ */
+export function normaliseFingerprint(
+  value: string | null | undefined,
+): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!FINGERPRINT_RE.test(trimmed)) return null;
+  return trimmed.replace(/:/g, "").toLowerCase();
+}
+
+/**
+ * Is this host an IPv6 literal?
+ *
+ * Deliberately loose — anything containing a colon that is not a bracketed
+ * form. A hostname cannot contain a colon, so a colon means either an IPv6
+ * literal or garbage, and both want bracketing so the result is at least
+ * unambiguous rather than silently reparsed as host:port by the client.
+ */
+export function isIPv6Literal(host: string): boolean {
+  return host.includes(":") && !host.startsWith("[");
+}
+
+/** Bracket an IPv6 literal; leave hostnames and IPv4 alone. */
+export function formatHost(host: string): string {
+  const bare = host.trim().replace(/^\[|\]$/g, "");
+  return isIPv6Literal(bare) ? `[${bare}]` : bare;
+}
+
+export function isDefaultPort(
+  scheme: EnrolmentScheme,
+  port: number | null,
+): boolean {
+  return port === null || port === DEFAULT_PORTS[scheme];
+}
+
+/**
+ * Read the connection the operator is currently using.
+ *
+ * `window.location` is authoritative for "the address this browser reached
+ * the server on" — which is the best available starting point, though not
+ * necessarily the address the PHONE can reach (a laptop on a VPN and a
+ * handset on wifi routinely disagree). The caller is expected to let the
+ * operator correct it before the code is generated.
+ */
+export function connectionFromLocation(loc: Location): EnrolmentConnection {
+  const scheme: EnrolmentScheme = loc.protocol === "http:" ? "http" : "https";
+  // ``loc.port`` is "" when the URL used the scheme default. ``loc.hostname``
+  // already strips the brackets from an IPv6 literal.
+  const port = loc.port ? Number(loc.port) : null;
+  return { host: loc.hostname, port, scheme };
+}
+
+/**
+ * Build the enrolment URI.
+ *
+ * Uses `URLSearchParams` rather than hand-rolled concatenation so a token or
+ * hostname containing a reserved character is escaped rather than silently
+ * truncating the URI at the offending byte.
+ */
+export function buildEnrolmentUri(payload: EnrolmentPayload): string {
+  const host = formatHost(payload.host);
+  if (!host) throw new Error("host is required to build an enrolment URI");
+
+  const params = new URLSearchParams();
+  params.set("host", host);
+  // Omit the port when it is the scheme default, per the format table — a
+  // redundant ``port=443`` is not wrong, but the client shows the operator
+  // what it parsed and the shorter form is the one they can eyeball.
+  if (!isDefaultPort(payload.scheme, payload.port)) {
+    params.set("port", String(payload.port));
+  }
+  // ``https`` is the assumed default, so only ``http`` needs stating. Being
+  // explicit about the insecure case is the right way round: a code that
+  // silently downgrades is the failure mode worth preventing.
+  if (payload.scheme === "http") {
+    params.set("scheme", "http");
+  }
+  if (payload.token) {
+    params.set("token", payload.token);
+  }
+  const fingerprint = normaliseFingerprint(payload.fingerprint);
+  if (fingerprint) {
+    params.set("fingerprint", fingerprint);
+  }
+  return `${ENROLMENT_SCHEME}://${ENROLMENT_ACTION}?${params.toString()}`;
+}
+
+/**
+ * Group a hex fingerprint into colon-separated bytes for display.
+ *
+ * The wire form is bare hex; this is only for showing an operator something
+ * they can compare against what their browser's certificate viewer reports,
+ * which uses the colon form.
+ */
+export function displayFingerprint(hex: string): string {
+  return (hex.match(/.{2}/g) ?? []).join(":").toUpperCase();
+}

--- a/frontend/src/lib/enrolment.ts
+++ b/frontend/src/lib/enrolment.ts
@@ -85,6 +85,19 @@ export function formatHost(host: string): string {
   return isIPv6Literal(bare) ? `[${bare}]` : bare;
 }
 
+/**
+ * Is this port a real TCP port number?
+ *
+ * `null` (meaning "the scheme default") is handled by `isDefaultPort`; this
+ * only judges a stated one. Worth checking rather than trusting: the value
+ * arrives from a free-text field via `Number(...)`, which answers `NaN` for
+ * anything unparseable and would otherwise reach the URI as a literal
+ * ``port=NaN`` that the client cannot parse.
+ */
+export function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+
 export function isDefaultPort(
   scheme: EnrolmentScheme,
   port: number | null,
@@ -104,7 +117,9 @@ export function isDefaultPort(
 export function connectionFromLocation(loc: Location): EnrolmentConnection {
   const scheme: EnrolmentScheme = loc.protocol === "http:" ? "http" : "https";
   // ``loc.port`` is "" when the URL used the scheme default. ``loc.hostname``
-  // already strips the brackets from an IPv6 literal.
+  // KEEPS the brackets on an IPv6 literal (the WHATWG host serialiser emits
+  // ``[::1]``), which is why `formatHost` strips before re-bracketing rather
+  // than bracketing blindly.
   const port = loc.port ? Number(loc.port) : null;
   return { host: loc.hostname, port, scheme };
 }
@@ -118,7 +133,12 @@ export function connectionFromLocation(loc: Location): EnrolmentConnection {
  */
 export function buildEnrolmentUri(payload: EnrolmentPayload): string {
   const host = formatHost(payload.host);
-  if (!host) throw new Error("host is required to build an enrolment URI");
+  if (!host) throw new Error("Enter the address this server is reachable at.");
+  if (payload.port !== null && !isValidPort(payload.port)) {
+    // Refusing beats emitting: an unparseable ``port=NaN`` in the code fails
+    // on the phone, where the operator has no way to see what went wrong.
+    throw new Error("Port must be a number between 1 and 65535.");
+  }
 
   const params = new URLSearchParams();
   params.set("host", host);

--- a/frontend/src/lib/qr.test.ts
+++ b/frontend/src/lib/qr.test.ts
@@ -75,6 +75,15 @@ describe("buildQrMatrix round-trips through a real decoder", () => {
     expect(decode(uri)).toBe(uri);
   });
 
+  it("decodes a non-ASCII payload as UTF-8, not truncated to latin1", () => {
+    // qrcode-generator's DEFAULT byte encoder is ``charCodeAt(i) & 0xff``,
+    // which mangles anything outside latin1 and reports no error — the exact
+    // silent corruption this file exists to catch. `qr.ts` installs a
+    // TextEncoder-backed one; without it this decodes to mojibake.
+    const value = "münchen.example — ✓";
+    expect(decode(value)).toBe(value);
+  });
+
   it("decodes the longest payload this feature can produce", () => {
     // A worst case: long hostname, non-default port, explicit http, a token
     // and a fingerprint. If the version bump this forces were mishandled the

--- a/frontend/src/lib/qr.test.ts
+++ b/frontend/src/lib/qr.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The QR render is verified by DECODING it, not by eyeballing it.
+ *
+ * The encoding comes from `qrcode-generator` and is not the part worth
+ * doubting. What needed pinning is everything this repo wrote on top: a
+ * transposed row/column, an inverted polarity, or a missing quiet zone all
+ * produce a code that looks entirely plausible on screen and scans as
+ * nothing at all. There is no way to catch that by looking.
+ *
+ * `jsqr` is an independent decoder (dev-only — it is never bundled), so a
+ * round-trip through it proves the rendered modules are a real QR code of
+ * the intended payload. Cross-checked once during development against
+ * ZXing, which agreed.
+ */
+
+import jsQR from "jsqr";
+import { describe, expect, it } from "vitest";
+
+import { buildEnrolmentUri } from "./enrolment";
+import { QUIET_ZONE, buildQrMatrix } from "./qr";
+
+/**
+ * Rasterise a matrix exactly as `QrCode` renders it — quiet zone included,
+ * dark modules black on a white ground — into the RGBA buffer jsQR wants.
+ */
+function rasterise(value: string, scale = 4) {
+  const m = buildQrMatrix(value);
+  const side = m.extent * scale;
+  const data = new Uint8ClampedArray(side * side * 4).fill(255);
+  for (let row = 0; row < m.count; row++) {
+    for (let col = 0; col < m.count; col++) {
+      if (!m.isDark(row, col)) continue;
+      for (let dy = 0; dy < scale; dy++) {
+        for (let dx = 0; dx < scale; dx++) {
+          const x = (col + QUIET_ZONE) * scale + dx;
+          const y = (row + QUIET_ZONE) * scale + dy;
+          const i = (y * side + x) * 4;
+          data[i] = data[i + 1] = data[i + 2] = 0;
+        }
+      }
+    }
+  }
+  return { data, side, matrix: m };
+}
+
+function decode(value: string): string | null {
+  const { data, side } = rasterise(value);
+  return jsQR(data, side, side)?.data ?? null;
+}
+
+describe("buildQrMatrix round-trips through a real decoder", () => {
+  it("decodes a full enrolment URI with token and fingerprint", () => {
+    const uri = buildEnrolmentUri({
+      host: "ddi.internal.example",
+      port: 8443,
+      scheme: "https",
+      token: "sddi_R7xK2mQ4vB8nL1pS5tW9zC3jH6dF0gA",
+      fingerprint: "a1b2c3d4e5f6".repeat(5) + "abcd",
+    });
+    expect(decode(uri)).toBe(uri);
+  });
+
+  it("decodes a bare token", () => {
+    const token = "sddi_R7xK2mQ4vB8nL1pS5tW9zC3jH6dF0gA";
+    expect(decode(token)).toBe(token);
+  });
+
+  it("decodes an IPv6 host, which brackets and percent-encodes", () => {
+    const uri = buildEnrolmentUri({
+      host: "2001:db8::1",
+      port: 8443,
+      scheme: "https",
+      token: "sddi_abc",
+    });
+    expect(decode(uri)).toBe(uri);
+  });
+
+  it("decodes the longest payload this feature can produce", () => {
+    // A worst case: long hostname, non-default port, explicit http, a token
+    // and a fingerprint. If the version bump this forces were mishandled the
+    // code would still render — as an unscannable square.
+    const uri = buildEnrolmentUri({
+      host: `${"a".repeat(50)}.internal.example.com`,
+      port: 65535,
+      scheme: "http",
+      token: `sddi_${"Z9".repeat(32)}`,
+      fingerprint: "f".repeat(64),
+    });
+    expect(uri.length).toBeGreaterThan(180);
+    expect(decode(uri)).toBe(uri);
+  });
+});
+
+describe("matrix geometry", () => {
+  it("puts a 4-module quiet zone inside the viewBox extent", () => {
+    // Without a light margin scanners cannot find the finder patterns'
+    // outer edges, and the code silently stops working at a distance.
+    const m = buildQrMatrix("hello");
+    expect(QUIET_ZONE).toBe(4);
+    expect(m.extent).toBe(m.count + QUIET_ZONE * 2);
+  });
+
+  it("renders the three finder patterns dark-side-out", () => {
+    // Mask-invariant, so this holds for any payload — and it fails loudly if
+    // the polarity is ever inverted.
+    const m = buildQrMatrix("hello");
+    const RING = [
+      [1, 1, 1, 1, 1, 1, 1],
+      [1, 0, 0, 0, 0, 0, 1],
+      [1, 0, 1, 1, 1, 0, 1],
+      [1, 0, 1, 1, 1, 0, 1],
+      [1, 0, 1, 1, 1, 0, 1],
+      [1, 0, 0, 0, 0, 0, 1],
+      [1, 1, 1, 1, 1, 1, 1],
+    ];
+    const finderAt = (top: number, left: number) =>
+      RING.every((row, r) =>
+        row.every((want, c) => m.isDark(top + r, left + c) === (want === 1)),
+      );
+    expect(finderAt(0, 0)).toBe(true);
+    expect(finderAt(0, m.count - 7)).toBe(true);
+    expect(finderAt(m.count - 7, 0)).toBe(true);
+  });
+
+  it("emits one path segment per dark module, at (x=col, y=row)", () => {
+    // Swapping the pair mirrors the code along its diagonal — which still
+    // renders as a tidy square and scans as nothing.
+    const m = buildQrMatrix("hello");
+    let dark = 0;
+    for (let r = 0; r < m.count; r++) {
+      for (let c = 0; c < m.count; c++) if (m.isDark(r, c)) dark++;
+    }
+    expect(m.d.split("M").length - 1).toBe(dark);
+    // The top-left finder guarantees a dark module at (0,0), which must land
+    // at the quiet-zone offset in BOTH axes.
+    expect(m.d.startsWith(`M${QUIET_ZONE} ${QUIET_ZONE}h1v1h-1z`)).toBe(true);
+  });
+
+  it("grows the version to fit rather than truncating the payload", () => {
+    const small = buildQrMatrix("hi");
+    const large = buildQrMatrix("x".repeat(600));
+    expect(large.count).toBeGreaterThan(small.count);
+    expect(decode("x".repeat(600))).toBe("x".repeat(600));
+  });
+});

--- a/frontend/src/lib/qr.ts
+++ b/frontend/src/lib/qr.ts
@@ -1,0 +1,63 @@
+/**
+ * QR matrix → SVG path (issue #906).
+ *
+ * Split out of the component so it can be tested. The encoding itself comes
+ * from `qrcode-generator` (the Kazuhiko Arase implementation most other QR
+ * libraries derive from — MIT, zero dependencies) and is not the part worth
+ * doubting; what needed pinning is everything below it. A transposed
+ * row/column or an inverted dark/light polarity produces a code that looks
+ * entirely plausible on screen and scans as nothing at all, and there is no
+ * way to notice by eye.
+ */
+
+import qrcode from "qrcode-generator";
+
+export type QrLevel = "L" | "M" | "Q" | "H";
+
+/**
+ * Quiet zone in modules. The spec requires 4 and scanners genuinely need it —
+ * without a light margin they cannot locate the finder patterns' outer edges.
+ */
+export const QUIET_ZONE = 4;
+
+export interface QrMatrix {
+  /** SVG path data covering every dark module, in module units. */
+  d: string;
+  /** Edge length of the viewBox in module units, quiet zone included. */
+  extent: number;
+  /** Module count of the code itself, excluding the quiet zone. */
+  count: number;
+  /** `true` when the module at (row, col) is dark. Excludes the quiet zone. */
+  isDark: (row: number, col: number) => boolean;
+}
+
+export function buildQrMatrix(value: string, level: QrLevel = "M"): QrMatrix {
+  // typeNumber 0 = "smallest version that fits". An enrolment URI carrying a
+  // token and a fingerprint runs ~180 characters, landing around version 9;
+  // letting the library pick keeps the module count — and so the scanning
+  // difficulty — at the minimum the payload allows.
+  const qr = qrcode(0, level);
+  qr.addData(value);
+  qr.make();
+
+  const count = qr.getModuleCount();
+  // One path for every dark module rather than one <rect> each: a version-9
+  // code is 53x53, so this is one DOM node instead of several hundred.
+  const parts: string[] = [];
+  for (let row = 0; row < count; row++) {
+    for (let col = 0; col < count; col++) {
+      if (qr.isDark(row, col)) {
+        // x = col, y = row. Getting this pair the wrong way round mirrors the
+        // code along its diagonal, which still renders as a tidy square.
+        parts.push(`M${col + QUIET_ZONE} ${row + QUIET_ZONE}h1v1h-1z`);
+      }
+    }
+  }
+
+  return {
+    d: parts.join(""),
+    extent: count + QUIET_ZONE * 2,
+    count,
+    isDark: (row, col) => qr.isDark(row, col),
+  };
+}

--- a/frontend/src/lib/qr.ts
+++ b/frontend/src/lib/qr.ts
@@ -12,6 +12,17 @@
 
 import qrcode from "qrcode-generator";
 
+// qrcode-generator's default byte encoder is ``charCodeAt(i) & 0xff`` — it
+// truncates anything outside latin1 instead of encoding it, so a non-ASCII
+// payload would produce a code that decodes to mojibake with no error at all.
+// The library ships a 'UTF-8' encoder, but ONLY in its CommonJS build; the
+// ESM build the bundler actually resolves does not register it, so supply one.
+// Every payload this repo builds today is ASCII (``URLSearchParams``
+// percent-encodes, and a token is base64url), for which UTF-8 is byte
+// identical — this is about the next caller, since silent corruption is
+// exactly what `qr.test.ts` exists to catch.
+qrcode.stringToBytes = (s: string) => Array.from(new TextEncoder().encode(s));
+
 export type QrLevel = "L" | "M" | "Q" | "H";
 
 /**

--- a/frontend/src/pages/admin/ApiTokensPage.tsx
+++ b/frontend/src/pages/admin/ApiTokensPage.tsx
@@ -25,6 +25,7 @@ import {
   buildEnrolmentUri,
   connectionFromLocation,
   displayFingerprint,
+  normaliseFingerprint,
   type EnrolmentConnection,
 } from "@/lib/enrolment";
 import { QrCode } from "@/components/QrCode";
@@ -372,26 +373,43 @@ function EnrolmentQr({ token }: { token: ApiTokenCreated }) {
 
   // Only fetched once the operator opens the section — no reason to ask the
   // server about certificates for an operator who just wants to copy-paste.
-  const { data: ctx } = useQuery({
+  const {
+    data: ctx,
+    isLoading: ctxLoading,
+    isError: ctxError,
+  } = useQuery({
     queryKey: ["api-token-enrolment-context"],
     queryFn: apiTokensApi.enrolmentContext,
     enabled: shown,
     staleTime: 5 * 60 * 1000,
   });
 
-  const fingerprint = pinCert ? (ctx?.tls_fingerprint_sha256 ?? null) : null;
+  // ONE predicate for "there is a fingerprint we can pin", used by both the
+  // checkbox and the URI. Deriving them separately let the UI assert pinning
+  // was on — naming a fingerprint in the copy — while `buildEnrolmentUri`
+  // silently dropped a value `normaliseFingerprint` rejected.
+  const pinnable = normaliseFingerprint(ctx?.tls_fingerprint_sha256);
+  const fingerprint = pinCert ? pinnable : null;
 
   let payload: string | null = null;
   let buildError: string | null = null;
   if (mode === "token") {
     payload = token.token;
+  } else if (ctxLoading) {
+    // Hold the code back until we know whether it can carry a fingerprint.
+    // Rendering it first would paint a complete, scannable, silently UNPINNED
+    // enrolment code — and pinning is the whole point of this shape.
+    buildError = "Checking this server's certificate…";
   } else {
     try {
       payload = buildEnrolmentUri({ ...conn, token: token.token, fingerprint });
-    } catch {
-      // The only way this throws is an empty host, which the operator can
-      // see and fix in the field right below.
-      buildError = "Enter the address this server is reachable at.";
+    } catch (err) {
+      // An empty host or a port that isn't a number — both are visible in the
+      // fields right below, so surface what the builder actually objected to.
+      buildError =
+        err instanceof Error && err.message
+          ? err.message
+          : "Enter the address this server is reachable at.";
     }
   }
 
@@ -481,12 +499,12 @@ function EnrolmentQr({ token }: { token: ApiTokenCreated }) {
             <input
               className={inputCls}
               value={conn.port ?? ""}
-              onChange={(e) =>
-                setConn({
-                  ...conn,
-                  port: e.target.value ? Number(e.target.value) : null,
-                })
-              }
+              onChange={(e) => {
+                // Digits only. `Number("8443/")` is NaN, which would reach the
+                // URI as a literal ``port=NaN`` the client cannot parse.
+                const digits = e.target.value.replace(/\D/g, "").slice(0, 5);
+                setConn({ ...conn, port: digits ? Number(digits) : null });
+              }}
               placeholder="port"
               inputMode="numeric"
               aria-label="Port"
@@ -507,7 +525,7 @@ function EnrolmentQr({ token }: { token: ApiTokenCreated }) {
             </select>
           </div>
 
-          {ctx?.tls_fingerprint_sha256 ? (
+          {pinnable ? (
             <label className="flex items-start gap-2 text-[11px] text-muted-foreground">
               <input
                 type="checkbox"
@@ -519,16 +537,22 @@ function EnrolmentQr({ token }: { token: ApiTokenCreated }) {
                 Pin this server&apos;s certificate — the app verifies what it is
                 offered against{" "}
                 <code className="break-all font-mono text-[10px]">
-                  {displayFingerprint(ctx.tls_fingerprint_sha256)}
+                  {displayFingerprint(pinnable)}
                 </code>
                 . Untick if something in front of SpatiumDDI re-terminates TLS,
                 since the app would then report a mismatch on a correct setup.
               </span>
             </label>
           ) : (
+            // A failed lookup must not read as a still-loading one: both leave
+            // the code unpinned, and only one of them is going to change.
             <p className="text-[11px] text-muted-foreground">
-              {ctx?.fingerprint_unavailable_reason ??
-                "Checking whether this server can pin its certificate…"}
+              {ctxLoading
+                ? "Checking whether this server can pin its certificate…"
+                : ctxError
+                  ? "Couldn't check this server's certificate, so the code below carries no fingerprint — the app will ask you to confirm the certificate by hand."
+                  : (ctx?.fingerprint_unavailable_reason ??
+                    "This server cannot state the certificate it presents, so the code below carries no fingerprint.")}
             </p>
           )}
         </div>

--- a/frontend/src/pages/admin/ApiTokensPage.tsx
+++ b/frontend/src/pages/admin/ApiTokensPage.tsx
@@ -1,6 +1,15 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Copy, Eye, EyeOff, Plus, Power, PowerOff, Trash2 } from "lucide-react";
+import {
+  Copy,
+  Eye,
+  EyeOff,
+  Plus,
+  Power,
+  PowerOff,
+  QrCode as QrCodeIcon,
+  Trash2,
+} from "lucide-react";
 import {
   apiTokensApi,
   API_TOKEN_SCOPES,
@@ -12,6 +21,13 @@ import {
   type ApiTokenScope,
 } from "@/lib/api";
 import { copyToClipboard } from "@/lib/clipboard";
+import {
+  buildEnrolmentUri,
+  connectionFromLocation,
+  displayFingerprint,
+  type EnrolmentConnection,
+} from "@/lib/enrolment";
+import { QrCode } from "@/components/QrCode";
 import { cn, zebraBodyCls } from "@/lib/utils";
 import { Modal } from "@/components/ui/modal";
 
@@ -322,6 +338,212 @@ function CreateTokenModal({
 }
 
 // ── Reveal-once Modal ──────────────────────────────────────────────────────
+// ── Device enrolment QR (issue #906) ───────────────────────────────────────
+//
+// Typing or pasting a token across devices is the worst step in the mobile
+// sign-in flow, and it is worse than annoying: an operator who cannot paste
+// cleanly emails the token to themselves or reads it aloud, and the
+// credential ends up somewhere it should never have been.
+//
+// Two payload shapes, per #906:
+//
+//   Token only    the bare token string — needs no format, works today
+//   Server+token  spatiumddi://enrol?host=…&token=…&fingerprint=…
+//
+// The enrolment form is the interesting one because of the fingerprint. A
+// self-hosted control plane usually presents a private-CA or self-signed
+// certificate, so the client must ask the operator to confirm it — and
+// comparing 64 hex characters by eye on a phone is exactly the check people
+// skim. Carrying the fingerprint in a code scanned from inside an
+// authenticated session turns that into a machine-checked comparison.
+//
+// The whole block is hidden behind an explicit reveal, matching the token
+// text above it. That is not decoration: a QR makes the credential
+// CAMERA-readable, so it is strictly easier to capture over a shoulder — or
+// from a screen-share — than the masked string beside it.
+
+function EnrolmentQr({ token }: { token: ApiTokenCreated }) {
+  const [shown, setShown] = useState(false);
+  const [mode, setMode] = useState<"enrol" | "token">("enrol");
+  const [conn, setConn] = useState<EnrolmentConnection>(() =>
+    connectionFromLocation(window.location),
+  );
+  const [pinCert, setPinCert] = useState(true);
+
+  // Only fetched once the operator opens the section — no reason to ask the
+  // server about certificates for an operator who just wants to copy-paste.
+  const { data: ctx } = useQuery({
+    queryKey: ["api-token-enrolment-context"],
+    queryFn: apiTokensApi.enrolmentContext,
+    enabled: shown,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const fingerprint = pinCert ? (ctx?.tls_fingerprint_sha256 ?? null) : null;
+
+  let payload: string | null = null;
+  let buildError: string | null = null;
+  if (mode === "token") {
+    payload = token.token;
+  } else {
+    try {
+      payload = buildEnrolmentUri({ ...conn, token: token.token, fingerprint });
+    } catch {
+      // The only way this throws is an empty host, which the operator can
+      // see and fix in the field right below.
+      buildError = "Enter the address this server is reachable at.";
+    }
+  }
+
+  if (!shown) {
+    return (
+      <button
+        type="button"
+        onClick={() => setShown(true)}
+        className="flex w-full items-center justify-center gap-2 rounded-md border border-dashed px-3 py-2 text-xs text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+      >
+        <QrCodeIcon className="h-3.5 w-3.5" />
+        Show enrolment QR code for the mobile app
+      </button>
+    );
+  }
+
+  return (
+    <div className="space-y-3 rounded-md border p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="inline-flex rounded-md border p-0.5 text-xs">
+          <button
+            type="button"
+            onClick={() => setMode("enrol")}
+            className={cn(
+              "rounded px-2 py-1",
+              mode === "enrol"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            Server + token
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("token")}
+            className={cn(
+              "rounded px-2 py-1",
+              mode === "token"
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            Token only
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShown(false)}
+          className="inline-flex items-center gap-1 rounded p-1 text-xs text-muted-foreground hover:bg-background hover:text-foreground"
+          title="Hide the QR code"
+        >
+          <EyeOff className="h-3.5 w-3.5" />
+          Hide
+        </button>
+      </div>
+
+      <div className="rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-[11px] text-amber-700 dark:text-amber-300">
+        This code contains the token. Anything with a camera pointed at this
+        screen can read it — don&apos;t show it on a shared screen or a call.
+      </div>
+
+      <div className="flex justify-center">
+        {payload ? (
+          <QrCode value={payload} size={216} title="Device enrolment QR code" />
+        ) : (
+          <div className="flex h-[216px] w-[216px] items-center justify-center rounded-md border border-dashed text-center text-xs text-muted-foreground">
+            {buildError}
+          </div>
+        )}
+      </div>
+
+      {mode === "enrol" && (
+        <div className="space-y-2">
+          <p className="text-[11px] text-muted-foreground">
+            Pre-filled from the address <em>this browser</em> used. Correct it
+            if the phone reaches the server differently — a laptop on a VPN and
+            a handset on wifi often disagree.
+          </p>
+          <div className="grid grid-cols-[1fr_5rem_5.5rem] gap-2">
+            <input
+              className={inputCls}
+              value={conn.host}
+              onChange={(e) => setConn({ ...conn, host: e.target.value })}
+              placeholder="ddi.internal.example"
+              aria-label="Host"
+            />
+            <input
+              className={inputCls}
+              value={conn.port ?? ""}
+              onChange={(e) =>
+                setConn({
+                  ...conn,
+                  port: e.target.value ? Number(e.target.value) : null,
+                })
+              }
+              placeholder="port"
+              inputMode="numeric"
+              aria-label="Port"
+            />
+            <select
+              className={inputCls}
+              value={conn.scheme}
+              onChange={(e) =>
+                setConn({
+                  ...conn,
+                  scheme: e.target.value === "http" ? "http" : "https",
+                })
+              }
+              aria-label="Scheme"
+            >
+              <option value="https">https</option>
+              <option value="http">http</option>
+            </select>
+          </div>
+
+          {ctx?.tls_fingerprint_sha256 ? (
+            <label className="flex items-start gap-2 text-[11px] text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={pinCert}
+                onChange={(e) => setPinCert(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>
+                Pin this server&apos;s certificate — the app verifies what it is
+                offered against{" "}
+                <code className="break-all font-mono text-[10px]">
+                  {displayFingerprint(ctx.tls_fingerprint_sha256)}
+                </code>
+                . Untick if something in front of SpatiumDDI re-terminates TLS,
+                since the app would then report a mismatch on a correct setup.
+              </span>
+            </label>
+          ) : (
+            <p className="text-[11px] text-muted-foreground">
+              {ctx?.fingerprint_unavailable_reason ??
+                "Checking whether this server can pin its certificate…"}
+            </p>
+          )}
+        </div>
+      )}
+
+      {mode === "token" && (
+        <p className="text-center text-[11px] text-muted-foreground">
+          The token on its own. Use this if the app is already pointed at this
+          server.
+        </p>
+      )}
+    </div>
+  );
+}
+
 // Shown after a successful create. The raw token is NEVER retrievable
 // again so we force the operator to copy it, and close the modal only
 // after explicit confirmation.
@@ -398,6 +620,7 @@ function RevealTokenModal({
             Authorization: Bearer {token.prefix}…
           </code>
         </p>
+        <EnrolmentQr token={token} />
         <div className="flex justify-end gap-2 pt-1">
           <button
             onClick={onClose}


### PR DESCRIPTION
Closes #906

Getting a token onto a phone meant typing or pasting it across devices. That's the worst step in the mobile sign-in flow, and worse than merely annoying: an operator who can't paste cleanly emails the token to themselves or reads it aloud, and the credential ends up somewhere it should never have been.

The reveal-token modal now offers a QR in two shapes:

| Shape | Payload |
|---|---|
| **Token only** | the bare token string — no format needed, works today |
| **Server + token** | `spatiumddi://enrol?host=…&port=…&scheme=…&token=…&fingerprint=…` |

Both are already parsed by the client in [spatiumddi-mobile](https://github.com/spatiumddi/spatiumddi-mobile), so the URI is a **contract with another repo**, not a local convention. `port` is omitted at the scheme default; `scheme` appears only when it's `http` — being explicit about the *insecure* case is the right way round, since a code that silently downgrades is the failure worth preventing. IPv6 hosts are bracketed so the client can't reparse them as `host:port`.

## The fingerprint is the interesting half

A self-hosted control plane presents a private-CA or self-signed certificate, so the client has to ask the operator to confirm it rather than blanket-trusting an unknown one. Comparing 64 hex characters by eye on a phone is exactly the check people skim. Scanned from inside an authenticated session, that comparison becomes machine-checked.

`GET /api/v1/api-tokens/enrolment-context` supplies it, gated on authentication only — matching token creation. That isn't a weakening: a TLS fingerprint is not a secret, it's what the server hands every client that connects, and anyone who can reach the port can compute it without asking.

**It answers only when SpatiumDDI actually owns the TLS termination** (an active `ApplianceCertificate` — the row deployed to the TLS secret the frontend serves). On Compose or plain Kubernetes an external proxy terminates TLS with a certificate this process has never seen, and the honest answer is `null` with a reason, not a guess. A fingerprint disagreeing with the wire would make the client report a mismatch on a *correct* setup, training operators to click through the one warning this exists to make meaningful. The UI can also untick pinning for the case where something in front re-terminates.

## The connection comes from the browser, not the server

Behind a proxy, split DNS or NAT the control plane doesn't know its own externally-reachable address, and would guess wrong on exactly the deployments this is most useful for. The UI starts from `window.location` and lets the operator correct it — a laptop on a VPN and a handset on wifi routinely disagree about how to reach one server.

## Exposure

The QR sits behind an explicit reveal and **is not mounted until then** (verified in-browser: zero matching elements before the click). A QR makes the credential *camera-readable*, so it's strictly easier to capture over a shoulder, or from a screen share, than the masked string beside it. It carries no exposure the displayed token doesn't — but it's easier to capture at a distance.

## This is where the frontend got its first test runner

Scope beyond the issue, flagged deliberately. vitest was added because **this code is verified by decoding what it renders**, via `jsqr` (dev-only, confirmed absent from the bundle). A transposed row/column or an inverted polarity produces a QR that looks entirely normal and scans as nothing — neither review nor `tsc` can catch that. Cross-checked during development against ZXing and segno. `npm test` runs in the existing Frontend Lint job (<1 s, reuses that job's install).

## Verification

Drove the real UI with Playwright and decoded the on-screen image with ZXing:

```
Server + token -> spatiumddi://enrol?host=localhost&port=8077&scheme=http&token=sddi_…
Token only     -> sddi_…
```

`scheme=http` correctly stated for the dev server; fingerprint correctly absent on Compose; QR confirmed absent from the DOM before reveal. 27 frontend + 7 backend tests, `make ci` green.

## Review findings (second commit)

Five defects, three of them ways the code on screen could be wrong without *looking* wrong:

- The enrol QR was painted before the enrolment-context query resolved, and a **failed** query was indistinguishable from a loading one — both left a complete, scannable, silently **unpinned** code on screen.
- The pin checkbox was gated on the fingerprint being truthy while the URI was gated on `normaliseFingerprint` accepting it, so a value failing the validator showed a ticked "pinning is on" checkbox over a QR carrying none.
- `qrcode-generator`'s ESM build encodes bytes as latin1 and never registers its own `'UTF-8'` encoder — verified directly, `stringToBytes("é")` returns `[233]` where UTF-8 is `[195,169]`. Harmless for today's ASCII payloads; fixed for the next caller.
- The port field ran `Number()` unvalidated, so `"8443/"` → `NaN` → a literal `port=NaN` the client can't parse.
- `buildQrMatrix` was unguarded in render; a payload past QR capacity would unwind to the app-level ErrorBoundary and destroy the reveal-once modal *along with a token that can never be shown again*.

## Decisions recorded

- **No new MCP tool** — `find_certificates` already returns `fingerprint_sha256`, so a second surface would be redundant (explicit call per non-negotiable #13).
- **No feature module** — this extends an existing resource rather than adding a top-level family.
- Ships `qrcode-generator` (MIT, zero dependencies, +10 kB gzip); NOTICE updated. All three new packages are at current latest, so Dependabot has nothing to raise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)