### PR TITLE
fix(api): publish an OpenAPI document a code generator can consume (#907)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -903,6 +903,61 @@ suggestion, free-space treemap.
     to `scripts/prune-release-assets.sh`**. The version handshake the issue
     wanted is `GET /api/v1/version` (unauthenticated), **not**
     `/health/platform`, which reports no version at all.
+  - ✅ [**The published document is consumable by a code generator**](https://github.com/spatiumddi/spatiumddi/issues/907)
+    — two defects found generating the Swift client against a running control
+    plane, both of which break a generated client *silently*: it compiles,
+    passes review, and is wrong. (1) FastAPI emits OpenAPI 3.1's nullable
+    idiom, `anyOf: [X, {"type": "null"}]`; a generator that cannot model the
+    `null` arm **skips the member — which drops the whole property from the
+    generated type**, with a warning rather than an error. Measured on this
+    document: 3,291 schema properties and 297 query parameters gone, including
+    `limit` on list endpoints, so the client could not paginate at all.
+    `app.openapi()` now states nullability the other way round
+    (`app/core/openapi_compat.py`): the plain schema, with the property out of
+    `required` — which is the half that carries it, since 971 of them were
+    nullable *and* required. **Request bodies keep their `required`**, though:
+    there it is not a description but what the server enforces, so publishing
+    a no-default `X | None` field as optional would have a generated client
+    omit a key and take a 422 (`ImportedZoneOut.soa`, the one schema in the
+    document used in both directions, got the default it should always have
+    had, and a test now fails loudly on the next one). **Deliberate trade, written down in `API.md`:**
+    the server still *sends* `null` rather than omitting the key, so a strict
+    response validator now sees an explicit null the schema no longer admits.
+    The alternative (`exclude_none` on responses) changes the wire for every
+    existing client to fix a documentation defect, and the validator complaint
+    is loud where the generated-code failure is silent. (2) Timestamps went
+    out as `datetime.isoformat()` — six fractional digits, or **none at all**
+    on a whole second, which is the nastier half: a decoder configured *for*
+    fractional seconds fails intermittently, depending on when a row happened
+    to be written. 6 of 7 endpoints a client called were undecodable, every
+    one of them a 200 OK. Now pinned to RFC 3339 with exactly three digits
+    (`app/core/json_datetime.py`), truncated not rounded. **The mechanism is
+    the interesting part**: the framework-blessed `Annotated[datetime,
+    PlainSerializer(...)]` means editing 714 annotations across 166 files and
+    trusting every future model to remember, `json_encoders` is deprecated and
+    gone in pydantic v3, and rewriting the rendered body means sniffing every
+    string in every response for something date-shaped — mutating opaque
+    operator data (a raw BIND query-log line carries a timestamp) and paying a
+    second traversal per request. So it wraps
+    `pydantic_core.core_schema.datetime_schema`, the one point every
+    `datetime` core schema is built through, from `app/__init__.py` — the only
+    import site that reliably beats the first model class, since isort would
+    reorder the equivalent line in `main.py` below the routers. `install()`
+    also patches FastAPI's own encoder table — ordered ahead of the stock
+    entry, because `datetime` subclasses a `date` whose encoder is registered
+    first — or the wire format would depend on whether a route declared a
+    `response_model`. Three response models (`AuditLogResponse`, `SessionRow`,
+    `UserResponse`) additionally carried their timestamps as **`str`** filled
+    by `isoformat()`, so they published with no `format: date-time` at all;
+    now declared `datetime` and serialised like everything else. **One trap found on the
+    way, worth more than the rest:** declaring the serialiser's obvious
+    `return_schema=str_schema()` rewrites the *serialisation* JSON schema —
+    which is the mode FastAPI publishes response models in — so every
+    `created_at` in the document silently lost `format: date-time`, trading a
+    decode failure for a client that never parses a date at all. Omitted, and
+    asserted in both schema modes. Tests assert on the **wire format**, never
+    on the patch: the regression worth catching is a future pydantic that
+    stops routing through that function.
 - ✅ [**Login banner**](https://github.com/spatiumddi/spatiumddi/issues/885) · [**custom logo**](https://github.com/spatiumddi/spatiumddi/issues/886) ·
   [**environment banner**](https://github.com/spatiumddi/spatiumddi/issues/887) · [**`app_title` wired up**](https://github.com/spatiumddi/spatiumddi/issues/888)
   — shipped together in PR

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,21 @@
+"""SpatiumDDI control-plane application package.
+
+Deliberately not empty: ``install()`` below has to run before the first
+pydantic model class in this package is created, and package ``__init__`` is
+the only import site that guarantees it. Python executes this module before
+any ``app.*`` submodule, in every entrypoint we have — uvicorn (``app.main``),
+the Celery worker and beat (``app.celery_app``), alembic's ``env.py``, the
+OpenAPI exporter and every test.
+
+Putting the call at the top of ``app/main.py`` instead would look equivalent
+and silently not be: isort sorts ``from app.core.json_datetime import …``
+after ``from app.api.v1.router import …``, so the routers — and every model
+they define — would already be imported by the time it ran.
+"""
+
+from app.core.json_datetime import install as _install_rfc3339_ms_timestamps
+
+# Issue #907: pin every JSON-serialised datetime to RFC 3339 with exactly
+# three fractional digits. See app/core/json_datetime.py for why this is a
+# schema-builder patch rather than 714 field annotations.
+_install_rfc3339_ms_timestamps()

--- a/backend/app/api/v1/audit/router.py
+++ b/backend/app/api/v1/audit/router.py
@@ -17,7 +17,12 @@ router = APIRouter(dependencies=[Depends(require_permission("read", "audit_log")
 
 class AuditLogResponse(BaseModel):
     id: str
-    timestamp: str
+    # A real ``datetime``, not a pre-formatted string (#907). Typed as ``str``
+    # it published as a bare ``type: string`` with no ``format: date-time`` —
+    # so a generated client read the API's most audit-relevant timestamp as
+    # text — and it went out in ``isoformat()``'s six-digit ``+00:00`` shape
+    # while every other timestamp in the API is millisecond ``Z``.
+    timestamp: datetime
     user_display_name: str
     auth_source: str
     action: str
@@ -32,13 +37,6 @@ class AuditLogResponse(BaseModel):
     @field_validator("id", mode="before")
     @classmethod
     def coerce_id(cls, v: object) -> str:
-        return str(v)
-
-    @field_validator("timestamp", mode="before")
-    @classmethod
-    def coerce_ts(cls, v: object) -> str:
-        if isinstance(v, datetime):
-            return v.isoformat()
         return str(v)
 
 

--- a/backend/app/api/v1/dns_import/router.py
+++ b/backend/app/api/v1/dns_import/router.py
@@ -87,7 +87,13 @@ class ImportedZoneOut(BaseModel):
     name: str
     zone_type: str
     kind: str
-    soa: ImportedSOAOut | None
+    # Defaulted, unlike its annotation alone would suggest, because this model
+    # is BOTH the preview response and the commit request payload (see
+    # ``PreviewOut``). Without a default pydantic makes the key mandatory on
+    # the way in, so the published contract had to say "required" — and a
+    # generated client then cannot express the null a zone with no SOA
+    # legitimately carries. Handled as None everywhere it is read (#907).
+    soa: ImportedSOAOut | None = None
     records: list[ImportedRecordOut]
     view_name: str | None = None
     forwarders: list[str] = Field(default_factory=list)

--- a/backend/app/api/v1/sessions/router.py
+++ b/backend/app/api/v1/sessions/router.py
@@ -48,9 +48,12 @@ class SessionRow(BaseModel):
     auth_source: str
     source_ip: str | None
     user_agent: str | None
-    created_at: str
-    last_seen_at: str | None
-    expires_at: str
+    # Real ``datetime``s (#907) — typed as strings these published without
+    # ``format: date-time`` and went out in a shape no other timestamp in the
+    # API uses.
+    created_at: datetime
+    last_seen_at: datetime | None
+    expires_at: datetime
     revoked: bool
     is_current: bool
 
@@ -71,9 +74,9 @@ def _row(
         auth_source=s.auth_source or "local",
         source_ip=s.source_ip,
         user_agent=s.user_agent,
-        created_at=s.created_at.isoformat(),
-        last_seen_at=s.last_seen_at.isoformat() if s.last_seen_at else None,
-        expires_at=s.expires_at.isoformat(),
+        created_at=s.created_at,
+        last_seen_at=s.last_seen_at,
+        expires_at=s.expires_at,
         revoked=bool(s.revoked),
         is_current=current_jti is not None and str(s.id) == current_jti,
     )

--- a/backend/app/api/v1/users/router.py
+++ b/backend/app/api/v1/users/router.py
@@ -45,13 +45,14 @@ class UserResponse(BaseModel):
     is_superadmin: bool
     force_password_change: bool
     auth_source: str
-    last_login_at: str | None = None
+    # Real ``datetime``s (#907); see the audit router for why.
+    last_login_at: datetime | None = None
     # Lockout state (issue #71). ``locked`` mirrors the live time
     # check so the UI doesn't have to compare timestamps in JS;
     # ``failed_login_count`` + ``failed_login_locked_until`` are
     # surfaced for triage / admin display.
     failed_login_count: int = 0
-    failed_login_locked_until: str | None = None
+    failed_login_locked_until: datetime | None = None
     locked: bool = False
 
     model_config = {"from_attributes": True}
@@ -60,11 +61,6 @@ class UserResponse(BaseModel):
     @classmethod
     def coerce_id(cls, v: object) -> str:
         return str(v)
-
-    @field_validator("last_login_at", "failed_login_locked_until", mode="before")
-    @classmethod
-    def coerce_dt(cls, v: object) -> str | None:
-        return v.isoformat() if v is not None else None
 
     @model_validator(mode="before")
     @classmethod

--- a/backend/app/core/json_datetime.py
+++ b/backend/app/core/json_datetime.py
@@ -78,9 +78,13 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-#: Guards ``_patch_pydantic`` against wrapping its own wrapper — ``install()``
-#: is safe to call from more than one entrypoint.
-_pydantic_patched = False
+#: Stamped on the wrapper so ``_patch_pydantic`` can recognise its own work.
+#: On the function rather than in a module-level flag because the question is
+#: "is ``core_schema`` already patched", not "has this module run" — the two
+#: differ if this module is ever imported twice under different names, and
+#: only the first one stops a wrapper wrapping a wrapper. Same shape as the
+#: encoder guard below, which asks its own target the same way.
+_PATCH_MARKER = "_spatium_rfc3339_ms"
 
 
 def to_rfc3339_ms(value: datetime) -> str:
@@ -130,13 +134,11 @@ def _patch_pydantic() -> None:
     more than it bought. Left absent, pydantic keeps the declared type's own
     schema and the serialiser still runs.
     """
-    global _pydantic_patched
-
     from pydantic_core import core_schema  # noqa: PLC0415 — patch target
 
-    if _pydantic_patched:
-        return
     build_datetime_schema = core_schema.datetime_schema
+    if getattr(build_datetime_schema, _PATCH_MARKER, False):
+        return
 
     def datetime_schema(*args: Any, **kwargs: Any) -> Any:
         schema = build_datetime_schema(*args, **kwargs)
@@ -149,8 +151,8 @@ def _patch_pydantic() -> None:
         )
         return schema
 
+    setattr(datetime_schema, _PATCH_MARKER, True)  # noqa: B010 — name is a constant
     core_schema.datetime_schema = datetime_schema  # type: ignore[assignment]
-    _pydantic_patched = True
 
 
 def _patch_fastapi_encoders() -> None:

--- a/backend/app/core/json_datetime.py
+++ b/backend/app/core/json_datetime.py
@@ -1,0 +1,189 @@
+"""RFC 3339 timestamps with a fixed millisecond precision (issue #907).
+
+Python's ``datetime.isoformat()`` — which is what pydantic's JSON serialiser
+and FastAPI's ``jsonable_encoder`` both reach for — emits *six* fractional
+digits, and omits the fraction entirely when the value happens to land on a
+whole second::
+
+    2026-05-14T21:59:10.586198Z     # the usual case
+    2026-05-14T21:59:10Z            # microsecond == 0
+
+Both are legal RFC 3339. Neither is what most generated clients decode.
+Foundation's ``ISO8601DateFormatter`` rejects fractional seconds unless
+``.withFractionalSeconds`` is set, and is unreliable above three digits even
+then — so a Swift client generated straight from our own OpenAPI document
+failed to decode 6 of 7 endpoints it called, every one of them a 200 OK. The
+second shape is the nastier of the two: a decoder configured *for* fractional
+seconds fails on a timestamp that has none, so the failure is intermittent and
+depends on whether a row happened to be written on a second boundary.
+
+So this module normalises every JSON-serialised ``datetime`` to exactly three
+fractional digits, keeping the ``Z`` suffix pydantic already emits for UTC::
+
+    2026-05-14T21:59:10.586Z
+    2026-05-14T21:59:10.000Z
+
+Nothing a DDI API exposes needs microseconds on a ``created_at``, and a fixed
+shape removes a hand-written workaround from every client that will ever be
+generated against this document.
+
+**Why a serialiser and not truncated values.** Rounding the ``datetime``
+objects themselves at the source fixes neither half: pydantic pads a
+millisecond-precision value back out to ``.586000`` (six digits again), and a
+value truncated to whole seconds serialises with no fraction at all — which is
+the intermittent case above, made permanent.
+
+**Why patch the schema builder.** The framework-blessed way to attach a
+serialiser to a type is ``Annotated[datetime, PlainSerializer(...)]``, which
+here means editing 714 annotations across 166 files and trusting every future
+model to remember — the definition of silent drift, and the sort of thing that
+regresses one PR later with no symptom. The alternatives are worse:
+``model_config['json_encoders']`` is deprecated and removed in pydantic v3
+(and warns once per field at import), and rewriting timestamps in the rendered
+response body means sniffing every string in every response for something that
+looks like a date — mutating opaque operator data (a raw BIND query-log line
+carries a timestamp) and paying a second full traversal per request.
+
+``pydantic_core.core_schema.datetime_schema()`` is the single point every
+``datetime`` core schema is built through, and ``serialization`` is a
+documented part of that schema. Patching it costs nothing per request (it runs
+at model-class creation), leaves validation and ``mode="python"`` dumps
+untouched, and cannot be forgotten by a new model.
+
+**What it does not reach.** A ``datetime`` sitting inside an ``Any`` /
+``dict[str, Any]`` field never builds a ``datetime_schema`` — pydantic infers
+a serialiser for it at runtime — so such a value still goes out at six digits.
+Left alone deliberately: those fields publish as untyped JSON, so no generated
+client points a date decoder at them, and covering them would mean walking the
+contents of every opaque payload on every response. Same for a timestamp a
+handler formatted into a string itself; the fix for one of those is to declare
+the field ``datetime`` and let this module serialise it, which is what
+``AuditLogResponse.timestamp`` and the session / user rows now do.
+
+The measurable cost is a Python call where pydantic-core had a Rust
+formatter: ~0.7 µs per timestamp, i.e. ~1.4 ms added to a 1,000-row response
+carrying two timestamps a row. Paid on serialisation only.
+
+The other cost is a dependency on a pydantic internal: if a future pydantic
+stops routing through this function, timestamps quietly revert to six digits.
+``backend/tests/test_json_datetime.py`` asserts on the serialised wire format
+rather than on the patch, so that regression fails a test instead of shipping.
+
+``install()`` is called from ``app/__init__.py`` — see the comment there for
+why that is the only import site that reliably runs first.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+#: Guards ``_patch_pydantic`` against wrapping its own wrapper — ``install()``
+#: is safe to call from more than one entrypoint.
+_pydantic_patched = False
+
+
+def to_rfc3339_ms(value: datetime) -> str:
+    """Serialise ``value`` as RFC 3339 with exactly three fractional digits.
+
+    Truncates rather than rounds — a timestamp must never move forward past
+    the instant it records — and preserves whatever offset the value carries:
+    ``Z`` for UTC (matching what pydantic already emitted), ``+02:00`` for
+    another zone, and no suffix at all for a naive datetime, which is the one
+    case where inventing an offset would be a lie rather than a reformat.
+    """
+    text = value.isoformat(timespec="milliseconds")
+    if text.endswith("+00:00"):
+        return f"{text[:-6]}Z"
+    return text
+
+
+def install() -> None:
+    """Make every JSON-serialised ``datetime`` millisecond-precise.
+
+    Idempotent, and must run before the first pydantic model class is created:
+    a core schema is built once, at class-creation time, so a model defined
+    before this call keeps the default six-digit serialiser forever.
+    """
+    _patch_pydantic()
+    _patch_fastapi_encoders()
+
+
+def _patch_pydantic() -> None:
+    """Attach the serialiser to every ``datetime`` core schema pydantic builds.
+
+    ``when_used="json"`` confines it to JSON output — ``model_dump()`` in
+    python mode still yields real ``datetime`` objects at full precision, so
+    internal callers that compare or do arithmetic on them are unaffected.
+
+    ``setdefault`` rather than assignment: a field that declares its own
+    serialiser (``Annotated[datetime, PlainSerializer(...)]``) has said
+    something more specific than this default, and keeps it.
+
+    No ``return_schema``. Declaring the obvious ``str_schema()`` there rewrites
+    what the *serialisation* JSON schema says the field is — and FastAPI
+    publishes response models in serialisation mode, so every ``created_at``
+    in the OpenAPI document would go from ``{"type": "string", "format":
+    "date-time"}`` to a bare string. ``format: date-time`` is exactly what a
+    generator reads to emit a date decoder rather than a ``String``, so
+    declaring the return type would have cost the clients this exists for far
+    more than it bought. Left absent, pydantic keeps the declared type's own
+    schema and the serialiser still runs.
+    """
+    global _pydantic_patched
+
+    from pydantic_core import core_schema  # noqa: PLC0415 — patch target
+
+    if _pydantic_patched:
+        return
+    build_datetime_schema = core_schema.datetime_schema
+
+    def datetime_schema(*args: Any, **kwargs: Any) -> Any:
+        schema = build_datetime_schema(*args, **kwargs)
+        schema.setdefault(
+            "serialization",
+            core_schema.plain_serializer_function_ser_schema(
+                to_rfc3339_ms,
+                when_used="json",
+            ),
+        )
+        return schema
+
+    core_schema.datetime_schema = datetime_schema  # type: ignore[assignment]
+    _pydantic_patched = True
+
+
+def _patch_fastapi_encoders() -> None:
+    """Cover the responses pydantic never sees.
+
+    A handler with no ``response_model`` (or one returning a bare dict) is
+    serialised by ``fastapi.encoders.jsonable_encoder``, which looks the type
+    up in its own ``ENCODERS_BY_TYPE`` table instead of going through pydantic.
+    Without this, the wire format would depend on whether a route happened to
+    declare a response model — the worst kind of inconsistency, because it is
+    invisible until a client hits the one endpoint that differs.
+
+    ``encoders_by_class_tuples`` is derived from that table once at import, and
+    ``jsonable_encoder`` reads it for subclass matches, so it has to be rebuilt
+    rather than left pointing at the stock encoder.
+
+    Rebuilt with our entry FIRST, which is load-bearing. ``jsonable_encoder``
+    takes the exact-type fast path for a plain ``datetime``, but falls to an
+    ``isinstance`` scan of that map in first-match order for anything else —
+    and ``datetime`` is a subclass of ``date``, whose entry is stock
+    ``isoformat``. Since ``date`` is registered ahead of ``datetime`` upstream,
+    leaving the order alone means a datetime SUBCLASS (freezegun's
+    ``FakeDatetime``, a driver's own) serialises in the six-digit format the
+    plain type no longer uses — the intermittent kind of inconsistency this
+    module exists to remove.
+    """
+    from fastapi import encoders  # noqa: PLC0415 — patch target
+
+    if encoders.ENCODERS_BY_TYPE.get(datetime) is to_rfc3339_ms:
+        return
+    encoders.ENCODERS_BY_TYPE[datetime] = to_rfc3339_ms
+    by_class = encoders.generate_encoders_by_class_tuples(encoders.ENCODERS_BY_TYPE)
+    encoders.encoders_by_class_tuples = {
+        to_rfc3339_ms: by_class.pop(to_rfc3339_ms),
+        **by_class,
+    }

--- a/backend/app/core/openapi_compat.py
+++ b/backend/app/core/openapi_compat.py
@@ -1,0 +1,298 @@
+"""Make the published OpenAPI document consumable by code generators (#907).
+
+FastAPI is a faithful OpenAPI 3.1 emitter, and 3.1 spells "nullable" as a
+union with the JSON Schema ``null`` type::
+
+    "feed_url": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Feed Url"}
+
+Strict generators do not all implement that arm. ``swift-openapi-generator``
+skips the member it cannot model — and skipping a member drops **the whole
+property** from the generated type, with a warning rather than an error. On
+this document that silently removed 3,291 schema properties and 297 query
+parameters from a client generated against a running control plane: models
+missing a third of their fields, and ``limit`` gone from list endpoints, so the
+client could not paginate at all. A client that compiles, passes review, and is
+quietly incomplete is precisely the drift a generated client exists to prevent.
+
+So the document states nullability the other way round — the way every
+generator already handles, and the way JSON Schema described optional fields
+before 3.1: the plain schema, with the property absent from ``required``::
+
+    "feed_url": {"type": "string", "title": "Feed Url"}
+
+**What this trades away.** The server still *sends* ``"feed_url": null`` rather
+than omitting the key, so a strict response validator (schemathesis, and our
+own live conformance fuzz) now sees an explicit null against a schema that no
+longer admits one. That is a real, deliberate cost, taken because the
+alternative — dropping ``null`` from responses via ``exclude_none`` — changes
+the wire for every existing client of this API, and because the generated-code
+failure is silent while the validator complaint is not. On the decode side
+nothing is lost: an absent key and an explicit null both land as ``nil`` /
+``undefined`` in every generator's optional-property handling.
+
+**Request bodies keep their ``required``.** Moving nullability onto ``required``
+is right for a response — an absent key and a null both decode to nil — and
+wrong for a request, where ``required`` is not a hint but what the server
+enforces: a field annotated ``X | None`` with no default is a key pydantic
+demands, and a generated client that believed the document and omitted it
+would get a 422 back. So the rewrite below collapses the union everywhere (a
+dropped property is unusable in either direction) but leaves ``required``
+alone on any schema reachable from a ``requestBody``. A schema used in both
+directions keeps it too: telling a client it may omit a key the server rejects
+is the worse of the two failures, and the real fix for one of those is to give
+the field a default so it is honestly optional.
+
+The union still collapses on the way in, so a generated client cannot send an
+explicit ``null`` to clear a field — but it could not before either, because
+the property it would have sent was dropped from the request model entirely.
+Clearing through such a client goes through whatever the endpoint's own
+convention is; being able to set the field at all is the step forward.
+
+Applied to the served document (``app.openapi()``), so ``/api/openapi.json``,
+``/api/docs`` and the release artifact ``scripts/export_openapi.py`` publishes
+all say the same thing — a client generated against a running server and one
+generated from the pinned release asset must not disagree.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Where a component reference points.
+_SCHEMA_REF_PREFIX = "#/components/schemas/"
+
+#: Keys whose values are *instance data*, not schemas — a ``default`` of
+#: ``{"anyOf": [...]}`` is somebody's literal payload, not a union to rewrite.
+#: ``default`` is context-sensitive: under ``responses`` it names the
+#: default-response object, which very much does contain schemas, so the walk
+#: below suppresses this set only where the parent is not a name-keyed map.
+_VALUE_KEYS = frozenset({"example", "examples", "enum", "const", "default"})
+
+#: Annotations worth carrying across a ``$ref`` collapse — prose a human
+#: wrote, not machine-generated noise. See ``_strip_null_arms``.
+_REF_SIBLINGS_WORTH_KEEPING = frozenset({"description", "deprecated"})
+
+#: Objects whose *keys are arbitrary names* rather than OpenAPI keywords:
+#: ``properties`` may legitimately hold a property called ``default``, and
+#: ``responses`` a response called ``default``. Their children are always
+#: recursed into.
+_NAME_KEYED_MAPS = frozenset(
+    {
+        "properties",
+        "patternProperties",
+        "$defs",
+        "definitions",
+        "schemas",
+        "responses",
+        "content",
+        "paths",
+        "webhooks",
+        "callbacks",
+        "headers",
+        # ``components.parameters`` / ``components.requestBodies`` are keyed by
+        # arbitrary names too. FastAPI inlines both rather than emitting them,
+        # so this is belt-and-braces — but the same key names appear on an
+        # Operation Object holding a LIST, and the list branch below ignores
+        # the flag, so listing them here cannot misread one.
+        "parameters",
+        "requestBodies",
+    }
+)
+
+
+def collapse_nullable_unions(document: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite every ``X | null`` union in ``document`` as plain ``X``.
+
+    Mutates in place (the caller owns FastAPI's cached document) and returns
+    it for convenience. Idempotent: a second pass finds no ``null`` arms left.
+    """
+    _walk(document, name_keyed=False, request_schemas=_request_schemas(document))
+    return document
+
+
+def _request_schemas(document: dict[str, Any]) -> frozenset[str]:
+    """Names under ``components/schemas`` reachable from any request body.
+
+    Transitive: a request body's ``$ref`` pulls in everything that schema
+    refers to, because a nested model is just as required as a top-level one.
+    """
+    reachable: set[str] = set()
+    pending: list[str] = []
+
+    def seed(node: Any) -> None:
+        for name in _referenced_names(node):
+            if name not in reachable:
+                reachable.add(name)
+                pending.append(name)
+
+    for item in (document.get("paths") or {}).values():
+        if not isinstance(item, dict):
+            continue
+        for operation in item.values():
+            if isinstance(operation, dict) and operation.get("requestBody"):
+                seed(operation["requestBody"])
+
+    schemas = (document.get("components") or {}).get("schemas") or {}
+    while pending:
+        seed(schemas.get(pending.pop()))
+    return frozenset(reachable)
+
+
+def _referenced_names(node: Any) -> set[str]:
+    """Every ``#/components/schemas/<name>`` reference under ``node``."""
+    found: set[str] = set()
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith(_SCHEMA_REF_PREFIX):
+            found.add(ref[len(_SCHEMA_REF_PREFIX) :])
+        for value in node.values():
+            found |= _referenced_names(value)
+    elif isinstance(node, list):
+        for value in node:
+            found |= _referenced_names(value)
+    return found
+
+
+def _walk(
+    node: Any,
+    *,
+    name_keyed: bool,
+    request_schemas: frozenset[str],
+    in_request: bool = False,
+    map_key: str | None = None,
+) -> None:
+    """Depth-first rewrite.
+
+    ``name_keyed`` says the node's own keys came from a user-chosen namespace
+    (property names, status codes, media types, paths), so none of them may be
+    read as an OpenAPI keyword. ``in_request`` says this subtree describes
+    something a client SENDS, where ``required`` is the server's demand rather
+    than a description of what it returns.
+    """
+    if isinstance(node, list):
+        for item in node:
+            _walk(item, name_keyed=False, request_schemas=request_schemas, in_request=in_request)
+        return
+    if not isinstance(node, dict):
+        return
+
+    if not name_keyed:
+        if not in_request:
+            _drop_nullable_from_required(node)
+        _strip_null_arms(node)
+
+    for key, value in node.items():
+        if not name_keyed and key in _VALUE_KEYS:
+            continue
+        child_name_keyed = not name_keyed and key in _NAME_KEYED_MAPS
+        if name_keyed and map_key == "schemas":
+            # ``key`` is the component's own name, so this is where a named
+            # schema learns whether anything sends it.
+            child_in_request = key in request_schemas
+        elif not name_keyed and key == "requestBody":
+            # An INLINE request body — no ``$ref`` for the reachability scan
+            # above to have found.
+            child_in_request = True
+        else:
+            child_in_request = in_request
+        _walk(
+            value,
+            name_keyed=child_name_keyed,
+            request_schemas=request_schemas,
+            in_request=child_in_request,
+            map_key=key if child_name_keyed else None,
+        )
+
+
+def _drop_nullable_from_required(schema: dict[str, Any]) -> None:
+    """Move nullability from the union onto the ``required`` list.
+
+    This is the half that keeps the rewrite honest for the 971 properties that
+    were nullable *and* required — ``str | None`` with no default is a required
+    key that may carry null. Collapsing the union without this would tell a
+    client the value is always a string, and the generated model would be
+    non-optional and fail to decode the first null it meets.
+    """
+    properties = schema.get("properties")
+    required = schema.get("required")
+    if not isinstance(properties, dict) or not isinstance(required, list):
+        return
+    nullable = {
+        name
+        for name, subschema in properties.items()
+        if isinstance(subschema, dict) and _is_nullable(subschema)
+    }
+    if not nullable:
+        return
+    remaining = [name for name in required if name not in nullable]
+    if remaining:
+        schema["required"] = remaining
+    else:
+        # An empty ``required`` is legal in 2020-12 but forbidden in OpenAPI
+        # 3.0, and generators read it as an oddity worth warning about. FastAPI
+        # omits the key when nothing is required; match that.
+        del schema["required"]
+
+
+def _is_nullable(schema: dict[str, Any]) -> bool:
+    """True if ``schema`` admits ``null`` through a union or a type array."""
+    for keyword in ("anyOf", "oneOf"):
+        arms = schema.get(keyword)
+        if isinstance(arms, list) and any(_is_null_arm(arm) for arm in arms):
+            return True
+    types = schema.get("type")
+    return isinstance(types, list) and "null" in types
+
+
+def _is_null_arm(arm: Any) -> bool:
+    return isinstance(arm, dict) and arm.get("type") == "null"
+
+
+def _strip_null_arms(schema: dict[str, Any]) -> None:
+    """Remove the ``null`` arm and collapse what is left, in place."""
+    types = schema.get("type")
+    if isinstance(types, list) and "null" in types:
+        # Not a shape FastAPI emits, handled because a hand-written
+        # ``json_schema_extra`` can, and it breaks the same generators.
+        remaining = [t for t in types if t != "null"]
+        if remaining:
+            schema["type"] = remaining[0] if len(remaining) == 1 else remaining
+
+    for keyword in ("anyOf", "oneOf"):
+        arms = schema.get(keyword)
+        if not isinstance(arms, list) or not any(_is_null_arm(arm) for arm in arms):
+            continue
+        rest = [arm for arm in arms if not _is_null_arm(arm)]
+        if not rest:
+            # A union of nothing but ``null`` — a field annotated ``None``.
+            # There is no plain schema to collapse to, so leave it alone; the
+            # property is already out of ``required`` and a generator drops it
+            # either way.
+            continue
+        if len(rest) > 1:
+            # e.g. ``Decimal | None`` -> [number, string-pattern, null]. Still
+            # a union, just no longer a nullable one.
+            schema[keyword] = rest
+            continue
+
+        member = rest[0]
+        del schema[keyword]
+        if isinstance(member, dict) and "$ref" in member:
+            # ``$ref`` beside sibling keywords is legal in 3.1 and read
+            # inconsistently by generators, so the reference is emitted with as
+            # little beside it as possible. What FastAPI leaves there is a
+            # generated wrapper title ("Response Get Account Api V1 …") plus,
+            # sometimes, an operator-written ``description`` — the title says
+            # nothing a client needs and goes; the description is somebody's
+            # documentation and stays, since losing it to a mechanical rewrite
+            # is a worse trade than a generator ignoring a keyword.
+            kept = {k: v for k, v in schema.items() if k in _REF_SIBLINGS_WORTH_KEEPING}
+            schema.clear()
+            schema.update(member)
+            for key, value in kept.items():
+                schema.setdefault(key, value)
+        elif isinstance(member, dict):
+            # The member's own keywords win over the parent's: the parent
+            # contributes annotations (``title``, ``description``, ``default``,
+            # ``readOnly``), the member the actual type and constraints.
+            schema.update(member)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api.health import router as health_router
 from app.api.v1.router import api_v1_router
 from app.config import settings
 from app.core.maintenance_mode import MaintenanceModeMiddleware
+from app.core.openapi_compat import collapse_nullable_unions
 from app.log import configure_logging
 from app.metrics import PrometheusMiddleware, metrics_endpoint
 
@@ -1060,15 +1061,31 @@ def create_app() -> FastAPI:
     # schema would break clients outside this repo in order to fix what is a
     # documentation defect.
     #
+    # The wrapper below carries a second rewrite too (#907, nullable unions);
+    # both exist for the same reason — the document is generated FOR consumers
+    # we do not control, so a defect in it breaks a client somewhere else with
+    # no local symptom.
+    #
     # Wraps FastAPI's own ``openapi()`` rather than re-deriving the document
     # with ``get_openapi``, so every generation setting the app carries
     # (webhooks, separate input/output schemas, servers) keeps applying. That
     # call caches into ``app.openapi_schema`` and returns the cached object, so
-    # this patches in place — the ``anyOf`` guard keeps it idempotent.
+    # this patches it in place, once.
     _generate_openapi = app.openapi
+    _normalised: dict | None = None
 
-    def _openapi_with_string_validation_detail() -> dict:
+    def _openapi_for_generators() -> dict:
+        nonlocal _normalised
+
         schema = _generate_openapi()
+        # ``_generate_openapi`` caches into ``app.openapi_schema`` and hands
+        # back the same object every time, so the rewrites below have already
+        # been applied to it — re-walking a 1.8 MB document on every
+        # ``/api/docs`` load would be pure waste. Identity, not a marker key:
+        # the published document must carry nothing that is not OpenAPI.
+        if _normalised is not None and schema is _normalised:
+            return schema
+
         props = (
             schema.get("components", {})
             .get("schemas", {})
@@ -1082,9 +1099,18 @@ def create_app() -> FastAPI:
                 "anyOf": [detail, {"type": "string"}],
                 "title": detail.get("title", "Detail"),
             }
+
+        # #907 — FastAPI's 3.1 ``anyOf: [X, {"type": "null"}]`` nullable idiom
+        # makes strict generators DROP the property (a warning, not an error),
+        # so a generated client is silently missing thousands of fields. Runs
+        # after the widening above so the union it just added — which has no
+        # null arm — is left alone.
+        collapse_nullable_unions(schema)
+
+        _normalised = schema
         return schema
 
-    app.openapi = _openapi_with_string_validation_detail  # type: ignore[method-assign]
+    app.openapi = _openapi_for_generators  # type: ignore[method-assign]
 
     return app
 

--- a/backend/tests/test_json_datetime.py
+++ b/backend/tests/test_json_datetime.py
@@ -28,7 +28,7 @@ from httpx import AsyncClient
 from pydantic import BaseModel, TypeAdapter
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.json_datetime import to_rfc3339_ms
+from app.core.json_datetime import install, to_rfc3339_ms
 from app.core.security import create_access_token, hash_password
 from app.main import app
 from app.models.auth import User
@@ -133,6 +133,20 @@ def test_a_plain_date_is_left_alone() -> None:
     """Only ``datetime`` moves. A ``date`` has no time to be precise about,
     and rewriting its encoder would change ``format: date`` fields."""
     assert jsonable_encoder({"on": _MICROSECONDS.date()}) == {"on": "2026-05-14"}
+
+
+def test_installing_twice_does_not_wrap_the_wrapper() -> None:
+    """``install()`` runs from a package ``__init__``, so a second call is a
+    plausible accident — and a wrapper wrapping a wrapper would keep working
+    while doing the whole schema build twice per model. The guard asks the
+    patch target whether it is already ours rather than tracking a flag of its
+    own, so it holds even if this module is imported twice under two names."""
+    from pydantic_core import core_schema  # noqa: PLC0415 — the patch target
+
+    before = core_schema.datetime_schema
+    install()
+    assert core_schema.datetime_schema is before
+    assert to_rfc3339_ms(_MICROSECONDS) == "2026-05-14T21:59:10.586Z"
 
 
 def test_python_mode_dumps_keep_full_precision() -> None:

--- a/backend/tests/test_json_datetime.py
+++ b/backend/tests/test_json_datetime.py
@@ -1,0 +1,248 @@
+"""Timestamps go out RFC 3339 with exactly three fractional digits (#907).
+
+A Swift client generated straight from this server's own OpenAPI document
+failed to decode 6 of 7 endpoints it called — all 200 OK, all rejected by
+Foundation's ``ISO8601DateFormatter``, which will not take the six fractional
+digits ``datetime.isoformat()`` emits::
+
+    DecodingError: dataCorrupted — Expected date string to be ISO8601-formatted
+    operationID: list_spaces_api_v1_ipam_spaces_get
+
+The assertions here are on the WIRE FORMAT, never on the patch that produces
+it. ``app/core/json_datetime.py`` works by wrapping
+``pydantic_core.core_schema.datetime_schema`` — an internal of a dependency we
+do not control — so the failure mode worth guarding is a future pydantic that
+stops routing through it and silently restores six digits. Asserting on the
+bytes catches that; asserting that the patch is installed would not.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime, timedelta, timezone
+from typing import Literal
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+from httpx import AsyncClient
+from pydantic import BaseModel, TypeAdapter
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.json_datetime import to_rfc3339_ms
+from app.core.security import create_access_token, hash_password
+from app.main import app
+from app.models.auth import User
+
+#: Exactly three fractional digits, and an offset that is either ``Z`` or
+#: ``±HH:MM``. Anchored: a partial match would accept the six-digit form.
+RFC3339_MS = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[+-]\d{2}:\d{2})$")
+
+_MICROSECONDS = datetime(2026, 5, 14, 21, 59, 10, 586198, tzinfo=UTC)
+
+
+# ── the formatter itself ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (_MICROSECONDS, "2026-05-14T21:59:10.586Z"),
+        # A whole second is the case that breaks decoders configured FOR
+        # fractional seconds: isoformat() drops the fraction entirely, so the
+        # shape changes depending on when the row happened to be written.
+        (datetime(2026, 5, 14, 21, 59, 10, tzinfo=UTC), "2026-05-14T21:59:10.000Z"),
+        # Truncated, never rounded — a timestamp must not move forward past
+        # the instant it records.
+        (datetime(2026, 5, 14, 21, 59, 10, 586999, tzinfo=UTC), "2026-05-14T21:59:10.586Z"),
+        (datetime(2026, 5, 14, 21, 59, 10, 999, tzinfo=UTC), "2026-05-14T21:59:10.000Z"),
+        # Offsets other than UTC keep their offset; only +00:00 becomes Z,
+        # which is what pydantic already emitted.
+        (
+            datetime(2026, 5, 14, 21, 59, 10, 586198, tzinfo=timezone(timedelta(hours=2))),
+            "2026-05-14T21:59:10.586+02:00",
+        ),
+        # Naive stays naive. Inventing an offset would be a lie, not a reformat.
+        (datetime(2026, 5, 14, 21, 59, 10, 586198), "2026-05-14T21:59:10.586"),
+    ],
+)
+def test_to_rfc3339_ms(value: datetime, expected: str) -> None:
+    assert to_rfc3339_ms(value) == expected
+
+
+# ── the two serialisation paths a response can take ───────────────────────
+
+
+class _Nested(BaseModel):
+    at: datetime
+
+
+class _Payload(BaseModel):
+    at: datetime
+    optional: datetime | None = None
+    nested: _Nested
+    listed: list[datetime] = []
+    mapped: dict[str, datetime] = {}
+
+
+def test_pydantic_json_serialisation_is_millisecond_precise() -> None:
+    """The response-model path: FastAPI serialises through pydantic in JSON
+    mode, and every datetime in the tree has to come out the same shape —
+    nested models, lists and dict values included."""
+    payload = _Payload(
+        at=_MICROSECONDS,
+        optional=_MICROSECONDS,
+        nested=_Nested(at=_MICROSECONDS),
+        listed=[_MICROSECONDS],
+        mapped={"k": _MICROSECONDS},
+    )
+    dumped = TypeAdapter(_Payload).dump_python(payload, mode="json")
+    emitted = [
+        dumped["at"],
+        dumped["optional"],
+        dumped["nested"]["at"],
+        dumped["listed"][0],
+        dumped["mapped"]["k"],
+    ]
+    assert all(RFC3339_MS.match(value) for value in emitted), emitted
+
+
+def test_jsonable_encoder_matches_the_response_model_path() -> None:
+    """The other path: a handler with no ``response_model`` is serialised by
+    ``jsonable_encoder``, which has its own encoder table and never consults
+    pydantic. If only one path were fixed, the wire format would depend on
+    whether a route happened to declare a response model."""
+    encoded = jsonable_encoder({"at": _MICROSECONDS, "whole": _MICROSECONDS.replace(microsecond=0)})
+    assert encoded == {"at": "2026-05-14T21:59:10.586Z", "whole": "2026-05-14T21:59:10.000Z"}
+
+
+def test_a_datetime_subclass_takes_the_same_path() -> None:
+    """``jsonable_encoder`` falls back to a first-match ``isinstance`` scan for
+    anything that is not exactly ``datetime`` — and ``datetime`` is a subclass
+    of ``date``, whose stock entry is plain ``isoformat``. Registered upstream
+    ahead of ``datetime``, that entry would claim a subclass (freezegun's
+    ``FakeDatetime``, a driver's own) and serialise it in the old format."""
+
+    class _Subclass(datetime):
+        pass
+
+    value = _Subclass(2026, 5, 14, 21, 59, 10, 586198, tzinfo=UTC)
+    assert jsonable_encoder({"at": value}) == {"at": "2026-05-14T21:59:10.586Z"}
+
+
+def test_a_plain_date_is_left_alone() -> None:
+    """Only ``datetime`` moves. A ``date`` has no time to be precise about,
+    and rewriting its encoder would change ``format: date`` fields."""
+    assert jsonable_encoder({"on": _MICROSECONDS.date()}) == {"on": "2026-05-14"}
+
+
+def test_python_mode_dumps_keep_full_precision() -> None:
+    """The serialiser is JSON-only. Internal callers that ``model_dump()`` in
+    python mode still get real datetimes at microsecond precision, so nothing
+    that compares or does arithmetic on them changes behaviour."""
+    dumped = TypeAdapter(_Payload).dump_python(
+        _Payload(at=_MICROSECONDS, nested=_Nested(at=_MICROSECONDS))
+    )
+    assert dumped["at"] == _MICROSECONDS
+
+
+def test_millisecond_output_still_validates() -> None:
+    """Round trip: what we emit has to be something we accept back."""
+    assert _Nested.model_validate({"at": to_rfc3339_ms(_MICROSECONDS)}).at == _MICROSECONDS.replace(
+        microsecond=586000
+    )
+
+
+@pytest.mark.parametrize("mode", ["validation", "serialization"])
+def test_the_document_still_describes_a_date_time_string(
+    mode: Literal["validation", "serialization"],
+) -> None:
+    """The serialiser must not leak into the schema: ``format: date-time`` is
+    what a generator reads to emit a date decoder rather than a plain string.
+
+    ``serialization`` is the mode that matters and the one that broke: FastAPI
+    publishes response models in it, and declaring the serialiser's return
+    type (the obvious ``return_schema=str_schema()``) silently rewrote every
+    ``created_at`` in the document to a bare string — trading the six-digit
+    decode failure for a client that never parses a date at all.
+    """
+    assert _Nested.model_json_schema(mode=mode)["properties"]["at"] == {
+        "format": "date-time",
+        "title": "At",
+        "type": "string",
+    }
+
+
+def test_the_served_document_keeps_date_time_on_timestamp_properties() -> None:
+    """The same guard at document level, where a client actually reads it —
+    on a plain timestamp and on one that was ``datetime | None`` and went
+    through the #907 nullable collapse."""
+    schemas = app.openapi()["components"]["schemas"]
+    assert schemas["AddressSetResponse"]["properties"]["created_at"] == {
+        "type": "string",
+        "format": "date-time",
+        "title": "Created At",
+    }
+    assert schemas["APITokenRow"]["properties"]["expires_at"] == {
+        "type": "string",
+        "format": "date-time",
+        "title": "Expires At",
+    }
+
+
+def test_hand_formatted_timestamp_fields_are_declared_as_timestamps() -> None:
+    """Three response models carried their timestamps as ``str`` and filled
+    them with ``isoformat()``, so they published as bare strings with no
+    ``format: date-time`` — a generated client read the audit trail's
+    timestamp as text — and they went out in the six-digit ``+00:00`` shape
+    every other timestamp in the API had just stopped using (#907)."""
+    schemas = app.openapi()["components"]["schemas"]
+    declared = {
+        "AuditLogResponse": ["timestamp"],
+        "SessionRow": ["created_at", "last_seen_at", "expires_at"],
+        "app__api__v1__users__router__UserResponse": [
+            "last_login_at",
+            "failed_login_locked_until",
+        ],
+    }
+    for name, properties in declared.items():
+        for prop in properties:
+            schema = schemas[name]["properties"][prop]
+            assert schema.get("format") == "date-time", f"{name}.{prop}: {schema}"
+
+
+# ── end to end, through a real endpoint ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_spaces_serialises_timestamps_for_a_generated_client(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """``list_spaces_api_v1_ipam_spaces_get`` is the operation named in the
+    issue's decoding failure — a 200 OK a generated client could not read."""
+    user = User(
+        username="ts-probe",
+        email="ts-probe@example.com",
+        display_name="ts-probe",
+        hashed_password=hash_password("password123"),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []  # mark loaded — is_effective_superadmin walks .groups
+    db_session.add(user)
+    await db_session.flush()
+    headers = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    await db_session.commit()
+
+    created = await client.post(
+        "/api/v1/ipam/spaces", headers=headers, json={"name": "ts-probe-space"}
+    )
+    assert created.status_code in (200, 201), created.text
+    assert RFC3339_MS.match(created.json()["created_at"]), created.json()["created_at"]
+
+    listed = await client.get("/api/v1/ipam/spaces", headers=headers)
+    assert listed.status_code == 200, listed.text
+    rows = listed.json()
+    rows = rows["items"] if isinstance(rows, dict) else rows
+    stamps = [row["created_at"] for row in rows] + [row["modified_at"] for row in rows]
+    assert stamps, "no rows to check — the fixture did not create a space"
+    assert all(RFC3339_MS.match(stamp) for stamp in stamps), stamps

--- a/backend/tests/test_openapi_export.py
+++ b/backend/tests/test_openapi_export.py
@@ -160,6 +160,21 @@ def test_empty_version_env_falls_back_instead_of_crashing() -> None:
 
 
 @_needs_exporter
+def test_export_carries_the_generator_normalisations() -> None:
+    """#907 — the artifact clients pin against must be the normalised document.
+
+    ``app.openapi()`` collapses OpenAPI 3.1's ``anyOf: [X, {"type": "null"}]``
+    nullable idiom, which strict generators answer by dropping the whole
+    property. A null arm surviving here means the exporter bypassed the
+    wrapper, and every client generated from the release asset would be
+    missing thousands of fields that the client generated from a running
+    server has.
+    """
+    raw = _run_raw({"VERSION": "2026.01.02-3"})
+    assert '"type": "null"' not in raw, "nullable unions survived into the exported artifact"
+
+
+@_needs_exporter
 def test_export_is_byte_reproducible() -> None:
     """The release attaches this artifact and the acceptance criterion is
     that it matches a local run at the same tag. Insertion-order-dependent

--- a/backend/tests/test_openapi_nullable.py
+++ b/backend/tests/test_openapi_nullable.py
@@ -1,0 +1,436 @@
+"""The document must not say "nullable" in a way generators drop (#907).
+
+FastAPI emits OpenAPI 3.1's ``anyOf: [X, {"type": "null"}]``. Strict
+generators that cannot model the ``null`` arm skip the member — and skipping a
+member drops the WHOLE property from the generated type, with a warning rather
+than an error. Measured on this document before the fix: 3,291 schema
+properties and 297 query parameters missing from a generated client, including
+``limit`` on list endpoints, so the client could not paginate at all.
+
+Two halves are tested, because either alone is a bug:
+
+* the union collapses to the plain schema, and
+* the property leaves ``required`` — 971 of them were nullable AND required
+  (``str | None`` with no default), and collapsing without that would promise
+  a client a value that is routinely null.
+
+No database and no client — the document is generated from the route table.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.openapi_compat import collapse_nullable_unions
+from app.main import app
+
+
+def _schema() -> dict[str, Any]:
+    return app.openapi()
+
+
+# ── the rewrite, shape by shape ───────────────────────────────────────────
+
+
+def test_two_arm_union_collapses_and_keeps_the_annotations() -> None:
+    doc = {
+        "properties": {"feed_url": {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "F"}},
+        "required": ["feed_url"],
+    }
+    collapse_nullable_unions(doc)
+    assert doc["properties"]["feed_url"] == {"type": "string", "title": "F"}
+    assert "required" not in doc
+
+
+def test_constraints_on_the_surviving_arm_are_preserved() -> None:
+    """The arm carries the type AND its constraints; the parent carries the
+    annotations. Losing ``maximum`` here would drop a bound the server still
+    enforces, so a generated client would build requests that 422."""
+    doc = {
+        "properties": {
+            "max_packets": {
+                "anyOf": [{"type": "integer", "maximum": 1000000, "minimum": 1}, {"type": "null"}],
+                "title": "Max Packets",
+                "default": 10000,
+            }
+        },
+        "required": ["max_packets"],
+    }
+    collapse_nullable_unions(doc)
+    assert doc["properties"]["max_packets"] == {
+        "type": "integer",
+        "maximum": 1000000,
+        "minimum": 1,
+        "title": "Max Packets",
+        "default": 10000,
+    }
+
+
+def test_a_nullable_ref_collapses_to_a_bare_ref() -> None:
+    """``$ref`` beside sibling keywords is legal in 3.1 and read
+    inconsistently by generators. What sits beside it is FastAPI's generated
+    wrapper title, which carries nothing a client needs."""
+    doc = {
+        "schema": {
+            "anyOf": [{"$ref": "#/components/schemas/ACMEAccountSummary"}, {"type": "null"}],
+            "title": "Response Get Account Api V1 Appliance Acme Account Get",
+        }
+    }
+    collapse_nullable_unions(doc)
+    assert doc["schema"] == {"$ref": "#/components/schemas/ACMEAccountSummary"}
+
+
+def test_a_multi_arm_union_stays_a_union_minus_the_null() -> None:
+    """``Decimal | None`` renders as [number, string-pattern, null]. Dropping
+    the null arm leaves a union that is no longer a NULLABLE one — collapsing
+    it to a single arm would throw away a form the server accepts."""
+    doc = {
+        "monthly_cost": {
+            "anyOf": [
+                {"type": "number"},
+                {"type": "string", "pattern": r"^\d+$"},
+                {"type": "null"},
+            ],
+            "title": "Monthly Cost",
+        }
+    }
+    collapse_nullable_unions(doc)
+    assert doc["monthly_cost"] == {
+        "anyOf": [{"type": "number"}, {"type": "string", "pattern": r"^\d+$"}],
+        "title": "Monthly Cost",
+    }
+
+
+def test_only_the_nullable_properties_leave_required() -> None:
+    doc = {
+        "properties": {
+            "id": {"type": "string"},
+            "site_id": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        },
+        "required": ["id", "site_id"],
+    }
+    collapse_nullable_unions(doc)
+    assert doc["required"] == ["id"]
+
+
+def test_a_type_array_is_normalised_too() -> None:
+    """Not a shape FastAPI emits, but ``json_schema_extra`` can hand-write it
+    and it breaks the same generators."""
+    doc = {"properties": {"note": {"type": ["string", "null"]}}, "required": ["note"]}
+    collapse_nullable_unions(doc)
+    assert doc["properties"]["note"] == {"type": "string"}
+    assert "required" not in doc
+
+
+def test_a_union_of_nothing_but_null_is_left_alone() -> None:
+    """A field annotated ``None`` has no plain schema to collapse to. Emitting
+    an empty schema would say "anything goes", which is the opposite."""
+    doc = {"properties": {"never": {"anyOf": [{"type": "null"}]}}, "required": ["never"]}
+    collapse_nullable_unions(doc)
+    assert doc["properties"]["never"] == {"anyOf": [{"type": "null"}]}
+    assert "required" not in doc
+
+
+def test_instance_data_is_not_rewritten() -> None:
+    """``default``/``example``/``enum`` hold somebody's literal payload. A
+    JSON-Schema-shaped example is data, not a union to collapse."""
+    doc = {
+        "properties": {
+            "tool_input_schema": {
+                "type": "object",
+                "example": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                "default": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            }
+        }
+    }
+    collapse_nullable_unions(doc)
+    prop = doc["properties"]["tool_input_schema"]
+    assert prop["example"] == {"anyOf": [{"type": "string"}, {"type": "null"}]}
+    assert prop["default"] == {"anyOf": [{"type": "string"}, {"type": "null"}]}
+
+
+def test_name_keyed_maps_do_not_shadow_keywords() -> None:
+    """``default`` is a value keyword under a schema and a RESPONSE under
+    ``responses`` — and a property may simply be called ``default``. Suppressing
+    the wrong one silently leaves a whole default-response body unrewritten."""
+    doc = {
+        "responses": {
+            "default": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "properties": {
+                                "default": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+                            },
+                            "required": ["default"],
+                        }
+                    }
+                }
+            }
+        }
+    }
+    collapse_nullable_unions(doc)
+    schema = doc["responses"]["default"]["content"]["application/json"]["schema"]
+    assert schema["properties"]["default"] == {"type": "string"}
+    assert "required" not in schema
+
+
+def test_a_request_body_schema_keeps_its_required_list() -> None:
+    """``required`` is a description on the way out and an ENFORCEMENT on the
+    way in. A field annotated ``X | None`` with no default is a key pydantic
+    demands, so publishing it as optional would have a generated client omit
+    it and take a 422 — trading a silent gap for a runtime failure."""
+    doc = {
+        "paths": {
+            "/thing": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {"schema": {"$ref": "#/components/schemas/ThingIn"}}
+                        }
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "ThingIn": {
+                    "properties": {"soa": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+                    "required": ["soa"],
+                },
+                "ThingOut": {
+                    "properties": {"soa": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+                    "required": ["soa"],
+                },
+            }
+        },
+    }
+    collapse_nullable_unions(doc)
+    schemas = doc["components"]["schemas"]
+    # The union collapses either way — a dropped property is unusable in both
+    # directions — but only the response side loses `required`.
+    assert schemas["ThingIn"]["properties"]["soa"] == {"type": "string"}
+    assert schemas["ThingIn"]["required"] == ["soa"]
+    assert schemas["ThingOut"]["properties"]["soa"] == {"type": "string"}
+    assert "required" not in schemas["ThingOut"]
+
+
+def test_request_reachability_is_transitive() -> None:
+    """A nested model is as required as the top-level one that refers to it."""
+    doc = {
+        "paths": {
+            "/thing": {
+                "post": {
+                    "requestBody": {
+                        "content": {"application/json": {"schema": {"$ref": "#/c/s/Outer"}}}
+                    }
+                }
+            }
+        },
+        "components": {
+            "schemas": {
+                "Outer": {"properties": {"inner": {"$ref": "#/components/schemas/Inner"}}},
+                "Inner": {
+                    "properties": {"x": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+                    "required": ["x"],
+                },
+            }
+        },
+    }
+    # The requestBody ref is written the long way so the seed is found by the
+    # same prefix the closure walks.
+    body = doc["paths"]["/thing"]["post"]["requestBody"]
+    body["content"]["application/json"]["schema"] = {"$ref": "#/components/schemas/Outer"}
+    collapse_nullable_unions(doc)
+    assert doc["components"]["schemas"]["Inner"]["required"] == ["x"]
+
+
+def test_an_inline_request_body_keeps_its_required_list() -> None:
+    """No ``$ref`` for the reachability scan to find — the flag has to ride
+    the walk itself."""
+    doc = {
+        "paths": {
+            "/thing": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "x": {"anyOf": [{"type": "string"}, {"type": "null"}]}
+                                    },
+                                    "required": ["x"],
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    collapse_nullable_unions(doc)
+    schema = doc["paths"]["/thing"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+    assert schema["properties"]["x"] == {"type": "string"}
+    assert schema["required"] == ["x"]
+
+
+def test_a_ref_collapse_keeps_prose_and_drops_generated_noise() -> None:
+    """The title is FastAPI's; the description is somebody's documentation."""
+    doc = {
+        "capabilities": {
+            "anyOf": [{"$ref": "#/components/schemas/SupervisorCapabilities"}, {"type": "null"}],
+            "title": "Capabilities",
+            "description": "Supervisor-advertised facts.",
+        }
+    }
+    collapse_nullable_unions(doc)
+    assert doc["capabilities"] == {
+        "$ref": "#/components/schemas/SupervisorCapabilities",
+        "description": "Supervisor-advertised facts.",
+    }
+
+
+def test_the_rewrite_is_idempotent() -> None:
+    doc: dict[str, Any] = {
+        "properties": {"a": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+        "required": ["a"],
+    }
+    once = collapse_nullable_unions(doc)
+    twice = collapse_nullable_unions(once)
+    assert twice == {"properties": {"a": {"type": "string"}}}
+
+
+# ── the served document ───────────────────────────────────────────────────
+
+
+def test_the_served_document_has_no_null_arms_left() -> None:
+    """One walk over the real document: any ``{"type": "null"}`` that survives
+    is a property a generator will drop from a model."""
+    offenders: list[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "null":
+                offenders.append(path)
+            if isinstance(node.get("type"), list) and "null" in node["type"]:
+                offenders.append(path)
+            for key, value in node.items():
+                walk(value, f"{path}/{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}/{index}")
+
+    walk(_schema(), "")
+    assert not offenders, f"{len(offenders)} null arms remain, e.g. {offenders[:5]}"
+
+
+def test_list_endpoints_still_declare_a_limit_a_client_can_send() -> None:
+    """The reported symptom: ``limit`` was nullable, so the generated client
+    had no way to pass it and could not paginate at all."""
+    checked = 0
+    for path, item in _schema()["paths"].items():
+        for method, operation in item.items():
+            if not isinstance(operation, dict):
+                continue
+            for param in operation.get("parameters") or []:
+                if param.get("name") != "limit" or param.get("in") != "query":
+                    continue
+                schema = param.get("schema") or {}
+                assert "anyOf" not in schema, f"{method.upper()} {path}: {schema}"
+                assert schema.get("type"), f"{method.upper()} {path}: {schema}"
+                checked += 1
+    assert checked, "no limit query parameters found — the assertion proved nothing"
+
+
+def test_a_response_model_keeps_every_property_a_client_needs() -> None:
+    """Spot-check from the issue: ``AddressSetResponse`` lost four fields to
+    the generator, all of them nullable."""
+    schema = _schema()["components"]["schemas"]["AddressSetResponse"]
+    for name in ("customer_id", "site_id", "start_address", "end_address"):
+        prop = schema["properties"][name]
+        assert "anyOf" not in prop, prop
+        assert prop.get("type") or "$ref" in prop, prop
+        # Nullability now lives here, which is what a generator reads to make
+        # the property optional.
+        assert name not in schema.get("required", []), name
+
+
+def test_no_shared_schema_is_required_and_nullable_at_once() -> None:
+    """The invariant the collapse cannot satisfy on its own.
+
+    A schema reachable from BOTH a request body and a response with a property
+    that is required AND nullable has no honest publication: say optional and a
+    client omits a key the server demands (422); say required and a client
+    cannot decode — or send — the null the server routinely uses. The rewrite
+    resolves it toward the write side, so the MODEL has to close the gap by
+    giving the field a default, as ``ImportedZoneOut.soa`` now does. This test
+    is what makes the next one loud instead of silent.
+
+    Nullability is only visible BEFORE the rewrite, so the raw FastAPI document
+    is generated here as an oracle — the one place ``get_openapi`` is the right
+    call rather than the wrong one, since it is deliberately not what we ship.
+    """
+    from fastapi.openapi.utils import get_openapi  # noqa: PLC0415 — see docstring
+
+    raw = get_openapi(
+        title=app.title,
+        version=app.version,
+        routes=app.routes,
+        separate_input_output_schemas=app.separate_input_output_schemas,
+    )
+    schemas = raw["components"]["schemas"]
+    shared = _reachable_from(raw, "requestBody") & _reachable_from(raw, "responses")
+    assert shared, "reachability found nothing — the assertion proved nothing"
+
+    offenders = [
+        f"{name}.{prop}"
+        for name in sorted(shared)
+        for prop in (schemas[name].get("required") or [])
+        if _is_nullable(schemas[name].get("properties", {}).get(prop))
+    ]
+    assert not offenders, (
+        "required AND nullable in a schema used both ways — give the field a "
+        f"default so it is honestly optional: {offenders}"
+    )
+
+
+def _is_nullable(schema: Any) -> bool:
+    if not isinstance(schema, dict):
+        return False
+    arms = schema.get("anyOf") or schema.get("oneOf") or []
+    return any(isinstance(arm, dict) and arm.get("type") == "null" for arm in arms)
+
+
+def _reachable_from(document: dict[str, Any], section: str) -> set[str]:
+    """Component-schema names reachable from every ``section`` in the paths."""
+    prefix = "#/components/schemas/"
+
+    def refs(node: Any) -> set[str]:
+        found: set[str] = set()
+        if isinstance(node, dict):
+            ref = node.get("$ref")
+            if isinstance(ref, str) and ref.startswith(prefix):
+                found.add(ref[len(prefix) :])
+            for value in node.values():
+                found |= refs(value)
+        elif isinstance(node, list):
+            for value in node:
+                found |= refs(value)
+        return found
+
+    schemas = document["components"]["schemas"]
+    seen: set[str] = set()
+    pending: list[str] = []
+    for item in document["paths"].values():
+        for operation in item.values():
+            if isinstance(operation, dict) and operation.get(section):
+                for name in refs(operation[section]):
+                    if name not in seen:
+                        seen.add(name)
+                        pending.append(name)
+    while pending:
+        for name in refs(schemas.get(pending.pop(), {})):
+            if name not in seen:
+                seen.add(name)
+                pending.append(name)
+    return seen

--- a/docs/API.md
+++ b/docs/API.md
@@ -129,6 +129,83 @@ is for. `scripts/prune-release-assets.sh` achieves that through its
 "unknown / future asset — leave untouched" default branch, so **do not add
 a pattern for `openapi.json` to the pruner**.
 
+### 2.2 Two shapes the document commits to for code generators
+
+A generated client fails *quietly*: it compiles, passes review, and is
+missing whatever the generator could not model. Both rules below exist
+because a client generated from this document was silently wrong (#907),
+and both apply to the served document and the release asset alike — a
+client built against a running server and one built against a pinned tag
+must not disagree.
+
+**Nullable is expressed by absence from `required`, not by a `null`
+union.** OpenAPI 3.1 spells an optional value as a union with the JSON
+Schema `null` type, and FastAPI emits exactly that. Strict generators
+that cannot model the `null` arm skip the member — and skipping a member
+drops **the whole property** from the generated type, with a warning
+rather than an error. So `app.openapi()` rewrites every such union to the
+plain schema and takes the property out of `required`:
+
+What FastAPI emits:
+
+```json
+{ "anyOf": [ { "type": "string" }, { "type": "null" } ], "title": "Feed Url" }
+```
+
+What the document publishes — and `feed_url` is no longer listed in the
+schema's `required`:
+
+```json
+{ "type": "string", "title": "Feed Url" }
+```
+
+A union with more than one non-`null` arm stays a union, minus the
+`null`; a nullable `$ref` collapses to a bare `$ref` (keeping any
+`description`, dropping the generated title).
+
+**Request bodies keep their `required` list.** On the way out `required`
+describes what the server sends; on the way in it is what the server
+*enforces*, and a field the model declares `X | None` with no default is
+a key pydantic demands. So a schema reachable from a `requestBody` is
+collapsed but never has a property taken out of `required` — a client
+that believed otherwise and omitted the key would get a 422 back. A
+schema used in both directions (the preview → commit payloads) is
+resolved the same way, so a model in that position should carry a
+default rather than rely on the document to paper over it.
+
+Note what this trades: the server still **sends** `"feed_url": null`
+rather than omitting the key, so a strict response validator sees an
+explicit null against a schema that no longer admits one. That is
+deliberate — the alternative (dropping nulls from responses) changes the
+wire for every existing client, and a validator complaint is loud where
+the generated-code failure is silent. Decoding loses nothing: an absent
+key and an explicit null both land as `nil` / `undefined`.
+
+**Timestamps are RFC 3339 with exactly three fractional digits.**
+
+```
+2026-05-14T21:59:10.586Z
+2026-05-14T21:59:10.000Z     ← a whole second still carries .000
+```
+
+Python's `isoformat()` emits six fractional digits, and none at all when
+the value lands on a whole second. Both are legal RFC 3339 and neither is
+what most generated decoders accept — Foundation's
+`ISO8601DateFormatter` rejects fractional seconds unless configured for
+them, and then rejects the values that have none. A fixed shape removes a
+hand-written workaround from every client. `format: date-time` on the
+property is unchanged, so a generator still emits a date decoder rather
+than a string; only the precision is pinned. See
+[`backend/app/core/json_datetime.py`](../backend/app/core/json_datetime.py).
+
+The rule covers every `datetime`-typed field the API returns. It does
+**not** reach a timestamp parked inside an untyped payload — an `Any` /
+`dict[str, Any]` field such as an evidence trail or an agent telemetry
+blob, or one a handler formatted into a string itself. Those publish as
+untyped JSON or bare strings, so no generated decoder points at them and
+nothing fails to decode; the fix for one of them is to declare the field
+as a `datetime` and let it serialise normally.
+
 ---
 
 ## 3. Authentication
@@ -389,8 +466,8 @@ Response — `201 Created`, `IPSpaceResponse`:
   "dns_additional_zone_ids": [],
   "ddns_enabled": false,
   "ddns_hostname_policy": "client_or_generated",
-  "created_at": "2026-06-27T12:00:00Z",
-  "modified_at": "2026-06-27T12:00:00Z"
+  "created_at": "2026-06-27T12:00:00.000Z",
+  "modified_at": "2026-06-27T12:00:00.000Z"
 }
 ```
 

--- a/scripts/export_openapi.py
+++ b/scripts/export_openapi.py
@@ -25,6 +25,13 @@ stamped with a version that never changes, which defeats pinning entirely.
 compose file and the release workflow both already set), and ``--version``
 here sets it explicitly.
 
+**It carries the generator normalisations.** That same wrapper also rewrites
+OpenAPI 3.1's ``anyOf: [X, {"type": "null"}]`` nullable idiom, which strict
+generators answer by dropping the whole property from the generated type —
+3,291 schema properties and 297 query parameters, silently, on this document
+(#907). A dump that bypasses ``app.openapi()`` publishes a contract whose
+clients are missing a third of every model.
+
 **It does not inherit operator branding.** ``info.title`` comes from
 ``settings.app_title``, which is operator-settable (#886/#888) — exporting on
 a branded install would otherwise publish "Acme DDI" as the name of the


### PR DESCRIPTION
Closes #907.

Both defects break a generated client **silently**: it compiles, passes review, and is missing a third of every model. That is the exact drift a generated client exists to prevent, introduced by generation itself.

## 1. Nullable unions

FastAPI emits OpenAPI 3.1's `anyOf: [X, {"type": "null"}]`. A generator that cannot model the `null` arm skips the member — and skipping a member drops **the whole property** from the generated type, with a warning rather than an error. Measured on this document: **3,291 schema properties and 297 query parameters** gone, `limit` among them, so a generated client could not paginate at all.

`app.openapi()` now states nullability the way every generator already handles it — the plain schema, with the property out of `required` (`backend/app/core/openapi_compat.py`). That second half is the load-bearing one: **971** of them were nullable *and* required, and collapsing the union alone would promise a value that is routinely null.

Applied to the served document, so `/api/openapi.json`, `/api/docs` and the release asset all say the same thing.

**Request bodies keep their `required`.** On the way out it describes what the server sends; on the way in it is what the server *enforces*, and a field annotated `X | None` with no default is a key pydantic demands — so publishing it as optional would have a generated client omit it and take a 422 back. Schemas reachable from a `requestBody` (transitively) are collapsed but never un-required. `ImportedZoneOut.soa` — the one schema in the whole document used in both directions — got the default it should always have had, and a test now fails loudly on the next one.

**The trade, written down in `docs/API.md`:** the server still *sends* `"feed_url": null` rather than omitting the key, so a strict response validator (schemathesis, the live conformance fuzz) now sees an explicit null against a schema that no longer admits one. Taken deliberately — `exclude_none` on responses would change the wire for every existing client to fix what is a documentation defect, and a validator complaint is loud where the generated-code failure is silent. Decoding loses nothing: absent and null both land as `nil`.

## 2. Microsecond timestamps

`datetime.isoformat()` emits six fractional digits, and **none at all** on a whole second. Both are legal RFC 3339; neither is what most generated decoders accept, and the second is the nastier — a decoder configured *for* fractional seconds fails on the values that have none, so it breaks depending on when a row happened to be written. 6 of 7 endpoints a client called were undecodable, every one of them a 200 OK. Now pinned to exactly three digits, truncated not rounded (`backend/app/core/json_datetime.py`).

**The mechanism is the interesting part.** `Annotated[datetime, PlainSerializer(...)]` is the framework-blessed answer and means editing **714 annotations across 166 files** plus trusting every future model to remember; `json_encoders` is deprecated and gone in pydantic v3; rewriting the rendered body means sniffing every string in every response for something date-shaped — mutating opaque operator data (a raw BIND query-log line carries a timestamp) and paying a second traversal per request. So it wraps `pydantic_core.core_schema.datetime_schema`, the single point every `datetime` core schema is built through, installed from `app/__init__.py` — the only import site that reliably beats the first model class, since isort would sort the equivalent line in `main.py` below the routers. FastAPI's own encoder table is patched too (ahead of the stock entry, because `datetime` subclasses `date`, whose encoder is registered first), or the wire format would depend on whether a route declared a `response_model`.

**One trap found on the way, worth more than the rest:** declaring the serialiser's obvious `return_schema=str_schema()` rewrites the *serialisation* JSON schema — which is the mode FastAPI publishes response models in — so every `created_at` in the document silently lost `format: date-time`, trading a decode failure for a client that never parses a date at all. Omitted, and asserted in both schema modes.

Three response models (`AuditLogResponse`, `SessionRow`, `UserResponse`) additionally carried their timestamps as `str` filled by `isoformat()`, so they published with no `format: date-time` and went out in the six-digit `+00:00` shape everything else had just stopped using. Declared `datetime` and serialised like the rest (556 `date-time` formats in the document now, up from 550).

Known limits, documented: a `datetime` inside an `Any` / `dict[str, Any]` payload never builds a `datetime_schema`, so it still goes out at six digits — those fields publish as untyped JSON, no generated decoder points at them, and covering them would mean walking the contents of every opaque payload on every response.

Cost: ~0.7 µs per timestamp (a Python call where pydantic-core had a Rust formatter), ~1.4 ms on a 1,000-row response carrying two timestamps a row.

## Tests

Assert on the **wire format**, never on the patch — the regression worth catching is a future pydantic that stops routing through that function.

- `backend/tests/test_json_datetime.py` — formatter cases (whole second, truncation, non-UTC offset, naive), both serialisation paths, `mode="python"` untouched, `format: date-time` in *both* schema modes, datetime subclass, plain `date` left alone, and `list_spaces_api_v1_ipam_spaces_get` end to end.
- `backend/tests/test_openapi_nullable.py` — every rewrite shape, instance data left alone, name-keyed maps that shadow keywords, idempotency, request-body `required` preserved (ref'd, transitive and inline), and a document-level guard that no schema used in both directions is required-and-nullable.
- `backend/tests/test_openapi_export.py` — the release asset carries the normalisation.

58 passing in the new + touched files; 158 more across surrounding regression batches. ruff / black / mypy clean on every touched file.

Verified live against a running control plane: 0 null arms in the served *and* exported documents, schema and property sets unchanged, `/api/v1/ipam/spaces`, `/audit`, `/sessions`, `/users` all emitting `...:10.586Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)