### PR TITLE
feat(metrics): InfluxDB v1/v2/v3 push export (#889)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Always read the relevant spec doc(s) before writing code for a feature area.
 | Cache / Sessions | Redis 7 |
 | Auth | python-jose + bcrypt (local), ldap3 (LDAP), joserfc (OIDC ID-token / JWKS), python3-saml (SAML), pyrad (RADIUS), tacacs_plus (TACACS+); Fernet for secrets at rest |
 | Logging | structlog → JSON → centralized log store (Loki / Elasticsearch) |
-| Metrics | Prometheus + Grafana (InfluxDB push export is **planned, not built** — [#889](https://github.com/spatiumddi/spatiumddi/issues/889)) |
+| Metrics | Prometheus + Grafana; InfluxDB v1 / v2 / v3 push export ([#889](https://github.com/spatiumddi/spatiumddi/issues/889)) |
 | Containerization | Docker (multi-stage, amd64+arm64), Docker Compose, Kubernetes + Helm |
 | Appliance OS | Alpine Linux (containers/appliance), Debian Stable (bare-metal ISO) |
 | Logo / Assets | `docs/assets/logo.svg`, `docs/assets/logo-icon.svg` — also copied to `frontend/src/assets/` |
@@ -443,10 +443,48 @@ probe-safety fix (#722) is not a vertical at all.
 - ✅ [**Decom-date awareness**](https://github.com/spatiumddi/spatiumddi/issues/46) — shipped `2026.06.11-1`: first-class `decom_date` on subnet + IP, a `decom_expiring` alert rule (severity escalation reused from the other `*_expiring` rules), a dashboard widget, and a `find_subnets_decommissioning` MCP tool. Migration `a3f7c1e92b48`.
 - ✅ [**Top-N reports**](https://github.com/spatiumddi/spatiumddi/issues/47) — shipped `2026.06.11-1`: a `/reports` surface (top subnets by utilization, owners by IP count, most-modified resources via `audit_log`, noisiest DNS clients), feature-module-gated with 4 MCP read tools.
 - ✅ [**Compliance / change report PDF**](https://github.com/spatiumddi/spatiumddi/issues/48) — shipped `2026.06.11-1`: `GET /api/v1/audit/export.pdf` renders an auditor-facing PDF of every `audit_log` mutation in a date range, grouped by user / resource / action, with a per-row SHA-256 tamper-evidence trailer.
-- ⬜ [**InfluxDB push export**](https://github.com/spatiumddi/spatiumddi/issues/889) — build the writer the tech-stack
-  table claimed for months but nothing implemented: periodic push of the
-  existing `metric_sample` rows to InfluxDB v1 / v2 / v3. Spec shape is
-  already written up in `docs/SHIPPED.md`; the code is greenfield.
+- ✅ [**InfluxDB push export**](https://github.com/spatiumddi/spatiumddi/issues/889) — the writer the tech-stack
+  table claimed for months while `grep -ri influx` over `backend/` returned
+  nothing. Now `InfluxDBTarget` + `backend/app/services/influxdb/`
+  (`line_protocol` / `client` / `collect` / `push`) + a 30 s beat task with
+  per-target interval gating, CRUD at `/settings/influxdb-targets` with a
+  **test-write**, and 1 MCP tool (`find_influxdb_targets`, default on,
+  superadmin-only). Migration `a2e7f31c9b48`.
+  **"All versions" is three declared versions over two wire dialects:**
+  `v3` is not a third client — every InfluxDB 3 product (Core, Enterprise,
+  Cloud Dedicated, Cloud Serverless) accepts the **v2** write endpoint, so
+  v3 reuses that path with `Authorization: Bearer` instead of `Token` and a
+  *database* named in the `bucket` parameter. All three verified against a
+  live server during development, `v1` via InfluxDB 2.7's DBRP
+  compatibility mapping.
+  **The idempotency (non-negotiable #9) is the server's, not ours:** line
+  protocol overwrites a point with an identical measurement + tag set +
+  timestamp. That is what makes a retry free — and it is *why* the cursor
+  is deliberately not a strict `>` on the high-water mark. It re-sends a
+  5-minute overlap so a bucket an agent reported late is still exported;
+  a strict cursor would skip it permanently and silently. Watermarks
+  advance only on a successful write, so a dead collector delays the
+  export rather than punching a hole in it (the samples sit in Postgres
+  until `prune_metrics` retires them, so a target that recovers inside
+  `metric_retention_days` backfills itself). `last_push_at` moves on
+  failure too, or a fast-failing target would retry on every 30 s tick
+  instead of on its own interval.
+  **Two shapes of metric, and the difference matters on a dashboard:**
+  the DNS/DHCP counter deltas carry the **agent's own 60 s bucket
+  timestamp**, so a backfill lands on the hour the traffic happened — and
+  60 s, not the push interval, is the resolution floor (`push_interval`
+  below that just re-sends the same bucket). The IPAM utilization and
+  per-scope lease gauges the spec asked for are sampled *at push time*
+  from counters the app already maintains — no new table, but also no
+  backfill: the first point is when the target was enabled. Documented
+  as such rather than labelled "realtime".
+  **Test is a real single-point write**, not a reachability ping: a
+  correct URL with the wrong bucket, org or token answers a GET perfectly
+  well and then rejects every point. Explicitly **not** a feature module
+  (non-negotiable #14) — no sidebar section, no router prefix, and "off"
+  is already `enabled=false` on the row. **Deferred:** API request
+  rate/latency and per-component health, which the old spec listed but
+  nothing samples at push cadence.
 
 #### Subnet planning & calculation tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,16 +459,28 @@ probe-safety fix (#722) is not a vertical at all.
   compatibility mapping.
   **The idempotency (non-negotiable #9) is the server's, not ours:** line
   protocol overwrites a point with an identical measurement + tag set +
-  timestamp. That is what makes a retry free — and it is *why* the cursor
-  is deliberately not a strict `>` on the high-water mark. It re-sends a
-  5-minute overlap so a bucket an agent reported late is still exported;
-  a strict cursor would skip it permanently and silently. Watermarks
-  advance only on a successful write, so a dead collector delays the
-  export rather than punching a hole in it (the samples sit in Postgres
-  until `prune_metrics` retires them, so a target that recovers inside
-  `metric_retention_days` backfills itself). `last_push_at` moves on
-  failure too, or a fast-failing target would retry on every 30 s tick
-  instead of on its own interval.
+  timestamp, so a retry is free. That is what lets each push run **two
+  queries per source on separate row budgets** — a forward drain
+  (strictly `> watermark`, capped) and a replay of the closed
+  `(watermark − 5 min, watermark]` window, so a bucket an agent reported
+  late is still exported rather than skipped permanently and silently.
+  The separation is load-bearing, not tidiness: fold the replay into the
+  drain's lower bound and a fleet dense enough to fill the row cap inside
+  that window returns a truncated batch whose maximum is *below* the
+  watermark — pulling the cursor backwards every tick until it pins on
+  the oldest retained sample, with every push still reporting success and
+  the UI still green. Replayed rows never set the cursor.
+  Watermarks advance only on a successful write, so a dead collector
+  delays the export rather than punching a hole in it (the samples sit in
+  Postgres until `prune_metrics` retires them, so a target that recovers
+  inside `metric_retention_days` backfills itself). `last_push_at` moves
+  on failure too, or a fast-failing target would retry on every 30 s tick
+  instead of on its own interval — and the push is wrapped in a broad
+  per-target boundary, because the sweep pushes every due target in one
+  transaction and an escaping exception would discard the state updates
+  of the ones that succeeded. `httpx.InvalidURL` is named explicitly
+  alongside `HTTPError` for that reason: it derives from `Exception`, not
+  from the httpx error base.
   **Two shapes of metric, and the difference matters on a dashboard:**
   the DNS/DHCP counter deltas carry the **agent's own 60 s bucket
   timestamp**, so a backfill lands on the hour the traffic happened — and
@@ -477,7 +489,10 @@ probe-safety fix (#722) is not a vertical at all.
   per-scope lease gauges the spec asked for are sampled *at push time*
   from counters the app already maintains — no new table, but also no
   backfill: the first point is when the target was enabled. Documented
-  as such rather than labelled "realtime".
+  as such rather than labelled "realtime". The lease gauge counts
+  **distinct addresses**: `dhcp_lease` is per-server and a Kea HA pair
+  mirrors each lease twice, so `COUNT(*)` would report 2× on exactly the
+  deployments that matter, and disagree with `pool_occupancy.py`.
   **Test is a real single-point write**, not a reachability ping: a
   correct URL with the wrong bucket, org or token answers a GET perfectly
   well and then rejects every point. Explicitly **not** a feature module

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -108,6 +108,7 @@ backend/alembic/versions/a1c7f3e9b284_bgp_hijack_monitoring.py:drop_table:206
 backend/alembic/versions/a1f4c7e92b30_dhcp_scope_provider_refs.py:drop_column:38
 backend/alembic/versions/a1f4d97c8e25_network_device_poll_igmp.py:drop_column:48
 backend/alembic/versions/a1f4d97c8e25_network_device_poll_igmp.py:drop_column:49
+backend/alembic/versions/a2e7f31c9b48_influxdb_push_export.py:drop_table:99
 backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:83
 backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:84
 backend/alembic/versions/a3c8e5d61b94_subnet_classification_tags.py:drop_column:85

--- a/backend/alembic/versions/a2e7f31c9b48_influxdb_push_export.py
+++ b/backend/alembic/versions/a2e7f31c9b48_influxdb_push_export.py
@@ -1,0 +1,99 @@
+"""InfluxDB push-export targets (issue #889)
+
+Creates ``influxdb_target`` — one row per InfluxDB destination the
+control plane pushes line protocol to. Three declared versions (v1 / v2
+/ v3) share two wire dialects; see ``app/models/influxdb.py``.
+
+Credentials are Fernet-encrypted ``LargeBinary`` columns following the
+``audit_forward_target.smtp_password_encrypted`` convention — the API
+returns ``password_set`` / ``token_set`` booleans, never the value.
+
+``last_dns_bucket_at`` / ``last_dhcp_bucket_at`` are per-source
+high-water marks so a restart doesn't re-push the retention window;
+they are an optimisation only, since line protocol overwrites a point
+with an identical measurement + tag set + timestamp.
+
+Revision ID: a2e7f31c9b48
+Revises: f1c7a92e4b06
+Create Date: 2026-08-23
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "a2e7f31c9b48"
+down_revision = "f1c7a92e4b06"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "influxdb_target",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("version", sa.String(length=4), nullable=False, server_default=sa.text("'v2'")),
+        sa.Column("url", sa.String(length=1024), nullable=False, server_default=sa.text("''")),
+        sa.Column("verify_tls", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("timeout_seconds", sa.Integer(), nullable=False, server_default=sa.text("10")),
+        # v1
+        sa.Column("database", sa.String(length=255), nullable=False, server_default=sa.text("''")),
+        sa.Column("username", sa.String(length=255), nullable=False, server_default=sa.text("''")),
+        sa.Column("password_encrypted", sa.LargeBinary(), nullable=True),
+        # v2 / v3
+        sa.Column("org", sa.String(length=255), nullable=False, server_default=sa.text("''")),
+        sa.Column("bucket", sa.String(length=255), nullable=False, server_default=sa.text("''")),
+        sa.Column("token_encrypted", sa.LargeBinary(), nullable=True),
+        sa.Column(
+            "measurement_prefix",
+            sa.String(length=64),
+            nullable=False,
+            server_default=sa.text("'spatiumddi_'"),
+        ),
+        sa.Column(
+            "push_interval_seconds", sa.Integer(), nullable=False, server_default=sa.text("60")
+        ),
+        sa.Column("push_dns_metrics", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("push_dhcp_metrics", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column(
+            "push_subnet_utilization", sa.Boolean(), nullable=False, server_default=sa.true()
+        ),
+        sa.Column("push_dhcp_scope_leases", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("last_dns_bucket_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_dhcp_bucket_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_push_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_push_points", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("last_push_error", sa.Text(), nullable=True),
+        # TimestampMixin columns need an explicit server_default: the ORM
+        # default only fires on an ORM insert, so a fresh install that
+        # writes a row through raw SQL would NULL-violate without it.
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_influxdb_target_name", "influxdb_target", ["name"], unique=True)
+    op.create_index("ix_influxdb_target_enabled", "influxdb_target", ["enabled"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_influxdb_target_enabled", table_name="influxdb_target")
+    op.drop_index("ix_influxdb_target_name", table_name="influxdb_target")
+    op.drop_table("influxdb_target")

--- a/backend/app/api/v1/settings/router.py
+++ b/backend/app/api/v1/settings/router.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 
 import structlog
 from fastapi import APIRouter, File, Header, HTTPException, Response, UploadFile, status
-from pydantic import BaseModel, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
@@ -22,6 +22,13 @@ from app.core.http_etag import etag_matches, format_etag
 from app.core.permissions import is_effective_superadmin, user_has_permission
 from app.models.audit import AuditLog
 from app.models.audit_forward import AuditForwardTarget
+from app.models.influxdb import (
+    DEFAULT_MEASUREMENT_PREFIX,
+    DEFAULT_PUSH_INTERVAL_SECONDS,
+    INFLUXDB_VERSIONS,
+    MIN_PUSH_INTERVAL_SECONDS,
+    InfluxDBTarget,
+)
 from app.models.oui import OUIVendor
 from app.models.settings import (
     BRANDING_ASSET_KIND_LOGO,
@@ -3072,6 +3079,347 @@ async def test_audit_target(
     except Exception as exc:  # noqa: BLE001
         raise HTTPException(status_code=502, detail=f"delivery failed: {exc}") from exc
     return {"status": "ok", "target": row.name}
+
+
+# ── InfluxDB push export (issue #889) ──────────────────────────────────────────
+#
+# CRUD + test-write for ``InfluxDBTarget``. Superadmin-gated and audited
+# like the audit-forward targets above, and secrets follow the same
+# shape: write-only in, boolean-only out.
+#
+# Deliberately NOT a feature module (non-negotiable #14 asks for the
+# decision to be explicit): this adds no sidebar section and no top-level
+# router prefix — it is a Settings-level integration that lives under the
+# existing ``/settings`` surface, same as audit forwarding. There is
+# nothing for an operator to "turn off" beyond deleting or disabling a
+# target, which the resource already models.
+
+
+class InfluxDBTargetBody(BaseModel):
+    name: str = Field(min_length=1, max_length=128)
+    enabled: bool = True
+    version: str = "v2"
+    url: str = ""
+    verify_tls: bool = True
+    timeout_seconds: int = Field(default=10, ge=1, le=120)
+    # v1
+    database: str = ""
+    username: str = ""
+    # ``None`` = leave the stored value alone (the operator is editing
+    # another field), ``""`` = clear, anything else = encrypt + replace.
+    # Same three-way contract as ``AuditTargetBody.smtp_password``.
+    password: str | None = None
+    # v2 / v3
+    org: str = ""
+    bucket: str = ""
+    token: str | None = None
+    measurement_prefix: str = Field(default=DEFAULT_MEASUREMENT_PREFIX, max_length=64)
+    push_interval_seconds: int = Field(
+        default=DEFAULT_PUSH_INTERVAL_SECONDS, ge=MIN_PUSH_INTERVAL_SECONDS, le=86400
+    )
+    push_dns_metrics: bool = True
+    push_dhcp_metrics: bool = True
+    push_subnet_utilization: bool = True
+    push_dhcp_scope_leases: bool = True
+
+    @field_validator("version")
+    @classmethod
+    def _valid_version(cls, v: str) -> str:
+        if v not in INFLUXDB_VERSIONS:
+            raise ValueError(f"version must be one of {list(INFLUXDB_VERSIONS)}")
+        return v
+
+    @field_validator("url")
+    @classmethod
+    def _valid_url(cls, v: str) -> str:
+        cleaned = v.strip()
+        if cleaned and not cleaned.startswith(("http://", "https://")):
+            raise ValueError("url must start with http:// or https://")
+        return cleaned
+
+    @field_validator("measurement_prefix")
+    @classmethod
+    def _valid_prefix(cls, v: str) -> str:
+        # The prefix is concatenated onto a measurement name and then
+        # line-protocol-escaped, so a stray comma or space would not
+        # corrupt the wire format — but it would produce a measurement
+        # name nobody can type into a Flux query. Reject early.
+        if v and not re.fullmatch(r"[A-Za-z0-9_.:-]*", v):
+            raise ValueError("measurement_prefix may only contain letters, digits, and _ . : -")
+        return v
+
+
+class InfluxDBTargetResponse(BaseModel):
+    id: str
+    name: str
+    enabled: bool
+    version: str
+    url: str
+    verify_tls: bool
+    timeout_seconds: int
+    database: str
+    username: str
+    # Secrets are never returned — only whether one is on file.
+    password_set: bool
+    org: str
+    bucket: str
+    token_set: bool
+    measurement_prefix: str
+    push_interval_seconds: int
+    push_dns_metrics: bool
+    push_dhcp_metrics: bool
+    push_subnet_utilization: bool
+    push_dhcp_scope_leases: bool
+    last_push_at: datetime | None
+    last_push_points: int
+    last_push_error: str | None
+    last_dns_bucket_at: datetime | None
+    last_dhcp_bucket_at: datetime | None
+    created_at: datetime
+    modified_at: datetime
+
+
+def _influx_to_response(t: InfluxDBTarget) -> InfluxDBTargetResponse:
+    return InfluxDBTargetResponse(
+        id=str(t.id),
+        name=t.name,
+        enabled=t.enabled,
+        version=t.version,
+        url=t.url or "",
+        verify_tls=bool(t.verify_tls),
+        timeout_seconds=int(t.timeout_seconds or 10),
+        database=t.database or "",
+        username=t.username or "",
+        password_set=bool(t.password_encrypted),
+        org=t.org or "",
+        bucket=t.bucket or "",
+        token_set=bool(t.token_encrypted),
+        measurement_prefix=t.measurement_prefix or "",
+        push_interval_seconds=int(t.push_interval_seconds or DEFAULT_PUSH_INTERVAL_SECONDS),
+        push_dns_metrics=bool(t.push_dns_metrics),
+        push_dhcp_metrics=bool(t.push_dhcp_metrics),
+        push_subnet_utilization=bool(t.push_subnet_utilization),
+        push_dhcp_scope_leases=bool(t.push_dhcp_scope_leases),
+        last_push_at=t.last_push_at,
+        last_push_points=int(t.last_push_points or 0),
+        last_push_error=t.last_push_error,
+        last_dns_bucket_at=t.last_dns_bucket_at,
+        last_dhcp_bucket_at=t.last_dhcp_bucket_at,
+        created_at=t.created_at,
+        modified_at=t.modified_at,
+    )
+
+
+def _apply_influx_body(t: InfluxDBTarget, body: InfluxDBTargetBody) -> None:
+    from app.core.crypto import encrypt_str
+
+    t.name = body.name
+    t.enabled = body.enabled
+    t.version = body.version
+    t.url = body.url
+    t.verify_tls = body.verify_tls
+    t.timeout_seconds = body.timeout_seconds
+    t.database = body.database
+    t.username = body.username
+    t.org = body.org
+    t.bucket = body.bucket
+    t.measurement_prefix = body.measurement_prefix
+    t.push_interval_seconds = body.push_interval_seconds
+    t.push_dns_metrics = body.push_dns_metrics
+    t.push_dhcp_metrics = body.push_dhcp_metrics
+    t.push_subnet_utilization = body.push_subnet_utilization
+    t.push_dhcp_scope_leases = body.push_dhcp_scope_leases
+    if body.password is not None:
+        t.password_encrypted = encrypt_str(body.password) if body.password else None
+    if body.token is not None:
+        t.token_encrypted = encrypt_str(body.token) if body.token else None
+
+
+def _assert_influx_writable(t: InfluxDBTarget) -> None:
+    """422 on a target the writer could not build a request for.
+
+    Runs at save time so the operator finds out in the form rather than
+    from a ``last_push_error`` string 60 s later. It is the *same*
+    function the pusher calls, so the two can't disagree about what a
+    valid target is.
+    """
+    from app.services.influxdb.client import InfluxTargetConfig, build_write_request
+
+    try:
+        build_write_request(
+            InfluxTargetConfig(
+                version=t.version,
+                url=t.url or "",
+                database=t.database or "",
+                username=t.username or "",
+                # Presence, not the value — the real secret is decrypted
+                # only on the push / test paths.
+                password="x" if t.password_encrypted else "",
+                org=t.org or "",
+                bucket=t.bucket or "",
+                token="x" if t.token_encrypted else "",
+            )
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+def _audit_influx(db: DB, current_user: CurrentUser, action: str, row: InfluxDBTarget) -> None:
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action=action,
+            resource_type="influxdb_target",
+            resource_id=str(row.id),
+            resource_display=row.name,
+            result="success",
+            # No credentials in the audit body — the encrypted columns are
+            # deliberately absent rather than redacted, so a future field
+            # can't leak in by being added to a dict comprehension.
+            new_value=(
+                None
+                if action == "delete"
+                else {
+                    "enabled": row.enabled,
+                    "version": row.version,
+                    "url": row.url,
+                    "database": row.database,
+                    "org": row.org,
+                    "bucket": row.bucket,
+                    "measurement_prefix": row.measurement_prefix,
+                    "push_interval_seconds": row.push_interval_seconds,
+                    "push_dns_metrics": row.push_dns_metrics,
+                    "push_dhcp_metrics": row.push_dhcp_metrics,
+                    "push_subnet_utilization": row.push_subnet_utilization,
+                    "push_dhcp_scope_leases": row.push_dhcp_scope_leases,
+                }
+            ),
+        )
+    )
+
+
+@router.get("/influxdb-targets", response_model=list[InfluxDBTargetResponse])
+async def list_influxdb_targets(current_user: CurrentUser, db: DB) -> list[InfluxDBTargetResponse]:
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    res = await db.execute(select(InfluxDBTarget).order_by(InfluxDBTarget.name))
+    return [_influx_to_response(t) for t in res.scalars().all()]
+
+
+@router.post(
+    "/influxdb-targets",
+    response_model=InfluxDBTargetResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_influxdb_target(
+    body: InfluxDBTargetBody, current_user: CurrentUser, db: DB
+) -> InfluxDBTargetResponse:
+    forbid_in_demo_mode("InfluxDB target creation is disabled")
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    row = InfluxDBTarget()
+    _apply_influx_body(row, body)
+    _assert_influx_writable(row)
+    db.add(row)
+    await db.flush()
+    _audit_influx(db, current_user, "create", row)
+    try:
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001 — name collisions land here
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=f"create failed: {exc}") from exc
+    await db.refresh(row)
+    return _influx_to_response(row)
+
+
+@router.put("/influxdb-targets/{target_id}", response_model=InfluxDBTargetResponse)
+async def update_influxdb_target(
+    target_id: uuid.UUID,
+    body: InfluxDBTargetBody,
+    current_user: CurrentUser,
+    db: DB,
+) -> InfluxDBTargetResponse:
+    forbid_in_demo_mode("InfluxDB target updates are disabled")
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    row = await db.get(InfluxDBTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+    _apply_influx_body(row, body)
+    _assert_influx_writable(row)
+    _audit_influx(db, current_user, "update", row)
+    try:
+        await db.commit()
+    except Exception as exc:  # noqa: BLE001
+        await db.rollback()
+        raise HTTPException(status_code=400, detail=f"update failed: {exc}") from exc
+    await db.refresh(row)
+    return _influx_to_response(row)
+
+
+@router.delete("/influxdb-targets/{target_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_influxdb_target(target_id: uuid.UUID, current_user: CurrentUser, db: DB) -> None:
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    row = await db.get(InfluxDBTarget, target_id)
+    if row is None:
+        return
+    _audit_influx(db, current_user, "delete", row)
+    await db.delete(row)
+    await db.commit()
+
+
+class InfluxDBTestResponse(BaseModel):
+    ok: bool
+    message: str
+    points: int
+
+
+@router.post("/influxdb-targets/{target_id}/test", response_model=InfluxDBTestResponse)
+async def test_influxdb_target(
+    target_id: uuid.UUID, current_user: CurrentUser, db: DB
+) -> InfluxDBTestResponse:
+    """Write one synthetic point and report the server's verdict.
+
+    Deliberately a *real* write rather than a reachability ping: a
+    correct URL with the wrong bucket, org or token answers a GET
+    perfectly well and then rejects every point. The point lands in the
+    target's own ``<prefix>export_test`` measurement so it never
+    contaminates a real series, and the watermarks are untouched — this
+    is a probe, not a push.
+    """
+    if not is_effective_superadmin(current_user):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN)
+    row = await db.get(InfluxDBTarget, target_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Target not found")
+
+    from app.core.ssrf import assert_safe_target
+    from app.services.influxdb.client import (
+        InfluxDBWriteError,
+        config_from_row,
+        write_lines,
+    )
+    from app.services.influxdb.line_protocol import Point, render_batch
+
+    # Advisory SSRF logging only (no block=True) — an InfluxDB on the
+    # same LAN, or on the appliance itself, is the common case. See
+    # app/core/ssrf.py.
+    assert_safe_target(row.url, label="influxdb")
+
+    point = Point(
+        measurement=f"{row.measurement_prefix or ''}export_test",
+        tags={"target": row.name},
+        fields={"ok": 1, "source": "spatiumddi"},
+        timestamp=int(datetime.now(UTC).timestamp()),
+    )
+    try:
+        await write_lines(config_from_row(row), render_batch([point]))
+    except (InfluxDBWriteError, ValueError) as exc:
+        return InfluxDBTestResponse(ok=False, message=str(exc), points=0)
+    return InfluxDBTestResponse(ok=True, message="1 point written", points=1)
 
 
 # ── Public branding surface (issues #885 / #886 / #887 / #888) ──────────────────

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -30,6 +30,7 @@ celery_app = Celery(
         "app.tasks.prune_internal_errors",
         "app.tasks.prune_logs",
         "app.tasks.prune_metrics",
+        "app.tasks.influxdb_push",
         "app.tasks.prune_multicast_memberships",
         "app.tasks.prune_pairing_codes",
         "app.tasks.firewall_lint_scan",
@@ -105,6 +106,7 @@ celery_app.conf.update(
         "app.tasks.prune_internal_errors.*": {"queue": "default"},
         "app.tasks.prune_logs.*": {"queue": "default"},
         "app.tasks.prune_metrics.*": {"queue": "default"},
+        "app.tasks.influxdb_push.*": {"queue": "default"},
         "app.tasks.subnet_utilization_snapshot.*": {"queue": "default"},
         "app.tasks.prune_multicast_memberships.*": {"queue": "default"},
         "app.tasks.prune_pairing_codes.*": {"queue": "default"},
@@ -307,6 +309,14 @@ celery_app.conf.update(
         "metric-samples-prune": {
             "task": "app.tasks.prune_metrics.prune_metric_samples",
             "schedule": schedule(run_every=24 * 3600.0),
+        },
+        # #889 — InfluxDB push export. Coarse 30 s tick; each target is
+        # gated on its own ``push_interval_seconds`` inside the task, so
+        # cadence edits in the UI apply without restarting beat. A tick
+        # with no enabled targets is one indexed SELECT and returns.
+        "influxdb-push": {
+            "task": "app.tasks.influxdb_push.push_influxdb_metrics",
+            "schedule": schedule(run_every=30.0),
         },
         # #44 — daily per-subnet utilization snapshot + 90-day prune,
         # powering the "% used over time" chart on the subnet detail.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -83,6 +83,7 @@ from app.models.firewall import (
 )
 from app.models.firewall_feed import FirewallFeed
 from app.models.fortinet import FortinetFirewall
+from app.models.influxdb import InfluxDBTarget
 from app.models.ipam import (
     CustomFieldDefinition,
     IPAddress,
@@ -293,6 +294,7 @@ __all__ = [
     "FirewallApplyState",
     "FirewallPolicy",
     "FirewallRule",
+    "InfluxDBTarget",
     "InternalError",
     "BackupTarget",
     "RestoreDrill",

--- a/backend/app/models/influxdb.py
+++ b/backend/app/models/influxdb.py
@@ -1,0 +1,123 @@
+"""InfluxDB push-export target (issue #889).
+
+One row per InfluxDB destination. SpatiumDDI is the *writer* — a Celery
+beat task formats line protocol from the existing metric tables and
+POSTs it. Nothing reads back.
+
+``version`` picks the wire dialect:
+
+* ``v1`` — legacy ``/write?db=…`` endpoint, HTTP basic auth.
+* ``v2`` — ``/api/v2/write?org=…&bucket=…``, ``Authorization: Token``.
+* ``v3`` — InfluxDB 3 (Core / Enterprise / Cloud Dedicated / Cloud
+  Serverless). Reuses the **v2 endpoint and code path**: a v3 database
+  is a v2 bucket, ``org`` is accepted-and-ignored, and auth is
+  ``Authorization: Bearer``. No separate client — see
+  ``app/services/influxdb/client.py``.
+
+Secrets follow the ``audit_forward`` convention: Fernet-encrypted
+``LargeBinary`` columns, never returned by the API (the response shape
+carries ``password_set`` / ``token_set`` booleans instead).
+
+The two ``last_*_bucket_at`` columns are per-source high-water marks so
+a worker restart doesn't re-push the whole retention window. They are
+an optimisation, not a correctness guarantee — line protocol is
+idempotent for identical measurement + tags + timestamp, so the pusher
+deliberately re-sends a small overlap window to catch late-arriving
+agent samples (see ``app/services/influxdb/push.py``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, LargeBinary, String, Text
+from sqlalchemy import text as sa_text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+# Wire dialects. ``v3`` is not a third client — it reuses the v2 write
+# endpoint with bearer auth and bucket=database naming.
+INFLUXDB_VERSIONS = ("v1", "v2", "v3")
+
+DEFAULT_MEASUREMENT_PREFIX = "spatiumddi_"
+# The beat tick is 30 s (see ``celery_app.beat_schedule``), so a shorter
+# interval than that can't be honoured. The real data floor is the 60 s
+# agent metric bucket regardless.
+MIN_PUSH_INTERVAL_SECONDS = 30
+DEFAULT_PUSH_INTERVAL_SECONDS = 60
+
+
+class InfluxDBTarget(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    __tablename__ = "influxdb_target"
+
+    name: Mapped[str] = mapped_column(String(128), nullable=False, unique=True, index=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, index=True)
+
+    # version: v1 | v2 | v3
+    version: Mapped[str] = mapped_column(String(4), nullable=False, default="v2")
+    # Base URL only — the writer appends the version-appropriate path.
+    url: Mapped[str] = mapped_column(String(1024), nullable=False, default="")
+    verify_tls: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    timeout_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=10)
+
+    # ── v1 fields ──────────────────────────────────────────────────
+    database: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    username: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # Fernet-encrypted at rest. On InfluxDB 3's v1 endpoint the API token
+    # rides here and the username is ignored — that is the documented
+    # compatibility shim, not a misuse of the column.
+    password_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+
+    # ── v2 / v3 fields ─────────────────────────────────────────────
+    org: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    # v2 bucket; on v3 this is the database name.
+    bucket: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    token_encrypted: Mapped[bytes | None] = mapped_column(LargeBinary, nullable=True)
+
+    measurement_prefix: Mapped[str] = mapped_column(
+        String(64), nullable=False, default=DEFAULT_MEASUREMENT_PREFIX
+    )
+    push_interval_seconds: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=DEFAULT_PUSH_INTERVAL_SECONDS
+    )
+
+    # ── what this target carries ───────────────────────────────────
+    # Per-target so an operator can point a small Grafana Cloud bucket at
+    # the DNS series only without paying for the IPAM gauges.
+    push_dns_metrics: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    push_dhcp_metrics: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    push_subnet_utilization: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+    push_dhcp_scope_leases: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=sa_text("true")
+    )
+
+    # ── push state ─────────────────────────────────────────────────
+    last_dns_bucket_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_dhcp_bucket_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_push_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_push_points: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # NULL means "no failure recorded"; it is cleared on the next success
+    # so the UI never shows a stale error next to a healthy target.
+    last_push_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+__all__ = [
+    "DEFAULT_MEASUREMENT_PREFIX",
+    "DEFAULT_PUSH_INTERVAL_SECONDS",
+    "INFLUXDB_VERSIONS",
+    "MIN_PUSH_INTERVAL_SECONDS",
+    "InfluxDBTarget",
+]

--- a/backend/app/services/ai/tools/observability.py
+++ b/backend/app/services/ai/tools/observability.py
@@ -23,9 +23,14 @@ open the UI":
   twenty resource types and the same per-type permission filtering
   (#879); output is the same hit shape (type / id / display /
   breadcrumb).
+* ``find_influxdb_targets`` — the #889 push-export destinations and
+  their delivery health. Superadmin-only (it describes the operator's
+  monitoring topology) and never returns a token or password.
 
 All read-only. No tool here is gated by a feature_module — log /
-metric / search surfaces are always-on platform infrastructure.
+metric / search surfaces are always-on platform infrastructure, and
+the InfluxDB export is a Settings-level integration with no sidebar
+surface of its own (non-negotiable #14).
 """
 
 from __future__ import annotations
@@ -37,7 +42,9 @@ from pydantic import BaseModel, Field
 from sqlalchemy import desc, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.permissions import is_effective_superadmin
 from app.models.auth import User
+from app.models.influxdb import InfluxDBTarget
 from app.models.logs import DHCPLogEntry, DNSQueryLogEntry
 from app.models.metrics import DHCPMetricSample, DNSMetricSample
 from app.services.ai.tools.base import register_tool
@@ -519,3 +526,92 @@ async def find_agents_with_config_failures(
                 }
             )
     return out[: args.limit]
+
+
+# ── find_influxdb_targets (issue #889) ─────────────────────────────
+
+
+class FindInfluxDBTargetsArgs(BaseModel):
+    name: str | None = Field(default=None, description="Substring match on target name.")
+    enabled_only: bool = Field(default=False, description="Only return targets with enabled=true.")
+    failing_only: bool = Field(
+        default=False,
+        description="Only return targets whose most recent push recorded an error.",
+    )
+    limit: int = Field(default=50, ge=1, le=200)
+
+
+@register_tool(
+    name="find_influxdb_targets",
+    description=(
+        "List configured InfluxDB push-export targets and their delivery "
+        "health. Each row carries name, version (v1 / v2 / v3), URL, the "
+        "database or bucket written to, measurement prefix, push interval, "
+        "which metric families it carries, and the last push's timestamp, "
+        "point count and error. Use to answer 'is the Grafana export "
+        "working?' or 'why did metrics stop arriving in InfluxDB?'. "
+        "Read-only, superadmin-only, and never returns tokens or passwords "
+        "— only whether one is on file."
+    ),
+    args_model=FindInfluxDBTargetsArgs,
+    category="ops",
+    default_enabled=True,
+)
+async def find_influxdb_targets(
+    db: AsyncSession, user: User, args: FindInfluxDBTargetsArgs
+) -> dict[str, Any]:
+    # Superadmin-gated to match ``GET /settings/influxdb-targets`` — the
+    # rows carry an operator's monitoring topology (hostnames, bucket
+    # names) even with the secrets stripped.
+    if not is_effective_superadmin(user):
+        return {
+            "error": (
+                "InfluxDB export targets are platform configuration and are "
+                "restricted to superadmin users. Ask your platform admin."
+            )
+        }
+
+    stmt = select(InfluxDBTarget)
+    if args.name:
+        stmt = stmt.where(InfluxDBTarget.name.ilike(f"%{args.name.strip()}%"))
+    if args.enabled_only:
+        stmt = stmt.where(InfluxDBTarget.enabled.is_(True))
+    if args.failing_only:
+        stmt = stmt.where(InfluxDBTarget.last_push_error.is_not(None))
+    stmt = stmt.order_by(InfluxDBTarget.name.asc()).limit(args.limit)
+
+    rows = list((await db.execute(stmt)).scalars().all())
+    return {
+        "targets": [
+            {
+                "id": str(t.id),
+                "name": t.name,
+                "enabled": t.enabled,
+                "version": t.version,
+                "url": t.url,
+                # v1 writes to a database, v2/v3 to a bucket. Reported
+                # under one key so the answer doesn't depend on which
+                # dialect the operator picked.
+                "destination": t.database if t.version == "v1" else t.bucket,
+                "org": t.org or None,
+                "measurement_prefix": t.measurement_prefix,
+                "push_interval_seconds": t.push_interval_seconds,
+                "carries": [
+                    label
+                    for label, on in (
+                        ("dns_queries", t.push_dns_metrics),
+                        ("dhcp_messages", t.push_dhcp_metrics),
+                        ("subnet_utilization", t.push_subnet_utilization),
+                        ("dhcp_scope_leases", t.push_dhcp_scope_leases),
+                    )
+                    if on
+                ],
+                "credential_on_file": bool(t.password_encrypted or t.token_encrypted),
+                "last_push_at": t.last_push_at.isoformat() if t.last_push_at else None,
+                "last_push_points": t.last_push_points,
+                "last_push_error": t.last_push_error,
+            }
+            for t in rows
+        ],
+        "count": len(rows),
+    }

--- a/backend/app/services/backup/rewrap.py
+++ b/backend/app/services/backup/rewrap.py
@@ -89,6 +89,8 @@ ENCRYPTED_COLUMNS: tuple[tuple[str, str, str], ...] = (
     ("event_subscription", "id", "secret_encrypted"),
     ("firewall_feed", "id", "token_encrypted"),
     ("fortinet_firewall", "id", "api_token_encrypted"),
+    ("influxdb_target", "id", "password_encrypted"),
+    ("influxdb_target", "id", "token_encrypted"),
     ("kubernetes_cluster", "id", "token_encrypted"),
     ("meraki_org", "id", "api_key_encrypted"),
     ("meraki_org", "id", "block_sync_api_key_encrypted"),

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -104,7 +104,7 @@ SECTIONS: tuple[Section, ...] = (
             "Platform-wide settings, branding assets, custom field "
             "definitions, IPAM templates, feature-module toggles, alert "
             "rules + events, conformity policies + results, platform-wide "
-            "tags, event subscriptions + outbox."
+            "tags, event subscriptions + outbox, InfluxDB export targets."
         ),
         tables=(
             "platform_settings",
@@ -122,6 +122,12 @@ SECTIONS: tuple[Section, ...] = (
             "conformity_result",
             "event_subscription",
             "event_outbox",
+            # #889. Configuration, not sample data — so it belongs here
+            # and NOT in the volatile ``metrics`` section, which is
+            # excluded from the default backup. A target whose Fernet
+            # columns survive a cross-install restore but whose row does
+            # not is the same silent failure from the other direction.
+            "influxdb_target",
         ),
     ),
     Section(

--- a/backend/app/services/influxdb/__init__.py
+++ b/backend/app/services/influxdb/__init__.py
@@ -1,0 +1,7 @@
+"""InfluxDB push export (issue #889).
+
+* ``line_protocol`` — escaping + point rendering (no I/O, no ORM).
+* ``client`` — version-aware write request builder + HTTP send.
+* ``collect`` — turns DB rows into points.
+* ``push`` — one target's end-to-end push, watermark handling included.
+"""

--- a/backend/app/services/influxdb/client.py
+++ b/backend/app/services/influxdb/client.py
@@ -1,0 +1,191 @@
+"""Version-aware InfluxDB write client (issue #889).
+
+Three declared versions, **two** wire dialects:
+
+===== ============================== ==============================
+ver   endpoint                       auth
+===== ============================== ==============================
+v1    ``/write?db=<database>``       HTTP basic (``username`` /
+                                     ``password``), omitted entirely
+                                     when both are blank
+v2    ``/api/v2/write?org&bucket``   ``Authorization: Token <token>``
+v3    ``/api/v2/write?bucket``       ``Authorization: Bearer <token>``
+===== ============================== ==============================
+
+``v3`` covers every InfluxDB 3 product (Core, Enterprise, Cloud
+Dedicated, Cloud Serverless). They all accept the v2 write endpoint;
+a v3 *database* is named in the ``bucket`` parameter and ``org`` is
+accepted-and-ignored by Core / Enterprise, so it is sent only when the
+operator set one (Cloud Serverless does use it). Bearer is the token
+scheme InfluxDB 3 documents; ``Token`` also works there, but not the
+other way round, so the two are kept distinct rather than collapsed.
+
+An operator pointing ``v1`` at an InfluxDB 3 server puts the API token
+in the *password* field — that is the documented compat shim, and it
+needs no code here beyond basic auth already sending it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+# Line protocol timestamps are sent in whole seconds — see
+# ``line_protocol.Point.timestamp``.
+_PRECISION = "s"
+
+
+class InfluxDBWriteError(Exception):
+    """A write was rejected or could not be delivered."""
+
+
+@dataclass(frozen=True)
+class InfluxTargetConfig:
+    """Everything the writer needs, with secrets already decrypted.
+
+    Deliberately not the ORM row: the push path decrypts once and this
+    stays a plain value object, so ``build_write_request`` is testable
+    without a database.
+    """
+
+    version: str
+    url: str
+    database: str = ""
+    username: str = ""
+    password: str = ""
+    org: str = ""
+    bucket: str = ""
+    token: str = ""
+    verify_tls: bool = True
+    timeout_seconds: int = 10
+
+
+@dataclass(frozen=True)
+class WriteRequest:
+    url: str
+    params: dict[str, str]
+    headers: dict[str, str]
+    auth: tuple[str, str] | None
+
+
+def build_write_request(cfg: InfluxTargetConfig) -> WriteRequest:
+    """Resolve endpoint, query params and auth for one target.
+
+    Raises ``ValueError`` when the target is missing a field its version
+    cannot write without — surfaced as a 422 on save and as the target's
+    ``last_push_error`` if it is somehow reached at push time.
+    """
+    base = cfg.url.strip().rstrip("/")
+    if not base:
+        raise ValueError("url is required")
+
+    headers: dict[str, str] = {"Content-Type": "text/plain; charset=utf-8"}
+    params: dict[str, str] = {"precision": _PRECISION}
+    auth: tuple[str, str] | None = None
+
+    if cfg.version == "v1":
+        if not cfg.database:
+            raise ValueError("database is required for InfluxDB v1")
+        url = f"{base}/write"
+        params["db"] = cfg.database
+        # Blank username AND blank password = an unauthenticated v1
+        # server, which is a legitimate (if unusual) on-prem setup.
+        if cfg.username or cfg.password:
+            auth = (cfg.username, cfg.password)
+    elif cfg.version in ("v2", "v3"):
+        if not cfg.bucket:
+            label = "database" if cfg.version == "v3" else "bucket"
+            raise ValueError(f"{label} is required for InfluxDB {cfg.version}")
+        if not cfg.token:
+            raise ValueError(f"token is required for InfluxDB {cfg.version}")
+        url = f"{base}/api/v2/write"
+        params["bucket"] = cfg.bucket
+        # v2 requires org; v3 ignores it on Core/Enterprise but Cloud
+        # Serverless honours it, so send whatever the operator gave us.
+        if cfg.org:
+            params["org"] = cfg.org
+        elif cfg.version == "v2":
+            raise ValueError("org is required for InfluxDB v2")
+        scheme = "Bearer" if cfg.version == "v3" else "Token"
+        headers["Authorization"] = f"{scheme} {cfg.token}"
+    else:
+        raise ValueError(f"unsupported InfluxDB version {cfg.version!r}")
+
+    return WriteRequest(url=url, params=params, headers=headers, auth=auth)
+
+
+async def write_lines(cfg: InfluxTargetConfig, body: str) -> None:
+    """POST one line-protocol batch. Raises ``InfluxDBWriteError``.
+
+    A no-op for an empty body so callers don't have to special-case an
+    idle tick — an empty POST is a 400 on some server versions.
+    """
+    if not body:
+        return
+    req = build_write_request(cfg)
+    timeout = float(max(1, cfg.timeout_seconds))
+    # ``auth`` is passed conditionally rather than as ``None``: httpx's
+    # sentinel for "no auth" is ``USE_CLIENT_DEFAULT``, and ``None`` is
+    # not in the parameter's declared type.
+    auth_kwargs: dict[str, Any] = {"auth": req.auth} if req.auth is not None else {}
+    try:
+        async with httpx.AsyncClient(timeout=timeout, verify=cfg.verify_tls) as client:
+            resp = await client.post(
+                req.url,
+                params=req.params,
+                headers=req.headers,
+                content=body.encode("utf-8"),
+                **auth_kwargs,
+            )
+    except httpx.HTTPError as exc:
+        raise InfluxDBWriteError(f"{type(exc).__name__}: {exc}") from exc
+    # 204 is the documented success for both endpoints; 200 shows up on
+    # some proxies. Anything else carries a body worth surfacing.
+    if resp.status_code not in (200, 204):
+        detail = resp.text.strip()[:300]
+        raise InfluxDBWriteError(f"HTTP {resp.status_code}{': ' + detail if detail else ''}")
+
+
+def config_from_row(row: Any) -> InfluxTargetConfig:
+    """Build a config from an ``InfluxDBTarget``, decrypting secrets.
+
+    Decryption failures (a rotated ``SECRET_KEY``) are surfaced as
+    ``InfluxDBWriteError`` rather than swallowed — pushing with an empty
+    token would fail as a 401 that reads like an operator typo.
+    """
+    from app.core.crypto import decrypt_str
+
+    password = ""
+    token = ""
+    try:
+        if row.password_encrypted:
+            password = decrypt_str(row.password_encrypted)
+        if row.token_encrypted:
+            token = decrypt_str(row.token_encrypted)
+    except Exception as exc:  # noqa: BLE001 — any Fernet failure is fatal here
+        raise InfluxDBWriteError(f"failed to decrypt stored credential: {exc}") from exc
+
+    return InfluxTargetConfig(
+        version=row.version,
+        url=row.url,
+        database=row.database or "",
+        username=row.username or "",
+        password=password,
+        org=row.org or "",
+        bucket=row.bucket or "",
+        token=token,
+        verify_tls=bool(row.verify_tls),
+        timeout_seconds=int(row.timeout_seconds or 10),
+    )
+
+
+__all__ = [
+    "InfluxDBWriteError",
+    "InfluxTargetConfig",
+    "WriteRequest",
+    "build_write_request",
+    "config_from_row",
+    "write_lines",
+]

--- a/backend/app/services/influxdb/client.py
+++ b/backend/app/services/influxdb/client.py
@@ -139,7 +139,13 @@ async def write_lines(cfg: InfluxTargetConfig, body: str) -> None:
                 content=body.encode("utf-8"),
                 **auth_kwargs,
             )
-    except httpx.HTTPError as exc:
+    # ``InvalidURL`` is deliberately named alongside ``HTTPError``: it
+    # derives straight from ``Exception``, not from the httpx error base,
+    # so catching ``HTTPError`` alone lets a malformed URL that passed the
+    # save-time scheme check (``http://influx:80o86``) escape this
+    # function entirely — aborting the whole beat sweep and rolling back
+    # every *other* target's state instead of recording one failure here.
+    except (httpx.HTTPError, httpx.InvalidURL) as exc:
         raise InfluxDBWriteError(f"{type(exc).__name__}: {exc}") from exc
     # 204 is the documented success for both endpoints; 200 shows up on
     # some proxies. Anything else carries a body worth surfacing.

--- a/backend/app/services/influxdb/collect.py
+++ b/backend/app/services/influxdb/collect.py
@@ -6,7 +6,10 @@ apart when reading a dashboard built on this data:
 **Counter deltas** (``dns_metric_sample`` / ``dhcp_metric_sample``) —
 agent-reported, already bucketed at 60 s, timestamped at the bucket. The
 pusher walks these forward from a high-water mark, so a point's
-timestamp is when the traffic happened, not when it was exported.
+timestamp is when the traffic happened, not when it was exported. Each
+push also replays a short window *behind* the mark to catch a bucket an
+agent reported late; the two are separate queries with separate row
+budgets — see ``_fetch_samples`` for why that matters.
 
 **Point-in-time gauges** (subnet utilization, per-scope active leases) —
 sampled here, at push time, from counters the application already
@@ -24,8 +27,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import distinct, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dhcp import DHCPLease, DHCPScope, DHCPServer, DHCPServerGroup
@@ -40,9 +44,9 @@ from app.services.influxdb.line_protocol import Point
 MAX_ROWS_PER_PUSH = 5000
 
 # How far back before the high-water mark to re-send. Agents can report a
-# bucket late (a restart, a blocked heartbeat), and a strict ``>`` cursor
-# would skip it permanently. Re-sending is free: line protocol overwrites
-# a point with the same measurement + tags + timestamp.
+# bucket late (a restart, a blocked heartbeat), and the forward drain
+# alone would skip it permanently. Re-sending is free: line protocol
+# overwrites a point with the same measurement + tags + timestamp.
 REPUSH_OVERLAP_SECONDS = 300
 
 MEASUREMENT_DNS = "dns_queries"
@@ -55,92 +59,124 @@ def _epoch(dt: datetime) -> int:
     return int((dt if dt.tzinfo else dt.replace(tzinfo=UTC)).timestamp())
 
 
-def _lower_bound(watermark: datetime | None) -> datetime | None:
+def _aware(dt: datetime) -> datetime:
+    return dt if dt.tzinfo else dt.replace(tzinfo=UTC)
+
+
+async def _fetch_samples(
+    db: AsyncSession,
+    sample_model: Any,
+    server_model: Any,
+    watermark: datetime | None,
+) -> tuple[list[Any], list[Any]]:
+    """Return ``(forward_rows, replay_rows)`` for one metric table.
+
+    Two queries with **separate row budgets**, and that separation is the
+    point rather than an optimisation:
+
+    * *forward* is strictly ``bucket_at > watermark``, so the cursor the
+      caller derives from it can only move forwards. A single query with
+      the overlap folded into its lower bound would, on a fleet dense
+      enough to fill ``MAX_ROWS_PER_PUSH`` inside the overlap window,
+      return a truncated batch whose maximum is *below* the watermark —
+      dragging the cursor backwards a little further every tick until it
+      pinned on the oldest retained sample. The export would stop
+      advancing while every push still reported success and the UI still
+      showed the target green.
+    * *replay* is the closed window ``(watermark - overlap, watermark]``,
+      re-sent so a bucket an agent reported late is still exported. It
+      never contributes to the cursor — these rows are, by definition,
+      already behind it.
+
+    ``replay`` is empty on the first push (no watermark yet), when every
+    row is ahead of the cursor anyway.
+    """
+    join_on = server_model.id == sample_model.server_id
+
+    forward_stmt = (
+        select(sample_model, server_model.name)
+        .join(server_model, join_on)
+        .order_by(sample_model.bucket_at.asc())
+        .limit(MAX_ROWS_PER_PUSH)
+    )
+    if watermark is not None:
+        forward_stmt = forward_stmt.where(sample_model.bucket_at > _aware(watermark))
+    forward = list((await db.execute(forward_stmt)).all())
+
     if watermark is None:
-        return None
-    tz_aware = watermark if watermark.tzinfo else watermark.replace(tzinfo=UTC)
-    return tz_aware - timedelta(seconds=REPUSH_OVERLAP_SECONDS)
+        return forward, []
+
+    mark = _aware(watermark)
+    replay_stmt = (
+        select(sample_model, server_model.name)
+        .join(server_model, join_on)
+        .where(sample_model.bucket_at > mark - timedelta(seconds=REPUSH_OVERLAP_SECONDS))
+        .where(sample_model.bucket_at <= mark)
+        .order_by(sample_model.bucket_at.asc())
+        .limit(MAX_ROWS_PER_PUSH)
+    )
+    return forward, list((await db.execute(replay_stmt)).all())
 
 
 async def collect_dns_points(
     db: AsyncSession, watermark: datetime | None
 ) -> tuple[list[Point], datetime | None]:
-    """DNS counter deltas newer than ``watermark`` (minus the overlap).
+    """DNS counter deltas: the forward drain plus the late-arrival replay.
 
-    Returns the points plus the newest ``bucket_at`` seen, which becomes
-    the target's next watermark — ``None`` when nothing was found, so the
-    caller leaves the stored value alone.
+    Returns the points plus the newest ``bucket_at`` **from the forward
+    drain only**, which becomes the target's next watermark. ``None``
+    when the drain was empty, so the caller leaves the stored cursor
+    alone rather than moving it to a replayed row.
     """
-    stmt = (
-        select(DNSMetricSample, DNSServer.name)
-        .join(DNSServer, DNSServer.id == DNSMetricSample.server_id)
-        .order_by(DNSMetricSample.bucket_at.asc())
-        .limit(MAX_ROWS_PER_PUSH)
-    )
-    lower = _lower_bound(watermark)
-    if lower is not None:
-        stmt = stmt.where(DNSMetricSample.bucket_at > lower)
 
-    points: list[Point] = []
-    newest: datetime | None = None
-    for sample, server_name in (await db.execute(stmt)).all():
-        points.append(
-            Point(
-                measurement=MEASUREMENT_DNS,
-                tags={"server": server_name or "", "server_id": str(sample.server_id)},
-                fields={
-                    "queries_total": int(sample.queries_total),
-                    "noerror": int(sample.noerror),
-                    "nxdomain": int(sample.nxdomain),
-                    "servfail": int(sample.servfail),
-                    "recursion": int(sample.recursion),
-                    "rate_dropped": int(sample.rate_dropped),
-                    "rate_slipped": int(sample.rate_slipped),
-                },
-                timestamp=_epoch(sample.bucket_at),
-            )
+    def _point(sample: Any, server_name: str | None) -> Point:
+        return Point(
+            measurement=MEASUREMENT_DNS,
+            tags={"server": server_name or "", "server_id": str(sample.server_id)},
+            fields={
+                "queries_total": int(sample.queries_total),
+                "noerror": int(sample.noerror),
+                "nxdomain": int(sample.nxdomain),
+                "servfail": int(sample.servfail),
+                "recursion": int(sample.recursion),
+                "rate_dropped": int(sample.rate_dropped),
+                "rate_slipped": int(sample.rate_slipped),
+            },
+            timestamp=_epoch(sample.bucket_at),
         )
-        if newest is None or sample.bucket_at > newest:
-            newest = sample.bucket_at
+
+    forward, replay = await _fetch_samples(db, DNSMetricSample, DNSServer, watermark)
+    points = [_point(s, n) for s, n in replay] + [_point(s, n) for s, n in forward]
+    # Rows come back ascending, so the drain's last row is its maximum.
+    newest = _aware(forward[-1][0].bucket_at) if forward else None
     return points, newest
 
 
 async def collect_dhcp_points(
     db: AsyncSession, watermark: datetime | None
 ) -> tuple[list[Point], datetime | None]:
-    """DHCP message-count deltas newer than ``watermark`` (minus overlap)."""
-    stmt = (
-        select(DHCPMetricSample, DHCPServer.name)
-        .join(DHCPServer, DHCPServer.id == DHCPMetricSample.server_id)
-        .order_by(DHCPMetricSample.bucket_at.asc())
-        .limit(MAX_ROWS_PER_PUSH)
-    )
-    lower = _lower_bound(watermark)
-    if lower is not None:
-        stmt = stmt.where(DHCPMetricSample.bucket_at > lower)
+    """DHCP message-count deltas — same two-query shape as the DNS side."""
 
-    points: list[Point] = []
-    newest: datetime | None = None
-    for sample, server_name in (await db.execute(stmt)).all():
-        points.append(
-            Point(
-                measurement=MEASUREMENT_DHCP,
-                tags={"server": server_name or "", "server_id": str(sample.server_id)},
-                fields={
-                    "discover": int(sample.discover),
-                    "offer": int(sample.offer),
-                    "request": int(sample.request),
-                    "ack": int(sample.ack),
-                    "nak": int(sample.nak),
-                    "decline": int(sample.decline),
-                    "release": int(sample.release),
-                    "inform": int(sample.inform),
-                },
-                timestamp=_epoch(sample.bucket_at),
-            )
+    def _point(sample: Any, server_name: str | None) -> Point:
+        return Point(
+            measurement=MEASUREMENT_DHCP,
+            tags={"server": server_name or "", "server_id": str(sample.server_id)},
+            fields={
+                "discover": int(sample.discover),
+                "offer": int(sample.offer),
+                "request": int(sample.request),
+                "ack": int(sample.ack),
+                "nak": int(sample.nak),
+                "decline": int(sample.decline),
+                "release": int(sample.release),
+                "inform": int(sample.inform),
+            },
+            timestamp=_epoch(sample.bucket_at),
         )
-        if newest is None or sample.bucket_at > newest:
-            newest = sample.bucket_at
+
+    forward, replay = await _fetch_samples(db, DHCPMetricSample, DHCPServer, watermark)
+    points = [_point(s, n) for s, n in replay] + [_point(s, n) for s, n in forward]
+    newest = _aware(forward[-1][0].bucket_at) if forward else None
     return points, newest
 
 
@@ -191,8 +227,13 @@ async def collect_dhcp_scope_lease_points(db: AsyncSession, now: datetime) -> li
     graph, and "the scope went quiet" is exactly what an operator wants
     to see.
     """
+    # DISTINCT on the address, not COUNT(*): ``dhcp_lease`` is per-server,
+    # and under Kea HA the partners both mirror the same lease — so a bare
+    # row count reports 2x the addresses actually in use on a redundant
+    # pair, and disagrees with ``services/dhcp/pool_occupancy.py``, which
+    # dedupes for exactly this reason.
     counts_stmt = (
-        select(DHCPLease.scope_id, func.count())
+        select(DHCPLease.scope_id, func.count(distinct(DHCPLease.ip_address)))
         .where(DHCPLease.scope_id.is_not(None), DHCPLease.state == "active")
         .group_by(DHCPLease.scope_id)
     )

--- a/backend/app/services/influxdb/collect.py
+++ b/backend/app/services/influxdb/collect.py
@@ -1,0 +1,242 @@
+"""Turn SpatiumDDI's stored metrics into InfluxDB points (issue #889).
+
+Two shapes of source, which behave differently and are worth telling
+apart when reading a dashboard built on this data:
+
+**Counter deltas** (``dns_metric_sample`` / ``dhcp_metric_sample``) —
+agent-reported, already bucketed at 60 s, timestamped at the bucket. The
+pusher walks these forward from a high-water mark, so a point's
+timestamp is when the traffic happened, not when it was exported.
+
+**Point-in-time gauges** (subnet utilization, per-scope active leases) —
+sampled here, at push time, from counters the application already
+maintains. There is no historical backfill for these: the first point is
+the moment the target was enabled. The 60 s agent bucket is the floor for
+the deltas; for the gauges the floor is the target's own
+``push_interval_seconds``.
+
+Every function returns ``Point`` objects with the measurement name
+*unprefixed*; ``push`` applies the target's ``measurement_prefix`` so the
+prefix isn't baked into the collectors.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp import DHCPLease, DHCPScope, DHCPServer, DHCPServerGroup
+from app.models.dns import DNSServer
+from app.models.ipam import IPSpace, Subnet
+from app.models.metrics import DHCPMetricSample, DNSMetricSample
+from app.services.influxdb.line_protocol import Point
+
+# Per-source cap on rows drained in a single push. A newly-enabled target
+# backfills the whole retention window in ``ceil(rows / MAX_ROWS)`` ticks
+# rather than in one oversized POST.
+MAX_ROWS_PER_PUSH = 5000
+
+# How far back before the high-water mark to re-send. Agents can report a
+# bucket late (a restart, a blocked heartbeat), and a strict ``>`` cursor
+# would skip it permanently. Re-sending is free: line protocol overwrites
+# a point with the same measurement + tags + timestamp.
+REPUSH_OVERLAP_SECONDS = 300
+
+MEASUREMENT_DNS = "dns_queries"
+MEASUREMENT_DHCP = "dhcp_messages"
+MEASUREMENT_SUBNET = "subnet_utilization"
+MEASUREMENT_SCOPE_LEASES = "dhcp_scope_leases"
+
+
+def _epoch(dt: datetime) -> int:
+    return int((dt if dt.tzinfo else dt.replace(tzinfo=UTC)).timestamp())
+
+
+def _lower_bound(watermark: datetime | None) -> datetime | None:
+    if watermark is None:
+        return None
+    tz_aware = watermark if watermark.tzinfo else watermark.replace(tzinfo=UTC)
+    return tz_aware - timedelta(seconds=REPUSH_OVERLAP_SECONDS)
+
+
+async def collect_dns_points(
+    db: AsyncSession, watermark: datetime | None
+) -> tuple[list[Point], datetime | None]:
+    """DNS counter deltas newer than ``watermark`` (minus the overlap).
+
+    Returns the points plus the newest ``bucket_at`` seen, which becomes
+    the target's next watermark — ``None`` when nothing was found, so the
+    caller leaves the stored value alone.
+    """
+    stmt = (
+        select(DNSMetricSample, DNSServer.name)
+        .join(DNSServer, DNSServer.id == DNSMetricSample.server_id)
+        .order_by(DNSMetricSample.bucket_at.asc())
+        .limit(MAX_ROWS_PER_PUSH)
+    )
+    lower = _lower_bound(watermark)
+    if lower is not None:
+        stmt = stmt.where(DNSMetricSample.bucket_at > lower)
+
+    points: list[Point] = []
+    newest: datetime | None = None
+    for sample, server_name in (await db.execute(stmt)).all():
+        points.append(
+            Point(
+                measurement=MEASUREMENT_DNS,
+                tags={"server": server_name or "", "server_id": str(sample.server_id)},
+                fields={
+                    "queries_total": int(sample.queries_total),
+                    "noerror": int(sample.noerror),
+                    "nxdomain": int(sample.nxdomain),
+                    "servfail": int(sample.servfail),
+                    "recursion": int(sample.recursion),
+                    "rate_dropped": int(sample.rate_dropped),
+                    "rate_slipped": int(sample.rate_slipped),
+                },
+                timestamp=_epoch(sample.bucket_at),
+            )
+        )
+        if newest is None or sample.bucket_at > newest:
+            newest = sample.bucket_at
+    return points, newest
+
+
+async def collect_dhcp_points(
+    db: AsyncSession, watermark: datetime | None
+) -> tuple[list[Point], datetime | None]:
+    """DHCP message-count deltas newer than ``watermark`` (minus overlap)."""
+    stmt = (
+        select(DHCPMetricSample, DHCPServer.name)
+        .join(DHCPServer, DHCPServer.id == DHCPMetricSample.server_id)
+        .order_by(DHCPMetricSample.bucket_at.asc())
+        .limit(MAX_ROWS_PER_PUSH)
+    )
+    lower = _lower_bound(watermark)
+    if lower is not None:
+        stmt = stmt.where(DHCPMetricSample.bucket_at > lower)
+
+    points: list[Point] = []
+    newest: datetime | None = None
+    for sample, server_name in (await db.execute(stmt)).all():
+        points.append(
+            Point(
+                measurement=MEASUREMENT_DHCP,
+                tags={"server": server_name or "", "server_id": str(sample.server_id)},
+                fields={
+                    "discover": int(sample.discover),
+                    "offer": int(sample.offer),
+                    "request": int(sample.request),
+                    "ack": int(sample.ack),
+                    "nak": int(sample.nak),
+                    "decline": int(sample.decline),
+                    "release": int(sample.release),
+                    "inform": int(sample.inform),
+                },
+                timestamp=_epoch(sample.bucket_at),
+            )
+        )
+        if newest is None or sample.bucket_at > newest:
+            newest = sample.bucket_at
+    return points, newest
+
+
+async def collect_subnet_utilization_points(db: AsyncSession, now: datetime) -> list[Point]:
+    """Point-in-time utilization gauge per live subnet.
+
+    Reads the already-maintained ``allocated_ips`` / ``total_ips``
+    counters — the same numbers the IPAM grid and the #44 daily history
+    show — so this adds a query, not a scan. ``percent`` is recomputed
+    here rather than read from ``utilization_percent`` so the three
+    fields on a point can never disagree with each other.
+    """
+    stmt = (
+        select(Subnet, IPSpace.name)
+        .join(IPSpace, IPSpace.id == Subnet.space_id)
+        .where(Subnet.deleted_at.is_(None))
+    )
+    ts = _epoch(now)
+    points: list[Point] = []
+    for subnet, space_name in (await db.execute(stmt)).all():
+        total = int(subnet.total_ips or 0)
+        allocated = int(subnet.allocated_ips or 0)
+        percent = (allocated / total * 100.0) if total > 0 else 0.0
+        points.append(
+            Point(
+                measurement=MEASUREMENT_SUBNET,
+                tags={
+                    "subnet": str(subnet.network),
+                    "subnet_id": str(subnet.id),
+                    "space": space_name or "",
+                },
+                fields={
+                    "allocated": allocated,
+                    "total": total,
+                    "percent": round(percent, 4),
+                },
+                timestamp=ts,
+            )
+        )
+    return points
+
+
+async def collect_dhcp_scope_lease_points(db: AsyncSession, now: datetime) -> list[Point]:
+    """Active-lease count per live DHCP scope.
+
+    Scopes with zero active leases are emitted as ``0`` rather than
+    omitted: an absent series and an empty scope look identical on a
+    graph, and "the scope went quiet" is exactly what an operator wants
+    to see.
+    """
+    counts_stmt = (
+        select(DHCPLease.scope_id, func.count())
+        .where(DHCPLease.scope_id.is_not(None), DHCPLease.state == "active")
+        .group_by(DHCPLease.scope_id)
+    )
+    counts: dict[uuid.UUID, int] = {
+        row[0]: int(row[1]) for row in (await db.execute(counts_stmt)).all()
+    }
+
+    scopes_stmt = (
+        select(DHCPScope, Subnet.network, DHCPServerGroup.name)
+        .join(Subnet, Subnet.id == DHCPScope.subnet_id)
+        .join(DHCPServerGroup, DHCPServerGroup.id == DHCPScope.group_id)
+        .where(DHCPScope.deleted_at.is_(None))
+    )
+    ts = _epoch(now)
+    points: list[Point] = []
+    for scope, network, group_name in (await db.execute(scopes_stmt)).all():
+        points.append(
+            Point(
+                measurement=MEASUREMENT_SCOPE_LEASES,
+                tags={
+                    "scope": scope.name or str(network),
+                    "scope_id": str(scope.id),
+                    "group": group_name or "",
+                    "subnet": str(network),
+                },
+                fields={
+                    "active_leases": counts.get(scope.id, 0),
+                    "is_active": bool(scope.is_active),
+                },
+                timestamp=ts,
+            )
+        )
+    return points
+
+
+__all__ = [
+    "MAX_ROWS_PER_PUSH",
+    "MEASUREMENT_DHCP",
+    "MEASUREMENT_DNS",
+    "MEASUREMENT_SCOPE_LEASES",
+    "MEASUREMENT_SUBNET",
+    "REPUSH_OVERLAP_SECONDS",
+    "collect_dhcp_points",
+    "collect_dhcp_scope_lease_points",
+    "collect_dns_points",
+    "collect_subnet_utilization_points",
+]

--- a/backend/app/services/influxdb/line_protocol.py
+++ b/backend/app/services/influxdb/line_protocol.py
@@ -1,0 +1,110 @@
+"""InfluxDB line-protocol rendering (issue #889).
+
+Pure formatting — no I/O, no ORM imports — so the escaping rules can be
+unit-tested directly. The rules differ per position and getting them
+wrong corrupts the series silently rather than erroring, which is why
+they live in one place:
+
+* **measurement** — escape ``,`` and space.
+* **tag key, tag value, field key** — escape ``,``, ``=`` and space.
+* **string field value** — wrap in double quotes, escape ``"`` and ``\\``.
+* newlines are illegal anywhere; they terminate the point.
+
+Integers are suffixed ``i`` (InfluxDB's integer field type); floats are
+written bare. Booleans render as ``true`` / ``false``.
+
+Empty tag values are dropped rather than written: InfluxDB treats a tag
+with an empty value as absent anyway, and emitting ``tag=`` produces a
+parse error on some server versions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+_MEASUREMENT_ESCAPES = {",": r"\,", " ": r"\ "}
+_KEY_ESCAPES = {",": r"\,", "=": r"\=", " ": r"\ "}
+
+
+def _apply(value: str, table: Mapping[str, str]) -> str:
+    # Newlines and carriage returns can't be escaped in line protocol —
+    # they end the point — so they are replaced with a space before the
+    # positional escaping runs (which then escapes that space).
+    cleaned = value.replace("\n", " ").replace("\r", " ")
+    return "".join(table.get(ch, ch) for ch in cleaned)
+
+
+def escape_measurement(value: str) -> str:
+    return _apply(value, _MEASUREMENT_ESCAPES)
+
+
+def escape_key(value: str) -> str:
+    """Escape a tag key, tag value, or field key."""
+    return _apply(value, _KEY_ESCAPES)
+
+
+def format_string_field(value: str) -> str:
+    cleaned = value.replace("\n", " ").replace("\r", " ")
+    escaped = cleaned.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def format_field_value(value: int | float | bool | str) -> str:
+    # bool before int — bool is an int subclass, and writing ``1i`` where
+    # the series already holds booleans is a field-type conflict InfluxDB
+    # rejects for the whole batch.
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return f"{value}i"
+    if isinstance(value, float):
+        return repr(value)
+    return format_string_field(str(value))
+
+
+@dataclass(frozen=True)
+class Point:
+    measurement: str
+    tags: Mapping[str, str]
+    fields: Mapping[str, int | float | bool | str]
+    # Epoch seconds. The writer always requests ``precision=s``; every
+    # source here is either a 60 s agent bucket or a point-in-time gauge,
+    # so sub-second resolution would be false precision.
+    timestamp: int
+
+
+def render_point(point: Point) -> str:
+    """Render one point. Raises ``ValueError`` if it carries no fields.
+
+    A field-less point is a line-protocol parse error, and the server
+    rejects the *entire* batch it arrives in — so it is caught here
+    rather than shipped.
+    """
+    if not point.fields:
+        raise ValueError(f"point {point.measurement!r} has no fields")
+    head = escape_measurement(point.measurement)
+    tag_parts = [
+        f"{escape_key(k)}={escape_key(v)}" for k, v in sorted(point.tags.items()) if v != ""
+    ]
+    if tag_parts:
+        head = head + "," + ",".join(tag_parts)
+    field_parts = [
+        f"{escape_key(k)}={format_field_value(v)}" for k, v in sorted(point.fields.items())
+    ]
+    return f"{head} {','.join(field_parts)} {int(point.timestamp)}"
+
+
+def render_batch(points: Iterable[Point]) -> str:
+    return "\n".join(render_point(p) for p in points)
+
+
+__all__ = [
+    "Point",
+    "escape_key",
+    "escape_measurement",
+    "format_field_value",
+    "format_string_field",
+    "render_batch",
+    "render_point",
+]

--- a/backend/app/services/influxdb/push.py
+++ b/backend/app/services/influxdb/push.py
@@ -22,11 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.influxdb import InfluxDBTarget
 from app.services.influxdb import collect
-from app.services.influxdb.client import (
-    InfluxDBWriteError,
-    config_from_row,
-    write_lines,
-)
+from app.services.influxdb.client import config_from_row, write_lines
 from app.services.influxdb.line_protocol import Point, render_batch
 
 logger = structlog.get_logger(__name__)
@@ -94,13 +90,25 @@ async def push_target(db: AsyncSession, row: InfluxDBTarget, *, now: datetime) -
 
         body = render_batch(_prefixed(points, row.measurement_prefix or ""))
         await write_lines(config_from_row(row), body)
-    except (InfluxDBWriteError, ValueError) as exc:
-        row.last_push_error = str(exc)[:1000]
+    # Broad on purpose: this is the per-target failure-isolation boundary.
+    # The caller pushes every due target inside one transaction, so an
+    # exception escaping here would abandon the sweep before its commit —
+    # discarding the state updates of the targets that *did* succeed, and
+    # leaving this one with no ``last_push_error`` to explain itself, so
+    # nothing anywhere would say what went wrong.
+    except Exception as exc:  # noqa: BLE001
+        row.last_push_error = str(exc)[:1000] or type(exc).__name__
         # ``last_push_at`` still advances on failure — otherwise a target
         # that errors fast would be retried on every 30 s beat tick
         # instead of on its own interval.
         row.last_push_at = now
-        logger.warning("influxdb_push_failed", target=row.name, points=len(points), error=str(exc))
+        logger.warning(
+            "influxdb_push_failed",
+            target=row.name,
+            points=len(points),
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
         return PushResult(str(row.id), row.name, 0, ok=False, error=str(exc))
 
     if dns_watermark is not None:

--- a/backend/app/services/influxdb/push.py
+++ b/backend/app/services/influxdb/push.py
@@ -1,0 +1,117 @@
+"""One target's end-to-end push (issue #889).
+
+Sequence per target: collect → render → POST → record state. The
+watermarks advance **only** on a successful write, so a dead collector
+means a delayed export, never a hole in the series (the samples stay in
+Postgres until ``prune_metrics`` retires them — a target offline longer
+than ``metric_retention_days`` loses whatever aged out, which is the
+same bound the built-in charts live under).
+
+The whole push for one target is a single POST. InfluxDB applies a
+line-protocol batch atomically per request, so a partial failure can't
+leave the watermark describing a half-written batch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.influxdb import InfluxDBTarget
+from app.services.influxdb import collect
+from app.services.influxdb.client import (
+    InfluxDBWriteError,
+    config_from_row,
+    write_lines,
+)
+from app.services.influxdb.line_protocol import Point, render_batch
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass
+class PushResult:
+    target_id: str
+    target_name: str
+    points: int
+    ok: bool
+    error: str | None = None
+
+
+def _prefixed(points: list[Point], prefix: str) -> list[Point]:
+    if not prefix:
+        return points
+    return [
+        Point(
+            measurement=f"{prefix}{p.measurement}",
+            tags=p.tags,
+            fields=p.fields,
+            timestamp=p.timestamp,
+        )
+        for p in points
+    ]
+
+
+def is_due(row: InfluxDBTarget, now: datetime) -> bool:
+    """Has this target's own interval elapsed since its last push?
+
+    Per-target gating inside a coarse beat tick — the ``ipam_dns_sync``
+    pattern — so changing an interval in the UI takes effect without
+    restarting beat. A target that has never pushed is always due.
+    """
+    if row.last_push_at is None:
+        return True
+    last = row.last_push_at if row.last_push_at.tzinfo else row.last_push_at.replace(tzinfo=UTC)
+    return (now - last).total_seconds() >= max(1, int(row.push_interval_seconds or 60))
+
+
+async def push_target(db: AsyncSession, row: InfluxDBTarget, *, now: datetime) -> PushResult:
+    """Collect, write and record one target. Never raises.
+
+    Errors land on ``last_push_error`` and in the log; the caller commits.
+    Callers that want the failure to propagate should read the result.
+    """
+    points: list[Point] = []
+    dns_watermark: datetime | None = None
+    dhcp_watermark: datetime | None = None
+
+    try:
+        if row.push_dns_metrics:
+            dns_points, dns_watermark = await collect.collect_dns_points(db, row.last_dns_bucket_at)
+            points.extend(dns_points)
+        if row.push_dhcp_metrics:
+            dhcp_points, dhcp_watermark = await collect.collect_dhcp_points(
+                db, row.last_dhcp_bucket_at
+            )
+            points.extend(dhcp_points)
+        if row.push_subnet_utilization:
+            points.extend(await collect.collect_subnet_utilization_points(db, now))
+        if row.push_dhcp_scope_leases:
+            points.extend(await collect.collect_dhcp_scope_lease_points(db, now))
+
+        body = render_batch(_prefixed(points, row.measurement_prefix or ""))
+        await write_lines(config_from_row(row), body)
+    except (InfluxDBWriteError, ValueError) as exc:
+        row.last_push_error = str(exc)[:1000]
+        # ``last_push_at`` still advances on failure — otherwise a target
+        # that errors fast would be retried on every 30 s beat tick
+        # instead of on its own interval.
+        row.last_push_at = now
+        logger.warning("influxdb_push_failed", target=row.name, points=len(points), error=str(exc))
+        return PushResult(str(row.id), row.name, 0, ok=False, error=str(exc))
+
+    if dns_watermark is not None:
+        row.last_dns_bucket_at = dns_watermark
+    if dhcp_watermark is not None:
+        row.last_dhcp_bucket_at = dhcp_watermark
+    row.last_push_at = now
+    row.last_push_points = len(points)
+    row.last_push_error = None
+    logger.info("influxdb_push_ok", target=row.name, points=len(points))
+    return PushResult(str(row.id), row.name, len(points), ok=True)
+
+
+__all__ = ["PushResult", "is_due", "push_target"]

--- a/backend/app/tasks/influxdb_push.py
+++ b/backend/app/tasks/influxdb_push.py
@@ -1,0 +1,72 @@
+"""InfluxDB push-export beat task (issue #889).
+
+Ticks every 30 s; each enabled target is gated on its own
+``push_interval_seconds`` inside the task, so cadence changes in the UI
+take effect without restarting beat (the ``ipam_dns_sync`` pattern).
+
+Idempotent per non-negotiable #9. Two things make a retry safe: line
+protocol overwrites a point with the same measurement + tag set +
+timestamp, so re-sending a batch is a no-op at the server; and a
+session-scoped advisory lock keeps two workers from pushing the same
+targets concurrently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import structlog
+from sqlalchemy import select, text
+
+from app.celery_app import celery_app
+from app.db import task_session
+from app.models.influxdb import InfluxDBTarget
+from app.services.influxdb.push import is_due, push_target
+
+logger = structlog.get_logger(__name__)
+
+# Session-stable advisory-lock key — one pusher at a time across api /
+# worker replicas. Released when the connection closes.
+_PUSH_LOCK_KEY = 0x53504D494E46  # "SPMINF"
+
+
+async def _push_all() -> dict[str, int]:
+    async with task_session() as db:
+        got = (
+            await db.execute(text("select pg_try_advisory_lock(:k)"), {"k": _PUSH_LOCK_KEY})
+        ).scalar()
+        if not got:
+            return {"targets": 0, "pushed": 0, "failed": 0, "points": 0, "skipped_locked": 1}
+
+        rows = list(
+            (await db.execute(select(InfluxDBTarget).where(InfluxDBTarget.enabled.is_(True))))
+            .scalars()
+            .all()
+        )
+        now = datetime.now(UTC)
+        due = [r for r in rows if is_due(r, now)]
+        pushed = failed = points = 0
+        for row in due:
+            result = await push_target(db, row, now=now)
+            if result.ok:
+                pushed += 1
+                points += result.points
+            else:
+                failed += 1
+        await db.commit()
+        return {
+            "targets": len(rows),
+            "pushed": pushed,
+            "failed": failed,
+            "points": points,
+            "skipped_locked": 0,
+        }
+
+
+@celery_app.task(name="app.tasks.influxdb_push.push_influxdb_metrics")
+def push_influxdb_metrics() -> dict[str, int]:
+    result = asyncio.run(_push_all())
+    if result.get("targets"):
+        logger.info("influxdb_push_sweep", **result)
+    return result

--- a/backend/tests/test_influxdb_export.py
+++ b/backend/tests/test_influxdb_export.py
@@ -28,15 +28,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.crypto import encrypt_str
 from app.core.security import create_access_token, hash_password
 from app.models.auth import User
+from app.models.dhcp import (
+    DHCPLease,
+    DHCPScope,
+    DHCPServer,
+    DHCPServerGroup,
+)
 from app.models.dns import DNSServer, DNSServerGroup
 from app.models.influxdb import InfluxDBTarget
+from app.models.ipam import IPBlock, IPSpace, Subnet
 from app.models.metrics import DNSMetricSample
 from app.services.influxdb.client import (
     InfluxDBWriteError,
     InfluxTargetConfig,
     build_write_request,
 )
-from app.services.influxdb.collect import REPUSH_OVERLAP_SECONDS, collect_dns_points
+from app.services.influxdb.collect import (
+    REPUSH_OVERLAP_SECONDS,
+    collect_dhcp_scope_lease_points,
+    collect_dns_points,
+)
 from app.services.influxdb.line_protocol import Point, render_batch, render_point
 from app.services.influxdb.push import is_due, push_target
 
@@ -366,25 +377,58 @@ async def test_collect_dns_points_reports_the_newest_bucket(db_session: AsyncSes
 
 
 @pytest.mark.asyncio
-async def test_collect_dns_points_resends_an_overlap_window(db_session: AsyncSession) -> None:
+async def test_collect_dns_points_replays_a_window_behind_the_mark(
+    db_session: AsyncSession,
+) -> None:
     """A late-arriving sample must not be skipped forever.
 
-    The cursor is deliberately not a strict ``>`` on the watermark: an
-    agent that reports a bucket after the watermark passed it would
-    otherwise never be exported. Re-sending is free — line protocol
-    overwrites a point with the same measurement, tags and timestamp.
+    The forward drain alone is a strict ``>`` on the watermark, so an
+    agent that reports a bucket after the cursor passed it would never be
+    exported. The replay window covers that. Re-sending is free — line
+    protocol overwrites a point with the same measurement, tags and
+    timestamp.
     """
     base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
     await _dns_sample(db_session, base, 10)
 
-    inside_overlap = base + timedelta(seconds=REPUSH_OVERLAP_SECONDS - 60)
-    points, _ = await collect_dns_points(db_session, inside_overlap)
+    inside_replay = base + timedelta(seconds=REPUSH_OVERLAP_SECONDS - 60)
+    points, newest = await collect_dns_points(db_session, inside_replay)
     assert len(points) == 1
+    # A replayed row is already behind the cursor, so it must not become
+    # the new one — that is what would drag the watermark backwards.
+    assert newest is None
 
-    beyond_overlap = base + timedelta(seconds=REPUSH_OVERLAP_SECONDS + 60)
-    points, newest = await collect_dns_points(db_session, beyond_overlap)
+    beyond_replay = base + timedelta(seconds=REPUSH_OVERLAP_SECONDS + 60)
+    points, newest = await collect_dns_points(db_session, beyond_replay)
     assert points == []
     assert newest is None
+
+
+@pytest.mark.asyncio
+async def test_truncated_batch_never_drags_the_watermark_backwards(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The row cap must not be able to move the cursor the wrong way.
+
+    Folding the replay window into the drain's lower bound would, on a
+    fleet dense enough to fill the cap inside that window, return a
+    truncated batch whose maximum is *below* the watermark — pulling the
+    cursor back a little further every tick until it pinned on the oldest
+    retained sample. The export would stop advancing while every push
+    still reported success. Separate budgets make it unrepresentable.
+    """
+    monkeypatch.setattr("app.services.influxdb.collect.MAX_ROWS_PER_PUSH", 2)
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    for i in range(6):
+        await _dns_sample(db_session, base + timedelta(seconds=i), 1)
+
+    # Watermark sits above four of the six samples, all of them inside the
+    # replay window — exactly the shape that used to regress.
+    watermark = base + timedelta(seconds=3)
+    points, newest = await collect_dns_points(db_session, watermark)
+    assert points  # the replay still ships
+    assert newest is not None
+    assert newest > watermark
 
 
 @pytest.mark.asyncio
@@ -462,3 +506,107 @@ async def test_failed_push_leaves_the_watermark_alone(db_session: AsyncSession) 
     # ``last_push_at`` still moves, or a fast-failing target would be
     # retried on every 30 s beat tick instead of on its own interval.
     assert row.last_push_at == now
+
+
+@pytest.mark.asyncio
+async def test_malformed_url_is_recorded_not_raised(db_session: AsyncSession) -> None:
+    """A bad URL must fail *this* target, not abort the whole sweep.
+
+    ``httpx.InvalidURL`` derives from ``Exception``, not from
+    ``httpx.HTTPError`` — so catching only the latter let a URL that
+    passed the save-time scheme check escape ``push_target`` entirely,
+    rolling back every other target's state update in the same
+    transaction and leaving nothing to explain why.
+    """
+    # A body is required for the request to be built at all — an empty
+    # batch short-circuits before httpx is reached.
+    await _dns_sample(db_session, datetime.now(UTC).replace(microsecond=0), 1)
+    row = InfluxDBTarget(
+        name=f"t-{uuid.uuid4().hex[:6]}",
+        version="v2",
+        # Scheme is valid, so this passes the save-time check; the port
+        # is not a number, which httpx only discovers at request time.
+        url="http://influx:80o86",
+        org="acme",
+        bucket="ddi",
+        token_encrypted=encrypt_str("tok"),
+        push_dhcp_metrics=False,
+        push_subnet_utilization=False,
+        push_dhcp_scope_leases=False,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    result = await push_target(db_session, row, now=datetime.now(UTC))
+    assert not result.ok
+    assert "InvalidURL" in (row.last_push_error or "")
+    # The cursor must not have moved — nothing was delivered.
+    assert row.last_dns_bucket_at is None
+
+
+@pytest.mark.asyncio
+async def test_scope_lease_gauge_counts_addresses_not_rows(
+    db_session: AsyncSession,
+) -> None:
+    """Under Kea HA both partners mirror the same lease.
+
+    ``dhcp_lease`` is per-server — "one lease event arrives here twice",
+    per the model's own docstring — so a bare row count reports 2x the
+    addresses actually in use on exactly the deployments redundancy is
+    for, and disagrees with ``pool_occupancy.py``, which dedupes.
+    """
+    space = IPSpace(name=f"s-{uuid.uuid4().hex[:6]}", description="")
+    db_session.add(space)
+    await db_session.flush()
+    block = IPBlock(space_id=space.id, network="10.62.0.0/16", name="b")
+    db_session.add(block)
+    await db_session.flush()
+    subnet = Subnet(space_id=space.id, block_id=block.id, network="10.62.0.0/24", name="s")
+    db_session.add(subnet)
+    await db_session.flush()
+
+    group = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db_session.add(group)
+    await db_session.flush()
+    scope = DHCPScope(group_id=group.id, subnet_id=subnet.id, name="ha-scope")
+    primary = DHCPServer(
+        name=f"kea-a-{uuid.uuid4().hex[:4]}",
+        host="10.0.0.1",
+        driver="kea",
+        server_group_id=group.id,
+    )
+    secondary = DHCPServer(
+        name=f"kea-b-{uuid.uuid4().hex[:4]}",
+        host="10.0.0.2",
+        driver="kea",
+        server_group_id=group.id,
+    )
+    db_session.add_all([scope, primary, secondary])
+    await db_session.flush()
+
+    # One address, mirrored by both HA partners; plus a second address on
+    # one partner only.
+    for server in (primary, secondary):
+        db_session.add(
+            DHCPLease(
+                server_id=server.id,
+                scope_id=scope.id,
+                ip_address="10.62.0.10",
+                mac_address="aa:bb:cc:00:00:01",
+                state="active",
+            )
+        )
+    db_session.add(
+        DHCPLease(
+            server_id=primary.id,
+            scope_id=scope.id,
+            ip_address="10.62.0.11",
+            mac_address="aa:bb:cc:00:00:02",
+            state="active",
+        )
+    )
+    await db_session.flush()
+
+    points = await collect_dhcp_scope_lease_points(db_session, datetime.now(UTC))
+    gauge = next(p for p in points if p.tags["scope_id"] == str(scope.id))
+    assert gauge.fields["active_leases"] == 2  # not 3

--- a/backend/tests/test_influxdb_export.py
+++ b/backend/tests/test_influxdb_export.py
@@ -1,0 +1,464 @@
+"""InfluxDB push export (issue #889).
+
+Three things are worth pinning here, because each fails *silently* rather
+than loudly:
+
+* **Line-protocol escaping.** A comma in a subnet description or a space
+  in a server name is not an error at the server — it re-parses as a
+  different tag, or as a field, and the series quietly forks. The rules
+  differ per position, which is why every position gets a case.
+* **Endpoint + auth selection per version.** v3 is not a third client;
+  it is the v2 endpoint with bearer auth and bucket=database naming. A
+  regression that collapsed the two token schemes would work against
+  InfluxDB 3 and break every v2 install.
+* **Watermark advance.** Advancing on a *failed* push is how you get a
+  permanent hole in a Grafana dashboard that nothing reports.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.crypto import encrypt_str
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import DNSServer, DNSServerGroup
+from app.models.influxdb import InfluxDBTarget
+from app.models.metrics import DNSMetricSample
+from app.services.influxdb.client import (
+    InfluxDBWriteError,
+    InfluxTargetConfig,
+    build_write_request,
+)
+from app.services.influxdb.collect import REPUSH_OVERLAP_SECONDS, collect_dns_points
+from app.services.influxdb.line_protocol import Point, render_batch, render_point
+from app.services.influxdb.push import is_due, push_target
+
+# ── line protocol ──────────────────────────────────────────────────
+
+
+def test_render_point_escapes_every_position() -> None:
+    line = render_point(
+        Point(
+            measurement="dns queries,agg",
+            tags={"server": "ns1 dc=1", "zone": "a,b"},
+            fields={"queries total": 5},
+            timestamp=1700000000,
+        )
+    )
+    # Measurement escapes comma + space, but NOT '=' (legal unescaped there).
+    assert line.startswith(r"dns\ queries\,agg,")
+    assert r"server=ns1\ dc\=1" in line
+    assert r"zone=a\,b" in line
+    assert r"queries\ total=5i" in line
+    assert line.endswith(" 1700000000")
+
+
+def test_integer_and_float_and_bool_field_types() -> None:
+    line = render_point(
+        Point(
+            measurement="m",
+            tags={},
+            fields={"i": 3, "f": 1.5, "b": True},
+            timestamp=1,
+        )
+    )
+    # bool must not render as an int — a `1i` where the series holds
+    # booleans is a field-type conflict InfluxDB rejects for the whole
+    # batch, not just the point.
+    assert "b=true" in line
+    assert "i=3i" in line
+    assert "f=1.5" in line
+
+
+def test_empty_tag_values_are_dropped() -> None:
+    line = render_point(
+        Point(measurement="m", tags={"a": "", "b": "x"}, fields={"v": 1}, timestamp=1)
+    )
+    assert "a=" not in line
+    assert "b=x" in line
+
+
+def test_newlines_cannot_terminate_a_point_early() -> None:
+    line = render_point(
+        Point(
+            measurement="m",
+            tags={"desc": "line1\nline2"},
+            fields={"v": 1},
+            timestamp=1,
+        )
+    )
+    assert "\n" not in line
+
+
+def test_string_field_is_quoted_and_escaped() -> None:
+    line = render_point(Point(measurement="m", tags={}, fields={"s": 'a"b\\c'}, timestamp=1))
+    assert 's="a\\"b\\\\c"' in line
+
+
+def test_field_less_point_is_refused_not_shipped() -> None:
+    # A field-less line is a parse error that rejects the whole batch it
+    # arrives in, so it must never reach the wire.
+    with pytest.raises(ValueError):
+        render_point(Point(measurement="m", tags={"a": "b"}, fields={}, timestamp=1))
+
+
+def test_render_batch_joins_with_newlines() -> None:
+    body = render_batch(
+        [
+            Point(measurement="a", tags={}, fields={"v": 1}, timestamp=1),
+            Point(measurement="b", tags={}, fields={"v": 2}, timestamp=2),
+        ]
+    )
+    assert body.split("\n") == ["a v=1i 1", "b v=2i 2"]
+
+
+# ── endpoint + auth per version ────────────────────────────────────
+
+
+def test_v1_uses_write_endpoint_and_basic_auth() -> None:
+    req = build_write_request(
+        InfluxTargetConfig(
+            version="v1",
+            url="http://influx:8086/",
+            database="spatium",
+            username="admin",
+            password="s3cret",
+        )
+    )
+    assert req.url == "http://influx:8086/write"
+    assert req.params["db"] == "spatium"
+    assert req.params["precision"] == "s"
+    assert req.auth == ("admin", "s3cret")
+    assert "Authorization" not in req.headers
+
+
+def test_v1_without_credentials_sends_no_auth() -> None:
+    req = build_write_request(
+        InfluxTargetConfig(version="v1", url="http://influx:8086", database="spatium")
+    )
+    assert req.auth is None
+
+
+def test_v2_uses_token_scheme() -> None:
+    req = build_write_request(
+        InfluxTargetConfig(
+            version="v2", url="http://influx:8086", org="acme", bucket="ddi", token="tok"
+        )
+    )
+    assert req.url == "http://influx:8086/api/v2/write"
+    assert req.params["org"] == "acme"
+    assert req.params["bucket"] == "ddi"
+    assert req.headers["Authorization"] == "Token tok"
+
+
+def test_v3_reuses_v2_endpoint_with_bearer_and_optional_org() -> None:
+    req = build_write_request(
+        InfluxTargetConfig(version="v3", url="http://influx:8181", bucket="ddi", token="tok")
+    )
+    assert req.url == "http://influx:8181/api/v2/write"
+    # v3 names a *database* in the bucket parameter, and org is optional
+    # (Core / Enterprise accept-and-ignore it).
+    assert req.params["bucket"] == "ddi"
+    assert "org" not in req.params
+    assert req.headers["Authorization"] == "Bearer tok"
+
+
+def test_v2_requires_org_but_v3_does_not() -> None:
+    with pytest.raises(ValueError, match="org is required"):
+        build_write_request(InfluxTargetConfig(version="v2", url="http://x", bucket="b", token="t"))
+
+
+@pytest.mark.parametrize(
+    ("cfg", "match"),
+    [
+        (InfluxTargetConfig(version="v1", url="", database="d"), "url is required"),
+        (InfluxTargetConfig(version="v1", url="http://x"), "database is required"),
+        (
+            InfluxTargetConfig(version="v2", url="http://x", org="o", bucket="b"),
+            "token is required",
+        ),
+        (
+            InfluxTargetConfig(version="v3", url="http://x", token="t"),
+            "database is required",
+        ),
+        (InfluxTargetConfig(version="v9", url="http://x"), "unsupported InfluxDB version"),
+    ],
+)
+def test_incomplete_targets_are_refused(cfg: InfluxTargetConfig, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        build_write_request(cfg)
+
+
+# ── per-target interval gating ─────────────────────────────────────
+
+
+def test_never_pushed_target_is_always_due() -> None:
+    now = datetime.now(UTC)
+    assert is_due(InfluxDBTarget(push_interval_seconds=3600, last_push_at=None), now)
+
+
+def test_interval_gate_holds_until_elapsed() -> None:
+    now = datetime.now(UTC)
+    row = InfluxDBTarget(push_interval_seconds=300, last_push_at=now - timedelta(seconds=299))
+    assert not is_due(row, now)
+    row.last_push_at = now - timedelta(seconds=300)
+    assert is_due(row, now)
+
+
+# ── CRUD API ───────────────────────────────────────────────────────
+
+
+async def _superadmin(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+def _v2_body(**over: object) -> dict:
+    body = {
+        "name": "grafana",
+        "enabled": True,
+        "version": "v2",
+        "url": "http://influx:8086",
+        "verify_tls": True,
+        "timeout_seconds": 10,
+        "database": "",
+        "username": "",
+        "org": "acme",
+        "bucket": "ddi",
+        "token": "tok",
+        "measurement_prefix": "spatiumddi_",
+        "push_interval_seconds": 60,
+        "push_dns_metrics": True,
+        "push_dhcp_metrics": True,
+        "push_subnet_utilization": True,
+        "push_dhcp_scope_leases": True,
+    }
+    body.update(over)
+    return body
+
+
+@pytest.mark.asyncio
+async def test_crud_roundtrip_never_returns_the_token(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+
+    r = await client.get("/api/v1/settings/influxdb-targets", headers=h)
+    assert r.status_code == 200, r.text
+    assert r.json() == []
+
+    secret = "s3cret-" + uuid.uuid4().hex
+    r = await client.post(
+        "/api/v1/settings/influxdb-targets", headers=h, json=_v2_body(token=secret)
+    )
+    assert r.status_code == 201, r.text
+    created = r.json()
+    assert created["token_set"] is True
+    # The secret must never appear in the response, under any key. (The
+    # needle is randomised so it can't collide with a field *name* — an
+    # earlier version of this assertion matched "token_set".)
+    assert secret not in r.text
+
+    target_id = created["id"]
+    # Omitting ``token`` on update means "keep what's stored" — the
+    # operator editing an interval must not silently clear the credential.
+    body = _v2_body(push_interval_seconds=120)
+    body.pop("token")
+    r = await client.put(f"/api/v1/settings/influxdb-targets/{target_id}", headers=h, json=body)
+    assert r.status_code == 200, r.text
+    assert r.json()["push_interval_seconds"] == 120
+    assert r.json()["token_set"] is True
+
+    r = await client.delete(f"/api/v1/settings/influxdb-targets/{target_id}", headers=h)
+    assert r.status_code == 204
+    r = await client.get("/api/v1/settings/influxdb-targets", headers=h)
+    assert r.json() == []
+
+
+@pytest.mark.asyncio
+async def test_unwritable_target_is_422_at_save_not_a_push_error_later(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    r = await client.post("/api/v1/settings/influxdb-targets", headers=h, json=_v2_body(bucket=""))
+    assert r.status_code == 422, r.text
+    assert "bucket is required" in r.text
+
+
+@pytest.mark.asyncio
+async def test_non_superadmin_is_forbidden(client: AsyncClient, db_session: AsyncSession) -> None:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Plain",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    h = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    assert (await client.get("/api/v1/settings/influxdb-targets", headers=h)).status_code == 403
+
+
+# ── collect + watermark ────────────────────────────────────────────
+
+
+async def _dns_sample(db: AsyncSession, bucket_at: datetime, queries: int) -> uuid.UUID:
+    group = DNSServerGroup(name=f"g-{uuid.uuid4().hex[:6]}")
+    db.add(group)
+    await db.flush()
+    server = DNSServer(
+        group_id=group.id,
+        name=f"ns {uuid.uuid4().hex[:4]}",
+        driver="bind9",
+        host="10.0.0.53",
+        port=53,
+    )
+    db.add(server)
+    await db.flush()
+    db.add(
+        DNSMetricSample(
+            server_id=server.id,
+            bucket_at=bucket_at,
+            queries_total=queries,
+            noerror=queries,
+            nxdomain=0,
+            servfail=0,
+            recursion=0,
+            rate_dropped=0,
+            rate_slipped=0,
+        )
+    )
+    await db.flush()
+    return server.id
+
+
+@pytest.mark.asyncio
+async def test_collect_dns_points_reports_the_newest_bucket(db_session: AsyncSession) -> None:
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    await _dns_sample(db_session, base, 10)
+    await _dns_sample(db_session, base + timedelta(minutes=1), 20)
+
+    points, newest = await collect_dns_points(db_session, None)
+    assert len(points) == 2
+    assert newest == base + timedelta(minutes=1)
+    # The bucket's own timestamp travels with the point — not "now" —
+    # so a backfill lands on the hour the traffic actually happened.
+    assert {p.timestamp for p in points} == {
+        int(base.timestamp()),
+        int((base + timedelta(minutes=1)).timestamp()),
+    }
+
+
+@pytest.mark.asyncio
+async def test_collect_dns_points_resends_an_overlap_window(db_session: AsyncSession) -> None:
+    """A late-arriving sample must not be skipped forever.
+
+    The cursor is deliberately not a strict ``>`` on the watermark: an
+    agent that reports a bucket after the watermark passed it would
+    otherwise never be exported. Re-sending is free — line protocol
+    overwrites a point with the same measurement, tags and timestamp.
+    """
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    await _dns_sample(db_session, base, 10)
+
+    inside_overlap = base + timedelta(seconds=REPUSH_OVERLAP_SECONDS - 60)
+    points, _ = await collect_dns_points(db_session, inside_overlap)
+    assert len(points) == 1
+
+    beyond_overlap = base + timedelta(seconds=REPUSH_OVERLAP_SECONDS + 60)
+    points, newest = await collect_dns_points(db_session, beyond_overlap)
+    assert points == []
+    assert newest is None
+
+
+@pytest.mark.asyncio
+async def test_successful_push_advances_the_watermark_and_prefixes(
+    db_session: AsyncSession,
+) -> None:
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    await _dns_sample(db_session, base, 42)
+
+    row = InfluxDBTarget(
+        name=f"t-{uuid.uuid4().hex[:6]}",
+        version="v2",
+        url="http://influx:8086",
+        org="acme",
+        bucket="ddi",
+        token_encrypted=encrypt_str("tok"),
+        measurement_prefix="pfx_",
+        push_dhcp_metrics=False,
+        push_subnet_utilization=False,
+        push_dhcp_scope_leases=False,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    sent: list[str] = []
+
+    async def _capture(cfg: object, body: str) -> None:
+        sent.append(body)
+
+    now = datetime.now(UTC)
+    with patch("app.services.influxdb.push.write_lines", new=_capture):
+        result = await push_target(db_session, row, now=now)
+
+    assert result.ok and result.points == 1
+    assert sent and sent[0].startswith("pfx_dns_queries,")
+    assert row.last_dns_bucket_at == base
+    assert row.last_push_error is None
+
+
+@pytest.mark.asyncio
+async def test_failed_push_leaves_the_watermark_alone(db_session: AsyncSession) -> None:
+    """Advancing on failure is how a dashboard gets a permanent hole.
+
+    The samples stay in Postgres until ``prune_metrics`` retires them, so
+    a target that recovers inside the retention window backfills — but
+    only if the cursor never moved past what was actually delivered.
+    """
+    base = datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10)
+    await _dns_sample(db_session, base, 42)
+
+    row = InfluxDBTarget(
+        name=f"t-{uuid.uuid4().hex[:6]}",
+        version="v2",
+        url="http://influx:8086",
+        org="acme",
+        bucket="ddi",
+        token_encrypted=encrypt_str("tok"),
+        push_dhcp_metrics=False,
+        push_subnet_utilization=False,
+        push_dhcp_scope_leases=False,
+    )
+    db_session.add(row)
+    await db_session.flush()
+
+    async def _boom(cfg: object, body: str) -> None:
+        raise InfluxDBWriteError("HTTP 401: unauthorized")
+
+    now = datetime.now(UTC)
+    with patch("app.services.influxdb.push.write_lines", new=_boom):
+        result = await push_target(db_session, row, now=now)
+
+    assert not result.ok
+    assert row.last_dns_bucket_at is None
+    assert row.last_push_error == "HTTP 401: unauthorized"
+    # ``last_push_at`` still moves, or a fast-failing target would be
+    # retried on every 30 s beat tick instead of on its own interval.
+    assert row.last_push_at == now

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -645,7 +645,8 @@ and does not want a second TSDB. The two are independent; running both
 is fine.
 
 Measurements, versions (v1 / v2 / v3), idempotency and the high-water
-marks are documented in
+marks (a strictly-forward drain plus a separately-budgeted replay
+window) are documented in
 [`features/SYSTEM_ADMIN.md` § 8](features/SYSTEM_ADMIN.md#influxdb-export-issue-889).
 The short version:
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -632,6 +632,72 @@ need `Get-DnsServerStatistics` / `Get-DhcpServerv4Statistics` calls
 over WinRM). The dashboard card shows "no data yet" rather than an
 error in that case.
 
+### InfluxDB Push Export (issue #889) — shipped
+
+The same two tables feed an outbound push. `InfluxDBTarget` rows are
+configured under **Settings → Metrics → InfluxDB Export**; a Celery
+beat task (`app.tasks.influxdb_push.push_influxdb_metrics`, 30 s tick,
+per-target interval gating) renders line protocol and POSTs it.
+
+This is a *push*, so it works where the Prometheus scrape does not —
+a control plane behind NAT, or an operator who already runs InfluxDB
+and does not want a second TSDB. The two are independent; running both
+is fine.
+
+Measurements, versions (v1 / v2 / v3), idempotency and the high-water
+marks are documented in
+[`features/SYSTEM_ADMIN.md` § 8](features/SYSTEM_ADMIN.md#influxdb-export-issue-889).
+The short version:
+
+* Counter deltas (`<prefix>dns_queries`, `<prefix>dhcp_messages`) carry
+  the **agent bucket's own timestamp** — 60 s is the resolution floor
+  no matter what push interval you pick.
+* Gauges (`<prefix>subnet_utilization`, `<prefix>dhcp_scope_leases`)
+  are sampled at push time and have no backfill.
+* v3 reuses the v2 write endpoint with bearer auth and
+  bucket=database naming, so InfluxDB 3 Core / Enterprise / Cloud all
+  work through the same path.
+
+#### Grafana with an InfluxDB datasource
+
+Add the datasource (**Connections → Add new connection → InfluxDB**),
+pick **Flux** as the query language, and point it at the same URL,
+org, bucket and token you gave the target. Then, for the two panels
+operators want first:
+
+DNS query rate per server, as queries/second:
+
+```flux
+from(bucket: "ddi")
+  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)
+  |> filter(fn: (r) => r._measurement == "spatiumddi_dns_queries")
+  |> filter(fn: (r) => r._field == "queries_total")
+  |> map(fn: (r) => ({r with _value: float(v: r._value) / 60.0}))
+  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)
+  |> group(columns: ["server"])
+```
+
+The `/ 60.0` is the load-bearing part: the stored value is a *delta
+per 60 s bucket*, not a rate and not a running counter, so neither
+`derivative()` nor a bare plot gives you queries/second.
+
+Subnet utilization, latest sample per subnet, for a table or gauge:
+
+```flux
+from(bucket: "ddi")
+  |> range(start: -1h)
+  |> filter(fn: (r) => r._measurement == "spatiumddi_subnet_utilization")
+  |> filter(fn: (r) => r._field == "percent")
+  |> last()
+  |> group()
+  |> keep(columns: ["subnet", "space", "_value"])
+```
+
+On a **v1** datasource the same series are reachable through InfluxQL,
+where the deltas are plain values (`SELECT sum("queries_total") FROM
+"spatiumddi_dns_queries" WHERE $timeFilter GROUP BY time($__interval),
+"server"`) — again a per-bucket sum, not `derivative()`.
+
 ### Celery / Worker Metrics (planned — not emitted)
 
 ```

--- a/docs/SHIPPED.md
+++ b/docs/SHIPPED.md
@@ -571,9 +571,10 @@ Mirrors CLAUDE.md's three mixed sections:
     column with `server_id` label would make the existing
     `/metrics` endpoint a full-featured scrape target for
     operators who prefer Grafana.
-  - **InfluxDB push export** (`InfluxDBTarget` spec in
-    `docs/features/SYSTEM_ADMIN.md §8.2`) — shape exists, writer
-    still pending.
+  - **InfluxDB push export** (`InfluxDBTarget`) — **shipped**
+    (#889). See `docs/features/SYSTEM_ADMIN.md §8` for the built
+    shape; the v1 / v2 / v3 writer, the beat task and the
+    high-water-mark semantics all live there.
   - **Per-qtype** (BIND) / **per-subnet** (Kea) breakdowns —
     `statistic-get-all` already carries per-subnet counters; the
     agent strips them for MVP. Adding them is column-only, no

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -753,35 +753,141 @@ GET /api/v1/version
 
 Available at `/metrics` when `prometheus_metrics_enabled=true`. Scraped by any Prometheus-compatible tool including Grafana Cloud.
 
-### InfluxDB Export
+### InfluxDB Export (issue #889)
 
-SpatiumDDI can push metrics to InfluxDB (v1.x and v2.x) for Grafana dashboards:
+**Settings → Metrics → InfluxDB Export.** SpatiumDDI is the *writer*: a
+Celery beat task formats [line protocol](https://docs.influxdata.com/influxdb/v2/reference/syntax/line-protocol/)
+from the metric tables the agents already fill and POSTs it. Nothing is
+read back, so a target's health is whatever its last push reported.
+Superadmin-only, audited, and independent of the Prometheus `/metrics`
+endpoint — running both is fine.
+
+Multiple targets run at once (a local InfluxDB alongside a hosted one),
+each with its own interval, prefix and metric selection.
+
+**Not a feature module** (non-negotiable #14, stated explicitly): this
+adds no sidebar section and no top-level router prefix. It is a
+Settings-level integration under the existing `/settings` surface, same
+as audit forwarding, and "off" is already modelled by disabling or
+deleting a target.
 
 ```
-InfluxDBTarget
-  id, name
-  version: enum(v1, v2)
-  url: str                   -- e.g., http://influxdb:8086
+InfluxDBTarget                    -- backend/app/models/influxdb.py
+  id, name (unique), enabled
+  version: enum(v1, v2, v3)
+  url: str                        -- base URL only, e.g. http://influxdb:8086
+  verify_tls: bool (default true)
+  timeout_seconds: int (default 10)
   -- v1 fields:
   database: str
-  username, password_ref
-  -- v2 fields:
-  org: str
-  bucket: str
-  token_ref: str             -- reference to encrypted secret
+  username: str
+  password_encrypted: bytes       -- Fernet at rest; API returns password_set only
+  -- v2 / v3 fields:
+  org: str                        -- required on v2; optional on v3
+  bucket: str                     -- on v3 this is the database name
+  token_encrypted: bytes          -- Fernet at rest; API returns token_set only
   measurement_prefix: str (default "spatiumddi_")
-  push_interval_seconds: int (default 60)
-  is_enabled: bool
+  push_interval_seconds: int (default 60, min 30)
+  push_dns_metrics / push_dhcp_metrics /
+  push_subnet_utilization / push_dhcp_scope_leases: bool (all default true)
+  -- push state (written by the task, read-only to the operator):
+  last_dns_bucket_at, last_dhcp_bucket_at    -- per-source high-water marks
+  last_push_at, last_push_points, last_push_error
 ```
 
-**Metrics pushed to InfluxDB:**
-- IP space/subnet utilization (current allocation %)
-- DHCP lease counts per scope
-- DNS query rates per server
-- API request rates and latencies
-- System health status per component
+#### "All versions" — v1, v2 and v3
 
-Multiple InfluxDB targets can be configured simultaneously (e.g., local InfluxDB + remote InfluxCloud).
+Three declared versions, **two** wire dialects. v3 is not a third
+client; it is the v2 write endpoint with different auth and naming, so
+InfluxDB 3 Core / Enterprise / Cloud Dedicated / Cloud Serverless are
+all covered by the same code path.
+
+| version | endpoint | auth | destination field |
+|---|---|---|---|
+| `v1` | `POST /write?db=…` | HTTP basic, omitted when username *and* password are blank | `database` |
+| `v2` | `POST /api/v2/write?org=…&bucket=…` | `Authorization: Token …` | `bucket` (`org` required) |
+| `v3` | `POST /api/v2/write?bucket=…` | `Authorization: Bearer …` | `bucket`, labelled **Database** in the UI (`org` optional — Core/Enterprise accept-and-ignore it, Cloud Serverless honours it) |
+
+Pointing a **v1** target at an InfluxDB 3 server also works: the API
+token goes in the *password* field and the username is ignored. That is
+InfluxDB's documented compatibility shim, and it needs nothing special
+here beyond basic auth already sending it.
+
+All three write with `precision=s`.
+
+#### What gets pushed
+
+Two shapes, which behave differently on a dashboard:
+
+**Counter deltas** — agent-reported, already bucketed at 60 s, carrying
+*the bucket's own timestamp*. A backfill therefore lands on the hour the
+traffic happened, not the hour it was exported.
+
+| measurement | tags | fields |
+|---|---|---|
+| `<prefix>dns_queries` | `server`, `server_id` | `queries_total`, `noerror`, `nxdomain`, `servfail`, `recursion`, `rate_dropped`, `rate_slipped` |
+| `<prefix>dhcp_messages` | `server`, `server_id` | `discover`, `offer`, `request`, `ack`, `nak`, `decline`, `release`, `inform` |
+
+**Point-in-time gauges** — sampled at push time from counters the
+application already maintains, so there is no historical backfill: the
+first point is the moment the target was enabled.
+
+| measurement | tags | fields |
+|---|---|---|
+| `<prefix>subnet_utilization` | `subnet`, `subnet_id`, `space` | `allocated`, `total`, `percent` |
+| `<prefix>dhcp_scope_leases` | `scope`, `scope_id`, `group`, `subnet` | `active_leases`, `is_active` |
+
+A scope with no active leases is exported as `0` rather than omitted —
+an absent series and an empty scope look identical on a graph, and "the
+scope went quiet" is what an operator wants to see.
+
+> **"Realtime" caveat.** The floor for the counter deltas is the **60 s
+> agent bucket**, not the push interval; setting a 30 s interval just
+> re-sends the same bucket. Sub-minute resolution would need agent-side
+> cadence changes and is out of scope. For the gauges, the floor *is*
+> the push interval.
+
+Not yet carried, because nothing samples them: API request rates and
+latencies, and per-component health status. The tracked deferrals in
+[`SHIPPED.md`](../SHIPPED.md) each widen what this export carries when
+they land — Windows DNS/DHCP stats over WinRM, and per-qtype (BIND) /
+per-subnet (Kea) breakdowns.
+
+#### Idempotency and the high-water marks
+
+Line protocol overwrites a point with an identical measurement, tag set
+and timestamp, so re-sending a batch is a no-op at the server. That is
+what makes the task safe to retry (non-negotiable #9), and it is why the
+cursor is *not* a strict `>` on the watermark: the pusher deliberately
+re-sends a 5-minute overlap window so a sample an agent reported late
+still gets exported rather than being skipped forever.
+
+The watermarks advance **only** on a successful write. A dead collector
+means a delayed export, never a hole — the samples stay in Postgres until
+`prune_metrics` retires them, so a target that recovers inside
+`metric_retention_days` backfills on its own. A newly-added target
+drains the whole retention window at 5 000 rows per source per push,
+so it converges over several ticks rather than in one oversized POST.
+
+`last_push_at` moves on failure as well as success — otherwise a
+fast-failing target would be retried on every 30 s beat tick instead of
+on its own interval.
+
+#### Test write
+
+The **Test** button performs a real single-point write to the target's
+own `<prefix>export_test` measurement, not a reachability check: a
+correct URL with the wrong bucket, org or token answers a plain GET
+perfectly well and then rejects every point. It leaves the watermarks
+alone — it is a probe, not
+a push.
+
+#### MCP
+
+`find_influxdb_targets` (default on, superadmin-only) reports each
+target's version, destination, what it carries, and its last push's
+timestamp, point count and error. Never returns a token or password —
+only whether one is on file.
 
 ---
 

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -837,6 +837,12 @@ first point is the moment the target was enabled.
 | `<prefix>subnet_utilization` | `subnet`, `subnet_id`, `space` | `allocated`, `total`, `percent` |
 | `<prefix>dhcp_scope_leases` | `scope`, `scope_id`, `group`, `subnet` | `active_leases`, `is_active` |
 
+`active_leases` counts **distinct addresses**, not `dhcp_lease` rows.
+That table is per-server, and under Kea HA both partners mirror the same
+lease, so a bare row count would report 2× the addresses actually in use
+on a redundant pair — and disagree with the pool-occupancy figures,
+which dedupe for the same reason.
+
 A scope with no active leases is exported as `0` rather than omitted —
 an absent series and an empty scope look identical on a graph, and "the
 scope went quiet" is what an operator wants to see.
@@ -857,21 +863,37 @@ per-subnet (Kea) breakdowns.
 
 Line protocol overwrites a point with an identical measurement, tag set
 and timestamp, so re-sending a batch is a no-op at the server. That is
-what makes the task safe to retry (non-negotiable #9), and it is why the
-cursor is *not* a strict `>` on the watermark: the pusher deliberately
-re-sends a 5-minute overlap window so a sample an agent reported late
-still gets exported rather than being skipped forever.
+what makes the task safe to retry (non-negotiable #9), and it is what
+lets each push do two queries per source instead of one:
+
+* a **forward drain**, strictly `bucket_at > watermark`, capped at
+  5 000 rows — so a newly-added target converges over several ticks
+  rather than in one oversized POST;
+* a **replay** of the closed window `(watermark - 5 min, watermark]`,
+  on its own row budget, so a bucket an agent reported *late* is still
+  exported instead of being skipped forever.
+
+The two budgets are separate deliberately. Folding the replay into the
+drain's lower bound would, on a fleet dense enough to fill the row cap
+inside that 5-minute window, return a truncated batch whose maximum sits
+*below* the watermark — dragging the cursor backwards a little further
+every tick until it pinned on the oldest retained sample. The export
+would stop advancing while every push still reported success and the UI
+still showed the target green. Replayed rows never contribute to the
+cursor, so it can only move forwards.
 
 The watermarks advance **only** on a successful write. A dead collector
 means a delayed export, never a hole — the samples stay in Postgres until
 `prune_metrics` retires them, so a target that recovers inside
-`metric_retention_days` backfills on its own. A newly-added target
-drains the whole retention window at 5 000 rows per source per push,
-so it converges over several ticks rather than in one oversized POST.
+`metric_retention_days` backfills on its own.
 
 `last_push_at` moves on failure as well as success — otherwise a
 fast-failing target would be retried on every 30 s beat tick instead of
-on its own interval.
+on its own interval. A failure is always recorded against the target
+that caused it: the push is wrapped in a broad per-target boundary,
+because the beat task pushes every due target in one transaction and an
+escaping exception would discard the state updates of the ones that
+succeeded.
 
 #### Test write
 

--- a/frontend/src/components/InfluxDBTargets.tsx
+++ b/frontend/src/components/InfluxDBTargets.tsx
@@ -1,0 +1,698 @@
+/**
+ * InfluxDB push-export target manager (issue #889).
+ *
+ * SpatiumDDI is the writer here — a Celery beat task formats line
+ * protocol from the existing metric tables and POSTs it on each
+ * target's own interval. Nothing is read back, so the row's health is
+ * whatever the last push reported.
+ *
+ * Three versions, two forms: v1 shows database + username/password, v2
+ * and v3 show org/bucket + token. v3 is InfluxDB 3 over the v2 write
+ * endpoint (a v3 *database* goes in the bucket field), which is why the
+ * label changes rather than the field.
+ *
+ * "Test" performs a real single-point write instead of a reachability
+ * check: a correct URL with the wrong bucket, org or token answers a
+ * GET perfectly well and then rejects every point.
+ */
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Pencil, Play, Plus, Trash2, X } from "lucide-react";
+
+import { Modal } from "@/components/ui/modal";
+import {
+  settingsApi,
+  type InfluxDBTarget,
+  type InfluxDBTargetWrite,
+  type InfluxDBVersion,
+} from "@/lib/api";
+
+const inputCls =
+  "w-full rounded-md border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50";
+
+const VERSION_LABELS: Record<InfluxDBVersion, string> = {
+  v1: "v1.x — /write, basic auth",
+  v2: "v2.x — /api/v2/write, token auth",
+  v3: "v3 (Core / Enterprise / Cloud) — v2 endpoint, bearer token",
+};
+
+// The beat tick is 30 s, so a shorter interval can't be honoured. The
+// real data floor is the 60 s agent metric bucket regardless.
+const MIN_INTERVAL_SECONDS = 30;
+
+const EMPTY: InfluxDBTargetWrite = {
+  name: "",
+  enabled: true,
+  version: "v2",
+  url: "",
+  verify_tls: true,
+  timeout_seconds: 10,
+  database: "",
+  username: "",
+  password: null,
+  org: "",
+  bucket: "",
+  token: null,
+  measurement_prefix: "spatiumddi_",
+  push_interval_seconds: 60,
+  push_dns_metrics: true,
+  push_dhcp_metrics: true,
+  push_subnet_utilization: true,
+  push_dhcp_scope_leases: true,
+};
+
+function targetToBody(t: InfluxDBTarget): InfluxDBTargetWrite {
+  return {
+    name: t.name,
+    enabled: t.enabled,
+    version: t.version,
+    url: t.url,
+    verify_tls: t.verify_tls,
+    timeout_seconds: t.timeout_seconds,
+    database: t.database,
+    username: t.username,
+    // Secrets are write-only — the server returns booleans only.
+    // ``null`` means "leave what is stored alone".
+    password: null,
+    org: t.org,
+    bucket: t.bucket,
+    token: null,
+    measurement_prefix: t.measurement_prefix,
+    push_interval_seconds: t.push_interval_seconds,
+    push_dns_metrics: t.push_dns_metrics,
+    push_dhcp_metrics: t.push_dhcp_metrics,
+    push_subnet_utilization: t.push_subnet_utilization,
+    push_dhcp_scope_leases: t.push_dhcp_scope_leases,
+  };
+}
+
+function errorDetail(e: unknown, fallback: string): string {
+  if (e && typeof e === "object" && "response" in e) {
+    const resp = (e as { response?: { data?: { detail?: unknown } } }).response;
+    if (resp?.data?.detail) return String(resp.data.detail);
+  }
+  return fallback;
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "never";
+  const secs = Math.max(0, Math.round((Date.now() - then) / 1000));
+  if (secs < 60) return `${secs}s ago`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  if (secs < 86400) return `${Math.round(secs / 3600)}h ago`;
+  return `${Math.round(secs / 86400)}d ago`;
+}
+
+export function InfluxDBTargets({ isSuperadmin }: { isSuperadmin: boolean }) {
+  const qc = useQueryClient();
+  const { data: targets = [], isLoading } = useQuery({
+    queryKey: ["influxdb-targets"],
+    queryFn: settingsApi.listInfluxTargets,
+    // The row carries last-push state written by a beat task, so it goes
+    // stale on its own; refresh while the page is open.
+    refetchInterval: 30000,
+  });
+
+  const [editing, setEditing] = useState<
+    { mode: "create" } | { mode: "edit"; row: InfluxDBTarget } | null
+  >(null);
+  const [confirmDelete, setConfirmDelete] = useState<InfluxDBTarget | null>(
+    null,
+  );
+  const [testState, setTestState] = useState<
+    Record<string, { status: "ok" | "error"; msg: string } | undefined>
+  >({});
+
+  const deleteMut = useMutation({
+    mutationFn: (id: string) => settingsApi.deleteInfluxTarget(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["influxdb-targets"] });
+      setConfirmDelete(null);
+    },
+  });
+
+  async function doTest(id: string) {
+    try {
+      const r = await settingsApi.testInfluxTarget(id);
+      setTestState((s) => ({
+        ...s,
+        [id]: { status: r.ok ? "ok" : "error", msg: r.message },
+      }));
+    } catch (e) {
+      setTestState((s) => ({
+        ...s,
+        [id]: { status: "error", msg: errorDetail(e, "test write failed") },
+      }));
+    }
+    window.setTimeout(() => {
+      setTestState((s) => {
+        const { [id]: _unused, ...rest } = s;
+        return rest;
+      });
+    }, 8000);
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="max-w-2xl text-xs text-muted-foreground">
+          Each enabled target receives DNS + DHCP counter deltas and, if
+          selected, point-in-time IPAM utilization and per-scope lease gauges,
+          as InfluxDB line protocol. Counter deltas carry the 60&nbsp;s agent
+          bucket's own timestamp — that bucket, not the push interval, is the
+          resolution floor.
+        </div>
+        {isSuperadmin && (
+          <button
+            type="button"
+            onClick={() => setEditing({ mode: "create" })}
+            className="inline-flex flex-shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:opacity-90"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add Target
+          </button>
+        )}
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full min-w-[860px] text-xs">
+          <thead className="bg-muted/40 text-left text-[11px] uppercase tracking-wider text-muted-foreground">
+            <tr>
+              <th className="whitespace-nowrap px-3 py-2 font-medium">Name</th>
+              <th className="whitespace-nowrap px-3 py-2 font-medium">
+                Version
+              </th>
+              <th className="whitespace-nowrap px-3 py-2 font-medium">
+                Destination
+              </th>
+              <th className="whitespace-nowrap px-3 py-2 font-medium">
+                Carries
+              </th>
+              <th className="whitespace-nowrap px-3 py-2 font-medium">
+                Last push
+              </th>
+              <th className="whitespace-nowrap px-3 py-2 font-medium">
+                Status
+              </th>
+              <th className="whitespace-nowrap px-3 py-2 text-right font-medium">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y">
+            {isLoading ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="px-3 py-4 text-center text-muted-foreground"
+                >
+                  Loading…
+                </td>
+              </tr>
+            ) : targets.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="px-3 py-6 text-center text-muted-foreground"
+                >
+                  No InfluxDB targets configured.
+                </td>
+              </tr>
+            ) : (
+              targets.map((t) => {
+                const dest =
+                  t.version === "v1"
+                    ? `${t.url || "?"} · db=${t.database || "?"}`
+                    : `${t.url || "?"} · ${t.version === "v3" ? "database" : "bucket"}=${t.bucket || "?"}`;
+                const carries = [
+                  t.push_dns_metrics ? "dns" : null,
+                  t.push_dhcp_metrics ? "dhcp" : null,
+                  t.push_subnet_utilization ? "ipam" : null,
+                  t.push_dhcp_scope_leases ? "leases" : null,
+                ]
+                  .filter(Boolean)
+                  .join(" · ");
+                const ts = testState[t.id];
+                return (
+                  <tr key={t.id}>
+                    <td className="whitespace-nowrap px-3 py-2 font-medium">
+                      {t.name}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2">{t.version}</td>
+                    <td className="break-all px-3 py-2 font-mono text-[11px]">
+                      {dest}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                      {carries || "nothing selected"}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                      {relativeTime(t.last_push_at)}
+                      {t.last_push_at && (
+                        <span className="ml-1 text-[11px]">
+                          ({t.last_push_points} pts)
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2">
+                      {!t.enabled ? (
+                        <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                          disabled
+                        </span>
+                      ) : t.last_push_error ? (
+                        <span
+                          className="inline-flex items-center gap-1 rounded bg-red-500/15 px-1.5 py-0.5 text-[11px] text-red-600"
+                          title={t.last_push_error}
+                        >
+                          <X className="h-3 w-3" /> push failing
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 rounded bg-emerald-500/15 px-1.5 py-0.5 text-[11px] font-medium text-emerald-600">
+                          <Check className="h-3 w-3" /> enabled
+                        </span>
+                      )}
+                      {ts && (
+                        <span
+                          className={
+                            "ml-2 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] " +
+                            (ts.status === "ok"
+                              ? "bg-emerald-500/15 text-emerald-600"
+                              : "bg-red-500/15 text-red-600")
+                          }
+                        >
+                          {ts.status === "ok" ? (
+                            <Check className="h-3 w-3" />
+                          ) : (
+                            <X className="h-3 w-3" />
+                          )}
+                          {ts.msg}
+                        </span>
+                      )}
+                      {t.enabled && t.last_push_error && (
+                        <div className="mt-1 max-w-md break-all text-[11px] text-red-600">
+                          {t.last_push_error}
+                        </div>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 text-right">
+                      <div className="inline-flex items-center gap-1">
+                        {isSuperadmin && (
+                          <>
+                            <button
+                              type="button"
+                              onClick={() => doTest(t.id)}
+                              title="Write one synthetic point to this target"
+                              className="rounded p-1 hover:bg-accent"
+                            >
+                              <Play className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setEditing({ mode: "edit", row: t })
+                              }
+                              title="Edit"
+                              className="rounded p-1 hover:bg-accent"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setConfirmDelete(t)}
+                              title="Delete"
+                              className="rounded p-1 text-destructive hover:bg-destructive/10"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {editing && (
+        <InfluxTargetModal
+          initial={
+            editing.mode === "create" ? EMPTY : targetToBody(editing.row)
+          }
+          existingId={editing.mode === "edit" ? editing.row.id : undefined}
+          passwordSet={
+            editing.mode === "edit" ? editing.row.password_set : false
+          }
+          tokenSet={editing.mode === "edit" ? editing.row.token_set : false}
+          onClose={() => setEditing(null)}
+        />
+      )}
+
+      {confirmDelete && (
+        <Modal
+          title={`Delete "${confirmDelete.name}"?`}
+          onClose={() => setConfirmDelete(null)}
+        >
+          <p className="text-sm text-muted-foreground">
+            Metrics stop being exported to this destination. Points already
+            written to InfluxDB are not removed.
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <button
+              onClick={() => setConfirmDelete(null)}
+              className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={() => deleteMut.mutate(confirmDelete.id)}
+              disabled={deleteMut.isPending}
+              className="rounded-md bg-destructive px-3 py-1.5 text-sm text-destructive-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {deleteMut.isPending ? "Deleting…" : "Delete"}
+            </button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+function InfluxTargetModal({
+  initial,
+  existingId,
+  passwordSet,
+  tokenSet,
+  onClose,
+}: {
+  initial: InfluxDBTargetWrite;
+  existingId?: string;
+  passwordSet: boolean;
+  tokenSet: boolean;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const [form, setForm] = useState<InfluxDBTargetWrite>(initial);
+  const [error, setError] = useState<string | null>(null);
+
+  const saveMut = useMutation({
+    mutationFn: async () => {
+      const body: InfluxDBTargetWrite = { ...form };
+      // ``null`` (the default on edit) means "keep the stored secret";
+      // the server reads an absent key the same way, so drop it rather
+      // than sending a null the operator never chose.
+      if (body.password === null) delete body.password;
+      if (body.token === null) delete body.token;
+      if (existingId) return settingsApi.updateInfluxTarget(existingId, body);
+      return settingsApi.createInfluxTarget(body);
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["influxdb-targets"] });
+      onClose();
+    },
+    onError: (e: unknown) => setError(errorDetail(e, "Save failed")),
+  });
+
+  const isV1 = form.version === "v1";
+  // v3 reuses v2's bucket parameter, but an InfluxDB 3 operator knows
+  // the value as a database name.
+  const bucketLabel = form.version === "v3" ? "Database" : "Bucket";
+
+  return (
+    <Modal
+      title={existingId ? `Edit "${initial.name}"` : "Add InfluxDB Target"}
+      onClose={onClose}
+      wide
+    >
+      <div className="space-y-3">
+        {error && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400">
+            {error}
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+          <label className="block">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Name
+            </div>
+            <input
+              className={inputCls}
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="Grafana prod"
+            />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Enabled
+            </div>
+            <select
+              className={inputCls}
+              value={form.enabled ? "1" : "0"}
+              onChange={(e) =>
+                setForm({ ...form, enabled: e.target.value === "1" })
+              }
+            >
+              <option value="1">Enabled</option>
+              <option value="0">Disabled</option>
+            </select>
+          </label>
+        </div>
+
+        <label className="block">
+          <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Version
+          </div>
+          <select
+            className={inputCls}
+            value={form.version}
+            onChange={(e) =>
+              setForm({ ...form, version: e.target.value as InfluxDBVersion })
+            }
+          >
+            {Object.entries(VERSION_LABELS).map(([k, v]) => (
+              <option key={k} value={k}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="block">
+          <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Base URL
+          </div>
+          <input
+            className={inputCls}
+            value={form.url}
+            onChange={(e) => setForm({ ...form, url: e.target.value })}
+            placeholder="http://influxdb:8086"
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            Base URL only — the write path is appended for you.
+          </p>
+        </label>
+
+        {isV1 ? (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <label className="block">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Database
+              </div>
+              <input
+                className={inputCls}
+                value={form.database}
+                onChange={(e) => setForm({ ...form, database: e.target.value })}
+                placeholder="spatiumddi"
+              />
+            </label>
+            <label className="block">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Username
+              </div>
+              <input
+                className={inputCls}
+                value={form.username}
+                onChange={(e) => setForm({ ...form, username: e.target.value })}
+                placeholder="(blank if unauthenticated)"
+              />
+            </label>
+            <label className="block">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Password
+              </div>
+              <input
+                type="password"
+                className={inputCls}
+                value={form.password ?? ""}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                placeholder={
+                  passwordSet ? "(stored — leave blank to keep)" : "Password"
+                }
+              />
+            </label>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <label className="block">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Org
+              </div>
+              <input
+                className={inputCls}
+                value={form.org}
+                onChange={(e) => setForm({ ...form, org: e.target.value })}
+                placeholder={
+                  form.version === "v3" ? "(optional on v3)" : "my-org"
+                }
+              />
+            </label>
+            <label className="block">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                {bucketLabel}
+              </div>
+              <input
+                className={inputCls}
+                value={form.bucket}
+                onChange={(e) => setForm({ ...form, bucket: e.target.value })}
+                placeholder="spatiumddi"
+              />
+            </label>
+            <label className="block">
+              <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                Token
+              </div>
+              <input
+                type="password"
+                className={inputCls}
+                value={form.token ?? ""}
+                onChange={(e) => setForm({ ...form, token: e.target.value })}
+                placeholder={
+                  tokenSet ? "(stored — leave blank to keep)" : "API token"
+                }
+              />
+            </label>
+          </div>
+        )}
+
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          <label className="block">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Measurement prefix
+            </div>
+            <input
+              className={inputCls}
+              value={form.measurement_prefix}
+              onChange={(e) =>
+                setForm({ ...form, measurement_prefix: e.target.value })
+              }
+              placeholder="spatiumddi_"
+            />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Push interval (s)
+            </div>
+            <input
+              type="number"
+              min={MIN_INTERVAL_SECONDS}
+              max={86400}
+              className={inputCls}
+              value={form.push_interval_seconds}
+              onChange={(e) =>
+                setForm({
+                  ...form,
+                  push_interval_seconds: Number(e.target.value),
+                })
+              }
+            />
+          </label>
+          <label className="block">
+            <div className="mb-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+              Timeout (s)
+            </div>
+            <input
+              type="number"
+              min={1}
+              max={120}
+              className={inputCls}
+              value={form.timeout_seconds}
+              onChange={(e) =>
+                setForm({ ...form, timeout_seconds: Number(e.target.value) })
+              }
+            />
+          </label>
+        </div>
+
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={form.verify_tls}
+            onChange={(e) => setForm({ ...form, verify_tls: e.target.checked })}
+          />
+          Verify TLS certificate (uncheck only for a private CA you cannot
+          install)
+        </label>
+
+        <div className="rounded-md border p-3">
+          <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            What this target carries
+          </div>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {(
+              [
+                [
+                  "push_dns_metrics",
+                  "DNS query counters (per server, 60 s buckets)",
+                ],
+                [
+                  "push_dhcp_metrics",
+                  "DHCP message counters (per server, 60 s buckets)",
+                ],
+                [
+                  "push_subnet_utilization",
+                  "Subnet utilization gauge (sampled at push time)",
+                ],
+                [
+                  "push_dhcp_scope_leases",
+                  "Active leases per DHCP scope (sampled at push time)",
+                ],
+              ] as const
+            ).map(([key, label]) => (
+              <label key={key} className="flex items-center gap-2 text-xs">
+                <input
+                  type="checkbox"
+                  checked={form[key]}
+                  onChange={(e) =>
+                    setForm({ ...form, [key]: e.target.checked })
+                  }
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2 border-t pt-3">
+          <button
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => saveMut.mutate()}
+            disabled={saveMut.isPending || !form.name || !form.url}
+            className="rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {saveMut.isPending ? "Saving…" : existingId ? "Save" : "Create"}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3873,6 +3873,70 @@ export interface OUITaskStatus {
   error: string | null;
 }
 
+// ── InfluxDB push export (issue #889) ─────────────────────────────────────────
+
+/** Three declared versions, two wire dialects: ``v3`` reuses the v2
+ *  write endpoint with bearer auth and bucket=database naming. */
+export type InfluxDBVersion = "v1" | "v2" | "v3";
+
+export interface InfluxDBTarget {
+  id: string;
+  name: string;
+  enabled: boolean;
+  version: InfluxDBVersion;
+  url: string;
+  verify_tls: boolean;
+  timeout_seconds: number;
+  database: string;
+  username: string;
+  /** Secrets are write-only — the server reports presence, never value. */
+  password_set: boolean;
+  org: string;
+  bucket: string;
+  token_set: boolean;
+  measurement_prefix: string;
+  push_interval_seconds: number;
+  push_dns_metrics: boolean;
+  push_dhcp_metrics: boolean;
+  push_subnet_utilization: boolean;
+  push_dhcp_scope_leases: boolean;
+  last_push_at: string | null;
+  last_push_points: number;
+  last_push_error: string | null;
+  last_dns_bucket_at: string | null;
+  last_dhcp_bucket_at: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface InfluxDBTargetWrite {
+  name: string;
+  enabled: boolean;
+  version: InfluxDBVersion;
+  url: string;
+  verify_tls: boolean;
+  timeout_seconds: number;
+  database: string;
+  username: string;
+  /** ``null`` = keep what is stored, ``""`` = clear, else replace. */
+  password?: string | null;
+  org: string;
+  bucket: string;
+  token?: string | null;
+  measurement_prefix: string;
+  push_interval_seconds: number;
+  push_dns_metrics: boolean;
+  push_dhcp_metrics: boolean;
+  push_subnet_utilization: boolean;
+  push_dhcp_scope_leases: boolean;
+}
+
+export interface InfluxDBTestResult {
+  ok: boolean;
+  message: string;
+  points: number;
+}
+
 export type AuditForwardKind = "syslog" | "webhook" | "smtp";
 export type AuditForwardWebhookFlavor =
   | "generic"
@@ -4046,6 +4110,26 @@ export const settingsApi = {
         status: string;
         target: string;
       }>(`/settings/audit-forward-targets/${id}/test`)
+      .then((r) => r.data),
+  /** Issue #889 — InfluxDB push-export targets. Superadmin-only server
+   *  side; secrets are write-only (the row carries `*_set` booleans). */
+  listInfluxTargets: () =>
+    api.get<InfluxDBTarget[]>("/settings/influxdb-targets").then((r) => r.data),
+  createInfluxTarget: (body: InfluxDBTargetWrite) =>
+    api
+      .post<InfluxDBTarget>("/settings/influxdb-targets", body)
+      .then((r) => r.data),
+  updateInfluxTarget: (id: string, body: InfluxDBTargetWrite) =>
+    api
+      .put<InfluxDBTarget>(`/settings/influxdb-targets/${id}`, body)
+      .then((r) => r.data),
+  deleteInfluxTarget: (id: string) =>
+    api.delete(`/settings/influxdb-targets/${id}`),
+  /** Writes one synthetic point — a real write, because a reachable URL
+   *  with the wrong bucket / org / token still answers a plain GET. */
+  testInfluxTarget: (id: string) =>
+    api
+      .post<InfluxDBTestResult>(`/settings/influxdb-targets/${id}/test`)
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { Modal } from "@/components/ui/modal";
 import { Toggle } from "@/components/ui/toggle";
 import { AuditForwardTargets } from "@/components/AuditForwardTargets";
+import { InfluxDBTargets } from "@/components/InfluxDBTargets";
 import { AgentBootstrapKeysSection } from "@/components/AgentBootstrapKeysSection";
 import { BrandLogo } from "@/components/BrandLogo";
 import { usePublicSettings } from "@/hooks/usePublicSettings";
@@ -98,6 +99,7 @@ type SectionId =
   | "network-domains"
   | "network-vrf"
   | "ai-digest"
+  | "influxdb-export"
   | "password-policy"
   | "account-lockout"
   | "agent-bootstrap-keys"
@@ -114,6 +116,7 @@ type SectionGroup =
   | "DNS"
   | "DHCP"
   | "Network"
+  | "Metrics"
   | "AI";
 
 interface SectionDef {
@@ -135,6 +138,10 @@ const GROUP_ORDER: SectionGroup[] = [
   "DNS",
   "DHCP",
   "Network",
+  "Metrics",
+  // "AI" was missing here while an "ai-digest" section declared it, so
+  // that section rendered only when the sidebar filter was non-empty.
+  "AI",
 ];
 
 // Which PlatformSettings keys each section owns — drives the per-section
@@ -190,6 +197,10 @@ const SECTION_FIELDS: Record<SectionId, (keyof PlatformSettings)[]> = {
   // service); they're intentionally not listed here so the singleton
   // Save button doesn't hit them.
   "audit-forward": [],
+  // Managed through the dedicated InfluxDBTargets component — the
+  // targets are their own rows, not PlatformSettings columns, so the
+  // singleton Save button owns nothing here.
+  "influxdb-export": [],
   "ip-allocation": ["ip_allocation_strategy"],
   "oui-lookup": ["oui_lookup_enabled", "oui_update_interval_hours"],
   "device-profiling": ["fingerbank_api_key"],
@@ -996,6 +1007,29 @@ const SECTIONS: SectionDef[] = [
       "rt",
       "validation",
       "strict",
+    ],
+  },
+
+  // ── Metrics ───────────────────────────────────────────────────────────
+  {
+    id: "influxdb-export",
+    title: "InfluxDB Export",
+    group: "Metrics",
+    description:
+      "Push DNS + DHCP counter deltas and IPAM / lease gauges to InfluxDB v1, v2 or v3 as line protocol, for Grafana dashboards. Multiple destinations can run at once (a local InfluxDB alongside a hosted one); each has its own interval, measurement prefix and metric selection. Prometheus scraping at /metrics is unaffected — the two exports are independent.",
+    keywords: [
+      "influx",
+      "influxdb",
+      "metrics",
+      "export",
+      "push",
+      "grafana",
+      "timeseries",
+      "time-series",
+      "telegraf",
+      "line protocol",
+      "bucket",
+      "observability",
     ],
   },
 
@@ -1845,6 +1879,10 @@ export function SettingsPage() {
 
             {activeId === "audit-forward" && (
               <AuditForwardTargets isSuperadmin={!!isSuperadmin} />
+            )}
+
+            {activeId === "influxdb-export" && (
+              <InfluxDBTargets isSuperadmin={!!isSuperadmin} />
             )}
 
             {activeId === "dhcp" && (


### PR DESCRIPTION
Closes #889

Builds the writer `CLAUDE.md`'s tech-stack table claimed for months while `grep -ri influx` over `backend/` returned nothing. The spec shape existed in `SYSTEM_ADMIN.md` §8.2; the code was greenfield.

`InfluxDBTarget` + `backend/app/services/influxdb/` (`line_protocol` / `client` / `collect` / `push`) + a 30 s beat task with per-target interval gating, CRUD at `/settings/influxdb-targets` with a **test-write**, a Settings → Metrics → InfluxDB Export surface, and 1 MCP tool (`find_influxdb_targets`, default on, superadmin-only). Migration `a2e7f31c9b48`.

## "All versions" is three declared versions over **two** wire dialects

`v3` is not a third client. Every InfluxDB 3 product (Core, Enterprise, Cloud Dedicated, Cloud Serverless) accepts the **v2** write endpoint, so v3 reuses that path with `Authorization: Bearer` instead of `Token` and a *database* named in the `bucket` parameter.

| version | endpoint | auth | destination |
|---|---|---|---|
| `v1` | `POST /write?db=…` | basic, omitted when username *and* password are blank | `database` |
| `v2` | `POST /api/v2/write?org&bucket` | `Token …` | `bucket` (`org` required) |
| `v3` | `POST /api/v2/write?bucket` | `Bearer …` | `bucket`, labelled **Database** in the UI (`org` optional) |

All three were verified against a live server during development — v2 and v1 against `influxdb:2.7` (v1 via its DBRP compatibility mapping), v3 against `influxdb:3-core` with auth enabled and a real admin token.

## The idempotency (non-negotiable #9) is the server's, not ours

Line protocol overwrites a point with an identical measurement + tag set + timestamp, so a retry is free. That is what lets each push run **two queries per source on separate row budgets**: a forward drain (strictly `> watermark`, capped at 5 000 rows) and a replay of the closed `(watermark − 5 min, watermark]` window, so a bucket an agent reported *late* is still exported rather than skipped permanently and silently.

The separation is load-bearing, not tidiness. Fold the replay into the drain's lower bound and a fleet dense enough to fill the row cap inside that window returns a truncated batch whose maximum sits *below* the watermark — pulling the cursor backwards every tick until it pins on the oldest retained sample, with every push still reporting success and the UI still green. Replayed rows never set the cursor, so forward-only is a property of the query shape rather than something a guard has to maintain.

Watermarks advance only on a successful write, so a dead collector delays the export rather than punching a hole in it — the samples sit in Postgres until `prune_metrics` retires them, so a target that recovers inside `metric_retention_days` backfills itself. `last_push_at` moves on failure too, or a fast-failing target would retry on every 30 s tick instead of on its own interval.

## Two shapes of metric, and the difference matters on a dashboard

The DNS/DHCP counter deltas carry the **agent's own 60 s bucket timestamp**, so a backfill lands on the hour the traffic happened — and 60 s, not the push interval, is the resolution floor. The IPAM utilization and per-scope lease gauges the spec asked for are sampled *at push time* from counters the app already maintains: no new table, but also no backfill, the first point is when the target was enabled. Documented as such rather than labelled "realtime".

`active_leases` counts **distinct addresses**: `dhcp_lease` is per-server and a Kea HA pair mirrors each lease twice, so `COUNT(*)` would report 2× on exactly the deployments redundancy is for, and disagree with `pool_occupancy.py`.

## Trimmings

**Test is a real single-point write**, not a reachability ping: a correct URL with the wrong bucket, org or token answers a GET perfectly well and then rejects every point. It writes to `<prefix>export_test` and leaves the watermarks alone.

Explicitly **not a feature module** (non-negotiable #14, stated rather than assumed) — no sidebar section, no router prefix, and "off" is already `enabled=false` on the row.

Secrets follow the `audit_forward` convention: Fernet at rest, write-only in, `password_set` / `token_set` booleans out. Superadmin on every endpoint, audited, with the credential columns deliberately absent from the audit body rather than redacted.

**Also fixes the "AI" settings group**, which declared a section but was missing from `GROUP_ORDER`, so "Operator Daily Digest" rendered only when the sidebar filter was non-empty.

Docs: `SYSTEM_ADMIN.md` §8 rewritten from spec to shipped shape; `OBSERVABILITY.md` gains the section plus Grafana Flux examples (the `/ 60.0` is load-bearing — the stored value is a delta per 60 s bucket, so neither `derivative()` nor a bare plot gives queries/second); `CLAUDE.md`'s inaccurate tech-stack row corrected and the roadmap marker flipped; `SHIPPED.md`'s deferred-follow-up note updated.

## Review pass

Three findings from `/code-review high`, all fixed in `04e9e755`:

1. **`httpx.InvalidURL` escaped the writer.** It derives from `Exception`, not `httpx.HTTPError`, so a URL that passed the save-time scheme check but is malformed at request time escaped `write_lines` *and* `push_target` — aborting the whole sweep before its commit, rolling back every other target's state update and recording no error anywhere. `push_target`'s handler is now broad on purpose: it is the per-target failure-isolation boundary.
2. **The lease gauge counted rows, not addresses** (the HA double-count above).
3. **A truncated batch could drag the watermark backwards** (the two-query split above).

## Verification

- `make ci` green (ruff / black / mypy 847 files, eslint / prettier / tsc / vitest, frontend build).
- `scripts/lint_migrations.py` and `make lint-untyped-routes` both clean.
- 29 new backend tests, plus `test_api_surface_917` / `test_openapi_*` / `test_audit_forward` / `test_ai_tool_modules` re-run green.
- End to end on the dev stack against a live InfluxDB: a 10k-point backlog drained across successive ticks with watermarks advancing monotonically to the current minute, then converged to 44 points per push with no errors; measurements, tags and field types confirmed by querying them back out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
