### PR TITLE
fix(health,celery): bound the beat heartbeat's Redis connect (#925)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1350,10 +1350,19 @@ suggestion, free-space treemap.
   failed; `socket_timeout` is deliberately *not* defaulted, since
   `core/agent_wake` parks a pub/sub read that is supposed to be slow and a
   read timeout would turn the wake bus into a reconnect loop. `beat_tick`
-  gains `soft_time_limit` / `time_limit` (a tick cannot outlive its own
-  interval and hold a slot) and `expires` (an outage backlog is discarded,
-  not replayed into the same key), and swallows+logs Redis errors rather
-  than filing a diagnostics row every 30 s for the length of an outage.
+  gains `soft_time_limit` / `time_limit`, both **under** its own 30 s
+  interval — a tick allowed to outlive the interval still accumulates one
+  occupied slot per interval, just more slowly — sized from measurement
+  (walking past one resolving-but-dead sentinel costs ~12.8 s at a 1 s
+  connect timeout, far more than the timeout itself because redis-py
+  retries internally, so a limit that does not clear it kills the tick just
+  before it succeeds). `expires` was tried and **removed in review**: Celery
+  stamps it as an absolute time from the *publisher's* clock and the
+  *worker* compares it, so a worker running ahead of beat would revoke every
+  tick and make the reported symptom permanent — trading the bug for a
+  strictly worse one, in exactly the post-reboot window where NTP has not
+  converged. Redis errors are swallowed and logged rather than filing a
+  diagnostics row every 30 s for the length of an outage.
   The health detail now names both suspects, and a stamp more than 90 s in
   the **future** reads as clock skew instead of as perfectly fresh — the
   plain `age_s > 90` test would have masked a genuinely dead beat behind a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1318,6 +1318,47 @@ suggestion, free-space treemap.
   itself, which needs `rndc tsig-list` (or the effective `named.conf` plus
   includes) from an affected node to say what named actually loaded.
 
+- ✅ [**celery-beat reported unhealthy forever after a slot upgrade**](https://github.com/spatiumddi/spatiumddi/issues/925)
+  — the rollup was right that something was broken and wrong about what.
+  **Beat only *schedules* `beat_tick`; a worker executes it**, so the
+  `spatium:beat:heartbeat` key is a round trip and its absence indicts
+  either end — while the old detail asserted "beat is stopped", which sent
+  the investigation to a pod that was running perfectly.
+  **Root cause, reproduced in isolation:** `make_sync_redis` in
+  `tasks/heartbeat.py` was **the one Redis caller of fourteen passing no
+  timeout at all**. #590 had bounded the sentinel hops but did it *per call
+  site*, and this was the site it missed. `REDIS_URL` on a multi-node
+  control plane lists sentinels by **per-pod headless DNS** (deliberately —
+  a client must reach every sentinel mid-failover), and those names keep
+  resolving through the 20–40 s a rebooting node takes to be marked
+  NotReady. Measured against an unreachable sentinel: unbounded is **still
+  blocked at 60 s** (and past 5 min); bounded returns `MasterNotFoundError`
+  in ~28 s. A tick is enqueued every 30 s regardless, so one wedged slot
+  per interval takes the default 4-slot pool in **~2 minutes** — which is
+  exactly the "still unhealthy after 120 s" the report measured, and why
+  *every* periodic job stops, not just the heartbeat.
+  **The second half is why it looked like beat's fault:** `inspect ping` is
+  answered by the worker's MainProcess pidbox consumer, independent of the
+  prefork pool, so a worker with **every** slot blocked still reports
+  `celery-workers: ok`. Verified directly against a 2-slot worker holding
+  two forever-tasks. Documented as a known limit rather than fixed with an
+  `inspect.active()` round trip — `/health/platform` is unauthenticated, so
+  every extra broadcast RPC there is amplification an anonymous caller
+  controls.
+  Fix: the connect timeout is now a **default inside
+  `core/redis_client.py`**, because a per-call-site convention is what
+  failed; `socket_timeout` is deliberately *not* defaulted, since
+  `core/agent_wake` parks a pub/sub read that is supposed to be slow and a
+  read timeout would turn the wake bus into a reconnect loop. `beat_tick`
+  gains `soft_time_limit` / `time_limit` (a tick cannot outlive its own
+  interval and hold a slot) and `expires` (an outage backlog is discarded,
+  not replayed into the same key), and swallows+logs Redis errors rather
+  than filing a diagnostics row every 30 s for the length of an outage.
+  The health detail now names both suspects, and a stamp more than 90 s in
+  the **future** reads as clock skew instead of as perfectly fresh — the
+  plain `age_s > 90` test would have masked a genuinely dead beat behind a
+  skewed worker clock. No migration, no new endpoint, no MCP change.
+
 #### CLI tool
 
 - ⬜ [**`spddi` CLI**](https://github.com/spatiumddi/spatiumddi/issues/83)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -225,6 +225,19 @@ async def platform_health() -> JSONResponse:
     # that can hang, so run it in a threadpool with a short overall
     # timeout. Returns a mapping like ``{"celery@worker-1": {"ok": "pong"}}``
     # or ``None`` when no worker responds in time.
+    #
+    # KNOWN LIMIT (#925), stated because it misleads exactly when it
+    # matters: ping is answered by the worker's MainProcess pidbox
+    # consumer, which is independent of the prefork pool. A worker whose
+    # every pool slot is blocked still answers "pong" and reports here as
+    # ok, while nothing it is given can actually run. Verified directly
+    # against a 2-slot worker with both slots occupied.
+    #
+    # Deliberately NOT fixed by adding an ``inspect.active()`` round trip:
+    # this endpoint is unauthenticated, so every extra broadcast RPC here
+    # is amplification an anonymous caller controls. The beat component
+    # above is the signal that does surface a wedged pool — which is why
+    # its detail must not blame beat for it.
     def _inspect_ping() -> dict[str, Any] | None:
         from app.celery_app import celery_app  # noqa: PLC0415
 
@@ -265,9 +278,19 @@ async def platform_health() -> JSONResponse:
         )
 
     # Celery beat — written by ``app.tasks.heartbeat.beat_tick`` every 30 s
-    # to ``spatium:beat:heartbeat`` with a 5-minute TTL. Missing key →
-    # beat is stopped or has been stopped for >5 min. Present but older
-    # than 90 s → degraded (two beat intervals missed).
+    # to ``spatium:beat:heartbeat`` with a 5-minute TTL. Missing key → no
+    # tick has landed for >5 min. Present but older than 90 s → degraded
+    # (two beat intervals missed).
+    #
+    # #925 — the detail below says "no tick" and NOT "beat is stopped",
+    # which is what it used to say and could not know. beat *schedules*
+    # this task; a **worker** executes it, so the key is a round trip and
+    # its absence indicts either end. The wording mattered: an operator
+    # (and a QA gate) reading "beat is stopped" went and looked at a beat
+    # pod that was running perfectly, while the actual fault was every
+    # worker pool slot wedged on an unbounded Redis connect — a state
+    # ``inspect ping`` reports as healthy, because the MainProcess answers
+    # it without involving the pool at all.
     try:
         from app.config import settings
         from app.core.redis_client import make_async_redis
@@ -290,7 +313,10 @@ async def platform_health() -> JSONResponse:
                 {
                     "name": "celery-beat",
                     "status": "error",
-                    "detail": "no heartbeat — beat is stopped",
+                    "detail": (
+                        "no beat tick in the last 5 min — beat is not "
+                        "scheduling, or no worker is executing its tick"
+                    ),
                 }
             )
         else:
