### PR TITLE
feat(ops): capability-aware service control on compose + Helm (#890)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -315,6 +315,21 @@ DHCP_LEASE_SYNC_INTERVAL_MINUTES=5
 # gets EACCES on every Docker call.
 # DOCKER_GID=999
 
+# Service control (#890) — Start / Stop / Restart this compose project's
+# containers from Admin -> Platform Insights -> Services. Superadmin-only
+# and audited.
+#
+# Requires the docker.sock mount above. Off by default because a
+# restart-capable socket is equivalent to root on the host: with it, an
+# operator who can reach that screen can stop the API, the database, or
+# anything else in this stack.
+#
+# Scope is the api container's own compose project label, so it can only
+# ever act on containers in THIS stack — never on something else running
+# on the same host. On Kubernetes the equivalent is a rollout restart;
+# see k8s/service-control/ and the Helm values api.serviceControl.*.
+# SERVICE_CONTROL_ENABLED=true
+
 # ──────────────────────────────────────────────────────────────────────────────
 # 15. Standalone agent compose files (optional)
 # ──────────────────────────────────────────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,9 +790,65 @@ suggestion, free-space treemap.
 - ⬜ [**Config snapshots + rollback**](https://github.com/spatiumddi/spatiumddi/issues/883) — audit-log-driven revert
   of a single change plus scoped named snapshots. Distinct from #882,
   which is an agent-side safety net rather than an operator action.
-- ⬜ [**Service restart from the GUI**](https://github.com/spatiumddi/spatiumddi/issues/890) — closes the #111 gap on
-  docker-compose and Helm deployments, where the appliance's supervisor
-  path has no equivalent.
+- ✅ [**Service restart from the GUI**](https://github.com/spatiumddi/spatiumddi/issues/890) — closes the #111 gap on
+  docker-compose and Helm, where the appliance's pod restart had no
+  equivalent. One surface at **Admin → Platform Insights → Services**
+  over `app/services/service_control/` (`backends` / `compose` / `kube`),
+  `GET|POST /system/services*`, opt-in RBAC in
+  `charts/spatiumddi` + `k8s/service-control/`, and 2 MCP tools
+  (`find_services` default on, `propose_restart_service` default **off**
+  per non-negotiable #13). No migration — nothing here is persisted
+  beyond the audit row.
+  **The capability is answered before anything is attempted**, which is
+  the design point rather than a nicety: the same 503 used to mean both
+  "this deployment cannot do that" and "the daemon is down", and those
+  need opposite responses from the operator. `GET /system/services`
+  reports the live backend (`kubernetes` / `compose` / `none`), whether
+  the gate is open, and the exact toggle to flip — so the UI renders the
+  buttons that exist instead of drawing one and learning from its error.
+  **The inventory is the allowlist.** An action names a service from the
+  listing and is resolved against a *fresh* one server-side, so there is
+  no second list to keep in sync and an id that is not currently ours is
+  a 404 rather than a string handed to a daemon. On compose the scope is
+  the api container's own `com.docker.compose.project` label — needs no
+  configuration, cannot be widened by a request, and **fails closed**: a
+  container that cannot identify its own project reports the backend
+  unavailable rather than falling back to a `spatiumddi-` name prefix,
+  which a co-tenant container could match on purpose. On Kubernetes it is
+  the api pod's own namespace filtered to `app.kubernetes.io/name` /
+  `part-of=spatiumddi`, which is also why the Role carries no
+  `resourceNames` (a release-name prefix isn't expressible there, and the
+  list would silently omit any workload added later).
+  **`start` / `stop` are deliberately absent on Kubernetes.** They would
+  mean scaling to zero and back, and restoring the previous replica count
+  needs somewhere durable to remember it — a control plane that forgets
+  is worse than one that never offered.
+  **Restarting the api that serves the page is allowed and flagged.** The
+  audit row commits and the 202 returns *before* the daemon is signalled,
+  because on compose the container stops the moment the request is
+  accepted and signalling inline would abort the response into a
+  connection reset; the row records `accepted`, not `success`, since
+  nothing survives to observe the outcome. Kubernetes doesn't have the
+  problem — a rollout keeps the current pod serving.
+  Gate defaults **off** everywhere except the appliance, where
+  `appliance_mode` implies it: `POST /appliance/containers/{name}/{action}`
+  has shipped the same control since #134, so an opt-in there would take
+  a capability away rather than add one. The env gate and the RBAC are
+  separate switches on purpose — each failure is reported as itself
+  ("enable SERVICE_CONTROL_ENABLED" vs "enable api.serviceControlRBAC")
+  rather than as an empty inventory that reads as "nothing to restart".
+  **Also fixed on the way:** the Fleet restart was one button hardcoded to
+  `deploy/dns-bind9`, so a node running PowerDNS, Technitium or Kea had no
+  restart at all — now a picker fed by
+  `GET /appliance/appliances/{id}/k8s/workloads` through the supervisor
+  proxy (and `StatefulSet` joined the restart endpoint's `kind` union, or
+  the picker could list a row that errors on click). And
+  `SYSTEM_ADMIN.md` described Start/Stop/Restart across Docker,
+  Kubernetes and bare-metal SSH `systemctl`, none of which had been
+  written; that section now documents what ships and says plainly that
+  the `systemctl` path is not planned.
+  **Deferred:** remote *compose*-based agents (legacy pre-#170 installs),
+  which have no supervisor to proxy through.
 
 #### Workflow & RBAC
 

--- a/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
+++ b/appliance/mkosi.extra/usr/local/bin/spatiumddi-firstboot
@@ -803,6 +803,19 @@ spec:
       # upgrade path; docker/k8s installs leave this off by default.
       upgradeOrchestratorRBAC:
         enabled: true
+      # #890 — the Services screen lists and rollout-restarts the chart's
+      # own workloads. ``serviceControl`` (the SERVICE_CONTROL_ENABLED env)
+      # is deliberately NOT set here: ``appliance_mode`` already implies
+      # the gate in app/config.py, because the appliance has shipped the
+      # same control at POST /appliance/containers/{name}/{action} since
+      # #134 and an opt-in would take away a capability rather than add
+      # one. The RBAC half has no such history, so it is granted here —
+      # without it the api can patch a Deployment (the base Role allows
+      # that for the TLS-Secret rollover) but cannot list any workload,
+      # and the Services screen would report an empty inventory on the one
+      # deployment where control is on by default.
+      serviceControlRBAC:
+        enabled: true
       # Appliance bind mounts. /var/lib/spatiumddi-host/release-state
       # backs the setup-complete flag, slot-upgrade triggers, and the
       # maintenance flag; without this the wizard's "Finish setup"

--- a/backend/app/api/v1/appliance/supervisor.py
+++ b/backend/app/api/v1/appliance/supervisor.py
@@ -5760,6 +5760,101 @@ async def pcap_upload(capture_id: uuid.UUID, request: Request, db: DB) -> dict[s
     return {"status": final_status}
 
 
+class ApplianceWorkloadRow(BaseModel):
+    """One restartable workload on an appliance's k3s."""
+
+    kind: str
+    name: str
+    namespace: str
+    component: str
+    image: str
+    desired: int
+    ready: int
+    state: str
+    last_restarted_at: str | None = None
+
+
+class ApplianceWorkloadsResponse(BaseModel):
+    workloads: list[ApplianceWorkloadRow]
+    #: Per-kind failures. Reported rather than raised so a cluster with an
+    #: RBAC gap on one kind still lists the others.
+    errors: list[str]
+
+
+@router.get(
+    "/appliances/{appliance_id}/k8s/workloads",
+    response_model=ApplianceWorkloadsResponse,
+    dependencies=[Depends(require_permission("admin", "appliance"))],
+    summary="List restartable Deployments / DaemonSets / StatefulSets on an appliance",
+)
+async def k8s_list_workloads(
+    appliance_id: uuid.UUID,
+    current_user: CurrentUser,
+    db: DB,
+    namespace: str = "spatium",
+) -> ApplianceWorkloadsResponse:
+    """Inventory for the Fleet restart picker (#890).
+
+    Before this the Fleet UI had exactly one restart button and it was
+    hardcoded to ``deploy/dns-bind9``, so a node running PowerDNS,
+    Technitium or Kea had no restart at all. Listing the workloads the
+    appliance actually runs replaces the guess.
+
+    Read-only, and filtered to workloads labelled as ours — an operator's
+    own Deployment in the same namespace is neither listed here nor
+    restartable through the sibling endpoint, which resolves its target
+    against this same label set.
+    """
+    import json as _json  # noqa: PLC0415 — lazy; only on this path.
+
+    from app.services.appliance import k8s_proxy as _proxy  # noqa: PLC0415
+    from app.services.service_control import kube as _kube  # noqa: PLC0415
+
+    _require_superadmin(current_user)
+    row = await db.get(Appliance, appliance_id)
+    if row is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND, "Appliance not found.")
+    if row.state != APPLIANCE_STATE_APPROVED:
+        raise HTTPException(
+            status.HTTP_409_CONFLICT,
+            f"Appliance in state {row.state!r}; kubeapi proxy unavailable.",
+        )
+
+    workloads: list[dict[str, object]] = []
+    errors: list[str] = []
+    for kind, plural in _kube.WORKLOAD_KINDS:
+        api_path = f"/apis/apps/v1/namespaces/{namespace}/{plural}"
+        try:
+            status_code, body = await _proxy.k8s_call(row.id, "GET", api_path, timeout=20.0)
+        except TimeoutError:
+            raise HTTPException(
+                status.HTTP_504_GATEWAY_TIMEOUT,
+                "Supervisor didn't reply in 20s. Is the appliance heartbeating?",
+            ) from None
+        if not 200 <= status_code < 300:
+            # Report per-kind rather than failing the whole call: a
+            # cluster with no StatefulSets and an RBAC gap on them should
+            # still list the Deployments the operator came here to restart.
+            errors.append(f"{plural}: kubeapi {status_code}")
+            continue
+        try:
+            items = (_json.loads(body.decode("utf-8")) or {}).get("items") or []
+        except (ValueError, UnicodeDecodeError) as exc:
+            errors.append(f"{plural}: unparseable response ({exc})")
+            continue
+        workloads.extend(
+            {**_kube.summarise_workload(kind, obj), "namespace": namespace}
+            for obj in items
+            if _kube.is_spatium_workload(obj)
+        )
+
+    workloads.sort(key=lambda w: (str(w["kind"]), str(w["name"])))
+    return ApplianceWorkloadsResponse(
+        workloads=[ApplianceWorkloadRow(**w) for w in workloads],  # type: ignore[arg-type]
+        errors=errors,
+    )
+
+
 class ApplianceRestartDeploymentRequest(BaseModel):
     """Operator-driven Deployment / DaemonSet rollout-restart.
 
@@ -5769,7 +5864,10 @@ class ApplianceRestartDeploymentRequest(BaseModel):
     controller spin up new pods and reap the old ones one at a time.
     """
 
-    kind: Literal["Deployment", "DaemonSet"]
+    # StatefulSet joined the union in #890: the Fleet picker lists every
+    # workload kind the appliance runs, so restricting the restart to two
+    # of the three would leave rows in the picker that error on click.
+    kind: Literal["Deployment", "DaemonSet", "StatefulSet"]
     namespace: str = Field(default="spatium", min_length=1, max_length=64)
     name: str = Field(min_length=1, max_length=253)
 

--- a/backend/app/api/v1/system/__init__.py
+++ b/backend/app/api/v1/system/__init__.py
@@ -1,17 +1,20 @@
 """System-level admin surface (issue #116).
 
-Exposes factory-reset at ``/system/factory-reset/*`` (#116) and the
-support bundle at ``/system/support-bundle*`` (#875). New top-level
+Exposes factory-reset at ``/system/factory-reset/*`` (#116), the
+support bundle at ``/system/support-bundle*`` (#875) and service
+lifecycle control at ``/system/services*`` (#890). New top-level
 system endpoints land under this prefix.
 """
 
 from fastapi import APIRouter
 
 from app.api.v1.system.factory_reset import router as factory_reset_router
+from app.api.v1.system.services import router as services_router
 from app.api.v1.system.support_bundle import router as support_bundle_router
 
 router = APIRouter()
 router.include_router(factory_reset_router, prefix="/factory-reset")
+router.include_router(services_router, prefix="/services")
 router.include_router(support_bundle_router, prefix="/support-bundle")
 
 __all__ = ["router"]

--- a/backend/app/api/v1/system/services.py
+++ b/backend/app/api/v1/system/services.py
@@ -1,0 +1,192 @@
+"""Capability-aware service lifecycle control (issue #890).
+
+* ``GET  /system/services``               — capability + inventory
+* ``POST /system/services/{id}/{action}`` — start / stop / restart
+
+The capability comes back on every list, so the UI never has to infer
+"unsupported" from a 503 — which is what it had to do before, and why
+the same 503 meant both "this deployment can't do that" and "the daemon
+is down".
+
+Superadmin on both routes, demo-mode-blocked on the action, and every
+action writes an audit row **before** the response. That ordering is not
+cosmetic: on docker-compose a self-targeted restart kills this process
+the moment the daemon accepts it, so the row has to be durable first,
+and it records ``accepted`` rather than ``success`` because nothing here
+survives to observe the outcome.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, BackgroundTasks, HTTPException, status
+from pydantic import BaseModel
+
+from app.api.deps import DB, SuperAdmin
+from app.core.demo_mode import forbid_in_demo_mode
+from app.models.audit import AuditLog
+from app.services import service_control
+from app.services.service_control.backends import (
+    apply_action,
+    apply_action_detached,
+    plan_action,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+class ServiceCapabilityResponse(BaseModel):
+    backend: str
+    flavor: str
+    enabled: bool
+    supported_actions: list[str]
+    reason: str | None
+
+
+class ServiceRow(BaseModel):
+    id: str
+    name: str
+    kind: str
+    state: str
+    image: str
+    detail: str
+    actions: list[str]
+    component: str | None = None
+    desired: int | None = None
+    ready: int | None = None
+    last_restarted_at: str | None = None
+
+
+class ServiceListResponse(BaseModel):
+    capability: ServiceCapabilityResponse
+    services: list[ServiceRow]
+    #: Set when the backend is live but could not be queried. The
+    #: capability still describes what this deployment *can* do, so the
+    #: UI distinguishes "no permission to list" from "nothing to list".
+    error: str | None = None
+
+
+class ServiceActionResponse(BaseModel):
+    id: str
+    action: str
+    status: str
+    #: True when the target is the api process answering this request —
+    #: the action runs after the response and the UI should expect the
+    #: session to blink rather than treat a dropped poll as a failure.
+    self_targeted: bool
+
+
+def _row(svc: service_control.ServiceSummary) -> ServiceRow:
+    return ServiceRow(
+        id=svc.id,
+        name=svc.name,
+        kind=svc.kind,
+        state=svc.state,
+        image=svc.image,
+        detail=svc.detail,
+        actions=list(svc.actions),
+        component=svc.extra.get("component"),
+        desired=svc.extra.get("desired"),
+        ready=svc.extra.get("ready"),
+        last_restarted_at=svc.extra.get("last_restarted_at"),
+    )
+
+
+@router.get("", response_model=ServiceListResponse)
+async def list_services(_: SuperAdmin) -> ServiceListResponse:
+    """Which lifecycle backend is live, and what it can act on."""
+    cap = await service_control.capability()
+    cap_out = ServiceCapabilityResponse(
+        backend=cap.backend,
+        flavor=cap.flavor,
+        enabled=cap.enabled,
+        supported_actions=list(cap.supported_actions),
+        reason=cap.reason,
+    )
+    try:
+        rows = await service_control.list_services(cap)
+    except service_control.ServiceControlError as exc:
+        return ServiceListResponse(capability=cap_out, services=[], error=str(exc))
+    return ServiceListResponse(capability=cap_out, services=[_row(r) for r in rows])
+
+
+@router.post(
+    "/{service_id}/{action}",
+    response_model=ServiceActionResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def act_on_service(
+    service_id: str,
+    action: str,
+    user: SuperAdmin,
+    db: DB,
+    background: BackgroundTasks,
+) -> ServiceActionResponse:
+    """Start / stop / restart one service. 202 — the outcome is async.
+
+    ``service_id`` is resolved against the live inventory rather than
+    passed through, so the set of things this endpoint can touch is
+    exactly the set it just listed.
+    """
+    forbid_in_demo_mode("Service lifecycle control is disabled")
+    if action not in service_control.ACTIONS:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST,
+            f"action must be one of {list(service_control.ACTIONS)}",
+        )
+    try:
+        plan = await plan_action(service_id, action)
+    except LookupError as exc:
+        raise HTTPException(
+            status.HTTP_404_NOT_FOUND,
+            f"No controllable service {service_id!r} in this deployment.",
+        ) from exc
+    except service_control.ServiceControlError as exc:
+        raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=user.auth_source,
+            action=f"service_{plan.action}",
+            resource_type="service",
+            resource_id=plan.service.id,
+            resource_display=plan.service.name,
+            # ``accepted``, not ``success``: the action is signalled after
+            # this row is committed and, when self-targeted, after this
+            # process has stopped existing.
+            result="accepted",
+            new_value={
+                "kind": plan.service.kind,
+                "action": plan.action,
+                "self_targeted": plan.is_self,
+            },
+        )
+    )
+    await db.commit()
+
+    if plan.is_self:
+        # Defer past the response — see ``apply_action_detached``.
+        background.add_task(apply_action_detached, plan)
+    else:
+        try:
+            await apply_action(plan)
+        except service_control.ServiceControlError as exc:
+            raise HTTPException(status.HTTP_502_BAD_GATEWAY, str(exc)) from exc
+
+    logger.info(
+        "service_control_action",
+        service=plan.service.id,
+        action=plan.action,
+        self_targeted=plan.is_self,
+        user=user.username,
+    )
+    return ServiceActionResponse(
+        id=plan.service.id,
+        action=plan.action,
+        status="accepted",
+        self_targeted=plan.is_self,
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -171,6 +171,20 @@ class Settings(BaseSettings):
     # it as a scanner / SSRF / relay. See app.core.demo_mode.
     demo_mode: bool = False
 
+    # Service control (#890) — lets a superadmin start / stop / restart
+    # the stack's own services from the web UI. Default OFF, and
+    # deliberately so on both backends it can use: on docker-compose the
+    # action goes through a restart-capable ``docker.sock``, which is
+    # equivalent to root on the host; on Kubernetes it needs RBAC the
+    # chart only grants when ``api.serviceControlRBAC.enabled`` is set,
+    # so turning this on without that produces an honest 403 rather than
+    # a silent no-op. Appliance installs are exempt — ``appliance_mode``
+    # implies the gate, because ``POST /appliance/containers/{name}/
+    # {action}`` already ships the same control there and requiring a new
+    # opt-in would remove a capability rather than add one.
+    # See app/services/service_control/.
+    service_control_enabled: bool = False
+
     # Appliance mode — set true by the appliance ISO compose env so
     # the API knows it's running on an appliance image (vs. plain
     # docker-compose / k8s). Gates the "Appliance" sidebar section

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -4717,3 +4717,149 @@ register(
         required_permission=("write", "bgp_lg_peer"),
     )
 )
+
+
+# ── restart_service operation (issue #890) ─────────────────────────────
+#
+# Restarting a control-plane service is the broadest-blast-radius write
+# in the product that isn't destructive: get the target wrong and DNS or
+# DHCP goes away for the length of a rollout. So it is superadmin-gated
+# at both preview and apply, and — like the REST route — the target is
+# resolved against the *live* inventory rather than trusted from the
+# caller, which means a hallucinated service name is a clean rejection at
+# preview time instead of a string handed to a daemon.
+
+
+class RestartServiceArgs(BaseModel):
+    """Args for ``restart_service`` — restart one SpatiumDDI service."""
+
+    service_id: str = Field(
+        description=(
+            "Service id exactly as returned by the service inventory: the "
+            "compose service name (e.g. 'api', 'dns-bind9') on docker-compose, "
+            "or 'Kind/name' (e.g. 'Deployment/spatiumddi-api') on Kubernetes."
+        )
+    )
+
+
+async def _resolve_restart_target(user: User, args: RestartServiceArgs) -> tuple[Any, str | None]:
+    """Shared superadmin + capability + inventory resolution.
+
+    Returns ``(plan, None)`` on success or ``(None, reason)`` — used by
+    preview and apply so the two cannot disagree about whether a restart
+    is legal.
+    """
+    from app.core.permissions import is_effective_superadmin  # noqa: PLC0415
+    from app.services import service_control  # noqa: PLC0415
+    from app.services.service_control.backends import plan_action  # noqa: PLC0415
+
+    if not is_effective_superadmin(user):
+        return None, (
+            "Restarting a service interrupts DNS / DHCP / API traffic, so it's "
+            "restricted to superadmin users."
+        )
+    try:
+        plan = await plan_action(args.service_id, "restart")
+    except LookupError:
+        return None, (
+            f"No controllable service {args.service_id!r} in this deployment. "
+            "List the inventory first — ids differ between docker-compose and "
+            "Kubernetes."
+        )
+    except service_control.ServiceControlError as exc:
+        return None, str(exc)
+    return plan, None
+
+
+async def _preview_restart_service(
+    db: AsyncSession, user: User, args: RestartServiceArgs
+) -> PreviewResult:
+    plan, reason = await _resolve_restart_target(user, args)
+    if plan is None:
+        return PreviewResult(ok=False, detail=reason or "restart unavailable")
+    svc = plan.service
+    lines = [
+        f"Restart **{svc.name}** (`{svc.id}`, {svc.kind}) — currently {svc.state}.",
+    ]
+    if plan.is_self:
+        lines.append(
+            "⚠️ This is the API container serving this session. It will drop "
+            "the connection; the UI reconnects once it is back."
+        )
+    if svc.kind != "container":
+        lines.append(
+            "Kubernetes rollout restart: pods are replaced one at a time, so "
+            "service continues if the workload has more than one replica."
+        )
+    else:
+        lines.append("The container stops and starts; anything it serves is down meanwhile.")
+    return PreviewResult(ok=True, detail="ready", preview_text="\n".join(lines))
+
+
+async def _apply_restart_service(
+    db: AsyncSession, user: User, args: RestartServiceArgs
+) -> dict[str, Any]:
+    from app.models.audit import AuditLog  # noqa: PLC0415
+    from app.services.service_control.backends import (  # noqa: PLC0415
+        apply_action,
+        apply_action_detached,
+    )
+
+    plan, reason = await _resolve_restart_target(user, args)
+    if plan is None:
+        raise ValueError(reason or "restart unavailable")
+
+    # Audit BEFORE signalling, and record ``accepted`` rather than
+    # ``success``: a self-targeted compose restart kills this process the
+    # moment the daemon accepts it, so nothing here survives to observe
+    # the outcome. Same ordering and same wording as the REST route.
+    db.add(
+        AuditLog(
+            user_id=user.id,
+            user_display_name=user.display_name,
+            auth_source=getattr(user, "auth_source", "local") or "local",
+            action="service_restart",
+            resource_type="service",
+            resource_id=plan.service.id,
+            resource_display=plan.service.name,
+            result="accepted",
+            new_value={
+                "kind": plan.service.kind,
+                "self_targeted": plan.is_self,
+                "via": "ai_proposal",
+            },
+        )
+    )
+    await db.commit()
+
+    if plan.is_self:
+        # No response to protect here the way the REST route has, but the
+        # commit above must still land before the daemon stops us.
+        await apply_action_detached(plan)
+    else:
+        await apply_action(plan)
+    return {
+        "id": plan.service.id,
+        "name": plan.service.name,
+        "kind": plan.service.kind,
+        "action": "restart",
+        "status": "accepted",
+        "self_targeted": plan.is_self,
+    }
+
+
+register(
+    Operation(
+        name="restart_service",
+        description=(
+            "Restart one SpatiumDDI service — a compose container or a "
+            "Kubernetes workload rollout (issue #890). Superadmin only. "
+            "Always route via propose_restart_service; the operator clicks "
+            "Apply, because this interrupts live DNS / DHCP / API traffic."
+        ),
+        args_model=RestartServiceArgs,
+        preview=_preview_restart_service,
+        apply=_apply_restart_service,
+        category="admin",
+    )
+)

--- a/backend/app/services/ai/operations.py
+++ b/backend/app/services/ai/operations.py
@@ -4737,7 +4737,7 @@ class RestartServiceArgs(BaseModel):
         description=(
             "Service id exactly as returned by the service inventory: the "
             "compose service name (e.g. 'api', 'dns-bind9') on docker-compose, "
-            "or 'Kind/name' (e.g. 'Deployment/spatiumddi-api') on Kubernetes."
+            "or 'Kind:name' (e.g. 'Deployment:spatiumddi-api') on Kubernetes."
         )
     )
 

--- a/backend/app/services/ai/tools/__init__.py
+++ b/backend/app/services/ai/tools/__init__.py
@@ -58,6 +58,7 @@ from app.services.ai.tools import (  # noqa: F401, E402
     reports,
     resolver,
     saved_views,
+    services,
     snmp,
     ssh,
     support_bundle,

--- a/backend/app/services/ai/tools/services.py
+++ b/backend/app/services/ai/tools/services.py
@@ -1,0 +1,141 @@
+"""Operator Copilot tools for service lifecycle control (issue #890).
+
+* ``find_services`` — the live inventory plus the capability answer
+  (which lifecycle backend this deployment has, and what it can do).
+  Read-only, default-enabled, superadmin-only.
+* ``propose_restart_service`` — gated write, **default-DISABLED**. A
+  restart interrupts live DNS / DHCP / API traffic, which is the widest
+  non-destructive blast radius in the product, so an operator opts in
+  before the copilot can even offer it (non-negotiable #13).
+
+Both go through ``app.services.service_control``, the same module the
+REST routes use, so the copilot cannot see or act on a service the API
+would not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.permissions import is_effective_superadmin
+from app.models.auth import User
+from app.services import service_control
+from app.services.ai import operations
+from app.services.ai.tools.base import register_tool
+
+_SUPERADMIN_ONLY = (
+    "Service lifecycle control can interrupt DNS / DHCP / API traffic and "
+    "is restricted to superadmin users. Ask your platform admin."
+)
+
+
+class FindServicesArgs(BaseModel):
+    state: str | None = Field(
+        default=None,
+        description=("Filter by state: running / degraded / stopped / exited. Omit for all."),
+    )
+    name: str | None = Field(default=None, description="Substring match on service id or name.")
+
+
+@register_tool(
+    name="find_services",
+    description=(
+        "List the SpatiumDDI services this deployment can control, and report "
+        "which lifecycle backend is live (kubernetes / compose / none), whether "
+        "control is enabled, and which actions it supports. Each row carries an "
+        "id, kind, state, image and readiness detail. Use to answer 'can I "
+        "restart the DNS server from here?' or 'is the worker running?'. "
+        "Read-only and superadmin-only."
+    ),
+    args_model=FindServicesArgs,
+    category="ops",
+    default_enabled=True,
+)
+async def find_services(db: AsyncSession, user: User, args: FindServicesArgs) -> dict[str, Any]:
+    if not is_effective_superadmin(user):
+        return {"error": _SUPERADMIN_ONLY}
+
+    cap = await service_control.capability()
+    out: dict[str, Any] = {
+        "backend": cap.backend,
+        "flavor": cap.flavor,
+        "control_enabled": cap.enabled,
+        "supported_actions": list(cap.supported_actions),
+        "reason": cap.reason,
+    }
+    try:
+        rows = await service_control.list_services(cap)
+    except service_control.ServiceControlError as exc:
+        # An available-but-unqueryable backend is reported as an error,
+        # never as an empty inventory — "nothing to restart" and "I was
+        # not allowed to look" are opposite answers.
+        out["services"] = []
+        out["count"] = 0
+        out["error"] = str(exc)
+        return out
+
+    needle = (args.name or "").strip().lower()
+    filtered = [
+        r
+        for r in rows
+        if (not args.state or r.state == args.state)
+        and (not needle or needle in r.id.lower() or needle in r.name.lower())
+    ]
+    out["services"] = [
+        {
+            "id": r.id,
+            "name": r.name,
+            "kind": r.kind,
+            "state": r.state,
+            "image": r.image,
+            "detail": r.detail,
+            "actions": list(r.actions),
+            **({"component": r.extra["component"]} if r.extra.get("component") else {}),
+        }
+        for r in filtered
+    ]
+    out["count"] = len(filtered)
+    return out
+
+
+@register_tool(
+    name="propose_restart_service",
+    description=(
+        "Prepare a proposal to restart one SpatiumDDI service — a compose "
+        "container or a Kubernetes workload rollout. The operator must click "
+        "Apply; the restart interrupts whatever that service serves. Returns "
+        "kind='proposal'; surface the preview and wait for the decision. Get "
+        "the service id from find_services — ids differ between docker-compose "
+        "and Kubernetes."
+    ),
+    args_model=operations.RestartServiceArgs,
+    writes=False,  # the propose tool is read-only; apply is the write
+    category="admin",
+    default_enabled=False,
+)
+async def propose_restart_service(
+    db: AsyncSession, user: User, args: operations.RestartServiceArgs
+) -> dict[str, Any]:
+    from app.services.ai.tools.proposals import _persist_proposal, _proposal_result  # noqa: PLC0415
+
+    op = operations.get_operation("restart_service")
+    if op is None:
+        return {"error": "Operation 'restart_service' is not registered"}
+    preview = await op.preview(db, user, args)
+    if not preview.ok:
+        return {
+            "kind": "proposal_rejected",
+            "operation": "restart_service",
+            "detail": preview.detail,
+        }
+    proposal = await _persist_proposal(
+        db,
+        user=user,
+        operation="restart_service",
+        args=args.model_dump(),
+        preview_text=preview.preview_text,
+    )
+    return _proposal_result(proposal, preview_text=preview.preview_text)

--- a/backend/app/services/service_control/__init__.py
+++ b/backend/app/services/service_control/__init__.py
@@ -1,0 +1,55 @@
+"""One lifecycle-control surface across every deployment shape (issue #890).
+
+Before this, restarting a SpatiumDDI service from the web UI worked on
+exactly one deployment: the k3s appliance, through
+``/appliance/containers/{name}/{action}``. Docker-compose had read-only
+stats over ``docker.sock``; the umbrella Helm chart had nothing. The
+docs described a Start/Stop/Restart surface spanning Docker, Kubernetes
+and bare-metal SSH ``systemctl`` that had never been written.
+
+This package answers the capability question *first* — ``capability()``
+reports which lifecycle backend is live and what it can do — so the UI
+renders what actually exists instead of discovering it from a 503.
+
+Two backends, deliberately different in what they offer:
+
+* **kubernetes** — ``restart`` only, as a rollout restart (bumping
+  ``kubectl.kubernetes.io/restartedAt`` on the pod template). ``start`` /
+  ``stop`` would mean scaling a workload to zero and back, which needs
+  somewhere durable to remember the previous replica count; a control
+  plane that forgets is worse than one that never offered.
+* **compose** — ``start`` / ``stop`` / ``restart``, since the Docker
+  daemon models exactly that.
+
+Both are **allowlisted against the live inventory**: an action names a
+service from ``list_services()`` and is resolved against that list
+server-side. An id that isn't in the inventory is a 404, so no
+caller-supplied string ever reaches the daemon as a container name or a
+workload path.
+
+Gating (see ``settings.service_control_enabled``): off by default on
+compose and plain Kubernetes, because a restart-capable ``docker.sock``
+is host-root-equivalent and the Kubernetes path needs RBAC the chart
+only grants when asked. On the appliance it is on, matching the control
+that endpoint already shipped.
+"""
+
+from app.services.service_control.backends import (
+    ACTIONS,
+    ServiceControlCapability,
+    ServiceControlError,
+    ServiceSummary,
+    apply_action,
+    capability,
+    list_services,
+)
+
+__all__ = [
+    "ACTIONS",
+    "ServiceControlCapability",
+    "ServiceControlError",
+    "ServiceSummary",
+    "apply_action",
+    "capability",
+    "list_services",
+]

--- a/backend/app/services/service_control/backends.py
+++ b/backend/app/services/service_control/backends.py
@@ -1,0 +1,341 @@
+"""Backend detection + the unified service inventory (issue #890).
+
+``capability()`` is the load-bearing entry point: it answers *what can
+this deployment actually do* before anything is attempted, so the UI
+renders the buttons that exist rather than learning from a 503 that the
+one it drew does not. Detection order is kubernetes → compose → none,
+because an appliance has both a ServiceAccount and (historically) a
+docker socket, and the pods are the real workloads there.
+
+Every action resolves its target against a fresh ``list_services()``.
+That makes the live inventory the allowlist — there is no separate list
+to keep in sync, and a caller-supplied id that is not currently ours is
+a 404 rather than a string handed to a daemon.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+import anyio
+import structlog
+
+from app.config import settings
+from app.services.service_control import compose as compose_backend
+from app.services.service_control import kube as kube_backend
+
+logger = structlog.get_logger(__name__)
+
+Backend = Literal["kubernetes", "compose", "none"]
+Action = Literal["start", "stop", "restart"]
+
+ACTIONS: tuple[str, ...] = ("start", "stop", "restart")
+
+# Kubernetes offers restart only — see ``kube.py`` for why start/stop are
+# deliberately absent rather than merely unimplemented.
+_KUBE_ACTIONS: tuple[str, ...] = ("restart",)
+_COMPOSE_ACTIONS: tuple[str, ...] = ("start", "stop", "restart")
+
+
+class ServiceControlError(RuntimeError):
+    """A lifecycle action could not be performed."""
+
+
+@dataclass(frozen=True)
+class ServiceSummary:
+    """One controllable unit, in whichever vocabulary its backend uses.
+
+    ``id`` is stable across polls and is what an action names: the
+    compose *service* name (``api``, ``worker``) or ``Kind/name`` for a
+    workload. Not a container id or pod name — those churn on every
+    restart, which is precisely what the operator just asked for.
+    """
+
+    id: str
+    name: str
+    kind: str
+    state: str
+    image: str = ""
+    detail: str = ""
+    actions: tuple[str, ...] = ()
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ServiceControlCapability:
+    backend: Backend
+    #: ``k3s-appliance`` / ``kubernetes`` / ``compose`` / ``none`` — the
+    #: backend plus enough context for the UI to name it honestly.
+    flavor: str
+    enabled: bool
+    supported_actions: tuple[str, ...]
+    #: Populated whenever ``enabled`` is false, or the backend is
+    #: reachable but degraded. Always operator-actionable prose.
+    reason: str | None = None
+
+
+def _control_gate_open() -> bool:
+    """Is lifecycle control allowed on this deployment?
+
+    Off by default. The appliance is the exception: it already ships
+    ``POST /appliance/containers/{name}/{action}`` with the same blast
+    radius, so requiring a new opt-in there would remove a control that
+    exists rather than adding one that does not.
+    """
+    return bool(settings.service_control_enabled or settings.appliance_mode)
+
+
+async def capability() -> ServiceControlCapability:
+    """Which lifecycle backend is live, and may it be used."""
+    gate = _control_gate_open()
+
+    if kube_backend.available():
+        flavor = "k3s-appliance" if settings.appliance_mode else "kubernetes"
+        reason = None
+        if not gate:
+            reason = (
+                "Service control is disabled. Set SERVICE_CONTROL_ENABLED=true on "
+                "the api (Helm: api.serviceControl.enabled) and grant the rollout "
+                "RBAC with api.serviceControlRBAC.enabled."
+            )
+        return ServiceControlCapability(
+            backend="kubernetes",
+            flavor=flavor,
+            enabled=gate,
+            supported_actions=_KUBE_ACTIONS,
+            reason=reason,
+        )
+
+    if compose_backend.socket_available():
+        identity = await compose_backend.own_identity()
+        if identity is None:
+            return ServiceControlCapability(
+                backend="none",
+                flavor="compose",
+                enabled=False,
+                supported_actions=(),
+                reason=(
+                    "The Docker socket is mounted but the api container's own "
+                    "compose project could not be read, so there is no safe scope "
+                    "to act within. Service control stays off."
+                ),
+            )
+        reason = None
+        if not gate:
+            reason = (
+                "Service control is disabled. Set SERVICE_CONTROL_ENABLED=true on "
+                "the api container — a restart-capable docker.sock is equivalent to "
+                "root on the host, so it is opt-in."
+            )
+        return ServiceControlCapability(
+            backend="compose",
+            flavor="compose",
+            enabled=gate,
+            supported_actions=_COMPOSE_ACTIONS,
+            reason=reason,
+        )
+
+    return ServiceControlCapability(
+        backend="none",
+        flavor="none",
+        enabled=False,
+        supported_actions=(),
+        reason=(
+            "No lifecycle backend is reachable: neither a Kubernetes ServiceAccount "
+            f"nor {compose_backend.DOCKER_SOCKET} is mounted into the api container."
+        ),
+    )
+
+
+async def list_services(cap: ServiceControlCapability | None = None) -> list[ServiceSummary]:
+    """The controllable inventory for the live backend.
+
+    Returns an empty list — not an error — when no backend is available,
+    so a caller can render the capability's ``reason`` without a special
+    case. A backend that IS available but fails to answer raises, because
+    an empty inventory would read as "nothing to restart".
+    """
+    cap = cap or await capability()
+    if cap.backend == "kubernetes":
+        try:
+            rows = await anyio.to_thread.run_sync(kube_backend.list_workloads)
+        except kube_backend.KubeControlError as exc:
+            raise ServiceControlError(str(exc)) from exc
+        return [
+            ServiceSummary(
+                id=f"{r['kind']}/{r['name']}",
+                name=r["name"],
+                kind=r["kind"],
+                state=r["state"],
+                image=r["image"],
+                detail=f"{r['ready']}/{r['desired']} ready",
+                actions=_KUBE_ACTIONS if cap.enabled else (),
+                extra={
+                    "component": r["component"],
+                    "desired": r["desired"],
+                    "ready": r["ready"],
+                    "last_restarted_at": r["last_restarted_at"],
+                },
+            )
+            for r in rows
+        ]
+
+    if cap.backend == "compose":
+        identity = await compose_backend.own_identity()
+        if identity is None:
+            raise ServiceControlError("compose project for the api container is unknown")
+        try:
+            rows = [
+                compose_backend.summarise(r)
+                for r in await compose_backend.list_project_containers(identity.project)
+            ]
+        except compose_backend.ComposeUnavailableError as exc:
+            raise ServiceControlError(str(exc)) from exc
+        out: list[ServiceSummary] = []
+        for r in rows:
+            # A container with no compose-service label is a one-off
+            # (``compose run``) and has no stable id to act on.
+            if not r["service"]:
+                continue
+            out.append(
+                ServiceSummary(
+                    id=r["service"],
+                    name=r["container_name"] or r["service"],
+                    kind="container",
+                    state=r["state"],
+                    image=r["image"],
+                    detail=r["status"],
+                    actions=_COMPOSE_ACTIONS if cap.enabled else (),
+                    extra={
+                        "container_id": r["container_id"],
+                        "project": identity.project,
+                        # Stamped per row so ``_self_service_id`` compares
+                        # against the daemon's own answer rather than
+                        # ``$HOSTNAME``, which an operator can override.
+                        "self_container_id": identity.container_id,
+                    },
+                )
+            )
+        out.sort(key=lambda s: s.id)
+        return out
+
+    return []
+
+
+def _self_service_id(services: list[ServiceSummary]) -> str | None:
+    """Which inventory row is the api process serving this request?
+
+    Only meaningful on compose, where stopping or restarting ourselves
+    kills the connection mid-response. On Kubernetes a rollout keeps the
+    current pod serving until the replacement is ready, so there is
+    nothing to defer.
+
+    Matches on the container id the *daemon* reported for us, falling
+    back to ``$HOSTNAME`` only when that is missing: compose lets a
+    service set ``hostname:``, and there the two are not the same value.
+    Getting this wrong is not a security problem but it is a visible one
+    — the operator gets a connection reset instead of a 202.
+    """
+    host = os.environ.get("HOSTNAME", "").strip()
+    for svc in services:
+        own = str(svc.extra.get("self_container_id") or "")
+        cid = str(svc.extra.get("container_id") or "")
+        if own and cid and cid == own:
+            return svc.id
+        if host and cid and cid.startswith(host[:12]):
+            return svc.id
+    return None
+
+
+@dataclass(frozen=True)
+class ActionPlan:
+    """A resolved, allowlisted action — everything needed to perform it."""
+
+    service: ServiceSummary
+    action: str
+    #: True when the target is the api container answering this request.
+    #: The router returns 202 and performs the action *after* the
+    #: response, because on compose the daemon stops us immediately and
+    #: the operator would otherwise see a connection reset.
+    is_self: bool
+
+
+async def plan_action(service_id: str, action: str) -> ActionPlan:
+    """Resolve ``service_id`` against the live inventory.
+
+    Raises ``LookupError`` when the id is not currently one of ours and
+    ``ServiceControlError`` when the backend or action is unavailable —
+    the router maps those to 404 and 409/503 respectively.
+    """
+    cap = await capability()
+    if not cap.enabled:
+        raise ServiceControlError(cap.reason or "Service control is not available.")
+    if action not in cap.supported_actions:
+        raise ServiceControlError(
+            f"{cap.backend} supports {list(cap.supported_actions)}, not {action!r}"
+        )
+    services = await list_services(cap)
+    match = next((s for s in services if s.id == service_id), None)
+    if match is None:
+        raise LookupError(service_id)
+    return ActionPlan(service=match, action=action, is_self=_self_service_id(services) == match.id)
+
+
+async def apply_action(plan: ActionPlan) -> None:
+    """Perform a previously-resolved action. Raises ``ServiceControlError``."""
+    if plan.service.kind == "container":
+        container_id = str(plan.service.extra.get("container_id") or "")
+        if not container_id:
+            raise ServiceControlError(f"no container id for {plan.service.id!r}")
+        try:
+            await compose_backend.act(container_id, plan.action)
+        except compose_backend.ComposeUnavailableError as exc:
+            raise ServiceControlError(str(exc)) from exc
+        return
+
+    try:
+        await anyio.to_thread.run_sync(
+            kube_backend.rollout_restart, plan.service.kind, plan.service.name
+        )
+    except kube_backend.KubeControlError as exc:
+        raise ServiceControlError(str(exc)) from exc
+
+
+async def apply_action_detached(plan: ActionPlan) -> None:
+    """Run ``apply_action`` after the response has been sent.
+
+    Used for a self-targeted compose action: the daemon kills this
+    process the moment it accepts the request, so signalling inline would
+    abort the response and the operator would see a connection reset
+    instead of the 202 that says it worked.
+    """
+    try:
+        await apply_action(plan)
+    except ServiceControlError as exc:
+        # Nothing left to return it to — the response is already sent —
+        # so the log is the only record, and the audit row written before
+        # the response deliberately says "accepted", not "succeeded".
+        logger.warning(
+            "service_control_detached_action_failed",
+            service=plan.service.id,
+            action=plan.action,
+            error=str(exc),
+        )
+
+
+__all__ = [
+    "ACTIONS",
+    "Action",
+    "ActionPlan",
+    "Backend",
+    "ServiceControlCapability",
+    "ServiceControlError",
+    "ServiceSummary",
+    "apply_action",
+    "apply_action_detached",
+    "capability",
+    "list_services",
+    "plan_action",
+]

--- a/backend/app/services/service_control/backends.py
+++ b/backend/app/services/service_control/backends.py
@@ -33,6 +33,11 @@ Action = Literal["start", "stop", "restart"]
 
 ACTIONS: tuple[str, ...] = ("start", "stop", "restart")
 
+# Separator between a Kubernetes workload's kind and name in a service
+# id. A colon, not a slash — see ``ServiceSummary.id`` for why a slash
+# makes the action route unreachable.
+WORKLOAD_ID_SEP = ":"
+
 # Kubernetes offers restart only — see ``kube.py`` for why start/stop are
 # deliberately absent rather than merely unimplemented.
 _KUBE_ACTIONS: tuple[str, ...] = ("restart",)
@@ -48,9 +53,17 @@ class ServiceSummary:
     """One controllable unit, in whichever vocabulary its backend uses.
 
     ``id`` is stable across polls and is what an action names: the
-    compose *service* name (``api``, ``worker``) or ``Kind/name`` for a
+    compose *service* name (``api``, ``worker``) or ``Kind:name`` for a
     workload. Not a container id or pod name — those churn on every
     restart, which is precisely what the operator just asked for.
+
+    **The separator is a colon, not a slash, and that is load-bearing.**
+    The action route is ``POST /system/services/{service_id}/{action}``,
+    where a path parameter matches ``[^/]+`` against the *unquoted*
+    path — so a ``%2F`` in the id is unescaped before routing and the
+    request misses the route entirely, 404ing before it reaches any
+    handler. Neither compose service names nor Kubernetes object names
+    may contain a colon, so ``Kind:name`` stays unambiguous.
     """
 
     id: str
@@ -165,7 +178,7 @@ async def list_services(cap: ServiceControlCapability | None = None) -> list[Ser
             raise ServiceControlError(str(exc)) from exc
         return [
             ServiceSummary(
-                id=f"{r['kind']}/{r['name']}",
+                id=f"{r['kind']}{WORKLOAD_ID_SEP}{r['name']}",
                 name=r["name"],
                 kind=r["kind"],
                 state=r["state"],
@@ -313,20 +326,24 @@ async def apply_action_detached(plan: ActionPlan) -> None:
     """
     try:
         await apply_action(plan)
-    except ServiceControlError as exc:
-        # Nothing left to return it to — the response is already sent —
-        # so the log is the only record, and the audit row written before
-        # the response deliberately says "accepted", not "succeeded".
+    # Broad on purpose: this runs after the response, so anything that
+    # escapes surfaces as an unhandled background-task error with no
+    # connection to return it on. The log is the only record — and the
+    # audit row written before the response deliberately says
+    # "accepted", not "succeeded", for exactly this reason.
+    except Exception as exc:  # noqa: BLE001
         logger.warning(
             "service_control_detached_action_failed",
             service=plan.service.id,
             action=plan.action,
             error=str(exc),
+            error_type=type(exc).__name__,
         )
 
 
 __all__ = [
     "ACTIONS",
+    "WORKLOAD_ID_SEP",
     "Action",
     "ActionPlan",
     "Backend",

--- a/backend/app/services/service_control/compose.py
+++ b/backend/app/services/service_control/compose.py
@@ -1,0 +1,170 @@
+"""Docker-compose lifecycle backend (issue #890).
+
+Talks to the local Docker daemon over the UDS the operator mounts into
+the api container — the same socket ``api/v1/admin/containers.py``
+already reads stats from, so no new plumbing and no new privilege
+beyond what the mount already grants.
+
+**The allowlist is the compose project we are ourselves in.** The api
+container reads its *own* labels (``com.docker.compose.project``) and
+only ever acts on containers carrying the same value. That needs no
+configuration, cannot be widened by a request, and fails closed: if we
+cannot identify our own project — the api is not running under compose,
+or the socket does not expose us — the backend reports unavailable
+rather than falling back to a name prefix, which a co-tenant container
+could match on purpose.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+DOCKER_SOCKET = "/var/run/docker.sock"
+
+_PROJECT_LABEL = "com.docker.compose.project"
+_SERVICE_LABEL = "com.docker.compose.service"
+
+
+class ComposeUnavailableError(RuntimeError):
+    """The Docker socket is absent, unreachable, or cannot identify us."""
+
+
+def socket_available() -> bool:
+    try:
+        return Path(DOCKER_SOCKET).is_socket()
+    except OSError:
+        return False
+
+
+def _client() -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        base_url="http://docker",
+        transport=httpx.AsyncHTTPTransport(uds=DOCKER_SOCKET),
+        timeout=15.0,
+    )
+
+
+def _self_id() -> str:
+    """Our own container id.
+
+    Docker sets the container hostname to the short container id unless
+    the operator overrode it, and the Docker API accepts a short id or a
+    name wherever it accepts an id — so this resolves either way.
+    """
+    return os.environ.get("HOSTNAME", "").strip()
+
+
+@dataclass(frozen=True)
+class SelfIdentity:
+    """Who the api container is, per the daemon.
+
+    ``container_id`` comes from the same inspect call as ``project``
+    rather than being assumed equal to ``$HOSTNAME``: compose lets an
+    operator set ``hostname:`` on a service, and where that happens the
+    hostname is not the container id. Self-detection matters — a
+    self-targeted action has to be deferred past the response or the
+    daemon kills this process mid-reply.
+    """
+
+    project: str
+    container_id: str
+
+
+async def own_identity() -> SelfIdentity | None:
+    """The compose project + container id of this api container.
+
+    ``None`` means "cannot establish scope", and every caller treats that
+    as unavailable rather than widening to all containers.
+    """
+    ident = _self_id()
+    if not ident:
+        return None
+    try:
+        async with _client() as client:
+            resp = await client.get(f"/containers/{ident}/json")
+            if resp.status_code != 200:
+                logger.debug("compose_self_inspect_status", status=resp.status_code)
+                return None
+            payload = resp.json() or {}
+            labels = (payload.get("Config") or {}).get("Labels") or {}
+    except (httpx.HTTPError, ValueError) as exc:
+        logger.debug("compose_self_inspect_failed", error=str(exc))
+        return None
+    project = labels.get(_PROJECT_LABEL)
+    if not project:
+        return None
+    return SelfIdentity(project=str(project), container_id=str(payload.get("Id") or "")[:12])
+
+
+def _short_name(raw_names: list[str] | None) -> str:
+    if not raw_names:
+        return ""
+    return str(raw_names[0]).lstrip("/")
+
+
+async def list_project_containers(project: str) -> list[dict[str, Any]]:
+    """Every container (running or not) in ``project``.
+
+    Filtering is done by the daemon via the ``label`` filter rather than
+    client-side, so a container that appears between the list and the
+    action still has to carry the label to be actionable.
+    """
+    # json.dumps rather than string interpolation: a project name is
+    # operator-chosen and can contain characters that would otherwise
+    # break out of the filter document.
+    filters = json.dumps({"label": [f"{_PROJECT_LABEL}={project}"]})
+    async with _client() as client:
+        resp = await client.get("/containers/json", params={"all": "true", "filters": filters})
+        if resp.status_code != 200:
+            raise ComposeUnavailableError(f"docker returned {resp.status_code} listing containers")
+        rows: list[dict[str, Any]] = resp.json()
+    return rows
+
+
+def summarise(row: dict[str, Any]) -> dict[str, Any]:
+    labels = row.get("Labels") or {}
+    return {
+        "service": str(labels.get(_SERVICE_LABEL) or ""),
+        "container_name": _short_name(row.get("Names")),
+        "container_id": str(row.get("Id", ""))[:12],
+        "image": str(row.get("Image") or ""),
+        "state": str(row.get("State") or "unknown"),
+        "status": str(row.get("Status") or ""),
+    }
+
+
+async def act(container_id: str, action: str) -> None:
+    """POST ``/containers/{id}/{action}`` and raise on anything but success.
+
+    ``container_id`` is always a full id taken from a fresh inventory
+    listing, never a caller-supplied string.
+    """
+    async with _client() as client:
+        resp = await client.post(f"/containers/{container_id}/{action}")
+    # 204 = done, 304 = already in the requested state (start on a running
+    # container). Both are the outcome the operator asked for.
+    if resp.status_code in (204, 304):
+        return
+    detail = resp.text.strip()[:300]
+    raise ComposeUnavailableError(f"docker {action} returned {resp.status_code}: {detail}")
+
+
+__all__ = [
+    "DOCKER_SOCKET",
+    "ComposeUnavailableError",
+    "SelfIdentity",
+    "act",
+    "list_project_containers",
+    "own_identity",
+    "socket_available",
+    "summarise",
+]

--- a/backend/app/services/service_control/compose.py
+++ b/backend/app/services/service_control/compose.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -53,14 +54,38 @@ def _client() -> httpx.AsyncClient:
     )
 
 
-def _self_id() -> str:
-    """Our own container id.
+# Docker bind-mounts /etc/hosts, /etc/hostname and /etc/resolv.conf from
+# /var/lib/docker/containers/<full-id>/ into every container, so the id
+# is readable out of our own mount table.
+_MOUNTINFO = Path("/proc/self/mountinfo")
+_CONTAINER_ID_RE = re.compile(r"/containers/([0-9a-f]{64})")
 
-    Docker sets the container hostname to the short container id unless
-    the operator overrode it, and the Docker API accepts a short id or a
-    name wherever it accepts an id — so this resolves either way.
+
+def _self_candidates() -> list[str]:
+    """Identifiers to try against ``/containers/{id}/json``, best first.
+
+    ``$HOSTNAME`` is NOT a reliable answer here. The Docker API resolves
+    that path segment as an id or a *name*, and while Docker defaults a
+    container's hostname to its own short id, compose lets a service set
+    ``hostname:`` — and there the value is neither. Inspect then 404s,
+    the capability collapses to ``none``, and the whole compose backend
+    disappears with no explanation.
+
+    So the mount table is tried first (it carries the real id regardless
+    of hostname) and ``$HOSTNAME`` is the fallback for the environments
+    where it isn't readable.
     """
-    return os.environ.get("HOSTNAME", "").strip()
+    out: list[str] = []
+    try:
+        match = _CONTAINER_ID_RE.search(_MOUNTINFO.read_text(encoding="utf-8"))
+        if match:
+            out.append(match.group(1))
+    except OSError as exc:
+        logger.debug("compose_self_mountinfo_failed", error=str(exc))
+    host = os.environ.get("HOSTNAME", "").strip()
+    if host and host not in out:
+        out.append(host)
+    return out
 
 
 @dataclass(frozen=True)
@@ -85,20 +110,21 @@ async def own_identity() -> SelfIdentity | None:
     ``None`` means "cannot establish scope", and every caller treats that
     as unavailable rather than widening to all containers.
     """
-    ident = _self_id()
-    if not ident:
-        return None
+    payload: dict[str, Any] | None = None
     try:
         async with _client() as client:
-            resp = await client.get(f"/containers/{ident}/json")
-            if resp.status_code != 200:
-                logger.debug("compose_self_inspect_status", status=resp.status_code)
-                return None
-            payload = resp.json() or {}
-            labels = (payload.get("Config") or {}).get("Labels") or {}
+            for ident in _self_candidates():
+                resp = await client.get(f"/containers/{ident}/json")
+                if resp.status_code == 200:
+                    payload = resp.json() or {}
+                    break
+                logger.debug("compose_self_inspect_status", ident=ident, status=resp.status_code)
     except (httpx.HTTPError, ValueError) as exc:
         logger.debug("compose_self_inspect_failed", error=str(exc))
         return None
+    if payload is None:
+        return None
+    labels = (payload.get("Config") or {}).get("Labels") or {}
     project = labels.get(_PROJECT_LABEL)
     if not project:
         return None
@@ -122,11 +148,23 @@ async def list_project_containers(project: str) -> list[dict[str, Any]]:
     # operator-chosen and can contain characters that would otherwise
     # break out of the filter document.
     filters = json.dumps({"label": [f"{_PROJECT_LABEL}={project}"]})
-    async with _client() as client:
-        resp = await client.get("/containers/json", params={"all": "true", "filters": filters})
-        if resp.status_code != 200:
-            raise ComposeUnavailableError(f"docker returned {resp.status_code} listing containers")
-        rows: list[dict[str, Any]] = resp.json()
+    # Transport failures are translated here rather than allowed to
+    # escape: an httpx timeout reaching the caller as a raw exception
+    # becomes an opaque 500 (and, on the self-targeted path, an
+    # unhandled background-task error) instead of the 502 / reported
+    # ``error`` the caller is written to surface.
+    try:
+        async with _client() as client:
+            resp = await client.get("/containers/json", params={"all": "true", "filters": filters})
+            if resp.status_code != 200:
+                raise ComposeUnavailableError(
+                    f"docker returned {resp.status_code} listing containers"
+                )
+            rows: list[dict[str, Any]] = resp.json()
+    except httpx.HTTPError as exc:
+        raise ComposeUnavailableError(f"{type(exc).__name__}: {exc}") from exc
+    except ValueError as exc:
+        raise ComposeUnavailableError(f"unparseable docker response: {exc}") from exc
     return rows
 
 
@@ -148,8 +186,11 @@ async def act(container_id: str, action: str) -> None:
     ``container_id`` is always a full id taken from a fresh inventory
     listing, never a caller-supplied string.
     """
-    async with _client() as client:
-        resp = await client.post(f"/containers/{container_id}/{action}")
+    try:
+        async with _client() as client:
+            resp = await client.post(f"/containers/{container_id}/{action}")
+    except httpx.HTTPError as exc:
+        raise ComposeUnavailableError(f"{type(exc).__name__}: {exc}") from exc
     # 204 = done, 304 = already in the requested state (start on a running
     # container). Both are the outcome the operator asked for.
     if resp.status_code in (204, 304):

--- a/backend/app/services/service_control/kube.py
+++ b/backend/app/services/service_control/kube.py
@@ -1,0 +1,197 @@
+"""Kubernetes lifecycle backend (issue #890).
+
+Rollout-restart of the chart's own workloads through the api pod's
+mounted ServiceAccount — the same mechanism the appliance's remote
+``/appliances/{id}/k8s/restart`` already drives over the supervisor
+proxy, applied locally.
+
+Scope is the api pod's own namespace, and within it only workloads
+labelled as ours (``app.kubernetes.io/name=spatiumddi`` or
+``part-of=spatiumddi`` — the umbrella and appliance charts respectively).
+A workload the operator dropped in the same namespace by hand is not
+listed and therefore not actionable, because actions resolve against the
+listing.
+
+``restart`` is the only verb. ``start`` / ``stop`` would mean scaling to
+zero and back, and restoring the previous replica count needs somewhere
+durable to keep it; a control plane that forgets how many replicas a
+workload had is worse than one that never offered to stop it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import quote
+
+import structlog
+
+from app.services.appliance import k8s
+
+logger = structlog.get_logger(__name__)
+
+# Workload kinds we list and can restart. Jobs are excluded on purpose:
+# re-running the migrate Job is a different operation with different
+# consequences, and "restart" on a completed Job means nothing.
+WORKLOAD_KINDS: tuple[tuple[str, str], ...] = (
+    ("Deployment", "deployments"),
+    ("StatefulSet", "statefulsets"),
+    ("DaemonSet", "daemonsets"),
+)
+
+_OURS_LABELS = ("app.kubernetes.io/name", "app.kubernetes.io/part-of")
+_OURS_VALUE = "spatiumddi"
+
+RESTART_ANNOTATION = "kubectl.kubernetes.io/restartedAt"
+
+
+class KubeControlError(RuntimeError):
+    """kubeapi refused, or is unreachable."""
+
+
+def available() -> bool:
+    return k8s.get_config() is not None
+
+
+def namespace() -> str | None:
+    cfg = k8s.get_config()
+    return cfg.namespace if cfg else None
+
+
+def is_spatium_workload(obj: dict[str, Any]) -> bool:
+    """Is this workload one of ours?
+
+    Both chart conventions count: the umbrella chart labels
+    ``app.kubernetes.io/name=spatiumddi``, the appliance chart
+    ``part-of=spatiumddi``. Anything else in the namespace is an
+    operator's own object and is neither listed nor actionable.
+    """
+    labels = (obj.get("metadata") or {}).get("labels") or {}
+    return any(labels.get(key) == _OURS_VALUE for key in _OURS_LABELS)
+
+
+def summarise_workload(kind: str, obj: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a kubeapi workload object to the shared summary shape.
+
+    Shared with the remote-appliance listing in
+    ``api/v1/appliance/supervisor.py``, which reads the same objects
+    through the supervisor proxy — so the local and remote Fleet views
+    cannot disagree about what a workload's state is.
+    """
+    meta = obj.get("metadata") or {}
+    st = obj.get("status") or {}
+    spec = obj.get("spec") or {}
+    if kind == "DaemonSet":
+        desired = int(st.get("desiredNumberScheduled") or 0)
+        ready = int(st.get("numberReady") or 0)
+    else:
+        # ``replicas`` is absent on a workload that has never been scaled
+        # and explicitly null while a HorizontalPodAutoscaler owns it, so
+        # the ``or 0`` covers both without treating either as a fault.
+        desired = int(spec.get("replicas") or 0)
+        ready = int(st.get("readyReplicas") or 0)
+    containers = ((spec.get("template") or {}).get("spec") or {}).get("containers") or []
+    image = str(containers[0].get("image", "")) if containers else ""
+    labels = meta.get("labels") or {}
+    return {
+        "kind": kind,
+        "name": str(meta.get("name") or ""),
+        "component": str(labels.get("app.kubernetes.io/component") or ""),
+        "image": image,
+        "desired": desired,
+        "ready": ready,
+        # A workload is "running" once every desired replica is ready;
+        # a scaled-to-zero one is reported as ``stopped`` rather than
+        # ``degraded``, because zero-of-zero ready is not a fault.
+        "state": ("stopped" if desired == 0 else ("running" if ready >= desired else "degraded")),
+        "last_restarted_at": (
+            ((spec.get("template") or {}).get("metadata") or {}).get("annotations") or {}
+        ).get(RESTART_ANNOTATION),
+    }
+
+
+def list_workloads() -> list[dict[str, Any]]:
+    """Every spatiumddi-labelled workload in the api pod's namespace."""
+    ns = namespace()
+    if ns is None:
+        raise KubeControlError("ServiceAccount not mounted; kubeapi unreachable")
+    out: list[dict[str, Any]] = []
+    for kind, plural in WORKLOAD_KINDS:
+        path = f"/apis/apps/v1/namespaces/{quote(ns)}/{plural}"
+        try:
+            status, body = k8s._request("GET", path)  # noqa: SLF001 — shared transport
+        except k8s.KubeapiUnavailableError as exc:
+            raise KubeControlError(str(exc)) from exc
+        if status == 403:
+            # The chart grants list on these only when service control is
+            # enabled. Say so rather than reporting an empty inventory,
+            # which reads as "nothing to restart".
+            raise KubeControlError(
+                f"kubeapi forbade listing {plural} in {ns}; enable "
+                "api.serviceControlRBAC in the chart values"
+            )
+        if status != 200:
+            raise KubeControlError(f"kubeapi status {status} listing {plural} in {ns}")
+        try:
+            items = (json.loads(bytes(body)) or {}).get("items") or []
+        except (ValueError, TypeError) as exc:
+            raise KubeControlError(f"unparseable kubeapi response for {plural}: {exc}") from exc
+        out.extend(summarise_workload(kind, obj) for obj in items if is_spatium_workload(obj))
+    out.sort(key=lambda r: (r["kind"], r["name"]))
+    return out
+
+
+def rollout_restart(kind: str, name: str) -> None:
+    """Bump ``restartedAt`` on one workload's pod template.
+
+    ``kind`` / ``name`` always come from a fresh ``list_workloads()``
+    match, so neither reaches kubeapi as an unvalidated path segment.
+    """
+    ns = namespace()
+    if ns is None:
+        raise KubeControlError("ServiceAccount not mounted; kubeapi unreachable")
+    plural = next((p for k, p in WORKLOAD_KINDS if k == kind), None)
+    if plural is None:
+        raise KubeControlError(f"unsupported workload kind {kind!r}")
+    path = f"/apis/apps/v1/namespaces/{quote(ns)}/{plural}/{quote(name)}"
+    payload = json.dumps(
+        {
+            "spec": {
+                "template": {
+                    "metadata": {"annotations": {RESTART_ANNOTATION: datetime.now(UTC).isoformat()}}
+                }
+            }
+        }
+    ).encode("utf-8")
+    try:
+        status, body = k8s._request(  # noqa: SLF001 — shared transport
+            "PATCH",
+            path,
+            body=payload,
+            content_type="application/strategic-merge-patch+json",
+        )
+    except k8s.KubeapiUnavailableError as exc:
+        raise KubeControlError(str(exc)) from exc
+    if status in (200, 201):
+        logger.info("service_control_rollout_restart", kind=kind, name=name, namespace=ns)
+        return
+    if status == 403:
+        raise KubeControlError(
+            f"kubeapi forbade patching {kind.lower()}/{name}; enable "
+            "api.serviceControlRBAC in the chart values"
+        )
+    raise KubeControlError(f"kubeapi status {status}: {bytes(body)[:200]!r}")
+
+
+__all__ = [
+    "RESTART_ANNOTATION",
+    "WORKLOAD_KINDS",
+    "KubeControlError",
+    "available",
+    "is_spatium_workload",
+    "list_workloads",
+    "namespace",
+    "rollout_restart",
+    "summarise_workload",
+]

--- a/backend/tests/test_service_control.py
+++ b/backend/tests/test_service_control.py
@@ -558,3 +558,153 @@ def test_self_detection_prefers_the_daemons_container_id(monkeypatch) -> None:
         ),
     ]
     assert backends._self_service_id(services) == "api"
+
+
+# ── review regressions (#890) ──────────────────────────────────────
+
+
+def test_workload_ids_never_contain_a_slash() -> None:
+    """A slash in the id makes the action route unreachable.
+
+    ``POST /system/services/{service_id}/{action}`` matches a path
+    parameter as ``[^/]+`` against the *unquoted* path, so a ``%2F`` in
+    the id is unescaped before routing and the request 404s before any
+    handler sees it. Verified live before this was caught: the encoded
+    form missed the route entirely while a slash-free id reached auth.
+    """
+    assert "/" not in backends.WORKLOAD_ID_SEP
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_service_id_survives_the_action_route(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """End-to-end proof for the finding above, over real routing."""
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    workload_id = f"Deployment{backends.WORKLOAD_ID_SEP}spatiumddi-api"
+    listed = [
+        ServiceSummary(
+            id=workload_id,
+            name="spatiumddi-api",
+            kind="Deployment",
+            state="running",
+            actions=("restart",),
+        )
+    ]
+    kube_cap = ServiceControlCapability(
+        backend="kubernetes",
+        flavor="kubernetes",
+        enabled=True,
+        supported_actions=("restart",),
+    )
+    applied: list[str] = []
+
+    async def _fake_apply(plan: backends.ActionPlan) -> None:
+        applied.append(plan.service.id)
+
+    with (
+        patch.object(backends, "capability", AsyncMock(return_value=kube_cap)),
+        patch.object(backends, "list_services", AsyncMock(return_value=listed)),
+        patch("app.api.v1.system.services.apply_action", _fake_apply),
+    ):
+        r = await client.post(f"/api/v1/system/services/{workload_id}/restart", headers=h)
+    assert r.status_code == 202, r.text
+    assert applied == [workload_id]
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_inventory_ids_are_route_safe() -> None:
+    """The id the listing produces is the id the route has to accept."""
+    with patch.object(
+        kube,
+        "list_workloads",
+        return_value=[
+            {
+                "kind": "Deployment",
+                "name": "spatiumddi-api",
+                "component": "api",
+                "image": "img",
+                "desired": 1,
+                "ready": 1,
+                "state": "running",
+                "last_restarted_at": None,
+            }
+        ],
+    ):
+        cap = ServiceControlCapability(
+            backend="kubernetes",
+            flavor="kubernetes",
+            enabled=True,
+            supported_actions=("restart",),
+        )
+        services = await backends.list_services(cap)
+    assert services[0].id == "Deployment:spatiumddi-api"
+    assert "/" not in services[0].id
+
+
+def test_self_identification_does_not_rely_on_hostname_alone(tmp_path, monkeypatch) -> None:
+    """``$HOSTNAME`` is not an id when a compose service sets ``hostname:``.
+
+    Docker resolves that path segment as an id or a *name*; a custom
+    hostname is neither, so inspect 404s, the capability collapses to
+    ``none``, and the whole compose backend silently disappears. The
+    mount table carries the real id regardless.
+    """
+    from app.services.service_control import compose as compose_mod
+
+    cid = "a" * 64
+    mountinfo = tmp_path / "mountinfo"
+    mountinfo.write_text(
+        f"1234 25 0:57 / /etc/hosts rw - ext4 /dev/sda1 rw,/var/lib/docker/containers/{cid}/hosts\n"
+    )
+    monkeypatch.setattr(compose_mod, "_MOUNTINFO", mountinfo)
+    monkeypatch.setenv("HOSTNAME", "a-friendly-name")
+    candidates = compose_mod._self_candidates()
+    # The real id first, the hostname only as a fallback.
+    assert candidates[0] == cid
+    assert "a-friendly-name" in candidates
+
+
+@pytest.mark.asyncio
+async def test_transport_failures_surface_as_backend_errors_not_500s() -> None:
+    """A raw httpx error escaping becomes an opaque 500 — or, on the
+    self-targeted path, an unhandled background-task exception."""
+    import httpx
+
+    from app.services.service_control import compose as compose_mod
+
+    class _Boom:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, *a, **kw):
+            raise httpx.ConnectTimeout("docker.sock timed out")
+
+        async def post(self, *a, **kw):
+            raise httpx.ConnectTimeout("docker.sock timed out")
+
+    with patch.object(compose_mod, "_client", lambda: _Boom()):
+        with pytest.raises(compose_mod.ComposeUnavailableError, match="ConnectTimeout"):
+            await compose_mod.list_project_containers("proj")
+        with pytest.raises(compose_mod.ComposeUnavailableError, match="ConnectTimeout"):
+            await compose_mod.act("abc123", "restart")
+
+
+@pytest.mark.asyncio
+async def test_detached_action_never_raises_past_the_response() -> None:
+    """It runs after the response, so there is nothing to return an error
+    to — an escape would be an unhandled background-task exception."""
+    plan = backends.ActionPlan(
+        service=ServiceSummary(id="api", name="proj-api-1", kind="container", state="running"),
+        action="restart",
+        is_self=True,
+    )
+
+    async def _explode(_plan: backends.ActionPlan) -> None:
+        raise RuntimeError("daemon vanished")
+
+    with patch.object(backends, "apply_action", _explode):
+        await backends.apply_action_detached(plan)  # must not raise

--- a/backend/tests/test_service_control.py
+++ b/backend/tests/test_service_control.py
@@ -1,0 +1,560 @@
+"""Service lifecycle control across deployment shapes (issue #890).
+
+Three properties carry the security of this feature, and each fails
+*quietly* rather than loudly if it regresses:
+
+* **The inventory is the allowlist.** An action resolves its target
+  against a fresh listing. A regression that passed ``service_id``
+  straight to the daemon would work perfectly for every legitimate
+  call and only show up when someone sent a name that wasn't ours.
+* **Compose scope is our own project.** Widening to a name prefix, or
+  falling back to "all containers" when self-identification fails,
+  would let the api act on a co-tenant container on the same host.
+* **The kubernetes backend offers restart only.** ``stop`` there would
+  mean scaling to zero with nothing durable remembering the replica
+  count.
+
+Plus the capability contract itself: an available-but-unqueryable
+backend must report an error, never an empty inventory — "nothing to
+restart" and "I was not allowed to look" are opposite answers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.audit import AuditLog
+from app.models.auth import User
+from app.services import service_control
+from app.services.service_control import backends, kube
+from app.services.service_control.backends import (
+    ServiceControlCapability,
+    ServiceControlError,
+    ServiceSummary,
+    plan_action,
+)
+from app.services.service_control.compose import SelfIdentity
+
+_IDENTITY = SelfIdentity(project="proj", container_id="cccccccccccc")
+
+
+# ── capability detection ───────────────────────────────────────────
+
+
+def _no_backends():
+    return (
+        patch.object(kube, "available", return_value=False),
+        patch.object(backends.compose_backend, "socket_available", return_value=False),
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_backend_names_the_missing_mount() -> None:
+    kube_p, sock_p = _no_backends()
+    with kube_p, sock_p:
+        cap = await backends.capability()
+    assert cap.backend == "none"
+    assert cap.enabled is False
+    assert cap.supported_actions == ()
+    # The reason has to be actionable — this is the string the UI shows
+    # instead of a button.
+    assert "docker.sock" in (cap.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_wins_over_compose_when_both_are_present() -> None:
+    """An appliance has both. The pods are the real workloads there."""
+    with (
+        patch.object(kube, "available", return_value=True),
+        patch.object(backends.compose_backend, "socket_available", return_value=True),
+        patch.object(backends.settings, "appliance_mode", True),
+    ):
+        cap = await backends.capability()
+    assert cap.backend == "kubernetes"
+    assert cap.flavor == "k3s-appliance"
+    # Appliance mode implies the gate — the same control already ships
+    # at POST /appliance/containers/{name}/{action}.
+    assert cap.enabled is True
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_offers_restart_only() -> None:
+    with (
+        patch.object(kube, "available", return_value=True),
+        patch.object(backends.settings, "appliance_mode", False),
+        patch.object(backends.settings, "service_control_enabled", True),
+    ):
+        cap = await backends.capability()
+    assert cap.backend == "kubernetes"
+    assert cap.supported_actions == ("restart",)
+    assert "stop" not in cap.supported_actions
+
+
+@pytest.mark.asyncio
+async def test_gate_off_reports_the_exact_toggle_to_flip() -> None:
+    with (
+        patch.object(kube, "available", return_value=True),
+        patch.object(backends.settings, "appliance_mode", False),
+        patch.object(backends.settings, "service_control_enabled", False),
+    ):
+        cap = await backends.capability()
+    assert cap.enabled is False
+    assert "SERVICE_CONTROL_ENABLED" in (cap.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_compose_fails_closed_when_it_cannot_identify_itself() -> None:
+    """No self-identification means no safe scope — not a wider one.
+
+    Falling back to a name prefix would let a co-tenant container named
+    ``spatiumddi-anything`` be restarted by this endpoint.
+    """
+    with (
+        patch.object(kube, "available", return_value=False),
+        patch.object(backends.compose_backend, "socket_available", return_value=True),
+        patch.object(backends.compose_backend, "own_identity", AsyncMock(return_value=None)),
+        patch.object(backends.settings, "service_control_enabled", True),
+    ):
+        cap = await backends.capability()
+    assert cap.backend == "none"
+    assert cap.enabled is False
+    assert "compose project" in (cap.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_compose_backend_offers_all_three_actions() -> None:
+    with (
+        patch.object(kube, "available", return_value=False),
+        patch.object(backends.compose_backend, "socket_available", return_value=True),
+        patch.object(
+            backends.compose_backend,
+            "own_identity",
+            AsyncMock(return_value=_IDENTITY),
+        ),
+        patch.object(backends.settings, "service_control_enabled", True),
+    ):
+        cap = await backends.capability()
+    assert cap.backend == "compose"
+    assert set(cap.supported_actions) == {"start", "stop", "restart"}
+
+
+# ── inventory ──────────────────────────────────────────────────────
+
+
+def _compose_row(service: str, name: str, state: str = "running") -> dict[str, Any]:
+    return {
+        "Id": "c" * 64,
+        "Names": [f"/{name}"],
+        "Image": "img:tag",
+        "State": state,
+        "Status": "Up 2 minutes",
+        "Labels": {
+            "com.docker.compose.project": "proj",
+            "com.docker.compose.service": service,
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_compose_inventory_skips_one_off_containers() -> None:
+    """``compose run`` containers have no service label and no stable id."""
+    rows = [_compose_row("api", "proj-api-1"), {**_compose_row("", "proj-run-abc")}]
+    rows[1]["Labels"].pop("com.docker.compose.service")
+    with (
+        patch.object(
+            backends.compose_backend,
+            "own_identity",
+            AsyncMock(return_value=_IDENTITY),
+        ),
+        patch.object(
+            backends.compose_backend,
+            "list_project_containers",
+            AsyncMock(return_value=rows),
+        ),
+    ):
+        cap = ServiceControlCapability(
+            backend="compose",
+            flavor="compose",
+            enabled=True,
+            supported_actions=("start", "stop", "restart"),
+        )
+        services = await backends.list_services(cap)
+    assert [s.id for s in services] == ["api"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_gate_lists_but_offers_no_actions() -> None:
+    """Read-only is a real state — the operator still gets to see what runs."""
+    with (
+        patch.object(
+            backends.compose_backend,
+            "own_identity",
+            AsyncMock(return_value=_IDENTITY),
+        ),
+        patch.object(
+            backends.compose_backend,
+            "list_project_containers",
+            AsyncMock(return_value=[_compose_row("api", "proj-api-1")]),
+        ),
+    ):
+        cap = ServiceControlCapability(
+            backend="compose",
+            flavor="compose",
+            enabled=False,
+            supported_actions=("start", "stop", "restart"),
+            reason="off",
+        )
+        services = await backends.list_services(cap)
+    assert services[0].actions == ()
+
+
+@pytest.mark.asyncio
+async def test_unqueryable_backend_raises_rather_than_reporting_empty() -> None:
+    """An empty inventory reads as "nothing to restart" — the opposite answer."""
+    with (
+        patch.object(kube, "available", return_value=True),
+        patch.object(
+            kube,
+            "list_workloads",
+            side_effect=kube.KubeControlError("kubeapi forbade listing deployments"),
+        ),
+    ):
+        cap = ServiceControlCapability(
+            backend="kubernetes",
+            flavor="kubernetes",
+            enabled=True,
+            supported_actions=("restart",),
+        )
+        with pytest.raises(ServiceControlError, match="forbade"):
+            await backends.list_services(cap)
+
+
+# ── the inventory is the allowlist ─────────────────────────────────
+
+
+_ENABLED_COMPOSE = ServiceControlCapability(
+    backend="compose",
+    flavor="compose",
+    enabled=True,
+    supported_actions=("start", "stop", "restart"),
+)
+
+
+@pytest.mark.asyncio
+async def test_unknown_service_id_never_reaches_the_daemon() -> None:
+    listed = [
+        ServiceSummary(
+            id="api",
+            name="proj-api-1",
+            kind="container",
+            state="running",
+            actions=("restart",),
+            extra={"container_id": "abc123"},
+        )
+    ]
+    with (
+        patch.object(backends, "capability", AsyncMock(return_value=_ENABLED_COMPOSE)),
+        patch.object(backends, "list_services", AsyncMock(return_value=listed)),
+    ):
+        with pytest.raises(LookupError):
+            await plan_action("../../etc/passwd", "restart")
+        with pytest.raises(LookupError):
+            await plan_action("some-other-stacks-container", "restart")
+
+
+@pytest.mark.asyncio
+async def test_action_unsupported_by_the_backend_is_refused() -> None:
+    kube_cap = ServiceControlCapability(
+        backend="kubernetes",
+        flavor="kubernetes",
+        enabled=True,
+        supported_actions=("restart",),
+    )
+    with patch.object(backends, "capability", AsyncMock(return_value=kube_cap)):
+        with pytest.raises(ServiceControlError, match="not 'stop'"):
+            await plan_action("Deployment/api", "stop")
+
+
+@pytest.mark.asyncio
+async def test_action_refused_while_the_gate_is_closed() -> None:
+    closed = ServiceControlCapability(
+        backend="compose",
+        flavor="compose",
+        enabled=False,
+        supported_actions=("start", "stop", "restart"),
+        reason="Service control is disabled.",
+    )
+    with patch.object(backends, "capability", AsyncMock(return_value=closed)):
+        with pytest.raises(ServiceControlError, match="disabled"):
+            await plan_action("api", "restart")
+
+
+# ── kubernetes label scoping ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("labels", "expected"),
+    [
+        ({"app.kubernetes.io/name": "spatiumddi"}, True),
+        ({"app.kubernetes.io/part-of": "spatiumddi"}, True),
+        ({"app.kubernetes.io/name": "someone-elses-app"}, False),
+        ({}, False),
+    ],
+)
+def test_only_spatiumddi_labelled_workloads_are_ours(
+    labels: dict[str, str], expected: bool
+) -> None:
+    assert kube.is_spatium_workload({"metadata": {"labels": labels}}) is expected
+
+
+def test_daemonset_readiness_reads_its_own_status_fields() -> None:
+    """A DaemonSet has no ``spec.replicas`` — reading it would report 0/0
+    ready on every node-local DNS / DHCP workload on the appliance."""
+    summary = kube.summarise_workload(
+        "DaemonSet",
+        {
+            "metadata": {"name": "dns-bind9", "labels": {}},
+            "spec": {"template": {"spec": {"containers": [{"image": "bind9:1"}]}}},
+            "status": {"desiredNumberScheduled": 3, "numberReady": 3},
+        },
+    )
+    assert summary["desired"] == 3
+    assert summary["ready"] == 3
+    assert summary["state"] == "running"
+
+
+def test_scaled_to_zero_is_stopped_not_degraded() -> None:
+    summary = kube.summarise_workload(
+        "Deployment",
+        {
+            "metadata": {"name": "worker", "labels": {}},
+            "spec": {"replicas": 0, "template": {"spec": {"containers": []}}},
+            "status": {},
+        },
+    )
+    assert summary["state"] == "stopped"
+
+
+def test_unsupported_kind_is_refused_before_any_kubeapi_call() -> None:
+    with patch.object(kube, "namespace", return_value="spatium"):
+        with pytest.raises(kube.KubeControlError, match="unsupported workload kind"):
+            kube.rollout_restart("Secret", "spatium-appliance-tls")
+
+
+# ── REST surface ───────────────────────────────────────────────────
+
+
+async def _superadmin(db: AsyncSession) -> str:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+@pytest.mark.asyncio
+async def test_list_reports_capability_even_with_no_backend(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    kube_p, sock_p = _no_backends()
+    with kube_p, sock_p:
+        r = await client.get("/api/v1/system/services", headers=h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["capability"]["backend"] == "none"
+    assert body["services"] == []
+    # The capability, not a 503 — the UI has to tell "cannot" from "down".
+    assert body["capability"]["reason"]
+
+
+@pytest.mark.asyncio
+async def test_non_superadmin_is_forbidden(client: AsyncClient, db_session: AsyncSession) -> None:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Plain",
+        hashed_password=hash_password("x"),
+        is_superadmin=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    h = {"Authorization": f"Bearer {create_access_token(str(user.id))}"}
+    assert (await client.get("/api/v1/system/services", headers=h)).status_code == 403
+    assert (await client.post("/api/v1/system/services/api/restart", headers=h)).status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unknown_service_is_404_and_writes_no_audit_row(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    with (
+        patch.object(backends, "capability", AsyncMock(return_value=_ENABLED_COMPOSE)),
+        patch.object(backends, "list_services", AsyncMock(return_value=[])),
+    ):
+        r = await client.post("/api/v1/system/services/nope/restart", headers=h)
+    assert r.status_code == 404, r.text
+    rows = (
+        (await db_session.execute(select(AuditLog).where(AuditLog.resource_type == "service")))
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_bad_action_is_400(client: AsyncClient, db_session: AsyncSession) -> None:
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    r = await client.post("/api/v1/system/services/api/nuke", headers=h)
+    assert r.status_code == 400, r.text
+
+
+@pytest.mark.asyncio
+async def test_action_audits_before_signalling_and_records_accepted(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``accepted``, not ``success``.
+
+    On compose a self-targeted restart kills this process the moment the
+    daemon takes the request, so nothing survives to observe the outcome
+    — and the row has to be durable before the signal either way.
+    """
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    listed = [
+        ServiceSummary(
+            id="worker",
+            name="proj-worker-1",
+            kind="container",
+            state="running",
+            actions=("restart",),
+            extra={"container_id": "abc123"},
+        )
+    ]
+    applied: list[tuple[str, str]] = []
+
+    async def _fake_apply(plan: backends.ActionPlan) -> None:
+        applied.append((plan.service.id, plan.action))
+
+    with (
+        patch.object(backends, "capability", AsyncMock(return_value=_ENABLED_COMPOSE)),
+        patch.object(backends, "list_services", AsyncMock(return_value=listed)),
+        patch("app.api.v1.system.services.apply_action", _fake_apply),
+    ):
+        r = await client.post("/api/v1/system/services/worker/restart", headers=h)
+
+    assert r.status_code == 202, r.text
+    assert r.json()["status"] == "accepted"
+    assert r.json()["self_targeted"] is False
+    assert applied == [("worker", "restart")]
+
+    row = (
+        (await db_session.execute(select(AuditLog).where(AuditLog.resource_type == "service")))
+        .scalars()
+        .one()
+    )
+    assert row.action == "service_restart"
+    assert row.resource_id == "worker"
+    assert row.result == "accepted"
+    assert row.new_value == {
+        "kind": "container",
+        "action": "restart",
+        "self_targeted": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_service_control_module_exports_stay_stable() -> None:
+    """The package facade is what the router, the MCP tool and the
+    operation all import — a rename here breaks three callers at once."""
+    for name in ("capability", "list_services", "apply_action", "ACTIONS"):
+        assert hasattr(service_control, name)
+
+
+@pytest.mark.asyncio
+async def test_self_targeted_action_is_deferred_past_the_response(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The api restarting itself must return 202 first.
+
+    On compose the daemon stops this process the moment it accepts the
+    request, so signalling inline aborts the response and the operator
+    sees a connection reset rather than the confirmation that it worked.
+    """
+    h = {"Authorization": f"Bearer {await _superadmin(db_session)}"}
+    listed = [
+        ServiceSummary(
+            id="api",
+            name="proj-api-1",
+            kind="container",
+            state="running",
+            actions=("restart",),
+            extra={
+                "container_id": _IDENTITY.container_id,
+                "self_container_id": _IDENTITY.container_id,
+            },
+        )
+    ]
+    inline: list[str] = []
+    deferred: list[str] = []
+
+    async def _inline(plan: backends.ActionPlan) -> None:
+        inline.append(plan.service.id)
+
+    async def _detached(plan: backends.ActionPlan) -> None:
+        deferred.append(plan.service.id)
+
+    with (
+        patch.object(backends, "capability", AsyncMock(return_value=_ENABLED_COMPOSE)),
+        patch.object(backends, "list_services", AsyncMock(return_value=listed)),
+        patch("app.api.v1.system.services.apply_action", _inline),
+        patch("app.api.v1.system.services.apply_action_detached", _detached),
+    ):
+        r = await client.post("/api/v1/system/services/api/restart", headers=h)
+
+    assert r.status_code == 202, r.text
+    assert r.json()["self_targeted"] is True
+    assert inline == []
+    assert deferred == ["api"]
+
+
+def test_self_detection_prefers_the_daemons_container_id(monkeypatch) -> None:
+    """``$HOSTNAME`` is not the container id when a service sets
+    ``hostname:``, so matching on it alone misses ourselves."""
+    monkeypatch.setenv("HOSTNAME", "a-friendly-name")
+    services = [
+        ServiceSummary(
+            id="api",
+            name="proj-api-1",
+            kind="container",
+            state="running",
+            extra={
+                "container_id": _IDENTITY.container_id,
+                "self_container_id": _IDENTITY.container_id,
+            },
+        ),
+        ServiceSummary(
+            id="worker",
+            name="proj-worker-1",
+            kind="container",
+            state="running",
+            extra={
+                "container_id": "dddddddddddd",
+                "self_container_id": _IDENTITY.container_id,
+            },
+        ),
+    ]
+    assert backends._self_service_id(services) == "api"

--- a/charts/spatiumddi/templates/api-rbac.yaml
+++ b/charts/spatiumddi/templates/api-rbac.yaml
@@ -54,6 +54,26 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "patch"]
+  {{- if .Values.api.serviceControlRBAC.enabled }}
+  # #890 — service lifecycle control. ``list`` so the Services screen can
+  # enumerate the chart's own workloads, ``patch`` so a rollout restart can
+  # bump ``kubectl.kubernetes.io/restartedAt`` on the pod template.
+  # Deployments already carry get+patch above; the list verb and the other
+  # two kinds are what this block adds.
+  #
+  # No ``resourceNames`` restriction, deliberately: workload names carry
+  # the release name as a prefix and a resourceNames list cannot express
+  # a prefix — it would have to be regenerated per release and would
+  # silently omit any workload added later. The narrowing that matters
+  # happens in the API instead:
+  # ``app/services/service_control/kube.py`` lists only objects labelled
+  # ``app.kubernetes.io/name=spatiumddi`` (or ``part-of``), and an action
+  # resolves its target against that listing, so an operator's own
+  # Deployment in this namespace is neither listed nor restartable.
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "patch"]
+  {{- end }}
   {{- if .Values.api.upgradeOrchestratorRBAC.enabled }}
   # #296 Phase C/D/E — the rolling-upgrade orchestrator reads
   # Deployments + Jobs in the release namespace during the chart-bump

--- a/charts/spatiumddi/templates/api.yaml
+++ b/charts/spatiumddi/templates/api.yaml
@@ -91,6 +91,13 @@ spec:
                   name: {{ include "spatiumddi.fullname" . }}-slot-image-mirror-auth
                   key: secret
             {{- end }}
+            {{- if .Values.api.serviceControl.enabled }}
+            # #890 — opt-in lifecycle control (Settings → Services). Pair
+            # with ``api.serviceControlRBAC.enabled`` or the api can see
+            # the capability but kubeapi refuses every list and patch.
+            - name: SERVICE_CONTROL_ENABLED
+              value: "true"
+            {{- end }}
             {{- with .Values.api.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/spatiumddi/values.yaml
+++ b/charts/spatiumddi/values.yaml
@@ -111,6 +111,27 @@ api:
   # resources at all.
   upgradeOrchestratorRBAC:
     enabled: false
+  # #890 — service lifecycle control (Settings → Services). Two
+  # independent switches, because they fail differently:
+  #
+  #   * ``serviceControl.enabled`` sets SERVICE_CONTROL_ENABLED on the api
+  #     and is what the capability probe reports to the UI. Without it the
+  #     Services screen renders read-only and says why.
+  #   * ``serviceControlRBAC.enabled`` grants the api SA ``list`` on
+  #     Deployments / StatefulSets / DaemonSets and ``patch`` on all three
+  #     (a rollout restart is a pod-template annotation bump). Without it
+  #     the api can list nothing and kubeapi answers 403 — which the code
+  #     surfaces as "enable api.serviceControlRBAC" rather than as an
+  #     empty inventory.
+  #
+  # Turn on both to get a working Services screen; either alone is a
+  # deliberate half-state that reports itself. Both default off: a
+  # restart interrupts live DNS / DHCP / API traffic, so it is opt-in.
+  # Requires ``serviceAccount.enabled`` for the SA to exist at all.
+  serviceControl:
+    enabled: false
+  serviceControlRBAC:
+    enabled: false
   # Appliance host bind mounts. The api writes the setup-complete
   # flag, slot-upgrade trigger files, rollback triggers, and the
   # maintenance flag into ``/var/lib/spatiumddi-host/release-state/``

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,11 +50,20 @@ services:
       CELERY_BROKER_URL: redis://redis:6379/1
       CELERY_RESULT_BACKEND: redis://redis:6379/2
       VERSION: ${SPATIUMDDI_VERSION:-dev}
+      # Service control (#890) — Admin → Platform Insights → Services
+      # gets Start / Stop / Restart buttons for THIS compose project's
+      # containers. Off by default: it needs the docker.sock mount below,
+      # and a restart-capable socket is equivalent to root on the host.
+      # Scope is the api container's own ``com.docker.compose.project``
+      # label, so it can never reach a container outside this stack.
+      SERVICE_CONTROL_ENABLED: ${SERVICE_CONTROL_ENABLED:-false}
     # Docker integration — uncomment both entries below to poll the
     # host's Docker daemon over its local Unix socket. Required when
-    # adding a Docker host with connection_type=unix. Read-only
-    # mount; SpatiumDDI only reads. Unnecessary for TCP+TLS remote
-    # daemons.
+    # adding a Docker host with connection_type=unix, and by service
+    # control (#890) — see SERVICE_CONTROL_ENABLED below. The ``:ro``
+    # mount is fine for both: it makes the socket *file* read-only, not
+    # the protocol, so lifecycle POSTs still work.
+    # Unnecessary for TCP+TLS remote daemons.
     #
     # ``DOCKER_GID`` must match the gid of ``/var/run/docker.sock``
     # on the host — find it with:

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -99,19 +99,112 @@ Clicking any component opens a detail panel:
 - Memory usage
 - Hit/miss ratio
 
-### Service Start / Stop / Restart
+### Service Start / Stop / Restart (issue #890)
 
-From the Health Dashboard, superadmins can:
-- **Start / Stop / Restart** any managed service (DHCP daemon, DNS daemon, Celery workers, API)
-- **Force sync** any DHCP or DNS server (push current config immediately)
-- **Test connectivity** to any backend server
+**Admin → Platform Insights → Services.** Superadmin-only, audited, and
+**off by default** on everything except the appliance.
 
-Service control operations are executed via:
-- **Docker/Compose**: Docker API calls to the container daemon
-- **Kubernetes**: Rollout restart via Kubernetes API
-- **Bare metal**: SSH to host, `systemctl start/stop/restart <service>`
+> This section previously described a Start/Stop/Restart surface spanning
+> Docker, Kubernetes and bare-metal SSH `systemctl`, none of which had
+> been written — the appliance's pod restart was the only thing that
+> existed. What follows is what ships.
 
-All service control actions are **audit logged**.
+#### Capability first, not a 503
+
+`GET /api/v1/system/services` answers *which lifecycle backend this
+deployment has* before anything is attempted, so the UI renders the
+actions that exist. That matters because the same 503 previously meant
+both "this deployment cannot do that" and "the daemon is down", and
+those need opposite responses from the operator.
+
+| Backend | Detected when | Actions | Mechanism |
+|---|---|---|---|
+| `kubernetes` (flavor `k3s-appliance` or `kubernetes`) | a Kubernetes ServiceAccount is projected into the api pod | `restart` | rollout restart — bump `kubectl.kubernetes.io/restartedAt` on the pod template |
+| `compose` | `/var/run/docker.sock` is mounted **and** the api can read its own `com.docker.compose.project` label | `start`, `stop`, `restart` | Docker API `POST /containers/{id}/{action}` |
+| `none` | neither | — | the response names the missing mount |
+
+**`start` / `stop` are deliberately absent on Kubernetes.** They would
+mean scaling a workload to zero and back, and restoring the previous
+replica count needs somewhere durable to remember it — a control plane
+that forgets how many replicas a workload had is worse than one that
+never offered to stop it.
+
+#### Scope: the inventory is the allowlist
+
+An action names a service from the inventory and is resolved against a
+fresh listing server-side. There is no second allowlist to keep in sync,
+and a caller-supplied id that is not currently one of ours is a 404
+rather than a string handed to a daemon.
+
+* **compose** — only containers whose `com.docker.compose.project` label
+  matches the api container's *own*. This needs no configuration and
+  cannot be widened by a request. It also fails closed: if the api
+  cannot identify its own project (it is not running under compose, or
+  the socket does not expose it), the backend reports unavailable rather
+  than falling back to a name prefix, which a co-tenant container could
+  match on purpose.
+* **kubernetes** — only workloads in the api pod's own namespace
+  labelled `app.kubernetes.io/name=spatiumddi` or
+  `app.kubernetes.io/part-of=spatiumddi`. An operator's own Deployment
+  in the same namespace is neither listed nor restartable.
+
+#### Enabling it
+
+| Deployment | Gate | RBAC / mount |
+|---|---|---|
+| Appliance | on — implied by `appliance_mode` | granted by `spatiumddi-firstboot` (`api.serviceControlRBAC`) |
+| Helm | `api.serviceControl.enabled=true` | `api.serviceControlRBAC.enabled=true` (needs `api.serviceAccount.enabled`) |
+| Raw manifests | `SERVICE_CONTROL_ENABLED=true` on the api | `kubectl apply -f k8s/service-control/rbac.yaml` |
+| docker-compose | `SERVICE_CONTROL_ENABLED=true` on the api | mount `/var/run/docker.sock` + `group_add: ["${DOCKER_GID}"]` |
+
+The two halves are independent and fail differently, which is why they
+are separate switches: without the gate the screen renders read-only and
+says so; without the RBAC, kubeapi answers 403 and the API reports
+"enable the service-control RBAC" instead of an empty inventory that
+would read as "nothing to restart".
+
+The appliance is exempt from the gate because
+`POST /api/v1/appliance/containers/{name}/{action}` has shipped the same
+control since #134 — requiring a new opt-in there would take a capability
+away rather than add one. Everywhere else it is off because a
+restart-capable `docker.sock` is equivalent to root on the host, and a
+restart interrupts live DNS / DHCP / API traffic.
+
+#### Restarting the API that serves the page
+
+Allowed, and flagged in the response as `self_targeted`. The audit row is
+committed and the `202` returned **before** the daemon is signalled — on
+compose the container stops the moment the request is accepted, so
+signalling inline would abort the response and the operator would see a
+connection reset instead of confirmation. For the same reason the row
+records `result="accepted"`, not `"success"`: nothing here survives to
+observe the outcome. On Kubernetes a rollout keeps the current pod
+serving until the replacement is ready, so this only bites on compose.
+
+#### Fleet: remote appliances
+
+The Fleet drilldown's restart is a **workload picker**, fed by
+`GET /api/v1/appliance/appliances/{id}/k8s/workloads` through the
+supervisor's kubeapi proxy, so it lists what that appliance actually
+runs. It was previously a single button hardcoded to
+`deploy/dns-bind9` — a node running PowerDNS, Technitium or Kea had no
+restart at all. Remote *compose*-based agents (legacy pre-#170 installs)
+stay out of scope.
+
+#### Not covered
+
+**Force sync** and **test connectivity** are per-server DNS / DHCP
+actions and live on those servers' own pages, not here. Bare-metal
+`systemctl` over SSH is **not** implemented and is not planned — the
+supported non-container path is the appliance, which runs k3s.
+
+#### MCP
+
+`find_services` (read, default on, superadmin-only) reports the
+capability and the inventory. `propose_restart_service` (default
+**off** — non-negotiable #13) prepares a proposal the operator must
+Apply; a restart is the widest non-destructive blast radius in the
+product, so the copilot cannot offer it until an operator opts in.
 
 ---
 

--- a/docs/features/SYSTEM_ADMIN.md
+++ b/docs/features/SYSTEM_ADMIN.md
@@ -136,6 +136,14 @@ fresh listing server-side. There is no second allowlist to keep in sync,
 and a caller-supplied id that is not currently one of ours is a 404
 rather than a string handed to a daemon.
 
+The id is the compose *service* name (`api`, `worker`) or `Kind:name`
+for a Kubernetes workload (`Deployment:spatiumddi-api`) — never a
+container id or pod name, which churn on exactly the restart the
+operator just asked for. The separator is a **colon, not a slash**,
+because the action route matches its path parameter as `[^/]+` against
+the *unquoted* path: a `%2F` in the id is unescaped before routing and
+the request would 404 before reaching any handler.
+
 * **compose** — only containers whose `com.docker.compose.project` label
   matches the api container's *own*. This needs no configuration and
   cannot be widened by a request. It also fails closed: if the api

--- a/frontend/src/components/ServicesPanel.tsx
+++ b/frontend/src/components/ServicesPanel.tsx
@@ -1,0 +1,287 @@
+/**
+ * Capability-aware service lifecycle control (issue #890).
+ *
+ * The backend answers *what this deployment can do* before anything is
+ * attempted, so this renders the actions that exist rather than drawing
+ * a button and learning from its 503 that the deployment never had one.
+ * Three shapes come out of that:
+ *
+ *  - no backend        → say which mount is missing, render nothing else
+ *  - backend, gated    → show the inventory read-only, with the exact
+ *                        toggle to flip (env var / Helm value)
+ *  - backend, enabled  → per-row actions, restricted to what the backend
+ *                        supports (Kubernetes: restart only)
+ *
+ * Restarting the API that serves this page is allowed and flagged: the
+ * request returns 202 before the daemon is signalled, so the operator
+ * sees confirmation rather than a connection reset, and the row goes
+ * into a "reconnecting" state instead of reporting failure.
+ */
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Info, Play, RefreshCw, Square } from "lucide-react";
+
+import { ConfirmModal } from "@/components/ui/confirm-modal";
+import {
+  serviceControlApi,
+  type ServiceAction,
+  type ServiceRow,
+} from "@/lib/api";
+import { cn, zebraBodyCls } from "@/lib/utils";
+
+const ACTION_LABEL: Record<ServiceAction, string> = {
+  start: "Start",
+  stop: "Stop",
+  restart: "Restart",
+};
+
+const ACTION_ICON: Record<
+  ServiceAction,
+  typeof Play | typeof Square | typeof RefreshCw
+> = {
+  start: Play,
+  stop: Square,
+  restart: RefreshCw,
+};
+
+const BACKEND_LABEL: Record<string, string> = {
+  "k3s-appliance": "Appliance (k3s)",
+  kubernetes: "Kubernetes",
+  compose: "Docker Compose",
+  none: "None",
+};
+
+function stateTone(state: string): string {
+  if (state === "running") {
+    return "bg-emerald-500/20 text-emerald-700 dark:text-emerald-400";
+  }
+  if (state === "degraded" || state === "restarting") {
+    return "bg-amber-500/20 text-amber-700 dark:text-amber-400";
+  }
+  if (state === "stopped" || state === "exited" || state === "created") {
+    return "bg-muted text-muted-foreground";
+  }
+  return "bg-rose-500/20 text-rose-700 dark:text-rose-400";
+}
+
+function errorDetail(e: unknown, fallback: string): string {
+  if (e && typeof e === "object" && "response" in e) {
+    const resp = (e as { response?: { data?: { detail?: unknown } } }).response;
+    if (resp?.data?.detail) return String(resp.data.detail);
+  }
+  return fallback;
+}
+
+export function ServicesPanel() {
+  const qc = useQueryClient();
+  const query = useQuery({
+    queryKey: ["service-control"],
+    queryFn: serviceControlApi.list,
+    refetchInterval: 10_000,
+  });
+
+  const [pending, setPending] = useState<{
+    row: ServiceRow;
+    action: ServiceAction;
+  } | null>(null);
+  const [note, setNote] = useState<{
+    tone: "ok" | "error";
+    text: string;
+  } | null>(null);
+
+  const actMut = useMutation({
+    mutationFn: ({ row, action }: { row: ServiceRow; action: ServiceAction }) =>
+      serviceControlApi.act(row.id, action),
+    onSuccess: (result) => {
+      setPending(null);
+      setNote({
+        tone: "ok",
+        text: result.self_targeted
+          ? `${ACTION_LABEL[result.action]} accepted for ${result.id} — this is the API serving this page, so it will briefly go away and come back.`
+          : `${ACTION_LABEL[result.action]} accepted for ${result.id}.`,
+      });
+      // A rollout / container restart takes a few seconds to show up;
+      // one delayed refetch on top of the 10 s poll makes the state
+      // change visible without hammering the endpoint.
+      window.setTimeout(
+        () => qc.invalidateQueries({ queryKey: ["service-control"] }),
+        3000,
+      );
+    },
+    onError: (e: unknown) => {
+      setPending(null);
+      setNote({ tone: "error", text: errorDetail(e, "Action failed") });
+    },
+  });
+
+  const cap = query.data?.capability;
+  const services = query.data?.services ?? [];
+
+  if (query.isLoading) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Detecting lifecycle backend…
+      </p>
+    );
+  }
+
+  if (!cap || cap.backend === "none") {
+    return (
+      <div className="rounded border border-amber-500/40 bg-amber-500/5 p-4">
+        <div className="flex items-center gap-2 text-sm font-medium text-amber-800 dark:text-amber-300">
+          <AlertTriangle className="h-4 w-4" />
+          No service-control backend on this deployment
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {cap?.reason ??
+            "The API could not determine how this deployment runs its services."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3 text-xs">
+        <span className="rounded bg-muted px-2 py-1 font-medium">
+          Backend: {BACKEND_LABEL[cap.flavor] ?? cap.flavor}
+        </span>
+        <span className="text-muted-foreground">
+          {cap.enabled
+            ? `Actions: ${cap.supported_actions.map((a) => ACTION_LABEL[a]).join(" · ")}`
+            : "Control disabled — read-only"}
+        </span>
+        <span className="text-muted-foreground">Auto-refresh every 10 s</span>
+      </div>
+
+      {!cap.enabled && cap.reason && (
+        <div className="rounded border border-blue-500/40 bg-blue-500/5 p-3">
+          <div className="flex items-center gap-2 text-xs font-medium text-blue-800 dark:text-blue-300">
+            <Info className="h-3.5 w-3.5" />
+            Service control is off
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">{cap.reason}</p>
+        </div>
+      )}
+
+      {query.data?.error && (
+        <div className="rounded border border-rose-500/40 bg-rose-500/5 p-3">
+          <div className="flex items-center gap-2 text-xs font-medium text-rose-800 dark:text-rose-300">
+            <AlertTriangle className="h-3.5 w-3.5" />
+            Backend is live but the inventory could not be read
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {query.data.error}
+          </p>
+        </div>
+      )}
+
+      {note && (
+        <div
+          className={cn(
+            "rounded border p-3 text-xs",
+            note.tone === "ok"
+              ? "border-emerald-500/40 bg-emerald-500/5 text-emerald-800 dark:text-emerald-300"
+              : "border-rose-500/40 bg-rose-500/5 text-rose-800 dark:text-rose-300",
+          )}
+        >
+          {note.text}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded border">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead className="bg-muted/40 text-xs">
+            <tr>
+              <th className="px-3 py-2 text-left font-medium">Service</th>
+              <th className="px-3 py-2 text-left font-medium">Kind</th>
+              <th className="px-3 py-2 text-left font-medium">State</th>
+              <th className="px-3 py-2 text-left font-medium">Detail</th>
+              <th className="px-3 py-2 text-right font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody className={zebraBodyCls}>
+            {services.length === 0 && (
+              <tr>
+                <td
+                  colSpan={5}
+                  className="px-3 py-4 text-center text-xs text-muted-foreground"
+                >
+                  No controllable services found.
+                </td>
+              </tr>
+            )}
+            {services.map((s) => (
+              <tr key={s.id}>
+                <td className="px-3 py-1.5">
+                  <div className="font-medium">{s.id}</div>
+                  <div className="text-[11px] text-muted-foreground">
+                    {s.image || s.name}
+                  </div>
+                </td>
+                <td className="px-3 py-1.5 text-xs text-muted-foreground">
+                  {s.kind}
+                </td>
+                <td className="px-3 py-1.5">
+                  <span
+                    className={cn(
+                      "inline-flex rounded px-1.5 py-0.5 text-[10px] font-medium",
+                      stateTone(s.state),
+                    )}
+                  >
+                    {s.state}
+                  </span>
+                </td>
+                <td className="px-3 py-1.5 text-xs text-muted-foreground">
+                  {s.detail || "—"}
+                </td>
+                <td className="px-3 py-1.5 text-right">
+                  <div className="inline-flex items-center gap-1">
+                    {s.actions.length === 0 && (
+                      <span className="text-[11px] text-muted-foreground">
+                        —
+                      </span>
+                    )}
+                    {s.actions.map((action) => {
+                      const Icon = ACTION_ICON[action];
+                      return (
+                        <button
+                          key={action}
+                          type="button"
+                          onClick={() => setPending({ row: s, action })}
+                          disabled={actMut.isPending}
+                          className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[11px] hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                          <Icon className="h-3 w-3" />
+                          {ACTION_LABEL[action]}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {pending && (
+        <ConfirmModal
+          open
+          title={`${ACTION_LABEL[pending.action]} ${pending.row.id}?`}
+          message={
+            pending.row.kind === "container"
+              ? `The container stops and starts. Anything ${pending.row.id} serves is unavailable meanwhile.`
+              : `Rollout ${pending.action}: pods are replaced one at a time, so service continues if this workload has more than one replica.`
+          }
+          confirmLabel={ACTION_LABEL[pending.action]}
+          tone="destructive"
+          loading={actMut.isPending}
+          onClose={() => setPending(null)}
+          onConfirm={() => actMut.mutate(pending)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ServicesPanel.tsx
+++ b/frontend/src/components/ServicesPanel.tsx
@@ -126,6 +126,28 @@ export function ServicesPanel() {
     );
   }
 
+  // A failed request is NOT "this deployment has no backend" — that is
+  // exactly the "cannot" vs "down" confusion the capability probe exists
+  // to remove, and rendering the no-backend panel here would reintroduce
+  // it one layer up. A 403 (this page is reachable without superadmin)
+  // and a network failure both land here.
+  if (query.isError) {
+    return (
+      <div className="rounded border border-rose-500/40 bg-rose-500/5 p-4">
+        <div className="flex items-center gap-2 text-sm font-medium text-rose-800 dark:text-rose-300">
+          <AlertTriangle className="h-4 w-4" />
+          Could not read the service inventory
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          {errorDetail(
+            query.error,
+            "The request failed. Service control is superadmin-only — if you are not a superadmin this is expected.",
+          )}
+        </p>
+      </div>
+    );
+  }
+
   if (!cap || cap.backend === "none") {
     return (
       <div className="rounded border border-amber-500/40 bg-amber-500/5 p-4">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12008,7 +12008,7 @@ export const applianceApprovalApi = {
   k8sRolloutRestart: (
     id: string,
     body: {
-      kind: "Deployment" | "DaemonSet";
+      kind: ApplianceWorkloadKind;
       namespace?: string;
       name: string;
     },
@@ -12020,6 +12020,16 @@ export const applianceApprovalApi = {
         kind: string;
         name: string;
       }>(`/appliance/appliances/${id}/k8s/restart`, body)
+      .then((r) => r.data),
+  /** #890 — what this appliance actually runs, so the Fleet restart
+   *  picker isn't hardcoded to one workload. Filtered server-side to
+   *  spatiumddi-labelled objects. */
+  k8sWorkloads: (id: string, namespace?: string) =>
+    api
+      .get<ApplianceWorkloadsResponse>(
+        `/appliance/appliances/${id}/k8s/workloads`,
+        { params: namespace ? { namespace } : undefined },
+      )
       .then((r) => r.data),
   // Issue #183 Phase 5 — reveal the stored kubeconfig after a
   // password re-confirmation. Same shape as the SNMP-community and
@@ -14254,6 +14264,89 @@ export const containersApi = {
   stats: (params: { prefix?: string; include_stopped?: boolean } = {}) =>
     api
       .get<ContainerStatsResponse>("/admin/containers/stats", { params })
+      .then((r) => r.data),
+};
+
+// ── Service lifecycle control (issue #890) ────────────────────────────────────
+
+/** Which lifecycle backend the deployment actually has. Reported before
+ *  anything is attempted, so the UI never infers "unsupported" from a 503. */
+/** #890 — the workload kinds the Fleet restart picker can act on.
+ *  StatefulSet joined the union so the picker can't list a row that
+ *  errors on click. */
+export type ApplianceWorkloadKind = "Deployment" | "DaemonSet" | "StatefulSet";
+
+export interface ApplianceWorkload {
+  kind: ApplianceWorkloadKind;
+  name: string;
+  namespace: string;
+  component: string;
+  image: string;
+  desired: number;
+  ready: number;
+  state: string;
+  last_restarted_at: string | null;
+}
+
+export interface ApplianceWorkloadsResponse {
+  workloads: ApplianceWorkload[];
+  /** Per-kind failures. Reported rather than swallowed so a cluster with
+   *  an RBAC gap on one kind still lists the others. */
+  errors: string[];
+}
+
+export type ServiceControlBackend = "kubernetes" | "compose" | "none";
+export type ServiceAction = "start" | "stop" | "restart";
+
+export interface ServiceControlCapability {
+  backend: ServiceControlBackend;
+  /** "k3s-appliance" | "kubernetes" | "compose" | "none" */
+  flavor: string;
+  enabled: boolean;
+  supported_actions: ServiceAction[];
+  /** Populated whenever control is unavailable — always actionable prose. */
+  reason: string | null;
+}
+
+export interface ServiceRow {
+  id: string;
+  name: string;
+  kind: string;
+  state: string;
+  image: string;
+  detail: string;
+  actions: ServiceAction[];
+  component: string | null;
+  desired: number | null;
+  ready: number | null;
+  last_restarted_at: string | null;
+}
+
+export interface ServiceListResponse {
+  capability: ServiceControlCapability;
+  services: ServiceRow[];
+  /** Backend is live but could not be queried — distinct from an empty
+   *  inventory, which would read as "nothing to restart". */
+  error: string | null;
+}
+
+export interface ServiceActionResult {
+  id: string;
+  action: ServiceAction;
+  status: string;
+  /** The target is the API serving this request; expect the session to
+   *  blink rather than treating a dropped poll as a failure. */
+  self_targeted: boolean;
+}
+
+export const serviceControlApi = {
+  list: () =>
+    api.get<ServiceListResponse>("/system/services").then((r) => r.data),
+  act: (id: string, action: ServiceAction) =>
+    api
+      .post<ServiceActionResult>(
+        `/system/services/${encodeURIComponent(id)}/${action}`,
+      )
       .then((r) => r.data),
 };
 

--- a/frontend/src/pages/admin/PlatformInsightsPage.tsx
+++ b/frontend/src/pages/admin/PlatformInsightsPage.tsx
@@ -12,6 +12,7 @@ import {
   RefreshCw,
   Server,
   Sparkles,
+  Wrench,
   Zap,
 } from "lucide-react";
 import {
@@ -28,11 +29,18 @@ import {
   type ContainerStat,
   type RedisOverview,
 } from "@/lib/api";
+import { ServicesPanel } from "@/components/ServicesPanel";
 import { cn, zebraBodyCls } from "@/lib/utils";
 import { Link } from "react-router-dom";
 import { ShieldCheck } from "lucide-react";
 
-type TabKey = "postgres" | "redis" | "containers" | "conformity" | "copilot";
+type TabKey =
+  | "postgres"
+  | "redis"
+  | "containers"
+  | "services"
+  | "conformity"
+  | "copilot";
 
 function formatBytes(n: number | null | undefined): string {
   if (n == null) return "—";
@@ -675,6 +683,18 @@ export function PlatformInsightsPage() {
               Containers
             </button>
             <button
+              onClick={() => setTab("services")}
+              className={cn(
+                "border-b-2 px-3 py-2 text-sm font-medium -mb-px transition-colors",
+                tab === "services"
+                  ? "border-primary text-foreground"
+                  : "border-transparent text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Wrench className="mr-1 inline h-3.5 w-3.5" />
+              Services
+            </button>
+            <button
               onClick={() => setTab("conformity")}
               className={cn(
                 "border-b-2 px-3 py-2 text-sm font-medium -mb-px transition-colors",
@@ -703,6 +723,7 @@ export function PlatformInsightsPage() {
 
         {tab === "postgres" && <PostgresPanel />}
         {tab === "redis" && <RedisPanel />}
+        {tab === "services" && <ServicesPanel />}
         {tab === "containers" && <ContainersPanel />}
         {tab === "conformity" && <ConformityPanel />}
         {tab === "copilot" && <AIUsagePanel />}

--- a/frontend/src/pages/appliance/FleetTab.tsx
+++ b/frontend/src/pages/appliance/FleetTab.tsx
@@ -30,6 +30,7 @@ import {
   dhcpApi,
   dnsApi,
   type ApplianceRow,
+  type ApplianceWorkload,
   type ApplianceState,
   type ApplianceUpgradeStep,
   type ControlPlaneReplaceResult,
@@ -3051,28 +3052,19 @@ function ApplianceHostMigrationSection({ row }: { row: ApplianceRow }) {
 // state (legacy compose appliances ship an empty cluster_health
 // dict, so this section quietly hides).
 function ApplianceClusterHealthSection({ row }: { row: ApplianceRow }) {
-  const qc = useQueryClient();
-  // Hooks must run unconditionally — declare the mutation up front,
-  // then bail later if cluster_health is empty.
-  const restartBind9 = useMutation({
-    mutationFn: () =>
-      applianceApprovalApi.k8sRolloutRestart(row.id, {
-        kind: "Deployment",
-        namespace: "spatium",
-        name: "dns-bind9",
-      }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ["appliance", "fleet"] }),
-  });
+  // Hooks must run unconditionally — declare state up front, then bail
+  // later if cluster_health is empty.
+  // #890 — the restart was a single button hardcoded to
+  // ``deploy/dns-bind9``, so a node running PowerDNS, Technitium or Kea
+  // had no restart at all. The picker lists what the appliance runs.
+  const [restartOpen, setRestartOpen] = useState(false);
+  const [restartResult, setRestartResult] = useState<string | null>(null);
   const [revealOpen, setRevealOpen] = useState(false);
   const [cidrEditorOpen, setCidrEditorOpen] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
 
   const ch = row.cluster_health ?? {};
   const ready = ch.kubeapi_ready === true;
-  // "Restart bind9" only makes sense on a node actually running the
-  // dns-bind9 role — on a control-plane seed (DNS off) the Deployment
-  // doesn't exist, so the button would just error. Gate it on the role.
-  const hasBind9 = (row.assigned_roles ?? []).includes("dns-bind9");
   const nodesTotal = ch.nodes_total;
   const nodesReady = ch.nodes_ready;
   const podsTotal = ch.pods_total;
@@ -3164,22 +3156,19 @@ function ApplianceClusterHealthSection({ row }: { row: ApplianceRow }) {
         sub-second on a healthy appliance.
       </p>
       <div className="mt-2 flex flex-wrap items-center gap-2">
-        {hasBind9 && (
-          <button
-            type="button"
-            onClick={() => restartBind9.mutate()}
-            disabled={!ready || restartBind9.isPending}
-            title="kubectl rollout restart deploy/dns-bind9 -n spatium"
-            className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[11px] hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {restartBind9.isPending ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
-            ) : (
-              <RefreshCw className="h-3 w-3" />
-            )}
-            Restart bind9
-          </button>
-        )}
+        <button
+          type="button"
+          onClick={() => {
+            setRestartResult(null);
+            setRestartOpen(true);
+          }}
+          disabled={!ready}
+          title="Rollout-restart a workload on this appliance's k3s"
+          className="inline-flex items-center gap-1 rounded-md border bg-background px-2 py-1 text-[11px] hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <RefreshCw className="h-3 w-3" />
+          Restart workload…
+        </button>
         <button
           type="button"
           onClick={() => setRevealOpen(true)}
@@ -3204,17 +3193,22 @@ function ApplianceClusterHealthSection({ row }: { row: ApplianceRow }) {
           <FileText className="h-3 w-3" />
           Pod logs
         </button>
-        {restartBind9.error && (
-          <span className="text-[11px] text-rose-700 dark:text-rose-300">
-            {formatApiError(restartBind9.error)}
-          </span>
-        )}
-        {restartBind9.isSuccess && (
+        {restartResult && (
           <span className="text-[11px] text-emerald-700 dark:text-emerald-300">
-            rollout-restart issued
+            {restartResult}
           </span>
         )}
       </div>
+      {restartOpen && (
+        <RestartWorkloadModal
+          appliance={row}
+          onClose={() => setRestartOpen(false)}
+          onRestarted={(label) => {
+            setRestartResult(`rollout-restart issued for ${label}`);
+            setRestartOpen(false);
+          }}
+        />
+      )}
       {revealOpen && (
         <RevealKubeconfigModal
           appliance={row}
@@ -3495,6 +3489,144 @@ function KubeapiCidrEditorModal({
               <CheckCircle2 className="h-3.5 w-3.5" />
             )}
             Save
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+// #890 — pick a workload to rollout-restart on this appliance's k3s.
+// Replaces the single hardcoded "Restart bind9" button, which meant a
+// node running PowerDNS, Technitium or Kea had no restart at all and a
+// control-plane seed with DNS off had a button that would have errored.
+// The list comes from the appliance itself through the supervisor's
+// kubeapi proxy, so it can't drift from what is actually deployed.
+function RestartWorkloadModal({
+  appliance,
+  onClose,
+  onRestarted,
+}: {
+  appliance: ApplianceRow;
+  onClose: () => void;
+  onRestarted: (label: string) => void;
+}) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const workloads = useQuery({
+    queryKey: ["appliance", "k8s-workloads", appliance.id],
+    queryFn: () => applianceApprovalApi.k8sWorkloads(appliance.id),
+  });
+  const restart = useMutation({
+    mutationFn: (w: ApplianceWorkload) =>
+      applianceApprovalApi.k8sRolloutRestart(appliance.id, {
+        kind: w.kind,
+        namespace: w.namespace,
+        name: w.name,
+      }),
+    onSuccess: (_res, w) => onRestarted(`${w.kind.toLowerCase()}/${w.name}`),
+  });
+
+  const rows = workloads.data?.workloads ?? [];
+  const chosen = rows.find((w) => `${w.kind}/${w.name}` === selected) ?? null;
+
+  return (
+    <Modal
+      title={`Restart a workload on ${appliance.hostname}`}
+      onClose={onClose}
+      wide
+    >
+      <div className="space-y-3">
+        {workloads.isLoading && (
+          <p className="text-xs text-muted-foreground">
+            Asking the appliance what it runs…
+          </p>
+        )}
+        {workloads.error && (
+          <p className="text-xs text-rose-700 dark:text-rose-300">
+            {formatApiError(workloads.error)}
+          </p>
+        )}
+        {/* Per-kind failures, not a whole-call failure: a cluster with an
+            RBAC gap on StatefulSets should still let you restart the
+            Deployments you came here for. */}
+        {(workloads.data?.errors ?? []).map((e) => (
+          <p key={e} className="text-[11px] text-amber-700 dark:text-amber-300">
+            {e}
+          </p>
+        ))}
+        {!workloads.isLoading && rows.length === 0 && !workloads.error && (
+          <p className="text-xs text-muted-foreground">
+            No SpatiumDDI workloads found in the spatium namespace.
+          </p>
+        )}
+        {rows.length > 0 && (
+          <div className="max-h-72 overflow-y-auto rounded-md border">
+            <table className="w-full text-xs">
+              <thead className="bg-muted/40 text-[11px] uppercase tracking-wider text-muted-foreground">
+                <tr>
+                  <th className="px-2 py-1.5 text-left font-medium">
+                    Workload
+                  </th>
+                  <th className="px-2 py-1.5 text-left font-medium">Kind</th>
+                  <th className="px-2 py-1.5 text-left font-medium">Ready</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((w) => {
+                  const id = `${w.kind}/${w.name}`;
+                  return (
+                    <tr
+                      key={id}
+                      onClick={() => setSelected(id)}
+                      className={cn(
+                        "cursor-pointer",
+                        selected === id ? "bg-primary/10" : "hover:bg-muted/50",
+                      )}
+                    >
+                      <td className="px-2 py-1.5">
+                        <div className="font-medium">{w.name}</div>
+                        <div className="text-[10px] text-muted-foreground">
+                          {w.image}
+                        </div>
+                      </td>
+                      <td className="px-2 py-1.5 text-muted-foreground">
+                        {w.kind}
+                      </td>
+                      <td className="px-2 py-1.5 font-mono">
+                        {w.ready}/{w.desired}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+        {restart.error && (
+          <p className="text-xs text-rose-700 dark:text-rose-300">
+            {formatApiError(restart.error)}
+          </p>
+        )}
+        <p className="text-[11px] text-muted-foreground">
+          Rollout restart replaces pods one at a time, so a workload with more
+          than one replica keeps serving through it.
+        </p>
+        <div className="flex justify-end gap-2 border-t pt-3">
+          <button
+            onClick={onClose}
+            className="rounded-md border px-3 py-1.5 text-sm hover:bg-accent"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => chosen && restart.mutate(chosen)}
+            disabled={!chosen || restart.isPending}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground hover:opacity-90 disabled:opacity-50"
+          >
+            {restart.isPending && (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            )}
+            Restart
           </button>
         </div>
       </div>

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -7,7 +7,8 @@ k8s/
 ├── base/              # Core application manifests (namespace, API, worker, frontend, migrations)
 ├── dns/               # Managed DNS server StatefulSets (bind9)
 ├── dhcp/              # Managed DHCP server StatefulSets (kea)
-└── ha/                # High-availability add-ons (PostgreSQL Patroni/CloudNativePG, Redis Sentinel)
+├── ha/                # High-availability add-ons (PostgreSQL Patroni/CloudNativePG, Redis Sentinel)
+└── service-control/   # Opt-in RBAC + api patch for GUI service restart (#890)
 ```
 
 ## Managed DHCP servers (Kea)
@@ -292,6 +293,31 @@ On first boot each agent:
 
 If `dns_require_agent_approval=true` the server appears in the DNS Server
 Group UI with `pending_approval=true` until an admin approves it.
+
+## Service control from the GUI (opt-in, issue #890)
+
+**Settings → Services** lets a superadmin rollout-restart SpatiumDDI's
+own workloads. It is off by default and needs two things, which fail
+differently — the UI names whichever one you skipped rather than
+rendering a button that 403s:
+
+```bash
+kubectl apply -f k8s/service-control/rbac.yaml
+kubectl -n spatiumddi patch deployment api \
+  --type=strategic --patch-file k8s/service-control/api-patch.yaml
+kubectl -n spatiumddi rollout status deployment/api
+```
+
+Helm equivalents: `api.serviceControl.enabled` (the env gate) and
+`api.serviceControlRBAC.enabled` (the Role), both `false` by default and
+both requiring `api.serviceAccount.enabled`. Appliance installs get the
+RBAC from `spatiumddi-firstboot` and the gate from `appliance_mode`.
+
+`restart` is the only verb on Kubernetes. `start` / `stop` would mean
+scaling to zero and back, and restoring the previous replica count needs
+somewhere durable to remember it. See
+[`k8s/service-control/README.md`](service-control/README.md) for the
+scoping rationale.
 
 ## Image Tags
 

--- a/k8s/service-control/README.md
+++ b/k8s/service-control/README.md
@@ -1,0 +1,50 @@
+# Service control (opt-in) — issue #890
+
+Lets a superadmin restart SpatiumDDI's own workloads from
+**Settings → Services** in the web UI, as a Kubernetes rollout restart
+(a `kubectl.kubernetes.io/restartedAt` bump on the pod template).
+
+**Off by default, in two independent halves**, because they fail
+differently and both failures are worth naming:
+
+| Half | What it does | Symptom when missing |
+|---|---|---|
+| `SERVICE_CONTROL_ENABLED=true` on the api | flips the capability the UI reads | Services screen renders read-only and says exactly this |
+| the `Role` + `RoleBinding` here | lets the api list + patch workloads | kubeapi 403 → the API reports "enable the service-control RBAC", not an empty list |
+
+Apply both, or the screen tells you which one you skipped.
+
+```bash
+kubectl apply -f k8s/service-control/rbac.yaml
+kubectl -n spatiumddi patch deployment api \
+  --type=strategic --patch-file k8s/service-control/api-patch.yaml
+kubectl -n spatiumddi rollout status deployment/api
+```
+
+## Why the Role has no `resourceNames`
+
+Workload names carry the release/deployment name, and a `resourceNames`
+list cannot express a prefix — it would need regenerating whenever a
+workload is added, and would silently omit the new one. The narrowing
+that matters is enforced in the API instead: `list_workloads()` returns
+only objects labelled `app.kubernetes.io/name=spatiumddi` (or
+`app.kubernetes.io/part-of=spatiumddi`), and an action resolves its
+target against that listing — so an operator's own Deployment in this
+namespace is neither listed nor restartable.
+
+`start` / `stop` are not offered on Kubernetes. They would mean scaling
+a workload to zero and back, and restoring the previous replica count
+needs somewhere durable to remember it; a control plane that forgets how
+many replicas a workload had is worse than one that never offered.
+
+## Removing it
+
+```bash
+kubectl delete -f k8s/service-control/rbac.yaml
+kubectl -n spatiumddi set env deployment/api SERVICE_CONTROL_ENABLED-
+```
+
+The Helm equivalents are `api.serviceControl.enabled` and
+`api.serviceControlRBAC.enabled` (both default `false`); appliance
+installs get the RBAC half from `spatiumddi-firstboot` and the gate from
+`appliance_mode`.

--- a/k8s/service-control/api-patch.yaml
+++ b/k8s/service-control/api-patch.yaml
@@ -1,0 +1,11 @@
+# Strategic-merge patch enabling the API half of service control (#890).
+# Pair with rbac.yaml — the env var alone reports the capability as on
+# and then takes a 403 from kubeapi on the first list.
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: SERVICE_CONTROL_ENABLED
+              value: "true"

--- a/k8s/service-control/rbac.yaml
+++ b/k8s/service-control/rbac.yaml
@@ -1,0 +1,43 @@
+# Service control RBAC (issue #890) — opt-in.
+#
+# Grants the api ServiceAccount enough to list SpatiumDDI's own workloads
+# and bump the pod-template annotation that triggers a rollout restart.
+# Namespace-scoped; no cluster-scoped grants and no ability to create or
+# delete anything.
+#
+# The base manifests in k8s/base/ run the api under the namespace's
+# ``default`` ServiceAccount, so that is what this binds. If you have
+# switched the api to a dedicated SA, change the ``subjects`` name to
+# match and set ``serviceAccountName`` on the Deployment accordingly.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spatiumddi-service-control
+  namespace: spatiumddi
+  labels:
+    app.kubernetes.io/name: spatiumddi
+    app.kubernetes.io/component: api
+rules:
+  # ``list`` powers the Services inventory; ``patch`` performs the
+  # rollout restart. No ``create`` / ``delete`` — the only mutation this
+  # feature makes is an annotation on an existing pod template.
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spatiumddi-service-control
+  namespace: spatiumddi
+  labels:
+    app.kubernetes.io/name: spatiumddi
+    app.kubernetes.io/component: api
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: spatiumddi
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spatiumddi-service-control


### PR DESCRIPTION
Closes #890

Restarting a SpatiumDDI service from the web UI worked on exactly one deployment: the k3s appliance. docker-compose had read-only stats over `docker.sock`; the umbrella Helm chart had nothing. Meanwhile `SYSTEM_ADMIN.md` described a Start/Stop/Restart surface spanning Docker, Kubernetes and bare-metal SSH `systemctl` that had never been written.

One surface at **Admin → Platform Insights → Services**, over `backend/app/services/service_control/` (`backends` / `compose` / `kube`), `GET|POST /system/services*`, opt-in RBAC in `charts/spatiumddi` + `k8s/service-control/`, and 2 MCP tools. No migration — nothing here is persisted beyond the audit row.

## The capability is answered before anything is attempted

This is the design point, not a nicety. The same 503 used to mean both *"this deployment cannot do that"* and *"the daemon is down"*, and those need opposite responses from the operator. `GET /system/services` reports the live backend, whether the gate is open, and the exact toggle to flip — so the UI renders the buttons that exist instead of drawing one and learning from its error.

| Backend | Detected when | Actions |
|---|---|---|
| `kubernetes` (`k3s-appliance` / `kubernetes`) | a ServiceAccount is projected into the api pod | `restart` (rollout) |
| `compose` | `docker.sock` mounted **and** the api can read its own project label | `start`, `stop`, `restart` |
| `none` | neither | — the response names the missing mount |

**`start` / `stop` are deliberately absent on Kubernetes.** They would mean scaling to zero and back, and restoring the previous replica count needs somewhere durable to remember it — a control plane that forgets is worse than one that never offered.

## The inventory is the allowlist

An action names a service from the listing and is resolved against a *fresh* one server-side, so there is no second list to keep in sync and an id that is not currently ours is a 404 rather than a string handed to a daemon.

On **compose** the scope is the api container's own `com.docker.compose.project` label — needs no configuration, cannot be widened by a request, and **fails closed**: a container that cannot identify its own project reports the backend unavailable rather than falling back to a `spatiumddi-` name prefix, which a co-tenant container could match on purpose.

On **Kubernetes** it is the api pod's own namespace filtered to `app.kubernetes.io/name|part-of=spatiumddi`. That is also why the Role carries no `resourceNames`: a release-name prefix isn't expressible there, and the list would silently omit any workload added later.

## Restarting the API that serves the page

Allowed, and flagged as `self_targeted`. The audit row commits and the `202` returns **before** the daemon is signalled — on compose the container stops the moment the request is accepted, so signalling inline would abort the response into a connection reset. For the same reason the row records `result="accepted"`, not `"success"`: nothing survives to observe the outcome.

## Gating

Off by default everywhere except the appliance, where `appliance_mode` implies it — `POST /appliance/containers/{name}/{action}` has shipped the same control since #134, so an opt-in there would take a capability away rather than add one.

The env gate and the RBAC are **separate switches on purpose**: each failure is reported as itself ("enable `SERVICE_CONTROL_ENABLED`" vs "enable `api.serviceControlRBAC`") rather than as an empty inventory that reads as "nothing to restart".

| Deployment | Gate | RBAC / mount |
|---|---|---|
| Appliance | implied by `appliance_mode` | `spatiumddi-firstboot` |
| Helm | `api.serviceControl.enabled` | `api.serviceControlRBAC.enabled` |
| Raw manifests | `SERVICE_CONTROL_ENABLED=true` | `k8s/service-control/rbac.yaml` |
| docker-compose | `SERVICE_CONTROL_ENABLED=true` | `docker.sock` + `group_add` |

## Also fixed on the way

- **The Fleet restart was one button hardcoded to `deploy/dns-bind9`**, so a node running PowerDNS, Technitium or Kea had no restart at all. Now a picker fed by `GET /appliance/appliances/{id}/k8s/workloads` through the supervisor proxy — and `StatefulSet` joined the restart endpoint's `kind` union, or the picker could list a row that errors on click.
- **`SYSTEM_ADMIN.md` §service-control** rewritten from the fiction to what ships, including saying plainly that the `systemctl`-over-SSH path is not planned.

## Review pass — four findings, all fixed in `15873df0`

1. **Kubernetes restart 404'd at the router**, on the one deployment where control is on by default. Ids were `Kind/name`, but a path parameter matches `[^/]+` against the *unquoted* path, so `%2F` is unescaped before routing and the request misses the route. Verified live: encoded id → 404 pre-auth, slash-free → reached the handler. Now `Kind:name`, with a regression test that posts a real k8s-style id through actual routing rather than asserting on the format.
2. **The panel rendered "no backend" for a failed request** — a 403 or a network error reintroduced, one layer up, the exact "cannot" vs "down" confusion the capability probe exists to remove.
3. **Compose self-identification relied on `$HOSTNAME`**, which Docker resolves as an id or *name*, not a hostname. With `hostname:` set on the api service, inspect 404s and the whole compose backend silently disappeared. The id now comes from `/proc/self/mountinfo`, with `$HOSTNAME` as the fallback it was written to be.
4. **Raw httpx errors escaped the compose backend** as opaque 500s (or an unhandled background-task exception on the self-targeted path) instead of the intended 502 / reported `error`.

## Verification

- `make ci` green (ruff / black / mypy 853 files, eslint / prettier / tsc / vitest, frontend build); `lint_migrations.py` and `make lint-untyped-routes` clean — the latter caught the new route publishing `{}` as its schema, so it is typed rather than baselined.
- 33 new backend tests, plus `test_rewrap_coverage` / `test_ai_tool_modules` / `test_openapi_conformance` re-run green.
- End to end on the dev stack: capability detection with and without the socket, list / start / stop / restart of a peer container, a self-targeted api restart returning 202 with its audit row already committed, and a re-run with `hostname:` set on the api service proving finding 3's fix.
- `helm template` rendered with the new values on and off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
