### PR TITLE
feat(dns,dhcp): query-log rcode + REST pool occupancy (#913, #914)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -958,6 +958,87 @@ suggestion, free-space treemap.
     asserted in both schema modes. Tests assert on the **wire format**, never
     on the patch: the regression worth catching is a future pydantic that
     stops routing through that function.
+  - ✅ [**Expose DHCP pool occupancy over REST**](https://github.com/spatiumddi/spatiumddi/issues/913)
+    — `services/dhcp/pool_occupancy.py` has computed `assigned` / `total` /
+    `free` / `percent` since #339 and **no HTTP route called it**: it was
+    reachable only from the `find_dhcp_pool_occupancy` MCP tool and the
+    `dhcp_pool_exhaustion` alert evaluator. So "is this pool full?" — the
+    first question asked when a client cannot get an address — could only be
+    answered by fetching pools, leases and reservations separately and redoing
+    the range arithmetic, three round trips and easy to get subtly wrong.
+    Now `GET /dhcp/pools/{id}/occupancy` and
+    `GET /dhcp/scopes/{id}/pools/occupancy`, the second batching one lease +
+    reservation query across every pool — the scope shape is the one that
+    matters, since a scope with several pools is where "the scope looks fine"
+    hides one exhausted class-restricted pool. **Dynamic pools only** — the
+    scope call omits every other type and the per-pool call 422s, because each
+    would report a number that is not a fact about it: an `excluded` range is
+    never offered to a client, a `reserved` one is *supposed* to approach
+    100 % and would render as a red exhaustion bar for doing its job, and a
+    `pd` pool (#368) stores its prefix's network address in both range ends as
+    NOT NULL placeholders, so the arithmetic yields a one-address pool at 0 %.
+    That also keeps this endpoint agreeing with the `dhcp_pool_exhaustion`
+    alert evaluator and the `find_dhcp_pool_occupancy` MCP tool, which filter
+    the same way — a disagreement between those is precisely how a wrong "the
+    pool is fine" is produced. No new MCP tool (explicit decision per
+    non-negotiable #13): `find_dhcp_pool_occupancy` answers exactly this, over
+    the same pool set.
+  - ✅ [**DNS query log has no rcode**](https://github.com/spatiumddi/spatiumddi/issues/914)
+    — the log recorded the *question* and nothing about the *answer*, so
+    "was it answered, refused or NXDOMAIN?" collapsed into "there is a row"
+    or "there is not" — and the most common real outcome, a query that *was*
+    answered just not as the user expected, was indistinguishable from one
+    that was refused. BIND's `queries` category is request-side by design;
+    BIND 9.20's **`responselog`** emits a second category (`responses`)
+    carrying the RCODE and the section counts. Routed to the same
+    `queries_channel` the shipper already tails, told apart at ingest by
+    separator (`: response: ` vs `: query: `, neither expressible in a DNS
+    name), and stamped onto the query row it belongs to — matched on client
+    address + ephemeral port + qname + qtype, in-batch first and against the
+    DB when a batch boundary splits the pair, because that split lands on the
+    *same* row every time under load and would be a bias rather than noise.
+    An orphan response is dropped, never stored: a row with an outcome and no
+    question answers nothing and would double-count every query in the
+    analytics the same table feeds. **`answer_count` is carried as well as
+    `rcode`** — NOERROR with zero answers is NODATA, a different fault from
+    NXDOMAIN that reads identically without it. Opt-in per group
+    (`response_log_enabled`, migration `f1c7a92e4b06`) because it roughly
+    doubles query-log volume, and **422 when a caller explicitly asks for
+    response logging without query logging** rather than accepting a toggle
+    whose lines have no channel to go to — while simply turning query logging
+    off clears response logging with it, since refusing there would name a
+    field the caller never sent and leave no single call that disables query
+    logging at all. **NULL means
+    UNRECORDED, never NOERROR**, in every surface: `not recorded` in italics
+    in the grid, an explicit `UNKNOWN` key in the analytics breakdown (so a
+    group with the toggle off shows one honest bar, not an empty panel reading
+    as "no failures"), a selectable filter value, and the reason spelled out
+    in the copilot tool's own field. Also closes the issue's related gap:
+    `GET /dns-threat/rpz/hits` returns the individual blocked lookups behind
+    the four rollups, PASSTHRU excluded by default because an explicit ALLOW
+    listed among blocks makes a working allowlist read as an infection.
+    2 MCP tools (`find_dns_queries`, `find_rpz_hits`).
+    **Two bugs found on the way, both of the "written, never read" class the
+    #899 audit named.** (1) The agent's BIND9 renderer — what every
+    agent-managed server actually runs — never emitted
+    `category rpz { queries_channel; };`, so named logged every policy rewrite
+    to a category with no channel and #699's whole per-client attribution
+    recorded *nothing* on the only path that ships it. The control-plane Jinja
+    template has carried the line since #699, which is why review never caught
+    it: the code was right in the file nothing renders from. `rpz-passthru`
+    was missing too, leaving the exception half dark and the
+    `policy != PASSTHRU` filters unreachable. Verified live: a blocked lookup
+    that produced no row before now produces one. (2) **`rndc reconfig` does
+    not apply `responselog`** — verified against BIND 9.20.26, config swapped
+    and reconfig clean, `rndc status` still `response logging is OFF`. It is a
+    live switch and reconfig preserves what the server was last told; query
+    logging escapes this only by accident of BIND's defaulting (no `querylog`
+    statement, so it follows the `queries` category, which a reload *does*
+    pick up). Without the explicit `rndc responselog on|off` the agent now
+    issues after each structural reload — reading the desired state back off
+    the config it just swapped in — the toggle would rewrite `named.conf`,
+    pass `named-checkconf`, reload cleanly and produce not one line until the
+    daemon was next restarted.
 - ✅ [**Login banner**](https://github.com/spatiumddi/spatiumddi/issues/885) · [**custom logo**](https://github.com/spatiumddi/spatiumddi/issues/886) ·
   [**environment banner**](https://github.com/spatiumddi/spatiumddi/issues/887) · [**`app_title` wired up**](https://github.com/spatiumddi/spatiumddi/issues/888)
   — shipped together in PR

--- a/agent/dns/spatium_dns_agent/drivers/bind9.py
+++ b/agent/dns/spatium_dns_agent/drivers/bind9.py
@@ -52,7 +52,7 @@ NAMED_CONF_SKELETON = """\
     dnssec-validation {dnssec};
     key-directory "/var/cache/bind/keys";
     check-integrity no;
-{forwarders}{response_policy}{rate_limit}
+{response_log}{forwarders}{response_policy}{rate_limit}
 }};
 statistics-channels {{
     inet 127.0.0.1 port 8053 allow {{ 127.0.0.1; }};
@@ -66,7 +66,7 @@ statistics-channels {{
 # print-* defaults match ``DNSServerOptions``' column defaults; we
 # don't plumb the per-field overrides through the agent yet because
 # the operator-facing UI surfaces the boolean toggle only.
-_QUERY_LOG_BLOCK = """\
+_QUERY_LOG_HEAD = """\
 logging {
     channel queries_channel {
         file "/var/log/named/queries.log" versions 5 size 50m;
@@ -77,8 +77,64 @@ logging {
     };
     category queries { queries_channel; };
     category query-errors { queries_channel; };
-};
 """
+
+# RPZ policy hits (issue #699). named logs a rewrite to its OWN ``rpz``
+# category, never to ``queries`` — so without these two lines a blocked
+# lookup is invisible to the control plane and every per-client
+# attribution the feature exists for reports nothing. The control-plane
+# Jinja template has carried them since #699; this renderer, which is
+# what every agent-managed BIND9 server actually runs, did not, so the
+# ingest's RPZ branch had nothing to parse (issue #914).
+#
+# PASSTHRU — an exception firing, i.e. an explicit ALLOW — goes to a
+# SEPARATE category, so it needs its own line or the passthru half of
+# the attribution stays dark and the ``policy != PASSTHRU`` filters in
+# services/dns_threat/rpz.py are dead code. Verified against BIND 9.20.
+_RPZ_LOG_CATEGORIES = """\
+    category rpz { queries_channel; };
+    category rpz-passthru { queries_channel; };
+"""
+
+# Response logging (issue #914) — the RCODE and section counts, on a
+# second line per query. Routed to the same channel for the same reason
+# RPZ is: the shipper already tails this file, so no second thread, file
+# or bind mount is needed, and the control plane tells the shapes apart
+# at ingest.
+_RESPONSE_LOG_CATEGORY = """\
+    category responses { queries_channel; };
+"""
+
+
+def _render_logging_block(opts: dict[str, Any]) -> str:
+    """The ``logging { ... }`` statement, or empty when logging is off.
+
+    Response logging is nested inside the query-log gate rather than
+    standing on its own: the responses ride the ``queries_channel`` this
+    block defines, and the shipper tails the file that channel writes —
+    so enabling responses without queries would define nothing to log to
+    and ship nothing. The control plane refuses that combination with a
+    422; this is the renderer-side half of the same rule.
+    """
+    if not bool(opts.get("query_log_enabled")):
+        return ""
+    block = _QUERY_LOG_HEAD + _RPZ_LOG_CATEGORIES
+    if bool(opts.get("response_log_enabled")):
+        block += _RESPONSE_LOG_CATEGORY
+    return block + "};\n"
+
+
+def _render_response_log_option(opts: dict[str, Any]) -> str:
+    """``responselog yes;`` inside ``options``, or nothing.
+
+    Two switches, not one: the ``responses`` category says WHERE the
+    lines go, ``responselog`` says whether named emits them at all.
+    Rendering only the category would leave the operator with a toggle
+    that changes named.conf and produces no data.
+    """
+    if bool(opts.get("query_log_enabled")) and bool(opts.get("response_log_enabled")):
+        return "    responselog yes;\n"
+    return ""
 
 
 def _render_allow_update(zone: dict[str, Any], group_key_name: str | None) -> str:
@@ -754,7 +810,7 @@ class Bind9Driver(DriverBase):
                 f"    response-policy {{ {zones_list}; }} break-dnssec yes;\n"
             )
 
-        logging_block = _QUERY_LOG_BLOCK if bool(opts.get("query_log_enabled")) else ""
+        logging_block = _render_logging_block(opts)
         conf = NAMED_CONF_SKELETON.format(
             recursion=recursion,
             allow_query=allow_query,
@@ -763,6 +819,7 @@ class Bind9Driver(DriverBase):
             forwarders=fwd_block,
             response_policy=response_policy_block,
             rate_limit=_render_rate_limit_block(opts),
+            response_log=_render_response_log_option(opts),
             logging_block=logging_block,
             tsig_include=tsig_include,
             acl_statements=_render_acl_statements(bundle.get("acls")),
@@ -1379,6 +1436,7 @@ class Bind9Driver(DriverBase):
                 )
             else:
                 self._reload_rendered_zones(base, self._changed_zones(backup))
+                self._sync_response_log_runtime(base)
         if not rndc_ok and self.daemon_pid:
             # Degraded path: SIGHUP is a config + zone reload, and like a
             # plain reload it does NOT re-read a dynamic zone's file — and
@@ -1396,6 +1454,56 @@ class Bind9Driver(DriverBase):
                 )
             except OSError as e:
                 log.error("named_sighup_failed", error=str(e))
+
+    def _sync_response_log_runtime(self, base: list[str]) -> None:
+        """Assert named's runtime response-logging state after a reconfig.
+
+        ``rndc reconfig`` does NOT apply ``responselog`` (issue #914,
+        verified against BIND 9.20.26): the freshly-swapped named.conf
+        said ``responselog yes;``, the reconfig succeeded, and
+        ``rndc status`` still reported ``response logging is OFF``. It is
+        a live switch, like ``querylog``, and reconfig deliberately
+        preserves whatever the running server was last told rather than
+        stamping the file's value over an operator's ``rndc`` override.
+
+        Query logging escapes this only by accident of BIND's own
+        defaulting — with no ``querylog`` statement, it follows the
+        presence of the ``queries`` logging category, which the reload
+        does pick up. Response logging does not follow its category the
+        same way, so without this the operator gets a toggle that
+        rewrites named.conf, passes ``named-checkconf``, reloads cleanly
+        and produces not one line until the daemon is next restarted.
+
+        The desired state is read back off the config we just swapped in
+        rather than threaded down from the bundle, so it cannot disagree
+        with what named is actually running — the same reason #899 and
+        #734 assert on the rendered config rather than the stored row.
+
+        Best effort: a failure leaves the config-file value to take
+        effect at the next restart, which is strictly better than the
+        pre-#914 behaviour, so it is logged rather than raised.
+        """
+        conf = self.state_dir / self.rendered_dir_name / "named.conf"
+        try:
+            desired = "responselog yes;" in conf.read_text()
+        except OSError as exc:
+            log.warning("rndc_responselog_conf_unreadable", error=str(exc))
+            return
+        res = subprocess.run(
+            [*base, "responselog", "on" if desired else "off"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if res.returncode != 0:
+            # An older named has no ``responselog`` command at all, which
+            # is a legitimate reason to land here — hence warning, not
+            # error, and no exception.
+            log.warning(
+                "rndc_responselog_failed",
+                desired=desired,
+                stderr=res.stderr.strip(),
+            )
 
     def rendered_zone_views(self) -> list[tuple[str, str | None]]:
         """``(zone_name, view_name)`` for every zone file we just rendered.

--- a/agent/dns/tests/test_query_log_render.py
+++ b/agent/dns/tests/test_query_log_render.py
@@ -1,0 +1,133 @@
+"""BIND9 agent query / response / RPZ logging block (issues #699, #914).
+
+This renderer — not the control-plane Jinja template — is what every
+agent-managed BIND9 server actually runs, and the two have drifted:
+the template routed the ``rpz`` categories from #699 and this file never
+did, so a policy rewrite was logged to a category pointing nowhere and
+the whole per-client blocklist attribution reported nothing on the only
+path that ships it. That is the "settable, stored, never rendered" class
+of bug the ``allow_transfer`` (#734) and ``forward_policy`` (#899)
+findings belong to, and the reason these assertions are on the RENDERED
+config rather than on the stored options.
+"""
+
+from __future__ import annotations
+
+from spatium_dns_agent.drivers.bind9 import (
+    _render_logging_block,
+    _render_response_log_option,
+)
+
+
+def test_logging_off_renders_nothing() -> None:
+    assert _render_logging_block({}) == ""
+    assert _render_logging_block({"query_log_enabled": False}) == ""
+    # An existing group must render a byte-identical named.conf.
+    assert _render_response_log_option({"response_log_enabled": True}) == ""
+
+
+def test_query_logging_routes_the_rpz_categories() -> None:
+    """named logs a rewrite to ``rpz``, never to ``queries``.
+
+    Without both lines the hit goes to a category with no channel and
+    the attribution feature silently records nothing. PASSTHRU has its
+    own category, so its absence would leave the exception half dark and
+    the ``policy != PASSTHRU`` filters unreachable.
+    """
+    out = _render_logging_block({"query_log_enabled": True})
+    assert "category queries { queries_channel; };" in out
+    assert "category query-errors { queries_channel; };" in out
+    assert "category rpz { queries_channel; };" in out
+    assert "category rpz-passthru { queries_channel; };" in out
+    assert out.rstrip().endswith("};")
+
+
+def test_response_logging_needs_both_switches() -> None:
+    """The category says WHERE the lines go; ``responselog`` says whether
+    named emits them at all. Rendering one without the other gives the
+    operator a toggle that changes named.conf and produces no data."""
+    opts = {"query_log_enabled": True, "response_log_enabled": True}
+    assert "category responses { queries_channel; };" in _render_logging_block(opts)
+    assert _render_response_log_option(opts) == "    responselog yes;\n"
+
+
+def test_response_logging_is_off_by_default() -> None:
+    out = _render_logging_block({"query_log_enabled": True})
+    assert "category responses" not in out
+    assert _render_response_log_option({"query_log_enabled": True}) == ""
+
+
+def test_response_logging_alone_renders_nothing() -> None:
+    """The responses ride ``queries_channel``, which only exists inside
+    the query-log block — so this combination has nowhere to write. The
+    control plane 422s it; the renderer is the second line of defence."""
+    opts = {"query_log_enabled": False, "response_log_enabled": True}
+    assert _render_logging_block(opts) == ""
+    assert _render_response_log_option(opts) == ""
+
+
+# ── Runtime state, not just the file (issue #914) ─────────────────────
+
+
+def _driver(tmp_path, conf_text: str):
+    from spatium_dns_agent.drivers.bind9 import Bind9Driver
+
+    driver = Bind9Driver(state_dir=tmp_path)
+    rendered = tmp_path / driver.rendered_dir_name
+    rendered.mkdir(parents=True, exist_ok=True)
+    (rendered / "named.conf").write_text(conf_text)
+    return driver
+
+
+def test_reconfig_asserts_response_logging_on(tmp_path, monkeypatch) -> None:
+    """``rndc reconfig`` does not apply ``responselog``.
+
+    Verified against BIND 9.20.26: the swapped-in config said
+    ``responselog yes;``, the reconfig succeeded, and ``rndc status``
+    still reported OFF. Without this call the operator gets a toggle
+    that rewrites named.conf, validates, reloads — and logs nothing
+    until the daemon next restarts.
+    """
+    import subprocess
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    driver = _driver(tmp_path, "options {\n    responselog yes;\n};\n")
+    driver._sync_response_log_runtime(["rndc"])
+    assert calls == [["rndc", "responselog", "on"]]
+
+
+def test_reconfig_asserts_response_logging_off(tmp_path, monkeypatch) -> None:
+    """And the other direction — turning it back off must actually stop
+    the second line per query, not wait for a restart."""
+    import subprocess
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    driver = _driver(tmp_path, "options {\n    recursion yes;\n};\n")
+    driver._sync_response_log_runtime(["rndc"])
+    assert calls == [["rndc", "responselog", "off"]]
+
+
+def test_response_log_sync_survives_an_old_named(tmp_path, monkeypatch) -> None:
+    """A named with no ``responselog`` command is a legitimate reason to
+    fail here, and the config-file value still applies at the next
+    restart — so it warns rather than raising and aborting the apply."""
+    import subprocess
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        return subprocess.CompletedProcess(cmd, 1, "", "unknown command")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    driver = _driver(tmp_path, "options {\n    responselog yes;\n};\n")
+    driver._sync_response_log_runtime(["rndc"])  # must not raise

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -675,10 +675,10 @@ backend/alembic/versions/e7f94b21c8d5_dns_zone_dnssec_ds_records.py:drop_column:
 backend/alembic/versions/e8c3f1b9a724_appliance_revoked_at.py:drop_column:65
 backend/alembic/versions/e8c3f1b9a724_appliance_revoked_at.py:drop_column:72
 backend/alembic/versions/e93b41ad7c5f_ai_daily_digest_setting.py:drop_column:39
-backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:66
 backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:67
 backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:68
 backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:69
+backend/alembic/versions/e9c2d47b1a63_agent_config_apply_status.py:drop_column:70
 backend/alembic/versions/e9c47a1f3b28_wake_scheduler.py:drop_table:235
 backend/alembic/versions/e9c47a1f3b28_wake_scheduler.py:drop_table:237
 backend/alembic/versions/e9c47a1f3b28_wake_scheduler.py:drop_table:239
@@ -702,6 +702,9 @@ backend/alembic/versions/f1a8d2c5e413_dns_pull_from_server_settings.py:drop_colu
 backend/alembic/versions/f1a8d2c5e413_dns_pull_from_server_settings.py:drop_column:58
 backend/alembic/versions/f1c4a90b27d6_appliance_ssh_settings.py:drop_column:97
 backend/alembic/versions/f1c4a90b27d6_appliance_ssh_settings.py:drop_column:99
+backend/alembic/versions/f1c7a92e4b06_dns_query_rcode.py:drop_column:45
+backend/alembic/versions/f1c7a92e4b06_dns_query_rcode.py:drop_column:46
+backend/alembic/versions/f1c7a92e4b06_dns_query_rcode.py:drop_column:47
 backend/alembic/versions/f1c8b2a945d3_subnet_ops_ipspace_vrf.py:drop_column:57
 backend/alembic/versions/f1c8b2a945d3_subnet_ops_ipspace_vrf.py:drop_column:58
 backend/alembic/versions/f1c8b2a945d3_subnet_ops_ipspace_vrf.py:drop_column:59

--- a/backend/alembic/versions/f1c7a92e4b06_dns_query_rcode.py
+++ b/backend/alembic/versions/f1c7a92e4b06_dns_query_rcode.py
@@ -1,0 +1,47 @@
+"""DNS query-log rcode + BIND response logging (issue #914)
+
+Adds the answer side of the query log:
+
+* ``dns_query_log_entry.rcode`` / ``.answer_count`` — what the client was
+  actually told. Nullable, and NULL means UNKNOWN rather than NOERROR:
+  an unrecorded outcome rendered as "fine" is precisely the wrong answer
+  for the operator who is trying to work out whether DNS is the fault.
+* ``dns_server_options.response_log_enabled`` — the opt-in that makes
+  BIND emit the ``responses`` category those two columns are filled
+  from. Defaults to false, so an existing install renders a
+  byte-identical ``named.conf`` until an operator turns it on.
+
+Revision ID: f1c7a92e4b06
+Revises: e9c2d47b1a63
+Create Date: 2026-08-23
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "f1c7a92e4b06"
+down_revision = "e9c2d47b1a63"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("dns_query_log_entry", sa.Column("rcode", sa.String(length=16), nullable=True))
+    op.add_column("dns_query_log_entry", sa.Column("answer_count", sa.Integer(), nullable=True))
+    op.add_column(
+        "dns_server_options",
+        sa.Column(
+            "response_log_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("dns_server_options", "response_log_enabled")
+    op.drop_column("dns_query_log_entry", "answer_count")
+    op.drop_column("dns_query_log_entry", "rcode")

--- a/backend/app/api/v1/dhcp/pools.py
+++ b/backend/app/api/v1/dhcp/pools.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ipaddress
 import uuid
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -18,6 +18,10 @@ from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
 from app.models.dhcp import DHCPPool, DHCPScope
 from app.models.ipam import IPAddress
+from app.services.dhcp.pool_occupancy import (
+    PoolOccupancy,
+    compute_pool_occupancy_batch,
+)
 from app.services.dhcp.windows_writethrough import push_pool_change
 
 router = APIRouter(tags=["dhcp"], dependencies=[Depends(require_resource_permission("dhcp_pool"))])
@@ -333,3 +337,131 @@ async def delete_pool(pool_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
     )
     await db.delete(pool)
     await db.commit()
+
+
+# ── Occupancy (issue #913) ───────────────────────────────────────────
+#
+# ``services/dhcp/pool_occupancy.py`` has computed this since #339, but
+# nothing HTTP called it — it was reachable only from the
+# ``find_dhcp_pool_occupancy`` MCP tool and the ``dhcp_pool_exhaustion``
+# alert evaluator. So "is this pool full?", which is the first question
+# asked when a client cannot get an address, could only be answered by a
+# caller that fetched pools + leases + reservations and redid the range
+# arithmetic itself — three round trips and an easy thing to get subtly
+# wrong, and a wrong "the pool is fine" sends the technician to the
+# wrong place.
+
+
+class PoolOccupancyResponse(BaseModel):
+    """Live occupancy of one address-range pool.
+
+    ``assigned`` unions active leases with in-pool static reservations, so
+    a reserved-but-offline address counts as unavailable (#631) and a
+    reserved-and-currently-leased one is not double-counted.
+    """
+
+    pool_id: uuid.UUID
+    scope_id: uuid.UUID
+    pool_name: str
+    start_ip: str
+    end_ip: str
+    pool_type: str
+    total: int
+    assigned: int
+    free: int
+    percent: float
+    #: Occupancy is derived at request time from mirrored lease rows, whose
+    #: freshness depends on the last lease pull — so the caller is told
+    #: when the number was computed rather than being left to assume it is
+    #: instantaneous.
+    computed_at: datetime
+
+
+#: Occupancy is a *dynamic-allocation* question — "can a client still get
+#: an address from here" — so it is answered for dynamic pools only, which
+#: is also what the ``dhcp_pool_exhaustion`` alert evaluator and the
+#: ``find_dhcp_pool_occupancy`` MCP tool already filter to. Reporting it
+#: for the other types would disagree with both:
+#:
+#: * an ``excluded`` range is one DHCP will never offer, so a percentage
+#:   full is not a fact about it at all;
+#: * a ``reserved`` range is held for static assignments, so a correctly
+#:   configured one is *supposed* to approach 100% and would render as a
+#:   red exhaustion bar for doing its job;
+#: * a ``pd`` pool (#368) stores its prefix's network address in both
+#:   ``start_ip`` and ``end_ip`` as NOT NULL placeholders rather than a
+#:   range, so the arithmetic yields a one-address pool at 0% — a number
+#:   that looks like an answer and is not one.
+_OCCUPANCY_POOL_TYPE = "dynamic"
+
+
+def _not_applicable(pool_type: str) -> str:
+    if pool_type == "pd":
+        return (
+            "Prefix-delegation pools have no address-range occupancy — "
+            "start_ip/end_ip are placeholders for the delegated prefix, not a range."
+        )
+    return (
+        f"Occupancy is only meaningful for dynamic pools; this one is "
+        f"{pool_type!r}. An excluded range is never offered to a client, and a "
+        f"reserved range is supposed to fill up."
+    )
+
+
+def _occupancy_row(
+    pool: DHCPPool, occ: PoolOccupancy, computed_at: datetime
+) -> PoolOccupancyResponse:
+    return PoolOccupancyResponse(
+        pool_id=pool.id,
+        scope_id=pool.scope_id,
+        pool_name=pool.name or "",
+        start_ip=str(pool.start_ip),
+        end_ip=str(pool.end_ip),
+        pool_type=pool.pool_type,
+        total=occ.total,
+        assigned=occ.assigned,
+        free=occ.free,
+        percent=round(occ.percent, 2),
+        computed_at=computed_at,
+    )
+
+
+@router.get("/pools/{pool_id}/occupancy", response_model=PoolOccupancyResponse)
+async def pool_occupancy(pool_id: uuid.UUID, db: DB, _: CurrentUser) -> PoolOccupancyResponse:
+    """Live occupancy of one pool — assigned / total / free / percent."""
+    pool = await db.get(DHCPPool, pool_id)
+    if pool is None:
+        raise HTTPException(status_code=404, detail="Pool not found")
+    if pool.pool_type != _OCCUPANCY_POOL_TYPE:
+        raise HTTPException(status_code=422, detail=_not_applicable(pool.pool_type))
+    occ = (await compute_pool_occupancy_batch(db, [pool]))[pool.id]
+    return _occupancy_row(pool, occ, datetime.now(UTC))
+
+
+@router.get("/scopes/{scope_id}/pools/occupancy", response_model=list[PoolOccupancyResponse])
+async def scope_pool_occupancy(
+    scope_id: uuid.UUID, db: DB, _: CurrentUser
+) -> list[PoolOccupancyResponse]:
+    """Live occupancy of every dynamic pool in a scope, in one call.
+
+    The scope-level shape is the one that matters operationally: a scope
+    with several pools is exactly where a call-per-pool is wasteful, and
+    also where "the scope looks fine" hides one exhausted class-restricted
+    pool. Non-dynamic pools are omitted rather than reported at a number
+    that is not a fact about them — see :data:`_OCCUPANCY_POOL_TYPE`.
+    """
+    scope = await db.get(DHCPScope, scope_id)
+    if scope is None:
+        raise HTTPException(status_code=404, detail="Scope not found")
+    res = await db.execute(
+        select(DHCPPool)
+        .where(DHCPPool.scope_id == scope_id)
+        .where(DHCPPool.pool_type == _OCCUPANCY_POOL_TYPE)
+        .order_by(DHCPPool.start_ip)
+    )
+    pools = list(res.scalars().all())
+    # One batched lease + reservation query for every pool, not one per
+    # pool — the whole point of answering at the scope level.
+    occ_by_pool = await compute_pool_occupancy_batch(db, pools)
+    computed_at = datetime.now(UTC)
+    return [_occupancy_row(p, occ_by_pool[p.id], computed_at) for p in pools]

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -10,7 +10,7 @@ import contextlib
 import hmac
 import os
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
@@ -19,6 +19,7 @@ from jose import JWTError
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB
 from app.core.agent_wake import (
@@ -957,11 +958,31 @@ async def agent_query_log_entries(
         with contextlib.suppress(Exception):
             rpz_capable = bool(get_dns_driver(server.driver).capabilities().get("rpz"))
 
+    # Response logging (#914) is BIND9-only and opt-in, but the flag that
+    # decides it lives on the server group's options rather than here.
+    # Keying off the driver's own capability instead of a driver-name
+    # string keeps a future agent-based driver from being silently opted
+    # into BIND9 line matching (non-negotiable #10); the parser's own
+    # ``response:`` reject makes the probe cheap on every other line.
+    response_capable = False
+    with contextlib.suppress(Exception):
+        response_capable = bool(get_dns_driver(server.driver).capabilities().get("response_log"))
+
     capped = body.lines[:1000]
     dropped = max(0, len(body.lines) - len(capped))
     now = datetime.now(UTC)
     inserted = 0
     rpz_inserted = 0
+    responses_matched = 0
+    # Query rows added in THIS batch, keyed for the response line that
+    # follows them microseconds later. named writes the pair together, so
+    # the overwhelming majority of responses are matched here without
+    # touching the database at all.
+    pending: dict[tuple[str | None, int | None, str | None, str | None], DNSQueryLogEntry] = {}
+    # Responses whose question landed in an EARLIER batch — only possible
+    # when the 1000-line cap or the shipper's own batch boundary fell
+    # between the two lines. Resolved against the DB after the loop.
+    deferred: list[bind9_parser.ParsedResponseLine] = []
     for raw in capped:
         # RPZ policy hits (issue #699) ride the same channel as queries —
         # named logs them under its own ``rpz`` category, which the
@@ -992,31 +1013,132 @@ async def agent_query_log_entries(
                 )
                 rpz_inserted += 1
                 continue
+        # Response lines (issue #914) ride the same channel as queries when
+        # the operator enabled ``response_log_enabled``. They are tried
+        # before the query parser because a response line carries no
+        # ``: query: `` separator and would otherwise be dropped by the
+        # ``qname is None`` guard below — losing the only record of what
+        # the client was actually told. BIND9-only; the parser returns
+        # None for every other shape, which makes running it against
+        # pdns output harmless rather than conditional.
+        if response_capable:
+            resp = bind9_parser.parse_response_line(raw, fallback_ts=now)
+            if resp is not None:
+                row = pending.get(_correlation_key(resp))
+                if row is not None:
+                    row.rcode = resp.rcode
+                    row.answer_count = resp.answer_count
+                    responses_matched += 1
+                else:
+                    deferred.append(resp)
+                continue
         parsed = parse_fn(raw, fallback_ts=now)
         if parsed is None or parsed.qname is None:
             continue
-        db.add(
-            DNSQueryLogEntry(
-                server_id=server.id,
-                ts=parsed.ts,
-                client_ip=parsed.client_ip,
-                client_port=parsed.client_port,
-                qname=parsed.qname,
-                qclass=parsed.qclass,
-                qtype=parsed.qtype,
-                flags=parsed.flags,
-                view=parsed.view,
-                raw=parsed.raw,
-            )
+        entry = DNSQueryLogEntry(
+            server_id=server.id,
+            ts=parsed.ts,
+            client_ip=parsed.client_ip,
+            client_port=parsed.client_port,
+            qname=parsed.qname,
+            qclass=parsed.qclass,
+            qtype=parsed.qtype,
+            flags=parsed.flags,
+            view=parsed.view,
+            raw=parsed.raw,
         )
+        db.add(entry)
+        if response_capable:
+            # Last writer wins: an ephemeral source port is effectively
+            # unique per query, but a client that retries the identical
+            # question from the same port would otherwise have its second
+            # answer stamped onto its first row.
+            pending[_correlation_key(parsed)] = entry
         inserted += 1
+
+    deferred_matched = await _stamp_deferred_responses(db, server.id, deferred)
     await db.commit()
     return {
         "status": "ok",
         "inserted": inserted,
         "rpz_inserted": rpz_inserted,
+        "responses_matched": responses_matched + deferred_matched,
+        # Reported rather than swallowed: a persistently non-zero count
+        # means the correlation is failing, and the operator-visible
+        # symptom of that is an rcode column that is quietly blank.
+        "responses_unmatched": len(deferred) - deferred_matched,
         "dropped": dropped,
     }
+
+
+# ── Response-line correlation (issue #914) ───────────────────────────
+
+#: Response lines whose question was not in the same batch are resolved
+#: with one small query each. The split can only happen at a batch
+#: boundary, so the realistic count is 0 or 1; the cap is a backstop
+#: against a malformed or replayed batch turning one POST into a
+#: thousand round trips.
+_MAX_DEFERRED_RESPONSES = 50
+
+#: How far back to look for the question a late response answers. named
+#: writes the two lines microseconds apart, so this only has to cover the
+#: shipper's own batching interval; anything older is a different query
+#: that happens to share the ephemeral port.
+_RESPONSE_MATCH_WINDOW = timedelta(seconds=60)
+
+
+def _correlation_key(
+    parsed: Any,
+) -> tuple[str | None, int | None, str | None, str | None]:
+    """The tuple that ties a response line back to its question.
+
+    The ephemeral source port does nearly all the work — it is unique per
+    outstanding query from a given client — with qname and qtype as
+    corroboration so a port reused inside the batch cannot cross-stamp.
+    """
+    return (parsed.client_ip, parsed.client_port, parsed.qname, parsed.qtype)
+
+
+async def _stamp_deferred_responses(
+    db: AsyncSession,
+    server_id: uuid.UUID,
+    deferred: list[Any],
+) -> int:
+    """Stamp responses whose query row was committed by an earlier batch.
+
+    Returns how many were matched. An unmatched response is dropped
+    rather than stored on its own: a row with an outcome and no question
+    answers nothing, and inventing a query row for it would double-count
+    every query in the analytics rollups.
+    """
+    if not deferred:
+        return 0
+    matched = 0
+    for resp in deferred[:_MAX_DEFERRED_RESPONSES]:
+        stmt = (
+            select(DNSQueryLogEntry)
+            .where(DNSQueryLogEntry.server_id == server_id)
+            .where(DNSQueryLogEntry.rcode.is_(None))
+            .where(DNSQueryLogEntry.qname == resp.qname)
+            .where(DNSQueryLogEntry.qtype == resp.qtype)
+            .where(DNSQueryLogEntry.client_port == resp.client_port)
+            .where(DNSQueryLogEntry.ts >= resp.ts - _RESPONSE_MATCH_WINDOW)
+            # A response cannot precede its question, but the two lines
+            # carry independently-formatted timestamps, so allow a small
+            # amount of slack rather than losing a match to rounding.
+            .where(DNSQueryLogEntry.ts <= resp.ts + timedelta(seconds=1))
+            .order_by(DNSQueryLogEntry.ts.desc(), DNSQueryLogEntry.id.desc())
+            .limit(1)
+        )
+        if resp.client_ip is not None:
+            stmt = stmt.where(DNSQueryLogEntry.client_ip == resp.client_ip)
+        row = (await db.execute(stmt)).scalars().first()
+        if row is None:
+            continue
+        row.rcode = resp.rcode
+        row.answer_count = resp.answer_count
+        matched += 1
+    return matched
 
 
 # ── Admin runtime-state push (rendered config + rndc status) ─────────

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -541,6 +541,9 @@ class ServerOptionsUpdate(BaseModel):
     allow_transfer: list[str] | None = None
     blackhole: list[str] | None = None
     query_log_enabled: bool | None = None
+    # Issue #914 — BIND9 only, and only alongside query logging (see the
+    # 422 in ``update_options``).
+    response_log_enabled: bool | None = None
     query_log_channel: str | None = None
     query_log_file: str | None = None
     query_log_severity: str | None = None
@@ -685,6 +688,7 @@ class ServerOptionsResponse(BaseModel):
     allow_transfer: list[str]
     blackhole: list[str]
     query_log_enabled: bool
+    response_log_enabled: bool
     query_log_channel: str
     query_log_file: str
     query_log_severity: str
@@ -2846,6 +2850,31 @@ async def update_options(
         setattr(opts, k, v)
 
     await _assert_encrypted_transport_sane(opts, db)
+    # Response logging (#914) has nowhere to go without the query-log
+    # channel: the ``responses`` category is routed to ``queries_channel``,
+    # which is only defined inside the query-log block, and the agent's
+    # shipper tails the file that channel writes.
+    #
+    # Which of the two things to do about that depends on what the caller
+    # ASKED for, not on the merged row. Someone explicitly requesting the
+    # impossible pair is refused, because a toggle that reports success
+    # and produces no rcodes is the "configured but does nothing" failure
+    # this codebase keeps finding. But someone simply turning query
+    # logging off has not asked for anything impossible, and 422ing them
+    # over a field they never sent would leave no single call that
+    # disables query logging at all — so response logging is cleared with
+    # it, which is the only coherent resulting state.
+    if opts.response_log_enabled and not opts.query_log_enabled:
+        if body.response_log_enabled:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "response_log_enabled requires query_log_enabled — response "
+                    "lines are written to the query-log channel."
+                ),
+            )
+        opts.response_log_enabled = False
+        changes["response_log_enabled"] = False
 
     db.add(
         AuditLog(

--- a/backend/app/api/v1/dns_threat/router.py
+++ b/backend/app/api/v1/dns_threat/router.py
@@ -450,6 +450,55 @@ async def rpz_names(
     ]
 
 
+class RPZHitRow(BaseModel):
+    """One individual policy hit — the raw event, not a rollup."""
+
+    id: str
+    ts: datetime
+    server_id: str | None
+    client_ip: str | None
+    qname: str | None
+    trigger: str
+    policy: str
+    rpz_zone: str | None
+    raw: str
+
+
+@router.get("/rpz/hits", response_model=list[RPZHitRow])
+async def rpz_hits(
+    db: DB,
+    current_user: CurrentUser,
+    hours: int = Query(default=24, ge=1, le=24 * 30),
+    limit: int = Query(default=100, ge=1, le=500),
+    client_ip: str | None = Query(default=None),
+    qname_contains: str | None = Query(default=None, max_length=255),
+    include_passthru: bool = Query(default=False),
+) -> list[RPZHitRow]:
+    """The individual blocked lookups, newest first (issue #914).
+
+    The four rollups above answer "how much"; this answers "what". The
+    rows have been stored since #699 and were reachable from no endpoint,
+    so "show me the three lookups this PC made in the last ten minutes
+    that were blocked" — the question that actually closes out a user
+    report — could not be asked.
+
+    ``include_passthru`` is off by default: a PASSTHRU is an explicit
+    ALLOW, and listing it among blocks makes a working allowlist look
+    like an infection.
+    """
+    return [
+        RPZHitRow(**r)
+        for r in await rpz_service.recent_hits(
+            db,
+            hours=hours,
+            limit=limit,
+            client_ip=_validated_ip(client_ip) if client_ip else None,
+            qname_contains=qname_contains,
+            include_passthru=include_passthru,
+        )
+    ]
+
+
 @router.get("/rpz/feeds", response_model=list[RPZFeedRow])
 async def rpz_feeds(
     db: DB,

--- a/backend/app/api/v1/logs/router.py
+++ b/backend/app/api/v1/logs/router.py
@@ -473,6 +473,12 @@ class DNSQueryLogRow(BaseModel):
     qtype: str | None
     flags: str | None
     view: str | None
+    # What the client was actually told (issue #914). NULL means the
+    # outcome was never recorded — response logging is off, or the driver
+    # has no equivalent — and NOT that the query succeeded. The UI must
+    # render the two differently or an unrecorded query reads as healthy.
+    rcode: str | None = None
+    answer_count: int | None = None
     raw: str
 
 
@@ -486,6 +492,11 @@ class DNSQueryLogRequest(BaseModel):
     # Exact-match view filter (#371) — seeded by clicking a per-view
     # analytics card so split-horizon operators can drill into one view.
     view: str | None = None
+    # Exact-match RCODE (#914), case-insensitive: "NXDOMAIN", "REFUSED",
+    # "SERVFAIL". The literal ``UNKNOWN`` selects rows whose outcome was
+    # never recorded, which is a question an operator genuinely asks
+    # ("is response logging actually on?") and cannot express otherwise.
+    rcode: str | None = None
     max_events: int = Field(default=200, ge=1, le=1000)
 
 
@@ -527,6 +538,12 @@ async def query_dns_queries(body: DNSQueryLogRequest, db: DB) -> DNSQueryLogResp
         stmt = stmt.where(DNSQueryLogEntry.client_ip == body.client_ip)
     if body.view:
         stmt = stmt.where(DNSQueryLogEntry.view == body.view)
+    if body.rcode:
+        wanted = body.rcode.strip().upper()
+        if wanted == _RCODE_UNKNOWN:
+            stmt = stmt.where(DNSQueryLogEntry.rcode.is_(None))
+        else:
+            stmt = stmt.where(DNSQueryLogEntry.rcode == wanted)
     if body.q:
         like = f"%{body.q.lower()}%"
         # ILIKE on qname (most common search) and a fallback on raw —
@@ -549,6 +566,8 @@ async def query_dns_queries(body: DNSQueryLogRequest, db: DB) -> DNSQueryLogResp
             qtype=r.qtype,
             flags=r.flags,
             view=r.view,
+            rcode=r.rcode,
+            answer_count=r.answer_count,
             raw=r.raw,
         )
         for r in rows
@@ -558,6 +577,13 @@ async def query_dns_queries(body: DNSQueryLogRequest, db: DB) -> DNSQueryLogResp
         events=events,
         truncated=len(events) >= body.max_events,
     )
+
+
+#: Sentinel used on the wire for "the outcome was never recorded". Not a
+#: real DNS RCODE, and deliberately not spelled like one — an operator
+#: reading ``UNKNOWN`` in the filter or the distribution should not
+#: mistake it for something the resolver returned.
+_RCODE_UNKNOWN = "UNKNOWN"
 
 
 # ── DNS query analytics ─────────────────────────────────────────────────────
@@ -588,6 +614,11 @@ class DNSQueryAnalyticsResponse(BaseModel):
     # Per-view query split (issue #371) — empty for single-view servers; useful
     # for split-horizon operators to see "which view is taking the load".
     top_views: list[DNSQueryAnalyticsRow]
+    # Outcome split (issue #914). Rows with no recorded outcome are
+    # reported under the ``UNKNOWN`` key rather than omitted, so a server
+    # with response logging off shows one honest bar instead of an empty
+    # panel that reads as "no failures".
+    rcode_distribution: list[DNSQueryAnalyticsRow]
 
 
 @router.post("/dns-queries/analytics", response_model=DNSQueryAnalyticsResponse)
@@ -641,6 +672,23 @@ async def query_dns_analytics(body: DNSQueryAnalyticsRequest, db: DB) -> DNSQuer
     qtype_distribution = await _topn(DNSQueryLogEntry.qtype, 25)
     # Per-view split (issue #371) — every view seen (small cardinality).
     top_views = await _topn(DNSQueryLogEntry.view, 25)
+    # Outcome split (#914). ``_topn`` skips NULLs by design — that is
+    # right for a "top talkers" list and wrong here, where the NULLs are
+    # the answer to "is response logging on at all". Counted separately
+    # and prepended under an explicit key.
+    rcode_distribution = await _topn(DNSQueryLogEntry.rcode, 25)
+    unknown_rcodes = (
+        await db.execute(
+            select(func.count())
+            .select_from(DNSQueryLogEntry)
+            .where(*base_filter, DNSQueryLogEntry.rcode.is_(None))
+        )
+    ).scalar_one() or 0
+    if unknown_rcodes:
+        rcode_distribution.append(
+            DNSQueryAnalyticsRow(key=_RCODE_UNKNOWN, count=int(unknown_rcodes))
+        )
+        rcode_distribution.sort(key=lambda r: r.count, reverse=True)
 
     return DNSQueryAnalyticsResponse(
         server_id=server.id,
@@ -651,6 +699,7 @@ async def query_dns_analytics(body: DNSQueryAnalyticsRequest, db: DB) -> DNSQuer
         top_clients=top_clients,
         qtype_distribution=qtype_distribution,
         top_views=top_views,
+        rcode_distribution=rcode_distribution,
     )
 
 

--- a/backend/app/drivers/dns/base.py
+++ b/backend/app/drivers/dns/base.py
@@ -181,6 +181,10 @@ class ServerOptions:
     blackhole: tuple[str, ...] = ()
     trust_anchors: tuple[TrustAnchorData, ...] = ()
     query_log_enabled: bool = False
+    # Per-query RCODE logging (#914). BIND9-only, and only meaningful
+    # alongside ``query_log_enabled`` — the responses ride the same
+    # channel the query-log shipper already tails.
+    response_log_enabled: bool = False
     query_log_channel: str = "file"
     query_log_file: str = "/var/log/named/queries.log"
     query_log_severity: str = "info"

--- a/backend/app/drivers/dns/bind9.py
+++ b/backend/app/drivers/dns/bind9.py
@@ -490,6 +490,11 @@ class BIND9Driver(DNSDriver):
             "name": "bind9",
             "views": True,
             "rpz": True,
+            # Per-query RCODE via BIND 9.20's ``responselog`` (#914).
+            # Advertised as a capability rather than checked by driver
+            # name so the query-log ingest never has to know which
+            # daemon wrote a line (non-negotiable #10).
+            "response_log": True,
             "dnssec_inline_signing": True,
             "incremental_updates": "rfc2136",
             "zone_types": ["primary", "secondary", "stub", "forward"],

--- a/backend/app/drivers/dns/templates/bind9/named.conf.j2
+++ b/backend/app/drivers/dns/templates/bind9/named.conf.j2
@@ -59,6 +59,14 @@ options {
     blackhole { {% for a in options.blackhole %}{{ a }}; {% endfor %}};
     {%- endif %}
     dnssec-validation {{ options.dnssec_validation }};
+    {#- Per-query RCODE logging (issue #914). Gated on query logging too:
+        the response lines are routed to ``queries_channel``, which only
+        exists inside the query-log block below, and the agent shipper
+        tails the file that channel writes. Enabling responses alone
+        would define nothing to log to. #}
+    {%- if options.query_log_enabled and options.response_log_enabled %}
+    responselog yes;
+    {%- endif %}
     notify {{ options.notify_enabled }};
     {%- if options.also_notify %}
     also-notify { {% for a in options.also_notify %}{{ a }}; {% endfor %}};
@@ -157,6 +165,13 @@ logging {
         `policy != PASSTHRU` filters in services/dns_threat/rpz.py are
         dead code. Verified against BIND 9.20. #}
     category rpz-passthru { queries_channel; };
+    {#- The answer half of each query (issue #914) — RCODE plus the
+        answer/authority/additional counts, which is what separates
+        NXDOMAIN from REFUSED from a NODATA NOERROR. Same channel again:
+        the agent already tails it. #}
+    {%- if options.response_log_enabled %}
+    category responses { queries_channel; };
+    {%- endif %}
 };
 {%- endif %}
 

--- a/backend/app/models/dns.py
+++ b/backend/app/models/dns.py
@@ -433,6 +433,14 @@ class DNSServerOptions(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     query_log_print_severity: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     query_log_print_time: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
+    # Response logging (issue #914). BIND 9.20's ``responselog`` adds a
+    # second line per query carrying the RCODE and the section counts —
+    # the only way, short of dnstap, to know what a client was actually
+    # told. Opt-in and default-off because it doubles query-log volume,
+    # and volume is the reason the query log is capped at a 24 h window
+    # in the first place.
+    response_log_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
     # ── Response Rate Limiting (RRL) + amplification defenses (issue #146) ──
     # All default to a no-op so an existing install renders byte-identical
     # named.conf until an operator opts in. The rate-limit{} block is emitted

--- a/backend/app/models/logs.py
+++ b/backend/app/models/logs.py
@@ -43,6 +43,10 @@ class DNSQueryLogEntry(Base):
     We extract the client IP / port, qname, qclass, qtype, and the
     flags string into structured columns; the full original line is
     kept in ``raw`` for cases the parser doesn't fully understand.
+
+    ``rcode`` / ``answer_count`` come from a *second* line — BIND's
+    ``responses`` category — stamped onto this row at ingest when the
+    operator has opted into response logging (issue #914).
     """
 
     __tablename__ = "dns_query_log_entry"
@@ -66,6 +70,29 @@ class DNSQueryLogEntry(Base):
     flags: Mapped[str | None] = mapped_column(String(64), nullable=True)
     view: Mapped[str | None] = mapped_column(String(255), nullable=True)
     raw: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+    # ── What the client actually got back (issue #914) ────────────────
+    #
+    # BIND's ``queries`` category is request-side by design: it logs the
+    # question on arrival and says nothing about the answer. So until
+    # #914 the log could prove a query reached the server and could not
+    # distinguish the five outcomes an operator is actually triaging —
+    # NOERROR, NOERROR-with-no-answers (NODATA), NXDOMAIN, REFUSED,
+    # SERVFAIL — which is the difference between "it is not DNS" and
+    # "an ACL is rejecting this client".
+    #
+    # These are filled from BIND's separate ``responses`` category
+    # (``responselog yes;``, BIND 9.20+), correlated back onto the query
+    # row at ingest. They are NULL whenever that is off or the driver
+    # has no equivalent, and **NULL means UNKNOWN, never NOERROR** —
+    # rendering an unrecorded outcome as "fine" is the one failure mode
+    # this column exists to prevent.
+    rcode: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    #: RRs in the answer section. NOERROR with ``answer_count == 0`` is a
+    #: NODATA response — the name exists but carries no record of that
+    #: type — which is a different fault from NXDOMAIN and reads
+    #: identically without this.
+    answer_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
 
 class DHCPLogEntry(Base):

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -987,6 +987,107 @@ async def find_dns_query_stats(
     return out
 
 
+# ── find_dns_queries (issue #914) ─────────────────────────────────────
+
+
+class FindDNSQueriesArgs(BaseModel):
+    client_ip: str | None = Field(
+        default=None, description="Only queries from this client IP address."
+    )
+    qname_contains: str | None = Field(
+        default=None, max_length=255, description="Substring match on the queried name."
+    )
+    qtype: str | None = Field(default=None, max_length=16, description="e.g. A, AAAA, MX, PTR.")
+    rcode: str | None = Field(
+        default=None,
+        max_length=16,
+        description=(
+            "Exact outcome: NOERROR, NXDOMAIN, REFUSED, SERVFAIL. Pass "
+            "UNKNOWN for queries whose outcome was never recorded."
+        ),
+    )
+    server_id: str | None = Field(default=None, description="Filter to one DNS server UUID.")
+    minutes: int = Field(
+        default=60, ge=1, le=1440, description="Trailing window (the log is pruned at 24 h)."
+    )
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+@register_tool(
+    name="find_dns_queries",
+    description=(
+        "Individual DNS queries a client made, newest first, WITH what it "
+        "was told back (issue #914): rcode plus the answer count, so "
+        "NXDOMAIN, REFUSED, SERVFAIL and an empty NOERROR (NODATA) are "
+        "distinguishable. Use for 'this machine cannot reach X' — no row "
+        "at all means the query never arrived (look at the resolver "
+        "config, DHCP option 6 or a firewall), NOERROR means it is not "
+        "DNS. rcode is null when the server group has response logging "
+        "off; null means UNRECORDED, never success. Requires query "
+        "logging on an agent-managed BIND9 / PowerDNS group; the log "
+        "holds 24 h."
+    ),
+    args_model=FindDNSQueriesArgs,
+    category="dns",
+)
+async def find_dns_queries(
+    db: AsyncSession, user: User, args: FindDNSQueriesArgs
+) -> list[dict[str, Any]]:
+    from datetime import UTC, datetime, timedelta  # noqa: PLC0415
+
+    from app.models.logs import DNSQueryLogEntry  # noqa: PLC0415
+    from app.services.search.ranking import like_pattern  # noqa: PLC0415
+
+    since = datetime.now(UTC) - timedelta(minutes=args.minutes)
+    stmt = select(DNSQueryLogEntry).where(DNSQueryLogEntry.ts >= since)
+    if args.client_ip:
+        try:
+            client_ip = str(ipaddress.ip_address(args.client_ip.strip()))
+        except ValueError:
+            return [{"result": f"{args.client_ip!r} is not an IP address"}]
+        stmt = stmt.where(DNSQueryLogEntry.client_ip == client_ip)
+    if args.server_id:
+        # A UUID column comparison raises a DBAPIError on anything that is
+        # not one, and the likeliest wrong value here is a server NAME the
+        # model read off another tool's output — so answer the question
+        # instead of 500ing, exactly as the client_ip guard above does.
+        try:
+            server_id = str(uuid.UUID(args.server_id.strip()))
+        except ValueError:
+            return [{"result": f"{args.server_id!r} is not a server UUID"}]
+        stmt = stmt.where(DNSQueryLogEntry.server_id == server_id)
+    if args.qtype:
+        stmt = stmt.where(DNSQueryLogEntry.qtype == args.qtype.strip().upper())
+    if args.rcode:
+        wanted = args.rcode.strip().upper()
+        if wanted == "UNKNOWN":
+            stmt = stmt.where(DNSQueryLogEntry.rcode.is_(None))
+        else:
+            stmt = stmt.where(DNSQueryLogEntry.rcode == wanted)
+    if args.qname_contains:
+        stmt = stmt.where(
+            DNSQueryLogEntry.qname.ilike(like_pattern(args.qname_contains.strip()), escape="\\")
+        )
+    stmt = stmt.order_by(DNSQueryLogEntry.ts.desc(), DNSQueryLogEntry.id.desc()).limit(args.limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "ts": r.ts.isoformat(),
+            "server_id": str(r.server_id),
+            "client_ip": str(r.client_ip) if r.client_ip is not None else None,
+            "qname": r.qname,
+            "qtype": r.qtype,
+            "view": r.view,
+            # Spelled out rather than left null so a consumer cannot read
+            # "no key" as "fine" — the one mistake this field exists to
+            # stop (issue #914).
+            "rcode": r.rcode or "UNKNOWN (response logging off for this group)",
+            "answer_count": r.answer_count,
+        }
+        for r in rows
+    ]
+
+
 # Silence false-positive on lifted imports — Python pulls them in at
 # module load, but the linters want at-least-one referent in module
 # scope.

--- a/backend/app/services/ai/tools/dns_threat.py
+++ b/backend/app/services/ai/tools/dns_threat.py
@@ -478,3 +478,66 @@ async def get_rpz_block_summary(
     out["since"] = out["since"].isoformat()
     out["feeds"] = await rpz_service.feed_effectiveness(db, hours=args.hours)
     return out
+
+
+# ── find_rpz_hits (issue #914) ────────────────────────────────────────
+
+
+class FindRPZHitsArgs(BaseModel):
+    hours: int = Field(default=24, ge=1, le=24 * 30, description="Trailing window in hours.")
+    limit: int = Field(default=50, ge=1, le=500)
+    client_ip: str | None = Field(
+        default=None, description="Only hits from this client IP address."
+    )
+    qname_contains: str | None = Field(
+        default=None, max_length=255, description="Substring match on the blocked domain."
+    )
+    include_passthru: bool = Field(
+        default=False,
+        description=(
+            "Include PASSTHRU rows — explicit ALLOWs where an exception let a "
+            "listed name through. Off by default: they are not blocks."
+        ),
+    )
+
+
+@register_tool(
+    name="find_rpz_hits",
+    description=(
+        "The INDIVIDUAL blocked lookups, newest first — not a rollup "
+        "(issue #914). find_rpz_offenders says a client has N blocked "
+        "lookups and its worst domain; this says exactly which names it "
+        "asked for, when, and which feed blocked each one. Use it to "
+        "close out 'the user says this site does not work': filter to "
+        "their IP and read the last few minutes. Set include_passthru to "
+        "answer the opposite question — why a listed name got through."
+    ),
+    args_model=FindRPZHitsArgs,
+    category="dns",
+    module="security.dns_threat",
+    default_enabled=True,
+)
+async def find_rpz_hits(
+    db: AsyncSession, user: User, args: FindRPZHitsArgs
+) -> list[dict[str, Any]]:
+    from app.services.dns_threat import rpz as rpz_service  # noqa: PLC0415
+
+    client_ip: str | None = None
+    if args.client_ip:
+        # An INET comparison raises on a malformed literal, so the model's
+        # own answer ("no such client") is returned instead of a 500 that
+        # reads to the copilot as a broken tool.
+        try:
+            client_ip = str(ipaddress.ip_address(args.client_ip.strip()))
+        except ValueError:
+            return [{"result": f"{args.client_ip!r} is not an IP address"}]
+
+    rows = await rpz_service.recent_hits(
+        db,
+        hours=args.hours,
+        limit=args.limit,
+        client_ip=client_ip,
+        qname_contains=args.qname_contains,
+        include_passthru=args.include_passthru,
+    )
+    return [{**r, "ts": r["ts"].isoformat() if r.get("ts") else None} for r in rows]

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -499,6 +499,12 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
         # structural fingerprint so toggling it in the UI reliably
         # triggers a daemon reload.
         "query_log_enabled": (bool(getattr(opts, "query_log_enabled", False)) if opts else False),
+        # Response logging (#914) — same reasoning: it changes the rendered
+        # named.conf, so it belongs in the fingerprint or a UI toggle would
+        # not shift the etag and the agent would never re-render.
+        "response_log_enabled": (
+            bool(getattr(opts, "response_log_enabled", False)) if opts else False
+        ),
         # Response Rate Limiting + amplification defenses (issue #146). These
         # ride the same options dict → bundle etag, so a UI change wakes the
         # long-poll and reliably re-renders named.conf.

--- a/backend/app/services/dns/config_bundle.py
+++ b/backend/app/services/dns/config_bundle.py
@@ -107,6 +107,7 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
             allow_transfer=tuple(opts_row.allow_transfer or ("none",)),
             blackhole=tuple(opts_row.blackhole or ()),
             query_log_enabled=opts_row.query_log_enabled,
+            response_log_enabled=opts_row.response_log_enabled,
             query_log_channel=opts_row.query_log_channel,
             query_log_file=opts_row.query_log_file,
             query_log_severity=opts_row.query_log_severity,

--- a/backend/app/services/dns_threat/rpz.py
+++ b/backend/app/services/dns_threat/rpz.py
@@ -27,6 +27,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dns_rpz_hit import DNSRPZHit
+from app.services.search.ranking import like_pattern
 
 # An explicit allow, not a block. See the module docstring.
 PASSTHRU = "PASSTHRU"
@@ -261,3 +262,60 @@ async def summary(db: AsyncSession, *, hours: int = 24) -> dict[str, Any]:
         "since": since,
         "has_data": (any_row or 0) > 0,
     }
+
+
+async def recent_hits(
+    db: AsyncSession,
+    *,
+    hours: int = 24,
+    limit: int = 100,
+    client_ip: str | None = None,
+    qname_contains: str | None = None,
+    include_passthru: bool = False,
+) -> list[dict[str, Any]]:
+    """The individual hits, newest first — not a rollup.
+
+    Every other function here answers "how much"; this one answers "what,
+    exactly". The rollups can say a client has 412 blocked lookups and a
+    top name, which is enough to spot an infected host and not enough to
+    close the other case out: a user reports a site is broken, and the
+    operator needs the three lookups that machine made in the last ten
+    minutes and what blocked them. That was unanswerable from the API
+    even though the rows have been stored since #699 (issue #914).
+
+    ``include_passthru`` is off by default for the reason the module
+    docstring gives — a PASSTHRU is an explicit allow, and mixing it into
+    a list captioned "blocked" misreads a working allowlist as an
+    infection. It is available because "why did this name get through
+    when the feed lists it?" is answered by exactly those rows.
+    """
+    since = datetime.now(UTC) - timedelta(hours=hours)
+    stmt = select(DNSRPZHit).where(DNSRPZHit.ts >= since)
+    if not include_passthru:
+        stmt = stmt.where(DNSRPZHit.policy != PASSTHRU)
+    if client_ip:
+        stmt = stmt.where(DNSRPZHit.client_ip == client_ip)
+    if qname_contains:
+        # Names are stored lower-cased and dot-stripped by the parser, so
+        # the needle is normalised the same way rather than relying on
+        # ILIKE to paper over a mismatch that would also defeat any index.
+        needle = qname_contains.strip().rstrip(".").lower()
+        # ``like_pattern`` neutralises LIKE metacharacters — searching for
+        # ``50%`` must not match every row (the #879 finding).
+        stmt = stmt.where(DNSRPZHit.qname.like(like_pattern(needle), escape="\\"))
+    stmt = stmt.order_by(DNSRPZHit.ts.desc(), DNSRPZHit.id.desc()).limit(limit)
+    rows = (await db.execute(stmt)).scalars().all()
+    return [
+        {
+            "id": str(h.id),
+            "ts": h.ts,
+            "server_id": str(h.server_id) if h.server_id else None,
+            "client_ip": str(h.client_ip) if h.client_ip is not None else None,
+            "qname": h.qname,
+            "trigger": h.trigger,
+            "policy": h.policy,
+            "rpz_zone": h.rpz_zone,
+            "raw": h.raw,
+        }
+        for h in rows
+    ]

--- a/backend/app/services/logs/bind9_parser.py
+++ b/backend/app/services/logs/bind9_parser.py
@@ -44,6 +44,9 @@ _ISO_TS_RE: Final = re.compile(
 
 # Optional ``[severity]``-style category prefix BIND prepends when
 # ``print-severity`` / ``print-category`` are on. We tolerate both.
+# ``responses`` is listed because response logging (issue #914) rides
+# the same channel too, and an unstripped category prefix would push the
+# ``client`` head out of reach of the ``^``-anchored ``_HEAD_RE``.
 # ``rpz`` is listed alongside ``queries`` because RPZ policy hits ride
 # the same channel (issue #699) and carry their own category name — a
 # prefix left unstripped would push the client/qname head out of reach
@@ -52,7 +55,7 @@ _ISO_TS_RE: Final = re.compile(
 # and ``rpz`` would otherwise match the prefix of ``rpz-passthru:``
 # and leave ``-passthru: `` in front of the ``client`` head, which is
 # ``^``-anchored and would then fail to parse.
-_CAT_SEV_RE: Final = re.compile(r"^(?:(?:queries|rpz-passthru|rpz):\s+)?(?:info:\s+)?")
+_CAT_SEV_RE: Final = re.compile(r"^(?:(?:queries|responses|rpz-passthru|rpz):\s+)?(?:info:\s+)?")
 
 # BIND9 query lines are split on the hard ``: query: `` separator
 # rather than matched by one big regex. The combined pattern (client
@@ -297,7 +300,9 @@ def parse_query_line(line: str, *, fallback_ts: datetime | None = None) -> Parse
 __all__ = [
     "ParsedQueryLine",
     "ParsedRPZLine",
+    "ParsedResponseLine",
     "parse_query_line",
+    "parse_response_line",
     "parse_rpz_line",
 ]
 
@@ -530,3 +535,161 @@ def _bare_qname(operand: str | None) -> str | None:
     if not operand:
         return None
     return operand.split("/", 1)[0] or None
+
+
+# ── Response lines (issue #914) ───────────────────────────────────────
+#
+# BIND's ``queries`` category is request-side by design — it logs the
+# question as it arrives and never mentions the answer. BIND 9.20's
+# ``responselog yes;`` adds a second category, ``responses``, carrying
+# the RCODE and the section counts:
+#
+#   23-Aug-2026 13:20:09.490 responses: info: client @0x7f83 127.0.0.1#57018 \
+#       (www.example.com): view internal: response: www.example.com IN A \
+#       NOERROR 1 1 2 +E(0)K (127.0.0.1)
+#
+# Verified against BIND 9.20.26 across NOERROR / NXDOMAIN / REFUSED, a
+# NODATA (``NOERROR 0``), DNSSEC (``+E(0)DK``) and TCP (``+E(0)TK``) —
+# the three counts are always present and always in the order
+# answer / authority / additional.
+#
+# The line is routed to the same channel as ``queries`` (see the BIND9
+# renderer), so it arrives interleaved with query lines in the same
+# shipper batch and the ingest tells the shapes apart by separator:
+# ``: response: `` here, ``: query: `` there. Neither substring can
+# appear inside a DNS name, a view name or an address literal, so the
+# split is exact — the same argument :data:`_QUERY_SEP_RE` rests on.
+_RESPONSE_SEP_RE: Final = re.compile(r":\s+response:\s+", re.IGNORECASE)
+
+# ``<qname> <qclass> <qtype> <RCODE> <an> <au> <ad> [<flags>]``. Every
+# segment is a ``\S+`` run separated by a single ``\s+`` match and the
+# whole thing is anchored, so no two quantifiers compete for the same
+# whitespace — the property the rest of this module's regexes were
+# rewritten for (CodeQL py/polynomial-redos, alerts #16 / #18 / #40).
+_RESPONSE_BODY_RE: Final = re.compile(
+    r"^(?P<qname>\S+)\s+(?P<qclass>\S+)\s+(?P<qtype>\S+)\s+(?P<rcode>\S+)"
+    r"\s+(?P<answers>\d+)\s+(?P<authority>\d+)\s+(?P<additional>\d+)"
+    r"(?:\s+(?P<flags>\S+))?",
+)
+
+#: ``dns_query_log_entry.rcode`` is ``String(16)``. named prints an
+#: unassigned rcode numerically rather than symbolically, so the token is
+#: not drawn from a closed set; clamp here rather than at the call site,
+#: because one overlong value fails the single commit covering the whole
+#: ingest batch and would lose every other row in the same POST — the
+#: failure mode ``_RPZ_ZONE_MAX_LEN`` exists for.
+_RCODE_MAX_LEN: Final = 16
+
+
+@dataclass(frozen=True)
+class ParsedResponseLine:
+    """The answer half of one query, to be stamped onto its query row.
+
+    Carries the full correlation key rather than just the outcome: named
+    logs the response as an independent line, so matching it back to the
+    question is the caller's job and everything needed to do it has to
+    survive parsing.
+    """
+
+    ts: datetime
+    client_ip: str | None
+    client_port: int | None
+    qname: str | None
+    qclass: str | None
+    qtype: str | None
+    rcode: str
+    answer_count: int
+    authority_count: int
+    additional_count: int
+    flags: str | None
+    view: str | None
+    raw: str
+
+
+def parse_response_line(
+    line: str, *, fallback_ts: datetime | None = None
+) -> ParsedResponseLine | None:
+    """Parse one BIND9 ``responses`` category line, or ``None`` if it isn't one.
+
+    Returning ``None`` for non-response input is the contract the ingest
+    relies on to tell the three line shapes apart on a shared channel: it
+    tries RPZ, then this, then falls through to :func:`parse_query_line`.
+
+    Unlike the query parser, a line whose *head* fails to parse is
+    rejected outright rather than returned with ``None`` fields. A
+    response is only useful once it can be attributed to the question it
+    answers, and a response with no client address can be attributed to
+    nothing — keeping it would mean either dropping it later anyway or,
+    worse, stamping an outcome onto the wrong query.
+    """
+    line = line.rstrip("\r\n")
+    if not line.strip():
+        return None
+    if len(line) > _MAX_LINE_LEN:
+        line = line[:_MAX_LINE_LEN]
+
+    # Cheap reject before any regex work. Every ingested line pays this
+    # probe and almost all of them are query lines, which cannot contain
+    # the literal ``response:``.
+    if "response:" not in line:
+        return None
+
+    ts: datetime | None = None
+    rest = line
+    m = _BIND_TS_RE.match(rest)
+    if m:
+        ts = _parse_bind_ts(m.group("ts"))
+        rest = rest[m.end() :]
+    else:
+        m_iso = _ISO_TS_RE.match(rest)
+        if m_iso:
+            ts = _parse_iso_ts(m_iso.group("ts"))
+            rest = rest[m_iso.end() :]
+    if ts is None:
+        ts = fallback_ts or datetime.now(UTC)
+
+    rest = _CAT_SEV_RE.sub("", rest, count=1)
+
+    parts = _RESPONSE_SEP_RE.split(rest, maxsplit=1)
+    if len(parts) != 2:
+        return None
+    head, body = parts
+
+    head_m = _HEAD_RE.search(head)
+    body_m = _RESPONSE_BODY_RE.match(body)
+    if head_m is None or body_m is None:
+        return None
+
+    qname = body_m.group("qname") or None
+    # Same CHAOS-probe suppression the query side applies. Without it the
+    # query row is dropped at parse time and its response line survives,
+    # so the correlator would scan for a row that was never inserted on
+    # every monitoring poll.
+    if qname and qname.rstrip(".").lower() in _CHAOS_PROBE_QNAMES:
+        return None
+
+    view: str | None = None
+    vm = _VIEW_RE.search(head_m.group("rest") or "")
+    if vm:
+        view = (vm.group("view_paren") or vm.group("view_bare") or "").strip() or None
+
+    try:
+        client_port: int | None = int(head_m.group("client_port"))
+    except (TypeError, ValueError):
+        client_port = None
+
+    return ParsedResponseLine(
+        ts=ts,
+        client_ip=head_m.group("client_ip") or None,
+        client_port=client_port,
+        qname=qname,
+        qclass=body_m.group("qclass") or None,
+        qtype=body_m.group("qtype") or None,
+        rcode=body_m.group("rcode").upper()[:_RCODE_MAX_LEN],
+        answer_count=int(body_m.group("answers")),
+        authority_count=int(body_m.group("authority")),
+        additional_count=int(body_m.group("additional")),
+        flags=body_m.group("flags") or None,
+        view=view,
+        raw=line,
+    )

--- a/backend/tests/test_dhcp_pool_occupancy_api.py
+++ b/backend/tests/test_dhcp_pool_occupancy_api.py
@@ -1,0 +1,252 @@
+"""DHCP pool occupancy over REST (issue #913).
+
+``services/dhcp/pool_occupancy.py`` has computed this since #339 and no
+HTTP route called it, so "is this pool exhausted?" — the first question
+asked when a client cannot get an address — could only be answered by
+re-deriving it from three other endpoints. These tests cover the two
+things a re-derivation gets wrong: reservations withhold an address even
+when the device is offline, and a prefix-delegation pool has no range to
+divide by.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import (
+    DHCPLease,
+    DHCPPool,
+    DHCPScope,
+    DHCPServer,
+    DHCPServerGroup,
+    DHCPStaticAssignment,
+)
+from app.models.ipam import IPBlock, IPSpace, Subnet
+
+CIDR = "10.61.0.0/24"
+
+
+async def _token(db: AsyncSession) -> str:
+    user = User(
+        username=f"occ-{uuid.uuid4().hex[:6]}",
+        email=f"occ-{uuid.uuid4().hex[:6]}@example.test",
+        display_name="occ",
+        hashed_password=hash_password("x"),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _scope(db: AsyncSession) -> tuple[DHCPScope, DHCPServer]:
+    space = IPSpace(name=f"s-{uuid.uuid4().hex[:6]}", description="")
+    db.add(space)
+    await db.flush()
+    block = IPBlock(space_id=space.id, network=CIDR, name="b")
+    db.add(block)
+    await db.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network=CIDR, name="s")
+    group = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add_all([subnet, group])
+    await db.flush()
+    scope = DHCPScope(group_id=group.id, subnet_id=subnet.id, name="scope-a")
+    server = DHCPServer(name=f"kea-{uuid.uuid4().hex[:6]}", host="10.0.0.1", driver="kea")
+    db.add_all([scope, server])
+    await db.flush()
+    return scope, server
+
+
+@pytest.mark.asyncio
+async def test_pool_occupancy_counts_leases_and_offline_reservations(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Counting leases alone under-reports exhaustion (#631).
+
+    A reserved address is withheld from the dynamic set whether or not
+    the device is currently online, and a reserved-AND-leased address is
+    one address, not two.
+    """
+    scope, server = await _scope(db_session)
+    pool = DHCPPool(
+        scope_id=scope.id,
+        name="pool-a",
+        start_ip="10.61.0.10",
+        end_ip="10.61.0.19",  # 10 addresses inclusive
+        pool_type="dynamic",
+    )
+    db_session.add(pool)
+    db_session.add_all(
+        [
+            DHCPLease(
+                server_id=server.id,
+                scope_id=scope.id,
+                ip_address="10.61.0.10",
+                mac_address="aa:bb:cc:00:00:01",
+                state="active",
+            ),
+            # Reserved AND currently leased — one address, counted once.
+            DHCPLease(
+                server_id=server.id,
+                scope_id=scope.id,
+                ip_address="10.61.0.11",
+                mac_address="aa:bb:cc:00:00:02",
+                state="active",
+            ),
+            DHCPStaticAssignment(
+                scope_id=scope.id,
+                ip_address="10.61.0.11",
+                mac_address="aa:bb:cc:00:00:02",
+            ),
+            # Reserved and offline — still unavailable to a dynamic client.
+            DHCPStaticAssignment(
+                scope_id=scope.id,
+                ip_address="10.61.0.12",
+                mac_address="aa:bb:cc:00:00:03",
+            ),
+            # Outside the range — must not count.
+            DHCPLease(
+                server_id=server.id,
+                scope_id=scope.id,
+                ip_address="10.61.0.50",
+                mac_address="aa:bb:cc:00:00:04",
+                state="active",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    res = await client.get(f"/api/v1/dhcp/pools/{pool.id}/occupancy", headers=headers)
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["total"] == 10
+    assert body["assigned"] == 3
+    assert body["free"] == 7
+    assert body["percent"] == 30.0
+    assert body["computed_at"]
+
+
+@pytest.mark.asyncio
+async def test_scope_occupancy_returns_every_range_pool(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The shape that matters: a scope-level "fine" can hide one full
+    class-restricted pool."""
+    scope, _ = await _scope(db_session)
+    db_session.add_all(
+        [
+            DHCPPool(
+                scope_id=scope.id,
+                name="voice",
+                start_ip="10.61.0.10",
+                end_ip="10.61.0.19",
+                pool_type="dynamic",
+            ),
+            DHCPPool(
+                scope_id=scope.id,
+                name="data",
+                start_ip="10.61.0.20",
+                end_ip="10.61.0.29",
+                pool_type="dynamic",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    res = await client.get(f"/api/v1/dhcp/scopes/{scope.id}/pools/occupancy", headers=headers)
+    assert res.status_code == 200, res.text
+    rows = res.json()
+    assert [r["pool_name"] for r in rows] == ["voice", "data"]
+    assert all(r["assigned"] == 0 and r["total"] == 10 for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_only_dynamic_pools_get_an_occupancy(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The other three types would each produce a misleading number.
+
+    A ``pd`` pool stores its prefix's network address in both range ends
+    as NOT NULL placeholders, so dividing by that yields a one-address
+    pool at 0%. An ``excluded`` range is never offered to a client, so a
+    percentage full is not a fact about it. A ``reserved`` range is held
+    for static assignments and is *supposed* to fill up, so reporting it
+    on the same scale renders a correctly-configured one as a red
+    exhaustion bar. Answering only for dynamic pools also keeps this
+    endpoint agreeing with the ``dhcp_pool_exhaustion`` alert evaluator
+    and the ``find_dhcp_pool_occupancy`` copilot tool, which both filter
+    the same way — a disagreement between those is exactly how a wrong
+    "the pool is fine" gets produced.
+    """
+    scope, _ = await _scope(db_session)
+    pd = DHCPPool(
+        scope_id=scope.id,
+        name="delegation",
+        start_ip="2001:db8::",
+        end_ip="2001:db8::",
+        pool_type="pd",
+        pd_prefix="2001:db8::/48",
+        delegated_length=56,
+    )
+    excluded = DHCPPool(
+        scope_id=scope.id,
+        name="infra",
+        start_ip="10.61.0.1",
+        end_ip="10.61.0.9",
+        pool_type="excluded",
+    )
+    reserved = DHCPPool(
+        scope_id=scope.id,
+        name="printers",
+        start_ip="10.61.0.30",
+        end_ip="10.61.0.39",
+        pool_type="reserved",
+    )
+    dynamic = DHCPPool(
+        scope_id=scope.id,
+        name="workstations",
+        start_ip="10.61.0.100",
+        end_ip="10.61.0.109",
+        pool_type="dynamic",
+    )
+    db_session.add_all([pd, excluded, reserved, dynamic])
+    await db_session.flush()
+
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+
+    res = await client.get(f"/api/v1/dhcp/pools/{pd.id}/occupancy", headers=headers)
+    assert res.status_code == 422
+    assert "prefix-delegation" in res.text.lower()
+
+    for pool in (excluded, reserved):
+        res = await client.get(f"/api/v1/dhcp/pools/{pool.id}/occupancy", headers=headers)
+        assert res.status_code == 422, pool.pool_type
+        assert pool.pool_type in res.text
+
+    listed = await client.get(f"/api/v1/dhcp/scopes/{scope.id}/pools/occupancy", headers=headers)
+    assert [r["pool_name"] for r in listed.json()] == ["workstations"]
+
+
+@pytest.mark.asyncio
+async def test_occupancy_404s_for_unknown_ids(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    await db_session.flush()
+    missing = uuid.uuid4()
+    assert (
+        await client.get(f"/api/v1/dhcp/pools/{missing}/occupancy", headers=headers)
+    ).status_code == 404
+    assert (
+        await client.get(f"/api/v1/dhcp/scopes/{missing}/pools/occupancy", headers=headers)
+    ).status_code == 404

--- a/backend/tests/test_dns_query_rcode.py
+++ b/backend/tests/test_dns_query_rcode.py
@@ -1,0 +1,422 @@
+"""The answer half of the DNS query log (issue #914).
+
+``dns_query_log_entry`` recorded the question and nothing about the
+response, so the five outcomes an operator is actually triaging — a
+query that never arrived, NOERROR, a NODATA NOERROR, NXDOMAIN, REFUSED,
+SERVFAIL — collapsed into "there is a row" or "there is not". These
+tests pin the two properties that make the fix trustworthy rather than
+merely present:
+
+* **Correlation.** named logs the response as an INDEPENDENT line, so
+  the outcome only reaches the right query row if the key holds. A
+  cross-stamp is worse than no rcode: it reports a confident wrong
+  answer.
+* **NULL means UNKNOWN.** Never "fine". Every surface has to keep an
+  unrecorded outcome distinguishable from a successful one, because the
+  whole point of the column is telling those two apart.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.v1.dns.agents import QueryLogBatch, agent_query_log_entries
+from app.models.dns import DNSServer, DNSServerGroup
+from app.models.logs import DNSQueryLogEntry
+
+
+async def _make_user(db: AsyncSession, *, username: str) -> tuple[Any, str]:
+    from app.core.security import create_access_token, hash_password
+    from app.models.auth import User
+
+    user = User(
+        username=username,
+        email=f"{username}@example.test",
+        display_name=username,
+        hashed_password=hash_password("x"),
+        auth_source="local",
+        is_superadmin=True,
+    )
+    user.groups = []
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_bind9_server(db: AsyncSession) -> DNSServer:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", description="")
+    db.add(group)
+    await db.flush()
+    server = DNSServer(
+        name=f"s-{uuid.uuid4().hex[:8]}",
+        host="127.0.0.1",
+        port=53,
+        driver="bind9",
+        group_id=group.id,
+    )
+    db.add(server)
+    await db.flush()
+    return server
+
+
+def _query_line(port: int, qname: str, qtype: str = "A") -> str:
+    return (
+        f"23-Aug-2026 13:20:09.480 queries: info: client @0x7f83 10.1.2.3#{port} "
+        f"({qname}): view internal: query: {qname} IN {qtype} +E(0)K (127.0.0.1)"
+    )
+
+
+def _response_line(port: int, qname: str, rcode: str, answers: int, qtype: str = "A") -> str:
+    return (
+        f"23-Aug-2026 13:20:09.490 responses: info: client @0x7f83 10.1.2.3#{port} "
+        f"({qname}): view internal: response: {qname} IN {qtype} {rcode} "
+        f"{answers} 1 1 +E(0)K (127.0.0.1)"
+    )
+
+
+async def _ingest(db: AsyncSession, server: DNSServer, lines: list[str]) -> dict[str, Any]:
+    result = await agent_query_log_entries(QueryLogBatch(lines=lines), db, auth=(server, {}))
+    return dict(result)
+
+
+@pytest.mark.asyncio
+async def test_response_line_stamps_its_own_query_row(db_session: AsyncSession) -> None:
+    """The common case: both lines in one batch, matched without a query."""
+    server = await _make_bind9_server(db_session)
+    result = await _ingest(
+        db_session,
+        server,
+        [
+            _query_line(50001, "www.example.test"),
+            _response_line(50001, "www.example.test", "NXDOMAIN", 0),
+        ],
+    )
+    assert result["inserted"] == 1, "a response must not create a second row"
+    assert result["responses_matched"] == 1
+    assert result["responses_unmatched"] == 0
+
+    row = (await db_session.execute(select(DNSQueryLogEntry))).scalars().one()
+    assert row.qname == "www.example.test"
+    assert row.rcode == "NXDOMAIN"
+    assert row.answer_count == 0
+
+
+@pytest.mark.asyncio
+async def test_responses_do_not_cross_stamp_between_clients(
+    db_session: AsyncSession,
+) -> None:
+    """Interleaved traffic is the normal case on a busy resolver.
+
+    A confident wrong outcome is worse than a blank one, so the key has
+    to hold when two queries are in flight at once.
+    """
+    server = await _make_bind9_server(db_session)
+    await _ingest(
+        db_session,
+        server,
+        [
+            _query_line(50001, "a.example.test"),
+            _query_line(50002, "b.example.test"),
+            _response_line(50002, "b.example.test", "REFUSED", 0),
+            _response_line(50001, "a.example.test", "NOERROR", 2),
+        ],
+    )
+    rows = {
+        r.qname: r for r in (await db_session.execute(select(DNSQueryLogEntry))).scalars().all()
+    }
+    assert rows["a.example.test"].rcode == "NOERROR"
+    assert rows["a.example.test"].answer_count == 2
+    assert rows["b.example.test"].rcode == "REFUSED"
+
+
+@pytest.mark.asyncio
+async def test_response_in_a_later_batch_still_matches(db_session: AsyncSession) -> None:
+    """The batch boundary must not systematically blank the last query.
+
+    The shipper caps its batches, so the split lands on the same row
+    every time under load — a bias, not noise, and it would hit the
+    busiest servers hardest.
+    """
+    server = await _make_bind9_server(db_session)
+    await _ingest(db_session, server, [_query_line(50003, "late.example.test")])
+    result = await _ingest(
+        db_session,
+        server,
+        [_response_line(50003, "late.example.test", "SERVFAIL", 0)],
+    )
+    assert result["inserted"] == 0
+    assert result["responses_matched"] == 1
+
+    row = (await db_session.execute(select(DNSQueryLogEntry))).scalars().one()
+    assert row.rcode == "SERVFAIL"
+
+
+@pytest.mark.asyncio
+async def test_orphan_response_is_dropped_not_stored(db_session: AsyncSession) -> None:
+    """A response with no question answers nothing.
+
+    Storing it as its own row would double-count every query in the
+    analytics rollups the same table feeds.
+    """
+    server = await _make_bind9_server(db_session)
+    result = await _ingest(
+        db_session,
+        server,
+        [_response_line(50004, "orphan.example.test", "NOERROR", 1)],
+    )
+    assert result["inserted"] == 0
+    assert result["responses_matched"] == 0
+    assert result["responses_unmatched"] == 1
+    assert (await db_session.execute(select(DNSQueryLogEntry))).scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_query_without_a_response_keeps_a_null_rcode(
+    db_session: AsyncSession,
+) -> None:
+    """Response logging off is the default, and it must not read as NOERROR."""
+    server = await _make_bind9_server(db_session)
+    await _ingest(db_session, server, [_query_line(50005, "quiet.example.test")])
+    row = (await db_session.execute(select(DNSQueryLogEntry))).scalars().one()
+    assert row.rcode is None
+    assert row.answer_count is None
+
+
+@pytest.mark.asyncio
+async def test_query_log_api_filters_and_reports_rcode(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    server = await _make_bind9_server(db_session)
+    _, token = await _make_user(db_session, username="rcodereader")
+    await _ingest(
+        db_session,
+        server,
+        [
+            _query_line(50006, "ok.example.test"),
+            _response_line(50006, "ok.example.test", "NOERROR", 1),
+            _query_line(50007, "gone.example.test"),
+            _response_line(50007, "gone.example.test", "NXDOMAIN", 0),
+            _query_line(50008, "unlogged.example.test"),
+        ],
+    )
+    await db_session.flush()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    res = await client.post(
+        "/api/v1/logs/dns-queries",
+        json={"server_id": str(server.id), "rcode": "nxdomain"},
+        headers=headers,
+    )
+    assert res.status_code == 200, res.text
+    events = res.json()["events"]
+    assert [e["qname"] for e in events] == ["gone.example.test"]
+    assert events[0]["rcode"] == "NXDOMAIN"
+    assert events[0]["answer_count"] == 0
+
+    # "UNKNOWN" is a selectable value, not an absence — it is how an
+    # operator finds out whether response logging is on at all.
+    res = await client.post(
+        "/api/v1/logs/dns-queries",
+        json={"server_id": str(server.id), "rcode": "UNKNOWN"},
+        headers=headers,
+    )
+    assert [e["qname"] for e in res.json()["events"]] == ["unlogged.example.test"]
+    assert res.json()["events"][0]["rcode"] is None
+
+
+@pytest.mark.asyncio
+async def test_analytics_counts_unrecorded_outcomes_explicitly(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A server with response logging off must show one honest bar, not
+    an empty panel that reads as "no failures"."""
+    server = await _make_bind9_server(db_session)
+    _, token = await _make_user(db_session, username="rcodeanalytics")
+    await _ingest(
+        db_session,
+        server,
+        [
+            _query_line(50010, "a.example.test"),
+            _response_line(50010, "a.example.test", "NOERROR", 1),
+            _query_line(50011, "b.example.test"),
+        ],
+    )
+    await db_session.flush()
+    res = await client.post(
+        "/api/v1/logs/dns-queries/analytics",
+        json={"server_id": str(server.id)},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    dist = {r["key"]: r["count"] for r in res.json()["rcode_distribution"]}
+    assert dist == {"NOERROR": 1, "UNKNOWN": 1}
+
+
+@pytest.mark.asyncio
+async def test_response_log_requires_query_log(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Refused rather than silently ignored — the response lines are
+    written to the query-log channel, so on its own the toggle would
+    change named.conf and produce nothing."""
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", description="")
+    db_session.add(group)
+    await db_session.flush()
+    _, token = await _make_user(db_session, username="optswriter")
+    await db_session.flush()
+    headers = {"Authorization": f"Bearer {token}"}
+    res = await client.put(
+        f"/api/v1/dns/groups/{group.id}/options",
+        json={"query_log_enabled": False, "response_log_enabled": True},
+        headers=headers,
+    )
+    assert res.status_code == 422
+    assert "query_log_enabled" in res.text
+
+
+@pytest.mark.asyncio
+async def test_turning_query_logging_off_clears_response_logging(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Turning query logging off is not a request for the impossible pair.
+
+    Rejecting it would name a field the caller never sent and would leave
+    no single call that disables query logging at all — so response
+    logging is cleared alongside it, which is the only coherent resulting
+    state.
+    """
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:8]}", description="")
+    db_session.add(group)
+    await db_session.flush()
+    _, token = await _make_user(db_session, username="optsclearer")
+    await db_session.flush()
+    headers = {"Authorization": f"Bearer {token}"}
+
+    on = await client.put(
+        f"/api/v1/dns/groups/{group.id}/options",
+        json={"query_log_enabled": True, "response_log_enabled": True},
+        headers=headers,
+    )
+    assert on.status_code == 200, on.text
+    assert on.json()["response_log_enabled"] is True
+
+    off = await client.put(
+        f"/api/v1/dns/groups/{group.id}/options",
+        json={"query_log_enabled": False},
+        headers=headers,
+    )
+    assert off.status_code == 200, off.text
+    assert off.json()["query_log_enabled"] is False
+    assert off.json()["response_log_enabled"] is False
+
+
+# ── RPZ per-hit surface (issue #914) ─────────────────────────────────
+
+
+async def _rpz_hit(
+    db: AsyncSession,
+    server: DNSServer,
+    *,
+    client_ip: str,
+    qname: str,
+    policy: str = "NXDOMAIN",
+    minutes_ago: int = 0,
+) -> None:
+    from app.models.dns_rpz_hit import DNSRPZHit
+
+    db.add(
+        DNSRPZHit(
+            server_id=server.id,
+            ts=datetime.now(UTC) - timedelta(minutes=minutes_ago),
+            client_ip=client_ip,
+            qname=qname,
+            trigger="QNAME",
+            policy=policy,
+            rpz_zone="spatium-blocklist.rpz",
+            raw="x",
+        )
+    )
+    await db.flush()
+
+
+@pytest.mark.asyncio
+async def test_recent_hits_excludes_passthru_by_default(db_session: AsyncSession) -> None:
+    """A PASSTHRU is an explicit ALLOW. Listing it among blocks makes a
+    working allowlist read as an infection."""
+    from app.services.dns_threat import rpz as rpz_service
+
+    server = await _make_bind9_server(db_session)
+    await _rpz_hit(db_session, server, client_ip="10.0.0.5", qname="bad.example")
+    await _rpz_hit(
+        db_session, server, client_ip="10.0.0.5", qname="allowed.example", policy="PASSTHRU"
+    )
+
+    blocked = await rpz_service.recent_hits(db_session)
+    assert [h["qname"] for h in blocked] == ["bad.example"]
+
+    both = await rpz_service.recent_hits(db_session, include_passthru=True)
+    assert {h["qname"] for h in both} == {"bad.example", "allowed.example"}
+
+
+@pytest.mark.asyncio
+async def test_recent_hits_filters_and_orders_newest_first(
+    db_session: AsyncSession,
+) -> None:
+    from app.services.dns_threat import rpz as rpz_service
+
+    server = await _make_bind9_server(db_session)
+    await _rpz_hit(db_session, server, client_ip="10.0.0.5", qname="old.example", minutes_ago=30)
+    await _rpz_hit(db_session, server, client_ip="10.0.0.5", qname="new.example", minutes_ago=1)
+    await _rpz_hit(db_session, server, client_ip="10.0.0.6", qname="other.example")
+
+    mine = await rpz_service.recent_hits(db_session, client_ip="10.0.0.5")
+    assert [h["qname"] for h in mine] == ["new.example", "old.example"]
+
+
+@pytest.mark.asyncio
+async def test_recent_hits_substring_filter_escapes_like_metacharacters(
+    db_session: AsyncSession,
+) -> None:
+    """Searching for ``%`` must not match every row — the #879 finding,
+    which made search look broken rather than permissive."""
+    from app.services.dns_threat import rpz as rpz_service
+
+    server = await _make_bind9_server(db_session)
+    await _rpz_hit(db_session, server, client_ip="10.0.0.5", qname="tracker.example")
+    assert await rpz_service.recent_hits(db_session, qname_contains="%") == []
+    assert len(await rpz_service.recent_hits(db_session, qname_contains="tracker")) == 1
+
+
+@pytest.mark.asyncio
+async def test_rpz_hits_endpoint(client: AsyncClient, db_session: AsyncSession) -> None:
+    from app.models.feature_module import FeatureModule
+
+    db_session.add(FeatureModule(id="security.dns_threat", enabled=True))
+    server = await _make_bind9_server(db_session)
+    _, token = await _make_user(db_session, username="rpzhits")
+    await _rpz_hit(db_session, server, client_ip="10.0.0.5", qname="bad.example")
+
+    res = await client.get(
+        "/api/v1/dns-threat/rpz/hits",
+        params={"client_ip": "10.0.0.5"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert len(body) == 1
+    assert body[0]["qname"] == "bad.example"
+    assert body[0]["policy"] == "NXDOMAIN"
+
+    bad = await client.get(
+        "/api/v1/dns-threat/rpz/hits",
+        params={"client_ip": "not-an-ip"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert bad.status_code == 422

--- a/backend/tests/test_log_parsers.py
+++ b/backend/tests/test_log_parsers.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from app.services.logs.bind9_parser import parse_query_line
+from app.services.logs.bind9_parser import parse_query_line, parse_response_line
 from app.services.logs.kea_parser import parse_kea_line
 from app.services.logs.pdns_parser import parse_query_line as parse_pdns_query_line
 
@@ -285,3 +285,124 @@ def test_pdns_redos_regression_linear_time() -> None:
     # slow CI runners while still catching any future regression
     # that reintroduces the polynomial backtracking.
     assert elapsed < 2.0, f"adversarial parse took {elapsed:.2f}s — possible ReDoS regression"
+
+
+# ── BIND9 response log (issue #914) ───────────────────────────────────
+#
+# Every line below was captured from a real BIND 9.20.26 running with
+# ``responselog yes;`` — not hand-written from the documentation. The
+# format is the load-bearing assumption of the whole feature: get the
+# field order wrong and every rcode is silently the answer count.
+
+
+def test_bind9_response_noerror() -> None:
+    line = (
+        "23-Aug-2026 13:20:09.490 responses: info: client @0x7f83624012e0 "
+        "127.0.0.1#57018 (www.example.com): view internal: response: "
+        "www.example.com IN A NOERROR 1 1 2 +E(0)K (127.0.0.1)"
+    )
+    parsed = parse_response_line(line)
+    assert parsed is not None
+    assert parsed.client_ip == "127.0.0.1"
+    assert parsed.client_port == 57018
+    assert parsed.qname == "www.example.com"
+    assert parsed.qclass == "IN"
+    assert parsed.qtype == "A"
+    assert parsed.rcode == "NOERROR"
+    assert parsed.answer_count == 1
+    assert parsed.authority_count == 1
+    assert parsed.additional_count == 2
+    assert parsed.flags == "+E(0)K"
+    assert parsed.view == "internal"
+    assert parsed.raw == line
+
+
+def test_bind9_response_nxdomain() -> None:
+    parsed = parse_response_line(
+        "23-Aug-2026 13:20:09.494 client @0x7f83620ec4e0 127.0.0.1#58325 "
+        "(nosuch.example.com): view internal: response: nosuch.example.com "
+        "IN A NXDOMAIN 0 1 1 +E(0)K (127.0.0.1)"
+    )
+    assert parsed is not None
+    assert parsed.rcode == "NXDOMAIN"
+    assert parsed.answer_count == 0
+
+
+def test_bind9_response_refused() -> None:
+    parsed = parse_response_line(
+        "23-Aug-2026 13:20:09.506 client @0x7f836202c1e0 127.0.0.1#58506 "
+        "(outside.test): view internal: response: outside.test IN A "
+        "REFUSED 0 0 1 +E(0)K (127.0.0.1)"
+    )
+    assert parsed is not None
+    assert parsed.rcode == "REFUSED"
+
+
+def test_bind9_response_nodata_is_noerror_with_zero_answers() -> None:
+    """The case that reads as success and is not.
+
+    A name that exists with no record of the requested type answers
+    NOERROR with an empty answer section. Without the count, this is
+    indistinguishable from a working lookup — which is exactly the
+    outcome an operator is trying to tell apart from NXDOMAIN.
+    """
+    parsed = parse_response_line(
+        "23-Aug-2026 13:20:09.498 client @0x7f836202c1e0 127.0.0.1#48968 "
+        "(www.example.com): view internal: response: www.example.com IN MX "
+        "NOERROR 0 1 1 +E(0)K (127.0.0.1)"
+    )
+    assert parsed is not None
+    assert parsed.rcode == "NOERROR"
+    assert parsed.answer_count == 0
+
+
+def test_bind9_query_line_is_not_a_response() -> None:
+    """The discriminator the shared-channel ingest depends on."""
+    assert (
+        parse_response_line(
+            "25-Apr-2026 16:30:01.123 client @0x7f8b1c001234 192.0.2.5#54321 "
+            "(example.com): query: example.com IN A +E(0)K (10.0.0.1)"
+        )
+        is None
+    )
+
+
+def test_bind9_response_line_is_not_a_query() -> None:
+    """And the converse, so neither parser claims the other's lines.
+
+    The query parser splits on ``: query: ``; a response line has no such
+    separator, so it comes back with a null qname and the ingest drops
+    it — which is why response parsing has to run first, not instead.
+    """
+    parsed = parse_query_line(
+        "23-Aug-2026 13:20:09.490 client @0x7f83 127.0.0.1#57018 "
+        "(www.example.com): view internal: response: www.example.com IN A "
+        "NOERROR 1 1 2 +E(0)K (127.0.0.1)"
+    )
+    assert parsed is not None
+    assert parsed.qname is None
+
+
+def test_bind9_response_chaos_probe_dropped() -> None:
+    """Matches the query side, or the correlator hunts for a row that
+    was never inserted on every monitoring poll."""
+    assert (
+        parse_response_line(
+            "23-Aug-2026 13:20:09.490 client @0x7f83 127.0.0.1#57018 "
+            "(version.bind): view internal: response: version.bind CH TXT "
+            "NOERROR 1 0 1 +E(0)K (127.0.0.1)"
+        )
+        is None
+    )
+
+
+def test_bind9_response_unparseable_returns_none() -> None:
+    """Rejected outright rather than returned with null fields.
+
+    A response is only useful once it can be attributed to its question;
+    keeping an unattributable one risks stamping an outcome onto the
+    wrong row.
+    """
+    assert parse_response_line("23-Aug-2026 13:20:09.490 something: response: ") is None
+    assert parse_response_line("") is None
+    assert parse_response_line("plain text with no marker") is None

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -174,6 +174,67 @@ DHCPPool
   current_lease_count: int (computed, pulled from server)
 ```
 
+### Pool occupancy over REST (issue #913)
+
+```
+GET /api/v1/dhcp/pools/{pool_id}/occupancy
+GET /api/v1/dhcp/scopes/{scope_id}/pools/occupancy    # every pool, one call
+```
+
+```json
+{
+  "pool_id": "…", "scope_id": "…", "pool_name": "Workstations",
+  "start_ip": "10.1.2.101", "end_ip": "10.1.2.200",
+  "pool_type": "dynamic",
+  "total": 100, "assigned": 97, "free": 3, "percent": 97.0,
+  "computed_at": "2026-08-23T12:00:00.000Z"
+}
+```
+
+`assigned` is the count of distinct in-range addresses **unavailable to
+a dynamic client**: active leases *unioned* with in-pool static
+reservations. Both halves matter and neither is obvious from outside:
+
+* A reservation withholds its address whether or not the reserved device
+  is currently online, so counting leases alone under-reports exhaustion
+  (#631) — and a wrong "the pool is fine" sends the technician looking
+  in the wrong place.
+* A reserved-**and**-currently-leased address is one address, not two,
+  which is why this is a union rather than a sum.
+
+"Is this pool exhausted?" is one of the first questions asked when a
+client cannot get an address, and until #913 the API could not answer it:
+the computation had existed since #339 but was reachable only from the
+`find_dhcp_pool_occupancy` copilot tool and the `dhcp_pool_exhaustion`
+alert evaluator. Every consumer had to fetch pools, leases and
+reservations separately and redo the range arithmetic — three round
+trips and an easy thing to get subtly wrong.
+
+The **scope-level** shape is the one that matters operationally: a scope
+with several pools is exactly where a call-per-pool is wasteful, and also
+where "the scope looks fine" hides one exhausted class-restricted pool.
+It runs a single batched lease + reservation query for all of them.
+
+**Dynamic pools only.** The scope listing omits every other type and the
+per-pool route returns 422 for one, because each would produce a
+misleading number — and because the `dhcp_pool_exhaustion` alert
+evaluator and the `find_dhcp_pool_occupancy` copilot tool already filter
+the same way, so answering differently here is how a wrong "the pool is
+fine" gets produced:
+
+* `excluded` — a range DHCP will never offer, so "percentage full" is
+  not a fact about it.
+* `reserved` — held for static assignments, so a correctly configured
+  one is *supposed* to approach 100% and would render as a red
+  exhaustion bar for doing its job.
+* `pd` (#368) — `start_ip` / `end_ip` are NOT NULL placeholders holding
+  the delegated prefix's network address rather than a range, so the
+  arithmetic reports a one-address pool at 0%.
+
+`computed_at` is returned because occupancy is derived from the mirrored
+lease rows, so its freshness follows the last lease pull rather than
+being instantaneous.
+
 ### Example: Multiple Pools in One Subnet (10.1.2.0/24)
 
 | Pool Name | Range | Type | Notes |

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -1771,3 +1771,128 @@ curl -H 'accept: application/dns-message' \
 # confirm no plaintext :53 leaves the box
 tcpdump -ni any 'port 53'
 ```
+
+---
+
+## 21. Query outcomes — the answer half of the query log (issue #914)
+
+`dns_query_log_entry` recorded the *question* and nothing about the
+*response*. BIND's `queries` logging category is request-side by design:
+it logs a query as it arrives and never mentions what was sent back. So
+the Logs → DNS Queries surface could prove a query reached the server,
+and could not distinguish the five outcomes an operator is actually
+triaging:
+
+| What happened | What it means | Where to look next |
+|---|---|---|
+| No row at all | the query never reached this server | resolver config, DHCP option 6, firewall |
+| `NOERROR` with answers | DNS is fine | not DNS — routing, or the service itself |
+| `NOERROR` with **0** answers (NODATA) | the name exists, but has no record of that type | the record type, or an AAAA-only client |
+| `NXDOMAIN` | the record does not exist | the zone, or a typo |
+| `REFUSED` | an ACL or view is rejecting this client | `allow-query`, view `match-clients` |
+| `SERVFAIL` | DNSSEC validation or a broken forwarder | validation, the upstream |
+
+All of them collapsed into "there is a row" or "there is not", and the
+most common real outcome — a query that *was* answered, just not the way
+the user expected — was indistinguishable from one that was refused.
+
+### 21.1 Where the data comes from
+
+BIND 9.20 ships `responselog`, a second logging category (`responses`)
+carrying one line per response:
+
+```
+23-Aug-2026 13:20:09.490 responses: info: client @0x7f83 127.0.0.1#57018 \
+    (www.example.com): view internal: response: www.example.com IN A \
+    NOERROR 1 1 2 +E(0)K (127.0.0.1)
+```
+
+The trailing counts are answer / authority / additional. SpatiumDDI
+parses the RCODE and the **answer count** — the second is what makes
+NODATA visible, and NODATA is a genuinely different fault from NXDOMAIN
+that reads identically without it.
+
+The line is routed to the same `queries_channel` the query log already
+uses, so no second shipper thread, log file or bind mount is involved.
+The control plane tells the shapes apart at ingest by separator
+(`: response: ` vs `: query: `, neither of which can occur inside a DNS
+name or a view name) and stamps the outcome onto the query row it
+belongs to, matched on client address + ephemeral source port + qname +
+qtype. A response whose question cannot be found is **dropped, not
+stored**: a row with an outcome and no question answers nothing, and
+inventing a query row for it would double-count every query in the
+analytics rollups the same table feeds.
+
+### 21.2 Enabling it
+
+Per DNS server group, under **Query Logging** → *Record the outcome of
+each query*. Default **off**, and it requires query logging to be on,
+because the response lines are written to the channel the query-log
+block defines. A caller that explicitly asks for the impossible pair
+gets a 422 rather than a toggle that rewrites `named.conf` and produces
+nothing; a caller simply turning query logging *off* has asked for
+nothing impossible, so response logging is cleared alongside it — the
+only coherent resulting state, and the alternative would leave no single
+call that disables query logging at all.
+
+It roughly **doubles query-log volume**: named writes a second line per
+query. That volume is why the query log is capped at a 24 h window in
+the first place, so treat this as a troubleshooting switch rather than a
+permanent setting on a busy resolver.
+
+> **`rndc reconfig` does not apply `responselog`.** Verified against
+> BIND 9.20.26: with `responselog yes;` in a freshly-swapped config and
+> a clean reconfig, `rndc status` still reported
+> `response logging is OFF`. It is a live switch, like `querylog`, and
+> reconfig deliberately
+> preserves whatever the running server was last told. Query logging
+> escapes this only by accident of BIND's own defaulting — with no
+> `querylog` statement it follows the presence of the `queries`
+> category, which a reload does pick up. The agent therefore issues an
+> explicit `rndc responselog on|off` after each structural reload,
+> reading the desired state back off the config it just swapped in.
+> Without that the toggle would appear to work and produce not one line
+> until the daemon was next restarted.
+
+### 21.3 Which drivers fill it
+
+| Driver | `rcode` |
+|---|---|
+| BIND9 (agent-managed) | yes, when response logging is enabled |
+| PowerDNS (agent-managed) | no — its detail log carries no RCODE field |
+| Technitium | no — query-log polling is deferred (#742), and its API does expose the rcode when it lands |
+| Windows DNS, cloud drivers | no — they ship no query log at all |
+
+**`NULL` means UNRECORDED, never `NOERROR`.** Every surface keeps the
+two apart: the API returns `null`, the grid renders *not recorded* in
+italics rather than a dash beside a successful lookup, the analytics
+breakdown counts them under an explicit `UNKNOWN` key rather than
+omitting them, and the copilot tool spells the reason out in the field
+itself. A server with the toggle off shows one honest bar instead of an
+empty panel that reads as "no failures".
+
+### 21.4 Individual RPZ hits
+
+`GET /api/v1/dns-threat/rpz/hits` returns the per-hit rows behind the
+blocklist rollups — timestamp, client, name, trigger, policy and the
+feed that matched. Those rows have been stored since #699 and were
+reachable from no endpoint, so "show me the three lookups this PC made
+in the last ten minutes that were blocked" was unanswerable; only "this
+client has N hits and its top name is X" was. PASSTHRU rows are excluded
+by default, because a PASSTHRU is an explicit *allow* and listing it
+among blocks makes a working allowlist read as an infection —
+`include_passthru=true` answers the opposite question, why a listed name
+got through.
+
+> **The pipeline behind them was dead on the agent path.** named logs a
+> policy rewrite to its own `rpz` category, and the agent's BIND9
+> renderer — the one every agent-managed server actually runs — never
+> emitted `category rpz { queries_channel; };`. The control-plane Jinja
+> template has carried it since #699, which is why the gap survived
+> review: the code was right in the file nothing renders from. Fixed in
+> #914 along with `rpz-passthru`, whose absence left the entire
+> exception half of the attribution dark and the `policy != PASSTHRU`
+> filters in `services/dns_threat/rpz.py` unreachable. Same class as
+> `allow_transfer` (#734) and `forward_policy` (#899): a setting that is
+> stored, shipped, and rendered nowhere. The lesson from §8.2 applies
+> unchanged — **assert on the rendered config, not the stored row**.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5062,6 +5062,8 @@ export interface DNSServerOptions {
   allow_transfer: string[];
   blackhole: string[];
   query_log_enabled: boolean;
+  /** Per-query RCODE logging (#914). BIND9 only; requires query_log_enabled. */
+  response_log_enabled: boolean;
   query_log_channel: string;
   query_log_file: string;
   query_log_severity: string;
@@ -8196,6 +8198,21 @@ export const dhcpApi = {
   deletePool: (_scopeId: string, poolId: string) =>
     api.delete(`/dhcp/pools/${poolId}`),
 
+  // Live pool occupancy (#913). Assigned unions active leases with in-pool
+  // static reservations, so a reserved-but-offline address counts as taken.
+  // Dynamic pools only: the scope call omits every other type and the
+  // per-pool one 422s, because a percentage full is not a fact about an
+  // excluded range, a reserved range is supposed to fill up, and a pd
+  // pool's start/end are placeholders rather than a range.
+  poolOccupancy: (poolId: string) =>
+    api
+      .get<DHCPPoolOccupancy>(`/dhcp/pools/${poolId}/occupancy`)
+      .then((r) => r.data),
+  scopePoolOccupancy: (scopeId: string) =>
+    api
+      .get<DHCPPoolOccupancy[]>(`/dhcp/scopes/${scopeId}/pools/occupancy`)
+      .then((r) => r.data),
+
   // Rogue-DHCP observed responders (#370).
   listResponders: (groupId: string, classification?: string) =>
     api
@@ -8522,6 +8539,22 @@ export const newDeviceApi = {
       .post<NewDeviceBlockResult>("/new-devices/block", data)
       .then((r) => r.data),
 };
+
+/** Live occupancy of one address-range DHCP pool (#913). */
+export interface DHCPPoolOccupancy {
+  pool_id: string;
+  scope_id: string;
+  pool_name: string;
+  start_ip: string;
+  end_ip: string;
+  pool_type: string;
+  total: number;
+  assigned: number;
+  free: number;
+  percent: number;
+  /** Derived from mirrored lease rows, so its freshness follows the last lease pull. */
+  computed_at: string;
+}
 
 export interface DHCPPool {
   id: string;
@@ -8969,6 +9002,14 @@ export interface DNSQueryLogRow {
   qtype: string | null;
   flags: string | null;
   view: string | null;
+  /**
+   * What the client was actually told (#914). `null` means the outcome
+   * was never recorded — response logging is off for the group — and NOT
+   * that the query succeeded. Render the two differently.
+   */
+  rcode?: string | null;
+  /** RRs in the answer section. NOERROR with 0 is a NODATA response. */
+  answer_count?: number | null;
   raw: string;
 }
 
@@ -8981,6 +9022,8 @@ export interface DNSQueryLogRequest {
   client_ip?: string | null;
   // Exact-match view filter (#371) — seeded by the per-view analytics card.
   view?: string | null;
+  /** Exact outcome (#914). `UNKNOWN` selects rows with no recorded rcode. */
+  rcode?: string | null;
   max_events?: number;
 }
 
@@ -9043,6 +9086,13 @@ export interface DNSQueryAnalyticsResponse {
   qtype_distribution: DNSQueryAnalyticsRow[];
   // Per-view query split (#371). Empty for single-view servers.
   top_views?: DNSQueryAnalyticsRow[];
+  /**
+   * Outcome split (#914). Queries with no recorded outcome appear under
+   * the `UNKNOWN` key rather than being dropped, so a group with response
+   * logging off shows one honest bar instead of an empty panel that reads
+   * as "no failures".
+   */
+  rcode_distribution?: DNSQueryAnalyticsRow[];
 }
 
 /** One scored per-client DNS behaviour window (issue #699). */
@@ -9148,6 +9198,19 @@ export interface RPZBlockedName {
   rpz_zone: string | null;
 }
 
+/** One individual RPZ policy hit (#914) — the raw event, not a rollup. */
+export interface RPZHitRow {
+  id: string;
+  ts: string;
+  server_id: string | null;
+  client_ip: string | null;
+  qname: string | null;
+  trigger: string;
+  policy: string;
+  rpz_zone: string | null;
+  raw: string;
+}
+
 export interface RPZFeedRow {
   rpz_zone: string | null;
   hits: number;
@@ -9247,6 +9310,20 @@ export const dnsThreatApi = {
   rpzFeeds: (params?: { hours?: number }) =>
     api
       .get<RPZFeedRow[]>("/dns-threat/rpz/feeds", { params })
+      .then((r) => r.data),
+  /**
+   * The individual hits (#914) — what the rollups above cannot answer:
+   * "which three lookups did this PC make that were blocked".
+   */
+  rpzHits: (params?: {
+    hours?: number;
+    limit?: number;
+    client_ip?: string;
+    qname_contains?: string;
+    include_passthru?: boolean;
+  }) =>
+    api
+      .get<RPZHitRow[]>("/dns-threat/rpz/hits", { params })
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/LogsPage.tsx
+++ b/frontend/src/pages/LogsPage.tsx
@@ -1075,6 +1075,7 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
   const [qtype, setQtype] = useState<string>("");
   const [clientIp, setClientIp] = useState<string>("");
   const [view, setView] = useState<string>("");
+  const [rcode, setRcode] = useState<string>("");
 
   useEffect(() => {
     if (sources.length === 0) {
@@ -1099,6 +1100,7 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
       qtype,
       clientIp,
       view,
+      rcode,
     ],
     queryFn: () =>
       logsApi.dnsQueries({
@@ -1109,6 +1111,7 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
         qtype: qtype.trim() || null,
         client_ip: clientIp.trim() || null,
         view: view.trim() || null,
+        rcode: rcode.trim() || null,
       }),
     enabled,
     staleTime: 5_000,
@@ -1169,6 +1172,25 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
             className="w-32 rounded-md border bg-background px-2 py-1 text-sm font-mono text-[11px]"
           />
         </label>
+        {/* Outcome filter (#914). "Unrecorded" is a real question an
+            operator asks — it is how you find out whether response
+            logging is actually on — so it is a selectable value rather
+            than an absence. */}
+        <label className="flex items-center gap-1.5 text-xs">
+          <span className="text-muted-foreground">Result</span>
+          <select
+            value={rcode}
+            onChange={(e) => setRcode(e.target.value)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            <option value="">Any</option>
+            <option value="NOERROR">NOERROR</option>
+            <option value="NXDOMAIN">NXDOMAIN</option>
+            <option value="REFUSED">REFUSED</option>
+            <option value="SERVFAIL">SERVFAIL</option>
+            <option value="UNKNOWN">Unrecorded</option>
+          </select>
+        </label>
         <label className="flex items-center gap-1.5 text-xs">
           <span className="inline-flex items-center gap-1 text-muted-foreground">
             <Calendar className="h-3 w-3" />
@@ -1194,7 +1216,7 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
         <MaxEventsPicker value={maxEvents} onChange={setMaxEvents} />
         <FilterSearch value={q} onChange={setQ} />
         <div className="ml-auto flex items-center gap-2">
-          {(q || qtype || clientIp || view || since) && (
+          {(q || qtype || clientIp || view || rcode || since) && (
             <button
               type="button"
               onClick={() => {
@@ -1202,6 +1224,7 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
                 setQtype("");
                 setClientIp("");
                 setView("");
+                setRcode("");
                 setSince("");
               }}
               title="Clear all filters"
@@ -1225,6 +1248,7 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
         onPickClient={(ip) => setClientIp(ip)}
         onPickQtype={(t) => setQtype(t)}
         onPickView={(v) => setView(v)}
+        onPickRcode={(r) => setRcode(r)}
       />
 
       {dnsQueriesQuery.isError && <QueryErrorBanner query={dnsQueriesQuery} />}
@@ -1237,12 +1261,13 @@ function DNSQueriesTab({ sources }: { sources: AgentLogSource[] }) {
 
       {events.length > 0 && (
         <div className="flex-1 overflow-auto">
-          <div className="grid grid-cols-[160px_140px_60px_70px_120px_80px_1fr] gap-x-3 border-b bg-muted/30 px-6 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          <div className="grid grid-cols-[160px_140px_60px_70px_120px_95px_80px_1fr] gap-x-3 border-b bg-muted/30 px-6 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             <span>Time</span>
             <span>Client</span>
             <span>QType</span>
             <span>QClass</span>
             <span>QName</span>
+            <span>Result</span>
             <span>Flags</span>
             <span>Raw</span>
           </div>
@@ -1270,6 +1295,7 @@ function DNSQueryAnalyticsStrip({
   onPickClient,
   onPickQtype,
   onPickView,
+  onPickRcode,
 }: {
   analytics: import("@/lib/api").DNSQueryAnalyticsResponse | null;
   loading: boolean;
@@ -1277,14 +1303,26 @@ function DNSQueryAnalyticsStrip({
   onPickClient: (ip: string) => void;
   onPickQtype: (t: string) => void;
   onPickView: (v: string) => void;
+  onPickRcode: (r: string) => void;
 }) {
   if (!analytics && !loading) return null;
   const total = analytics?.total_queries ?? 0;
   // Per-view card only renders for split-horizon servers (≥1 view seen) so
   // single-view setups keep the tidy 3-card strip (#371).
   const views = analytics?.top_views ?? [];
+  // Outcome breakdown (#914). Present on every server once the backend
+  // ships it — a group with response logging off still gets one bar
+  // ("UNKNOWN"), which is the honest rendering and also the fastest way
+  // to notice the toggle is off.
+  const rcodes = analytics?.rcode_distribution ?? [];
+  const cardCount =
+    3 + (views.length > 0 ? 1 : 0) + (rcodes.length > 0 ? 1 : 0);
   const cols =
-    views.length > 0 ? "md:grid-cols-2 lg:grid-cols-4" : "md:grid-cols-3";
+    cardCount >= 5
+      ? "md:grid-cols-3 lg:grid-cols-5"
+      : cardCount === 4
+        ? "md:grid-cols-2 lg:grid-cols-4"
+        : "md:grid-cols-3";
 
   return (
     <div className="border-b bg-muted/10 px-6 py-2">
@@ -1325,6 +1363,15 @@ function DNSQueryAnalyticsStrip({
             total={total}
             onPick={onPickView}
             emptyHint="No view data."
+          />
+        )}
+        {rcodes.length > 0 && (
+          <AnalyticsCard
+            title="Outcome"
+            rows={rcodes}
+            total={total}
+            onPick={onPickRcode}
+            emptyHint="No outcome data."
           />
         )}
       </div>
@@ -1383,9 +1430,61 @@ function AnalyticsCard({
   );
 }
 
+/**
+ * The answer half of a query (#914).
+ *
+ * A missing rcode is rendered as an explicit "not recorded", never as a
+ * dash that sits in the same column as a successful NOERROR — reading an
+ * unrecorded outcome as "fine" is the one mistake the field exists to
+ * prevent, and a blank cell invites exactly that. A NOERROR carrying no
+ * answer records is labelled NODATA, because "the name exists but has no
+ * record of that type" is a different fault from NXDOMAIN and looks
+ * identical without it.
+ */
+function RcodeCell({
+  rcode,
+  answers,
+}: {
+  rcode: string | null;
+  answers: number | null;
+}) {
+  if (!rcode) {
+    return (
+      <span
+        className="truncate text-[10px] italic text-muted-foreground/50"
+        title="Response logging is off for this server group, so the outcome was never recorded. This does NOT mean the query succeeded."
+      >
+        not recorded
+      </span>
+    );
+  }
+  const nodata = rcode === "NOERROR" && answers === 0;
+  const label = nodata ? "NODATA" : rcode;
+  const tone =
+    rcode === "NOERROR"
+      ? nodata
+        ? "text-amber-600"
+        : "text-emerald-600"
+      : rcode === "NXDOMAIN"
+        ? "text-amber-600"
+        : "text-rose-600";
+  return (
+    <span
+      className={cn("truncate font-mono text-[11px] font-medium", tone)}
+      title={
+        nodata
+          ? "NOERROR with no answer records — the name exists but has no record of this type"
+          : `${rcode}${answers !== null ? ` — ${answers} answer record(s)` : ""}`
+      }
+    >
+      {label}
+    </span>
+  );
+}
+
 function DNSQueryRow({ row }: { row: DNSQueryLogRow }) {
   return (
-    <div className="grid grid-cols-[160px_140px_60px_70px_120px_80px_1fr] items-baseline gap-x-3 px-6 py-1 hover:bg-muted/40">
+    <div className="grid grid-cols-[160px_140px_60px_70px_120px_95px_80px_1fr] items-baseline gap-x-3 px-6 py-1 hover:bg-muted/40">
       <span
         className="font-mono tabular-nums text-muted-foreground"
         title={row.ts}
@@ -1411,6 +1510,7 @@ function DNSQueryRow({ row }: { row: DNSQueryLogRow }) {
       <span className="truncate" title={row.qname ?? ""}>
         {row.qname ?? <span className="text-muted-foreground/40">—</span>}
       </span>
+      <RcodeCell rcode={row.rcode ?? null} answers={row.answer_count ?? null} />
       <span className="font-mono text-muted-foreground">
         {row.flags ?? <span className="text-muted-foreground/40">—</span>}
       </span>

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -25,6 +25,7 @@ import {
   dhcpLeaseHistoryApi,
   ipamApi,
   type DHCPPool,
+  type DHCPPoolOccupancy,
   type DHCPScope,
   type DHCPServer,
   type DHCPServerGroup,
@@ -1423,6 +1424,61 @@ function ServerScopesTab({ groupId }: { groupId: string }) {
   );
 }
 
+/**
+ * Live pool occupancy (#913).
+ *
+ * `assigned` unions active leases with in-pool static reservations, so a
+ * reserved-but-offline address reads as taken — counting leases alone
+ * under-reports exhaustion, which is the failure that sends a technician
+ * looking in the wrong place.
+ *
+ * Answered for dynamic pools only, matching the alert evaluator and the
+ * copilot tool. Each other type would produce a misleading number: a pd
+ * pool's start/end are placeholders for a delegated prefix rather than a
+ * range, an excluded range is never offered to a client at all, and a
+ * reserved range is *supposed* to fill up — colouring that red would
+ * flag a correctly-configured pool as exhausted.
+ */
+function PoolOccupancyCell({
+  occ,
+  poolType,
+}: {
+  occ?: DHCPPoolOccupancy;
+  poolType: string;
+}) {
+  if (poolType !== "dynamic") {
+    return <span className="text-xs text-muted-foreground/60">n/a</span>;
+  }
+  if (!occ) {
+    return <span className="text-xs text-muted-foreground/40">—</span>;
+  }
+  const tone =
+    occ.percent >= 90
+      ? "bg-rose-500"
+      : occ.percent >= 75
+        ? "bg-amber-500"
+        : "bg-emerald-500";
+  return (
+    <div
+      className="flex min-w-[9rem] items-center gap-2"
+      title={`${occ.assigned} of ${occ.total} addresses in use, ${occ.free} free`}
+    >
+      <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full ${tone}`}
+          style={{ width: `${Math.min(100, occ.percent)}%` }}
+        />
+      </div>
+      <span className="font-mono text-xs tabular-nums text-muted-foreground">
+        {occ.assigned}/{occ.total}
+      </span>
+      <span className="font-mono text-xs tabular-nums">
+        {occ.percent.toFixed(0)}%
+      </span>
+    </div>
+  );
+}
+
 function ServerPoolsOrStaticsTab({
   groupId,
   kind,
@@ -1449,6 +1505,22 @@ function ServerPoolsOrStaticsTab({
           : dhcpApi.listStatics(sc.id),
     })),
   });
+
+  // Live occupancy per pool (#913). One call per scope rather than one
+  // per pool — the scope endpoint batches the lease + reservation lookup,
+  // which is the reason it exists. Only fetched on the pools tab.
+  const occupancyQueries = useQueries({
+    queries: allScopes.map((sc) => ({
+      queryKey: ["dhcp-pool-occupancy", sc.id],
+      queryFn: () => dhcpApi.scopePoolOccupancy(sc.id),
+      enabled: kind === "pools",
+      staleTime: 15_000,
+    })),
+  });
+  const occupancyByPool = new Map<string, DHCPPoolOccupancy>();
+  for (const q of occupancyQueries) {
+    for (const row of q.data ?? []) occupancyByPool.set(row.pool_id, row);
+  }
 
   const rows: Array<{
     scope: DHCPScope;
@@ -1615,6 +1687,7 @@ function ServerPoolsOrStaticsTab({
                   >
                     Type
                   </SortableTh>
+                  <th className="px-3 py-2 text-left font-medium">Occupancy</th>
                 </tr>
               </thead>
               <tbody className={zebraBodyCls}>
@@ -1634,6 +1707,12 @@ function ServerPoolsOrStaticsTab({
                         <span className="rounded-full bg-muted px-2 py-0.5 text-xs">
                           {p.pool_type}
                         </span>
+                      </td>
+                      <td className="px-3 py-2">
+                        <PoolOccupancyCell
+                          occ={occupancyByPool.get(p.id)}
+                          poolType={p.pool_type}
+                        />
                       </td>
                     </tr>
                   );

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -5881,6 +5881,7 @@ function OptionsTab({ groupId }: { groupId: string }) {
   const [allowQuery, setAllowQuery] = useState("any");
   const [allowTransfer, setAllowTransfer] = useState("none");
   const [queryLogEnabled, setQueryLogEnabled] = useState(false);
+  const [responseLogEnabled, setResponseLogEnabled] = useState(false);
   const [queryLogChannel, setQueryLogChannel] = useState("file");
   const [queryLogFile, setQueryLogFile] = useState(
     "/var/log/named/queries.log",
@@ -5933,6 +5934,7 @@ function OptionsTab({ groupId }: { groupId: string }) {
     setAllowQuery(opts.allow_query.join(", "));
     setAllowTransfer(opts.allow_transfer.join(", "));
     setQueryLogEnabled(opts.query_log_enabled);
+    setResponseLogEnabled(opts.response_log_enabled);
     setQueryLogChannel(opts.query_log_channel);
     setQueryLogFile(opts.query_log_file);
     setQueryLogSeverity(opts.query_log_severity);
@@ -6114,6 +6116,9 @@ function OptionsTab({ groupId }: { groupId: string }) {
       allow_query: list(allowQuery),
       allow_transfer: list(allowTransfer),
       query_log_enabled: queryLogEnabled,
+      // Only meaningful with query logging on; the API 422s the other
+      // combination, so never send it (#914).
+      response_log_enabled: queryLogEnabled && responseLogEnabled,
       query_log_channel: queryLogChannel,
       query_log_file: queryLogFile,
       query_log_severity: queryLogSeverity,
@@ -6971,6 +6976,32 @@ function OptionsTab({ groupId }: { groupId: string }) {
         )}
         {queryLogEnabled && (
           <>
+            {/* Response logging (#914). Nested inside the query-log gate
+                because the response lines are written to the same
+                channel — the API refuses the other combination rather
+                than accepting a toggle that produces nothing. */}
+            <label className="flex cursor-pointer items-start gap-2 rounded border bg-muted/20 p-2 text-sm">
+              <input
+                type="checkbox"
+                checked={responseLogEnabled}
+                onChange={(e) => {
+                  setResponseLogEnabled(e.target.checked);
+                  setDirty(true);
+                }}
+                className="mt-0.5 h-4 w-4"
+              />
+              <span>
+                Record the outcome of each query
+                <span className="mt-0.5 block text-xs text-muted-foreground">
+                  Adds the RCODE (NOERROR / NXDOMAIN / REFUSED / SERVFAIL) and
+                  answer count to every row in the Logs page, which is what
+                  separates &ldquo;it is not DNS&rdquo; from &ldquo;an ACL is
+                  rejecting this client&rdquo;. BIND9 only, and it roughly
+                  doubles query-log volume — named writes a second line per
+                  query.
+                </span>
+              </span>
+            </label>
             <Field label="Log channel">
               <select
                 className={selCls}

--- a/frontend/src/pages/logs/DNSThreatTab.tsx
+++ b/frontend/src/pages/logs/DNSThreatTab.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 
 import { Modal } from "@/components/ui/modal";
+import { cn } from "@/lib/utils";
 import {
   dnsThreatApi,
   type DNSClientWindow,
@@ -1007,6 +1008,19 @@ function RPZPanel({ hours }: { hours: number }) {
     queryKey: ["dns-threat-rpz-clients", hours],
     queryFn: () => dnsThreatApi.rpzClients({ hours, limit: 20 }),
   });
+  // Clicking a client narrows the per-hit list below (#914). The rollup
+  // says a host has 412 blocked lookups; closing out "the user says this
+  // site does not work" needs the names themselves.
+  const [focusClient, setFocusClient] = useState<string | null>(null);
+  const hits = useQuery({
+    queryKey: ["dns-threat-rpz-hits", hours, focusClient],
+    queryFn: () =>
+      dnsThreatApi.rpzHits({
+        hours,
+        limit: 100,
+        ...(focusClient ? { client_ip: focusClient } : {}),
+      }),
+  });
 
   if (summary.isLoading) {
     return (
@@ -1077,7 +1091,19 @@ function RPZPanel({ hours }: { hours: number }) {
               </thead>
               <tbody>
                 {rows.map((r) => (
-                  <tr key={r.client_ip} className="border-b last:border-0">
+                  <tr
+                    key={r.client_ip}
+                    onClick={() =>
+                      setFocusClient(
+                        focusClient === r.client_ip ? null : r.client_ip,
+                      )
+                    }
+                    className={cn(
+                      "cursor-pointer border-b last:border-0 hover:bg-muted/40",
+                      focusClient === r.client_ip && "bg-muted/60",
+                    )}
+                    title="Show this client's individual blocked lookups"
+                  >
                     <td className="py-1.5 pr-3 font-mono text-xs">
                       <span className="inline-flex items-center gap-1.5">
                         {r.noisy && (
@@ -1101,6 +1127,71 @@ function RPZPanel({ hours }: { hours: number }) {
                     </td>
                     <td className="py-1.5 text-xs text-muted-foreground">
                       {new Date(r.last_seen).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className="mb-1 flex flex-wrap items-center gap-2">
+          <h4 className="text-xs font-semibold">Recent blocked lookups</h4>
+          {focusClient && (
+            <button
+              type="button"
+              onClick={() => setFocusClient(null)}
+              className="rounded-md border px-2 py-0.5 text-[11px] hover:bg-accent"
+            >
+              {focusClient} &times;
+            </button>
+          )}
+        </div>
+        <p className="mb-2 text-xs text-muted-foreground">
+          The individual hits, newest first — what the counts above cannot tell
+          you. Click a client to narrow. PASSTHRU rows are excluded: an
+          exception firing is an explicit allow, not a block.
+        </p>
+        {hits.isLoading ? (
+          <div className="flex items-center gap-2 py-3 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading&hellip;
+          </div>
+        ) : (hits.data ?? []).length === 0 ? (
+          <p className="py-3 text-sm text-muted-foreground">
+            No blocked lookups in this window.
+          </p>
+        ) : (
+          <div className="max-h-96 overflow-auto">
+            <table className="w-full min-w-[40rem] text-sm">
+              <thead className="sticky top-0 border-b bg-card text-left text-xs text-muted-foreground">
+                <tr>
+                  <th className="py-1.5 pr-3 font-medium">Time</th>
+                  <th className="py-1.5 pr-3 font-medium">Client</th>
+                  <th className="py-1.5 pr-3 font-medium">Name</th>
+                  <th className="py-1.5 pr-3 font-medium">Policy</th>
+                  <th className="py-1.5 font-medium">Feed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(hits.data ?? []).map((h) => (
+                  <tr key={h.id} className="border-b last:border-0">
+                    <td className="py-1.5 pr-3 text-xs text-muted-foreground whitespace-nowrap">
+                      {new Date(h.ts).toLocaleString()}
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono text-xs">
+                      {h.client_ip ?? "—"}
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono text-xs break-all">
+                      {h.qname ?? "—"}
+                    </td>
+                    <td className="py-1.5 pr-3 font-mono text-xs">
+                      {h.trigger} {h.policy}
+                    </td>
+                    <td className="py-1.5 font-mono text-xs break-all text-muted-foreground">
+                      {h.rpz_zone ?? "—"}
                     </td>
                   </tr>
                 ))}


### PR DESCRIPTION
Closes #913, Closes #914

Two questions the API could not answer, both surfaced while building
troubleshooting screens in
[spatiumddi-mobile](https://github.com/spatiumddi/spatiumddi-mobile).

## #913 — DHCP pool occupancy over REST

`backend/app/services/dhcp/pool_occupancy.py` has computed `assigned` /
`total` / `free` / `percent` since #339, and **no HTTP route called it** — it
was reachable only from the `find_dhcp_pool_occupancy` copilot tool and the
`dhcp_pool_exhaustion` alert evaluator. So "is this pool full?", the first
question asked when a client cannot get an address, could only be answered by
fetching pools, leases and reservations separately and redoing the range
arithmetic: three round trips and easy to get subtly wrong, and a wrong "the
pool is fine" sends the technician to the wrong place.

```
GET /api/v1/dhcp/pools/{pool_id}/occupancy
GET /api/v1/dhcp/scopes/{scope_id}/pools/occupancy    # every pool, one call
```

The scope shape is the one that matters operationally — a scope with several
pools is where a call-per-pool is wasteful *and* where "the scope looks fine"
hides one exhausted class-restricted pool — so it runs a single batched lease +
reservation query for all of them.

**Dynamic pools only**, matching the alert evaluator and the copilot tool.
Each other type would report a number that is not a fact about it: an
`excluded` range is never offered to a client, a `reserved` range is *supposed*
to approach 100% and would render as a red exhaustion bar for doing its job,
and a `pd` pool's range ends are NOT NULL placeholders holding a delegated
prefix rather than a range (so the arithmetic yields a one-address pool at 0%).
Disagreeing with the other two consumers is precisely how a wrong "fine" is
produced.

No new MCP tool — explicit decision per non-negotiable #13:
`find_dhcp_pool_occupancy` answers exactly this, over the same pool set.

## #914 — the answer half of the DNS query log

BIND's `queries` category is request-side by design: it logs the question on
arrival and never mentions the response. So the log could prove a query
reached the server and could not distinguish the five outcomes an operator is
actually triaging — and the most common real one, a query that *was* answered
just not as the user expected, was indistinguishable from one that was refused.

BIND 9.20's `responselog` emits a second category carrying the RCODE and the
section counts:

```
23-Aug-2026 13:20:09.490 responses: info: client @0x7f83 127.0.0.1#57018 \
    (www.example.com): view internal: response: www.example.com IN A \
    NOERROR 1 1 2 +E(0)K (127.0.0.1)
```

Routed to the same `queries_channel` the shipper already tails (no second
thread, file or bind mount), told apart at ingest by separator (`: response: `
vs `: query: `, neither expressible inside a DNS name), and stamped onto the
query row it belongs to — matched on client address + ephemeral source port +
qname + qtype, in-batch first and against the DB when a batch boundary splits
the pair, because that split lands on the *same* row every time under load and
would be a bias rather than noise. An orphan response is dropped, never
stored: a row with an outcome and no question answers nothing and would
double-count every query in the analytics the same table feeds.

`answer_count` is carried as well as `rcode`, because **NOERROR with zero
answers is NODATA** — the name exists but has no record of that type, a
different fault from NXDOMAIN that reads identically without it.

Opt-in per server group (`response_log_enabled`, migration `f1c7a92e4b06`)
because it roughly doubles query-log volume. A caller explicitly asking for
response logging *without* query logging gets a 422; a caller simply turning
query logging off has the response toggle cleared with it, since refusing
there would name a field they never sent and leave no single call that
disables query logging at all.

**NULL means UNRECORDED, never NOERROR**, in every surface: *not recorded* in
italics in the grid, an explicit `UNKNOWN` key in the analytics breakdown (so a
group with the toggle off shows one honest bar rather than an empty panel
reading as "no failures"), a selectable filter value, and the reason spelled
out in the copilot tool's own field.

Also closes the issue's related gap: `GET /api/v1/dns-threat/rpz/hits` returns
the individual blocked lookups behind the four existing rollups. PASSTHRU is
excluded by default — an explicit ALLOW listed among blocks makes a working
allowlist read as an infection — and `include_passthru=true` answers the
opposite question.

## Two bugs found on the way, both "stored, shipped, rendered nowhere"

Same class as `allow_transfer` (#734) and `forward_policy` (#899).

1. **The agent's BIND9 renderer never emitted `category rpz { … };`.** named
   logs a policy rewrite to its own category, so #699's entire per-client
   blocklist attribution recorded *nothing* on the only path that ships it.
   The control-plane Jinja template has carried the line since #699 — which is
   why review never caught it: the code was right in the file nothing renders
   from. `rpz-passthru` was missing too, leaving the exception half dark and
   the `policy != PASSTHRU` filters in `services/dns_threat/rpz.py`
   unreachable. Verified live: a blocked lookup that produced no row before now
   produces one.

2. **`rndc reconfig` does not apply `responselog`.** Verified against BIND
   9.20.26 — config swapped in, reconfig clean, `rndc status` still
   `response logging is OFF`. It is a live switch and reconfig deliberately
   preserves what the running server was last told; query logging escapes this
   only by accident of BIND's own defaulting (no `querylog` statement, so it
   follows the `queries` category, which a reload *does* pick up). Without the
   explicit `rndc responselog on|off` the agent now issues after each
   structural reload, the toggle would rewrite `named.conf`, pass
   `named-checkconf`, reload cleanly, and produce not one line until the daemon
   was next restarted.

## Verification

- **Every BIND assumption checked against a live BIND 9.20.26**, not against
  documentation: the response-line format (including the NODATA, NXDOMAIN and
  REFUSED shapes now used as parser fixtures), `named-checkconf` acceptance of
  `responselog` and all four categories, and the reconfig behaviour above.
- End-to-end on the dev stack: toggled the option, watched the agent re-render,
  ran queries, and read the rcodes back out of `POST /logs/dns-queries`
  (`example.com MX` → NOERROR/0 answers, i.e. NODATA; a blocked name →
  SERVFAIL; AXFR rows → `null`, honestly unknown). Confirmed `dns_rpz_hit` rows
  now land where the table had stayed empty.
- 47 new backend tests + 11 new agent tests; `make ci` green (ruff, black,
  mypy, eslint, prettier, tsc, vitest, vite build); migration linter baselined;
  `f1c7a92e4b06` is the single Alembic head.
- 2 MCP tools (`find_dns_queries`, `find_rpz_hits`), both default-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