@@ -300,6 +326,13 @@ async def platform_health() -> JSONResponse:
             if age_s > 90:
                 status_str = "warn"
                 detail = f"last tick {age_s:.0f}s ago (stalled)"
+            elif age_s < -90:
+                # A tick stamped in the future is clock skew between the
+                # node that ran it and this one, not a healthy beat — and
+                # the plain ``age_s > 90`` test read it as perfectly fresh,
+                # so a skewed clock could hide a genuinely dead beat.
+                status_str = "warn"
+                detail = f"last tick {-age_s:.0f}s in the future (clock skew)"
             else:
                 status_str = "ok"
                 detail = f"last tick {age_s:.0f}s ago"

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -235,9 +235,9 @@ async def platform_health() -> JSONResponse:
     #
     # Deliberately NOT fixed by adding an ``inspect.active()`` round trip:
     # this endpoint is unauthenticated, so every extra broadcast RPC here
-    # is amplification an anonymous caller controls. The beat component
-    # above is the signal that does surface a wedged pool — which is why
-    # its detail must not blame beat for it.
+    # is amplification an anonymous caller controls. The celery-beat
+    # component BELOW is the signal that does surface a wedged pool —
+    # which is why its detail must not blame beat for it.
     def _inspect_ping() -> dict[str, Any] | None:
         from app.celery_app import celery_app  # noqa: PLC0415
 
@@ -333,6 +333,12 @@ async def platform_health() -> JSONResponse:
                 # so a skewed clock could hide a genuinely dead beat.
                 status_str = "warn"
                 detail = f"last tick {-age_s:.0f}s in the future (clock skew)"
+            elif age_s < 0:
+                # Skew too small to be worth warning about, but "last tick
+                # -12s ago" is nonsense on a dashboard. Clamp the wording;
+                # sub-threshold skew between two nodes is normal.
+                status_str = "ok"
+                detail = "last tick just now"
             else:
                 status_str = "ok"
                 detail = f"last tick {age_s:.0f}s ago"

--- a/backend/app/core/redis_client.py
+++ b/backend/app/core/redis_client.py
@@ -19,6 +19,20 @@ The master name comes from ``settings.redis_sentinel_master``
 (default ``mymaster``). The Sentinel auth password comes from
 ``settings.redis_sentinel_password`` when set, else the password
 embedded in the URL.
+
+**Connect timeouts default to bounded, here** (#925). ``REDIS_URL`` on a
+multi-node control plane lists the sentinels by their *per-pod headless*
+DNS names, deliberately, so a client can reach every sentinel mid-failover.
+The cost is that those names keep resolving for the 20-40 s a node takes to
+be marked NotReady, so a connect to a rebooting node's sentinel SYNs into a
+black hole. With no ``socket_connect_timeout`` that connect is unbounded:
+measured still blocked at 60 s (and past 5 min) against an unreachable
+sentinel, versus ~28 s to a clean ``MasterNotFoundError`` once bounded.
+
+#590 fixed that per call site, and #925 is the call site it missed — the
+beat heartbeat, the one Redis caller in the codebase passing no timeout at
+all. A default that call sites may override is the shape that cannot be
+missed again; the alternative is a 15th caller getting it wrong.
 """
 
 from __future__ import annotations
@@ -34,6 +48,26 @@ from redis.sentinel import Sentinel as SentinelSync
 from app.config import settings
 
 _SENTINEL_SCHEMES = ("sentinel://", "redis+sentinel://")
+
+# Applied when a caller passes no ``socket_connect_timeout`` (#925). Matches
+# what the health checks already choose, so the codebase has one number.
+DEFAULT_CONNECT_TIMEOUT_SECONDS = 2.0
+
+
+def _with_default_timeouts(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Bound the CONNECT, and only the connect.
+
+    ``socket_timeout`` is deliberately NOT defaulted. It bounds every socket
+    *read*, and ``core.agent_wake`` parks a pub/sub connection on
+    ``get_message(timeout=…)`` for up to a full wake tick waiting for a
+    message that is supposed to be slow in arriving — a default read timeout
+    would tear that down mid-wait and turn the wake bus into a reconnect
+    loop. Callers that only ever issue request/response commands can and do
+    pass ``socket_timeout`` themselves.
+    """
+    if "socket_connect_timeout" not in kwargs:
+        kwargs = {**kwargs, "socket_connect_timeout": DEFAULT_CONNECT_TIMEOUT_SECONDS}
+    return kwargs
 
 
 def is_sentinel_url(url: str) -> bool:
@@ -73,7 +107,11 @@ def make_async_redis(url: str, **kwargs: Any) -> aioredis.Redis:
     ``from_url``. ``sentinel://`` URLs resolve the current master via
     Sentinel and return a master-bound client that re-resolves on
     reconnect (so it follows failover).
+
+    A caller that passes no ``socket_connect_timeout`` gets
+    ``DEFAULT_CONNECT_TIMEOUT_SECONDS`` (#925); passing one overrides it.
     """
+    kwargs = _with_default_timeouts(kwargs)
     if not is_sentinel_url(url):
         return aioredis.from_url(url, **kwargs)
 
@@ -122,7 +160,11 @@ def _sentinel_kwargs(password: str | None, kwargs: dict[str, Any]) -> dict[str, 
 def make_sync_redis(url: str, **kwargs: Any) -> redis_sync.Redis:
     """Synchronous counterpart of ``make_async_redis`` — for the Celery
     tasks (e.g. the beat heartbeat) that run outside the asyncio loop.
+
+    Same default connect timeout, and this is the path that needed it: the
+    beat heartbeat called it with no kwargs at all (#925).
     """
+    kwargs = _with_default_timeouts(kwargs)
     if not is_sentinel_url(url):
         return redis_sync.from_url(url, **kwargs)
 

--- a/backend/app/tasks/heartbeat.py
+++ b/backend/app/tasks/heartbeat.py
@@ -6,6 +6,29 @@ platform-health endpoint reads that key to distinguish "beat is
 running" from "beat has stalled" — celery has no built-in beat-
 liveness primitive, so a self-pinged heartbeat is the simplest
 reliable signal.
+
+**It is a round trip, not a beat-side stamp**, and that matters when
+reading the health verdict: beat *schedules* this task and a **worker**
+executes it. A missing key therefore means "beat is not scheduling **or**
+no worker ran the tick" — see ``app/api/health.py``.
+
+#925 — this task is bounded on three axes because it used to be bounded
+on none, and an unbounded heartbeat is worse than no heartbeat:
+
+* the Redis client gets a connect timeout (now the helper's default);
+* ``soft_time_limit`` stops one tick outliving its own 30 s interval and
+  occupying a pool slot. Ticks are enqueued unconditionally every 30 s,
+  so a tick that blocks forever wedges one slot per interval and takes
+  the whole worker pool inside a few minutes — while ``inspect ping``,
+  answered by the MainProcess, keeps reporting the worker healthy;
+* ``expires`` discards a tick that has been queued too long instead of
+  running a backlog of them after an outage, which would write the same
+  key N times for no benefit.
+
+A Redis failure is logged and swallowed rather than raised. The health
+endpoint already reports the outage from the key's absence, and letting
+this raise would file a diagnostics row every 30 s for the length of the
+outage — burying the signal under the symptom.
 """
 
 from __future__ import annotations
@@ -23,23 +46,61 @@ logger = structlog.get_logger(__name__)
 BEAT_HEARTBEAT_KEY = "spatium:beat:heartbeat"
 BEAT_HEARTBEAT_TTL_SECONDS = 300
 
+# The schedule interval this task is registered at, in
+# ``celery_app.beat_schedule["platform-beat-heartbeat"]``.
+BEAT_HEARTBEAT_INTERVAL_SECONDS = 30
+
+# Long enough for a sentinel round trip that has to walk past one dead
+# sentinel (measured ~28 s against an unreachable one, so a tick during a
+# node reboot is *expected* to hit this), short enough that a wedged tick
+# frees its slot well inside the next few intervals.
+_SOFT_TIME_LIMIT_SECONDS = 20
+_HARD_TIME_LIMIT_SECONDS = 30
+
+# Four intervals. Normal worker backlog never trips it; an outage backlog
+# is discarded rather than replayed.
+_EXPIRES_SECONDS = BEAT_HEARTBEAT_INTERVAL_SECONDS * 4
+
 
 @celery_app.task(
     name="app.tasks.heartbeat.beat_tick",
     bind=True,
     ignore_result=True,
+    soft_time_limit=_SOFT_TIME_LIMIT_SECONDS,
+    time_limit=_HARD_TIME_LIMIT_SECONDS,
+    expires=_EXPIRES_SECONDS,
 )
 def beat_tick(self) -> str:  # noqa: ARG001 — bind=True boilerplate
-    r = make_sync_redis(settings.redis_url)
+    r = None
     try:
+        r = make_sync_redis(
+            settings.redis_url,
+            # Explicit rather than relying on the helper's default: this is
+            # the caller whose missing timeout caused #925, and a reader
+            # checking "is this one bounded?" should not have to go look.
+            socket_connect_timeout=2,
+            socket_timeout=2,
+        )
         r.set(
             BEAT_HEARTBEAT_KEY,
             datetime.now(UTC).isoformat(),
             ex=BEAT_HEARTBEAT_TTL_SECONDS,
         )
+        return "ok"
+    except Exception as exc:  # noqa: BLE001 — see the module docstring
+        logger.warning("beat_heartbeat_write_failed", error=str(exc))
+        return "unavailable"
     finally:
-        r.close()
-    return "ok"
+        if r is not None:
+            try:
+                r.close()
+            except Exception:  # noqa: BLE001 — closing a broken client
+                pass
 
 
-__all__ = ["beat_tick", "BEAT_HEARTBEAT_KEY", "BEAT_HEARTBEAT_TTL_SECONDS"]
+__all__ = [
+    "BEAT_HEARTBEAT_INTERVAL_SECONDS",
+    "BEAT_HEARTBEAT_KEY",
+    "BEAT_HEARTBEAT_TTL_SECONDS",
+    "beat_tick",
+]

--- a/backend/app/tasks/heartbeat.py
+++ b/backend/app/tasks/heartbeat.py
@@ -21,9 +21,21 @@ on none, and an unbounded heartbeat is worse than no heartbeat:
   so a tick that blocks forever wedges one slot per interval and takes
   the whole worker pool inside a few minutes — while ``inspect ping``,
   answered by the MainProcess, keeps reporting the worker healthy;
-* ``expires`` discards a tick that has been queued too long instead of
-  running a backlog of them after an outage, which would write the same
-  key N times for no benefit.
+* the Redis connect timeout is deliberately tighter than the platform
+  default. This is a 30 s-cadence liveness ping, not a data path: failing
+  fast and retrying on the next tick beats waiting.
+
+**``expires`` is deliberately NOT set.** It looks like the right way to
+stop an outage backlog replaying, and it introduces a worse failure than
+the one it prevents: Celery stamps ``expires`` as an *absolute* timestamp
+from the **publisher's** clock (beat) and ``Request.maybe_expire``
+compares it against the **worker's** clock. A worker node whose clock runs
+ahead of beat's by more than the window revokes every tick, the key is
+never written, and ``/health/platform`` sits red permanently — the exact
+symptom this file exists to prevent, in exactly the post-reboot window
+where NTP has not converged. The backlog it would have prevented is
+harmless anyway: every tick writes the same key, and with the time limits
+above the pool cannot wedge, so a backlog drains in seconds.
 
 A Redis failure is logged and swallowed rather than raised. The health
 endpoint already reports the outage from the key's absence, and letting
@@ -50,16 +62,26 @@ BEAT_HEARTBEAT_TTL_SECONDS = 300
 # ``celery_app.beat_schedule["platform-beat-heartbeat"]``.
 BEAT_HEARTBEAT_INTERVAL_SECONDS = 30
 
-# Long enough for a sentinel round trip that has to walk past one dead
-# sentinel (measured ~28 s against an unreachable one, so a tick during a
-# node reboot is *expected* to hit this), short enough that a wedged tick
-# frees its slot well inside the next few intervals.
-_SOFT_TIME_LIMIT_SECONDS = 20
-_HARD_TIME_LIMIT_SECONDS = 30
+# Sized from measurement, not intuition. Walking past a sentinel that
+# resolves but does not answer costs far more than its connect timeout,
+# because redis-py retries internally: measured 17.5 s per dead sentinel at
+# a 2 s connect timeout, 12.8 s at 1 s. A rolling node reboot leaves one
+# sentinel in that state, so the limit has to clear ~13 s comfortably or it
+# soft-kills the tick just before it would have succeeded — degrading
+# celery-beat for the length of every upgrade, which is the #925 symptom
+# rather than its fix.
+#
+# Both limits stay UNDER the 30 s schedule interval. That is the property
+# that matters: a tick which can outlive its own interval still accumulates
+# one occupied slot per interval, just more slowly.
+_SOFT_TIME_LIMIT_SECONDS = 25
+_HARD_TIME_LIMIT_SECONDS = 28
 
-# Four intervals. Normal worker backlog never trips it; an outage backlog
-# is discarded rather than replayed.
-_EXPIRES_SECONDS = BEAT_HEARTBEAT_INTERVAL_SECONDS * 4
+# Tighter than the platform default (2 s) on purpose — see the module
+# docstring. At 1 s a dead sentinel costs ~12.8 s instead of ~17.5 s, which
+# is what makes two of them fit inside the limits above.
+_CONNECT_TIMEOUT_SECONDS = 1
+_SOCKET_TIMEOUT_SECONDS = 2
 
 
 @celery_app.task(
@@ -68,7 +90,6 @@ _EXPIRES_SECONDS = BEAT_HEARTBEAT_INTERVAL_SECONDS * 4
     ignore_result=True,
     soft_time_limit=_SOFT_TIME_LIMIT_SECONDS,
     time_limit=_HARD_TIME_LIMIT_SECONDS,
-    expires=_EXPIRES_SECONDS,
 )
 def beat_tick(self) -> str:  # noqa: ARG001 — bind=True boilerplate
     r = None
@@ -78,8 +99,8 @@ def beat_tick(self) -> str:  # noqa: ARG001 — bind=True boilerplate
             # Explicit rather than relying on the helper's default: this is
             # the caller whose missing timeout caused #925, and a reader
             # checking "is this one bounded?" should not have to go look.
-            socket_connect_timeout=2,
-            socket_timeout=2,
+            socket_connect_timeout=_CONNECT_TIMEOUT_SECONDS,
+            socket_timeout=_SOCKET_TIMEOUT_SECONDS,
         )
         r.set(
             BEAT_HEARTBEAT_KEY,

--- a/backend/tests/test_beat_heartbeat.py
+++ b/backend/tests/test_beat_heartbeat.py
@@ -53,13 +53,34 @@ def test_tick_cannot_outlive_its_own_interval_by_much() -> None:
     )
 
 
-def test_stale_queued_ticks_expire_rather_than_replaying() -> None:
-    """After an outage the queue holds a backlog of ticks that all write the
-    same key. Running them is pure waste; the expiry is generous enough that
-    ordinary worker backlog never trips it."""
-    assert beat_tick.expires is not None
-    assert beat_tick.expires > BEAT_HEARTBEAT_INTERVAL_SECONDS
-    assert beat_tick.expires < BEAT_HEARTBEAT_TTL_SECONDS
+def test_expires_is_not_set() -> None:
+    """``expires`` would trade this bug for a worse one.
+
+    Celery stamps it as an *absolute* timestamp from the **publisher's**
+    clock (beat) and ``Request.maybe_expire`` compares it against the
+    **worker's** clock — verified against the installed celery. A worker
+    node running ahead of beat by more than the window revokes every tick,
+    so the key is never written and ``/health/platform`` sits red
+    permanently: the reported symptom, made unconditional, in exactly the
+    post-reboot window where NTP has not converged.
+
+    The backlog it would prevent is harmless — every tick writes the same
+    key, and the time limits above stop the pool wedging, so a backlog
+    drains in seconds.
+    """
+    assert beat_tick.expires is None
+
+
+def test_limits_clear_a_realistic_sentinel_outage() -> None:
+    """A rolling node reboot leaves one sentinel resolving-but-dead.
+
+    Measured cost of walking past one: ~12.8 s at the 1 s connect timeout
+    this task uses (~17.5 s at 2 s) — far more than the connect timeout,
+    because redis-py retries internally. A soft limit that does not clear
+    that comfortably kills the tick just before it would have succeeded,
+    degrading celery-beat for the length of every upgrade.
+    """
+    assert beat_tick.soft_time_limit >= 20
 
 
 def test_redis_failure_is_swallowed_and_logged(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_beat_heartbeat.py
+++ b/backend/tests/test_beat_heartbeat.py
@@ -1,0 +1,116 @@
+"""The beat heartbeat must be bounded, and must not lie about who failed (#925).
+
+`/health/platform` reported `celery-beat` unhealthy indefinitely after a
+slot upgrade on a 3-node appliance, while `celery-workers` stayed green.
+Both halves of that were reproduced directly:
+
+1. ``make_sync_redis`` with no ``socket_connect_timeout`` — which is what
+   ``beat_tick`` used to pass — blocks **indefinitely** against a sentinel
+   that resolves but does not answer (still blocked at 60 s; ~28 s to a
+   clean ``MasterNotFoundError`` once bounded). ``REDIS_URL`` on a
+   multi-node control plane deliberately lists sentinels by per-pod
+   headless DNS, and those names keep resolving through the 20-40 s a
+   rebooting node takes to be marked NotReady — so a slot upgrade walks
+   straight into it while a single-node install never does.
+
+2. ``inspect ping`` answers ``pong`` with **every** prefork slot blocked
+   (verified against a 2-slot worker holding two forever-tasks). So a
+   worker whose pool is wedged reports healthy, and the only component
+   that goes red is the one named after the innocent process.
+
+A tick is enqueued every 30 s regardless, so one unbounded tick per
+interval takes a 4-slot pool in ~2 minutes — which is exactly the "still
+unhealthy after 120s" the report measured.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.tasks.heartbeat import (
+    BEAT_HEARTBEAT_INTERVAL_SECONDS,
+    BEAT_HEARTBEAT_KEY,
+    BEAT_HEARTBEAT_TTL_SECONDS,
+    beat_tick,
+)
+
+
+def test_tick_cannot_outlive_its_own_interval_by_much() -> None:
+    """A tick that never returns wedges one pool slot per interval.
+
+    The limits are what turn "the worker pool is gone in two minutes and
+    never comes back" into "this tick failed, the next one tries again".
+    """
+    soft = beat_tick.soft_time_limit
+    hard = beat_tick.time_limit
+    assert soft is not None and hard is not None, "an unbounded tick is the bug"
+    assert soft < hard, "the soft limit must fire first so the task exits cleanly"
+    assert hard <= BEAT_HEARTBEAT_INTERVAL_SECONDS, (
+        "a tick allowed to outlive its interval still accumulates one wedged "
+        "slot per interval, just more slowly"
+    )
+
+
+def test_stale_queued_ticks_expire_rather_than_replaying() -> None:
+    """After an outage the queue holds a backlog of ticks that all write the
+    same key. Running them is pure waste; the expiry is generous enough that
+    ordinary worker backlog never trips it."""
+    assert beat_tick.expires is not None
+    assert beat_tick.expires > BEAT_HEARTBEAT_INTERVAL_SECONDS
+    assert beat_tick.expires < BEAT_HEARTBEAT_TTL_SECONDS
+
+
+def test_redis_failure_is_swallowed_and_logged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A Redis outage must not raise out of this task.
+
+    The health endpoint already reports the outage from the key's absence.
+    Raising would file a diagnostics row every 30 s for the duration —
+    burying the signal under its own symptom.
+    """
+
+    def _boom(*_args: object, **_kwargs: object) -> object:
+        raise ConnectionError("sentinel unreachable")
+
+    monkeypatch.setattr("app.tasks.heartbeat.make_sync_redis", _boom)
+    assert beat_tick.run() == "unavailable"
+
+
+def test_client_that_fails_mid_write_is_still_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The old body closed in a ``finally`` too, but only because the
+    constructor sat outside the ``try``. Keep the close proven."""
+    closed: list[bool] = []
+
+    class _Client:
+        def set(self, *_a: object, **_k: object) -> None:
+            raise ConnectionError("dropped mid-write")
+
+        def close(self) -> None:
+            closed.append(True)
+
+    monkeypatch.setattr("app.tasks.heartbeat.make_sync_redis", lambda *a, **k: _Client())
+    assert beat_tick.run() == "unavailable"
+    assert closed == [True], "a client leaked on the failure path"
+
+
+def test_happy_path_writes_a_parseable_timestamp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The health check does ``datetime.fromisoformat`` on this value and
+    subtracts it from now, so the format is a contract between two files."""
+    written: dict[str, object] = {}
+
+    class _Client:
+        def set(self, key: str, value: str, ex: int | None = None) -> None:
+            written.update(key=key, value=value, ex=ex)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr("app.tasks.heartbeat.make_sync_redis", lambda *a, **k: _Client())
+    assert beat_tick.run() == "ok"
+    assert written["key"] == BEAT_HEARTBEAT_KEY
+    assert written["ex"] == BEAT_HEARTBEAT_TTL_SECONDS
+
+    parsed = datetime.fromisoformat(str(written["value"]))
+    assert parsed.tzinfo is not None, "a naive stamp makes the age arithmetic explode"
+    assert abs(datetime.now(UTC) - parsed) < timedelta(seconds=30)

--- a/backend/tests/test_platform_health_beat_detail.py
+++ b/backend/tests/test_platform_health_beat_detail.py
@@ -74,6 +74,20 @@ async def test_stale_tick_warns(client: AsyncClient, monkeypatch: pytest.MonkeyP
 
 
 @pytest.mark.asyncio
+async def test_small_forward_skew_renders_sensibly(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Sub-threshold skew between two nodes is normal and stays ``ok`` — but
+    it must not render as ``last tick -45s ago``, which is nonsense on a
+    dashboard and was what the bare subtraction produced."""
+    stamp = (datetime.now(UTC) + timedelta(seconds=45)).isoformat()
+    monkeypatch.setattr("app.core.redis_client.make_async_redis", lambda *a, **k: _FakeRedis(stamp))
+    beat = _beat((await client.get("/health/platform")).json())
+    assert beat["status"] == "ok"
+    assert "-" not in beat["detail"], beat["detail"]
+
+
+@pytest.mark.asyncio
 async def test_tick_stamped_in_the_future_is_not_reported_healthy(
     client: AsyncClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_platform_health_beat_detail.py
+++ b/backend/tests/test_platform_health_beat_detail.py
@@ -1,0 +1,90 @@
+"""The beat component must not blame beat for a fault it cannot see (#925).
+
+The detail used to read "no heartbeat — beat is stopped". That is an
+assertion the check is not able to make: beat *schedules*
+``app.tasks.heartbeat.beat_tick`` and a **worker** executes it, so the key
+is a round trip and its absence indicts either end.
+
+The wording had a cost. On the reported appliance beat was running
+perfectly and the real fault was every worker prefork slot blocked on an
+unbounded Redis connect — a state ``inspect ping`` reports as healthy,
+because the MainProcess answers it without involving the pool. So the one
+red component named the one process that was fine, and the investigation
+went there.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+
+
+def _beat(body: dict) -> dict:
+    return next(c for c in body["components"] if c["name"] == "celery-beat")
+
+
+class _FakeRedis:
+    """Stands in for the platform-health Redis client."""
+
+    def __init__(self, value: str | None) -> None:
+        self._value = value
+
+    async def get(self, _key: str) -> bytes | None:
+        return self._value.encode() if self._value is not None else None
+
+    async def ping(self) -> bool:
+        return True
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_missing_key_does_not_claim_beat_is_stopped(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("app.core.redis_client.make_async_redis", lambda *a, **k: _FakeRedis(None))
+    body = (await client.get("/health/platform")).json()
+    beat = _beat(body)
+
+    assert beat["status"] == "error"
+    detail = beat["detail"].lower()
+    assert "beat is stopped" not in detail, "re-asserting a fault the check cannot see"
+    # It must name the other suspect, or the reader draws the old conclusion.
+    assert "worker" in detail
+
+
+@pytest.mark.asyncio
+async def test_fresh_tick_is_ok(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    stamp = datetime.now(UTC).isoformat()
+    monkeypatch.setattr("app.core.redis_client.make_async_redis", lambda *a, **k: _FakeRedis(stamp))
+    beat = _beat((await client.get("/health/platform")).json())
+    assert beat["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_stale_tick_warns(client: AsyncClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    stamp = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+    monkeypatch.setattr("app.core.redis_client.make_async_redis", lambda *a, **k: _FakeRedis(stamp))
+    beat = _beat((await client.get("/health/platform")).json())
+    assert beat["status"] == "warn"
+    assert "stalled" in beat["detail"]
+
+
+@pytest.mark.asyncio
+async def test_tick_stamped_in_the_future_is_not_reported_healthy(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Clock skew between the node that ran the tick and this one.
+
+    The plain ``age_s > 90`` test read a future stamp as perfectly fresh, so
+    a skewed worker clock could mask a beat that had genuinely stopped —
+    the age only grows back through the window once the skew is exceeded.
+    """
+    stamp = (datetime.now(UTC) + timedelta(seconds=600)).isoformat()
+    monkeypatch.setattr("app.core.redis_client.make_async_redis", lambda *a, **k: _FakeRedis(stamp))
+    beat = _beat((await client.get("/health/platform")).json())
+    assert beat["status"] == "warn"
+    assert "skew" in beat["detail"]

--- a/backend/tests/test_redis_client.py
+++ b/backend/tests/test_redis_client.py
@@ -70,3 +70,63 @@ def test_sentinel_kwargs_without_password_or_knobs() -> None:
 
     assert _sentinel_kwargs(None, {}) == {}
     assert _sentinel_kwargs(None, {"socket_timeout": 5}) == {"socket_timeout": 5}
+
+
+# ── Default connect timeout (#925) ───────────────────────────────────
+#
+# #590 bounded the sentinel hops but did it at each call site. #925 is the
+# call site that missed: the beat heartbeat passed no timeout at all, so
+# its connect to a rebooting node's still-resolving sentinel was unbounded
+# — measured still blocked at 60 s, against ~28 s to a clean
+# MasterNotFoundError once bounded. These pin the default that makes the
+# omission unrepresentable.
+
+
+def test_default_connect_timeout_is_applied_when_caller_passes_nothing() -> None:
+    from app.core.redis_client import DEFAULT_CONNECT_TIMEOUT_SECONDS, _with_default_timeouts
+
+    assert _with_default_timeouts({}) == {"socket_connect_timeout": DEFAULT_CONNECT_TIMEOUT_SECONDS}
+
+
+def test_caller_supplied_connect_timeout_wins() -> None:
+    from app.core.redis_client import _with_default_timeouts
+
+    assert _with_default_timeouts({"socket_connect_timeout": 0.5}) == {
+        "socket_connect_timeout": 0.5
+    }
+
+
+def test_socket_timeout_is_never_defaulted() -> None:
+    """The read timeout must stay opt-in.
+
+    ``core.agent_wake`` parks a pub/sub connection waiting for a message
+    that is *supposed* to be slow. A defaulted ``socket_timeout`` would tear
+    that read down mid-wait and turn the wake bus into a reconnect loop, so
+    the default deliberately bounds the connect only.
+    """
+    from app.core.redis_client import _with_default_timeouts
+
+    assert "socket_timeout" not in _with_default_timeouts({})
+    assert _with_default_timeouts({"socket_timeout": 9})["socket_timeout"] == 9
+
+
+def test_default_reaches_a_plain_url_client() -> None:
+    """End to end through the real constructor, not just the helper."""
+    from app.core.redis_client import DEFAULT_CONNECT_TIMEOUT_SECONDS, make_async_redis
+
+    client = make_async_redis("redis://127.0.0.1:6379/0")
+    kwargs = client.connection_pool.connection_kwargs
+    assert kwargs["socket_connect_timeout"] == DEFAULT_CONNECT_TIMEOUT_SECONDS
+
+
+def test_default_reaches_the_sentinel_hops() -> None:
+    """The hops are the half that hung — a default that stops at the master
+    connection would leave the actual #925 path unbounded."""
+    from app.core.redis_client import (
+        DEFAULT_CONNECT_TIMEOUT_SECONDS,
+        _sentinel_kwargs,
+        _with_default_timeouts,
+    )
+
+    hop_kwargs = _sentinel_kwargs(None, _with_default_timeouts({}))
+    assert hop_kwargs["socket_connect_timeout"] == DEFAULT_CONNECT_TIMEOUT_SECONDS

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -760,11 +760,32 @@ All services expose:
     run in a threadpool with a 3 s overall timeout (so a dead broker
     can't hang the endpoint). Detail carries the worker count; full
     list surfaces on UI hover.
+
+    > **Known limit (#925).** Ping is answered by the worker's
+    > MainProcess pidbox consumer, which is independent of the prefork
+    > pool. A worker whose every pool slot is blocked still answers
+    > `pong` and reports `ok` here, while nothing it is handed can run.
+    > Verified directly against a 2-slot worker holding two
+    > forever-tasks. Detecting pool saturation would need an
+    > `inspect.active()` round trip, and this endpoint is
+    > unauthenticated — every extra broadcast RPC is amplification an
+    > anonymous caller controls — so the `celery-beat` component below
+    > is the signal that surfaces a wedged pool instead.
+
   - `celery-beat` — reads the `spatium:beat:heartbeat` key from
     Redis (written by `app.tasks.heartbeat.beat_tick` every 30 s with
     a 5-min TTL). Age folded into `ok` (≤ 90 s), `warn` (> 90 s — two
-    beat intervals missed), or `error` (missing — beat stopped or
-    down > 5 min).
+    beat intervals missed, or a stamp more than 90 s in the *future*,
+    which is clock skew between the node that ran the tick and this
+    one), or `error` (missing — no tick has landed for > 5 min).
+
+    **`error` here does not mean beat is broken.** Beat *schedules*
+    this task; a **worker** executes it, so the key is a round trip and
+    its absence indicts either end. The detail says so. It used to read
+    "beat is stopped", and that cost real investigation time on #925 —
+    the appliance's beat was running perfectly and the fault was every
+    worker pool slot wedged on an unbounded Redis connect, which per the
+    note above is a state `celery-workers` reports as healthy.
 - Consumed by the Dashboard → Platform Health card. Authenticated
   dashboard users only — the endpoint itself is unauthenticated for
   parity with the other `/health/*` probes, and exposes nothing a

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -331,8 +331,11 @@ no timeout blocks indefinitely — measured still blocked at 60 s — and a
 tick is enqueued every 30 s regardless, so a 4-slot pool is gone in about
 two minutes and never comes back. Every Redis client now gets a default
 connect timeout (`app/core/redis_client.py`) and the heartbeat task carries
-`soft_time_limit` / `time_limit` / `expires`, so a tick fails and frees its
-slot instead of holding it.
+`soft_time_limit` / `time_limit`, both under its own 30 s interval, so a
+tick fails and frees its slot instead of holding it. (`expires` is
+deliberately absent — Celery stamps it from the *publisher's* clock and the
+*worker* compares it, so on a skewed pair it would revoke every tick and
+make this symptom permanent.)
 
 A `warn` reading `last tick Ns in the future (clock skew)` means the node
 that ran the tick and the node serving this endpoint disagree about the

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -287,3 +287,53 @@ permanent (hard) delete path, which refuses unless you either:
 System placeholder rows (the `.0` network and `.255` broadcast) and
 DHCP-lease mirrored rows (`auto_from_lease=True`) do **not** count as
 blockers — they're cleaned up automatically on delete.
+
+---
+
+## `/health/platform` says `celery-beat` is unhealthy
+
+**Read the component name as a symptom, not a diagnosis.** Beat only
+*schedules* `app.tasks.heartbeat.beat_tick`; a **worker** executes it and
+writes the `spatium:beat:heartbeat` key the check reads. So a red
+`celery-beat` means *no tick landed*, which has two very different causes —
+and `celery-workers` cannot be used to rule the second one out, because
+`inspect ping` is answered by the worker's MainProcess and stays green
+while every prefork slot is blocked (see `docs/OBSERVABILITY.md` § Platform
+health).
+
+Split them in about a minute:
+
+```bash
+# 1. Is beat scheduling? Look for the send line, once per 30 s.
+kubectl -n spatiumddi logs deploy/spatiumddi-beat --tail=20 | grep 'Sending due task'
+docker compose logs --tail=20 beat | grep 'Sending due task'      # compose
+
+# 2. Is a worker executing it? Look for the matching succeeded line.
+kubectl -n spatiumddi logs deploy/spatiumddi-worker --tail=50 | grep beat_tick
+
+# 3. Can the pool run anything at all? active == concurrency means it can't.
+kubectl -n spatiumddi exec deploy/spatiumddi-worker -- \
+  celery -A app.celery_app inspect active --timeout 5
+```
+
+| What you see | Where the fault is |
+|---|---|
+| No "Sending due task" | Beat really is stopped — check the pod / its `wait-for-migrate` init container |
+| Sending, but no `beat_tick` succeeded | The worker is not consuming — check the pool (step 3) and the broker |
+| `active` count equals `--concurrency` | The pool is wedged; every scheduled job across the platform has stopped, not just the heartbeat |
+
+**The case #925 was filed for** is the third row, after a slot upgrade on a
+multi-node control plane. `REDIS_URL` lists sentinels by their per-pod
+headless DNS names (deliberately — a client must reach every sentinel
+mid-failover), and those names keep resolving through the 20-40 s a
+rebooting node takes to be marked NotReady. A connect to one of them with
+no timeout blocks indefinitely — measured still blocked at 60 s — and a
+tick is enqueued every 30 s regardless, so a 4-slot pool is gone in about
+two minutes and never comes back. Every Redis client now gets a default
+connect timeout (`app/core/redis_client.py`) and the heartbeat task carries
+`soft_time_limit` / `time_limit` / `expires`, so a tick fails and frees its
+slot instead of holding it.
+
+A `warn` reading `last tick Ns in the future (clock skew)` means the node
+that ran the tick and the node serving this endpoint disagree about the
+time — check NTP on both rather than looking at Celery.


### PR DESCRIPTION
The rollup was right that something was broken and **wrong about what**. Both halves of the mechanism were reproduced directly rather than inferred.

Closes #925.

---

## Root cause

`app/tasks/heartbeat.py` was **the one Redis caller of fourteen passing no timeout at all.** [#590](https://github.com/spatiumddi/spatiumddi/issues/590) bounded the sentinel hops but did it *per call site*, and this is the site it missed.

`REDIS_URL` on a multi-node control plane lists sentinels by their **per-pod headless DNS** names — deliberately, so a client can reach every sentinel mid-failover (`_helpers.tpl`, `redisSentinelHosts`). The cost is that those names keep resolving through the 20–40 s a rebooting node takes to be marked NotReady. A slot upgrade reboots every node in turn, so it walks straight into that window; a single-node install never does, which is the fresh-vs-upgraded asymmetry the report saw.

Measured against a sentinel that resolves but does not answer:

| client | outcome |
|---|---|
| no timeout (what `beat_tick` passed) | **still blocked at 60 s**, and past 5 min |
| `socket_connect_timeout=2` | `MasterNotFoundError` after ~28 s |

A tick is enqueued **every 30 s regardless**, so one blocked tick per interval takes the default 4-slot pool in **~2 minutes** — which is exactly the *"still unhealthy after 120s"* the report measured, and why *every* periodic job stops rather than just the heartbeat.

## Why it looked like beat's fault

`inspect ping` is answered by the worker's **MainProcess pidbox consumer**, independent of the prefork pool. Verified directly against a 2-slot worker holding two forever-tasks:

```
active tasks per slot: {'probe@…': 2}      <- pool completely full
ping while ALL slots blocked: {'probe@…': {'ok': 'pong'}}
```

So the wedged worker reported `celery-workers: ok`, and the only red component was the one named after the process that was running perfectly. The detail then said **"no heartbeat — beat is stopped"**, which the check cannot know: beat *schedules* `beat_tick` and a **worker** executes it, so the key is a round trip and its absence indicts either end.

That wording is the actual reported harm — it sent the investigation to the wrong pod.

## The fix

**1. The connect timeout is now a default inside `core/redis_client.py`**, because a per-call-site convention is precisely what failed. `socket_timeout` is deliberately *not* defaulted: `core/agent_wake` parks a pub/sub read that is *supposed* to be slow, and a read timeout would turn the wake bus into a reconnect loop.

**2. `beat_tick` carries `soft_time_limit` / `time_limit`, both under its own 30 s interval** — a tick allowed to outlive the interval still accumulates one occupied slot per interval, just more slowly. Sized from measurement, not intuition: walking past one dead sentinel costs 17.5 s at a 2 s connect timeout and 12.8 s at 1 s, far more than the timeout itself because redis-py retries internally. The task uses a 1 s connect so a realistic outage clears the limits comfortably. Redis errors are logged and swallowed rather than filing a diagnostics row every 30 s for the length of an outage.

**3. The health detail names both suspects**, and a stamp in the *future* now reads as clock skew rather than as perfectly fresh — the plain `age_s > 90` test would have masked a genuinely dead beat behind a skewed worker clock.

The `celery-workers` ping limitation is **documented rather than fixed**: detecting pool saturation needs an `inspect.active()` round trip, and `/health/platform` is unauthenticated, so every extra broadcast RPC there is amplification an anonymous caller controls.

## Removed in review — worth knowing

The first cut also set `expires=120` to stop an outage backlog replaying. Code review caught that this **trades the bug for a worse one**: Celery stamps `expires` as an *absolute* timestamp from the **publisher's** clock (beat), and `Request.maybe_expire` compares it against the **worker's** — verified against the installed celery. A worker running ahead of beat by more than the window revokes *every* tick, so the key is never written and `/health/platform` sits red **permanently** — the reported symptom, made unconditional, in exactly the post-reboot window where NTP has not converged.

It is gone, with a test pinning it absent and the reasoning recorded so it doesn't get re-added. The backlog it addressed is harmless: every tick writes the same key, and with the time limits the pool cannot wedge, so a backlog drains in seconds.

## Verification

- Both halves of the mechanism reproduced in-container (unbounded hang; ping-while-wedged).
- `beat_tick._get_exec_options()` on the running image → `{'soft_time_limit': 25, 'time_limit': 28, 'expires': None}`.
- Live stack: rollup `ok`, `celery-beat ok — last tick 26s ago`, ticks completing in <1 ms.
- 24 tests across 4 files (3 new/extended); 152 passed across every Redis / health / celery / wake suite.
- `ruff` + `black` + `mypy app` clean.

No migration, no new endpoint, no MCP change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
