### PR TITLE
feat(dhcp): compile device fingerprints into Kea client classes (#700)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -691,7 +691,9 @@ suggestion, free-space treemap.
   (`find_dhcp_device_policies`, `preview_dhcp_device_policy`, both read-only,
   default on), a Device Policies tab. Permissions ride on `dhcp_client_class`
   — a device policy *is* a client class, generated rather than typed — so the
-  builtin DHCP Editor role gains it with no role migration. Explicitly **not**
+  builtin DHCP Editor role gains **read** with no role migration (writes stay
+  superadmin, matching the hand-authored client-class surface rather than
+  quietly widening it). Explicitly **not**
   a feature module (non-negotiable #14): it adds no top-level family, and
   "off" is already `enabled=false` on the row.
   **The compiler cannot match the category, and says so.** Fingerbank
@@ -715,6 +717,25 @@ suggestion, free-space treemap.
   bytes rather than syntax. An absent option 60 compiles to `not
   option[60].exists` rather than being ignored, which would silently widen the
   match to every device sharing the request list.
+  **Nine findings from /code-review, all confirmed and fixed**, two of which
+  were live 500s. The worst: `Signature` carried `order=True`, whose generated
+  `__lt__` compares `None` against `str` the moment two in-class signatures
+  agree on option 55 and differ on whether option 60 is present — a
+  `TypeError` raised *inside* `build_config_bundle`, i.e. a 500 on the agent
+  long-poll that stops the whole group converging. Every fixture happened to
+  differ on option 55, which is why the suite was green. Sorting now goes
+  through an explicit key that gives absence a defined position. Also: an
+  explicit `null` reached NOT NULL columns through `exclude_unset` (500 → now
+  422, while a null on a *nullable* field still clears it, which
+  `exclude_none` would have broken); the new table was absent from the backup
+  catalogue, so a selective `dhcp` restore would TRUNCATE-CASCADE it and never
+  repopulate it — a failing test caught that one; `compiled_expression` echoed
+  the override, making the documented comparison impossible; the preview GET
+  committed `last_compiled_at`, an unaudited write on a `read`-authorised path
+  that maintenance mode does not gate (the column was dropped — the only other
+  compile site is the bundle build, and stamping there would write on every
+  long-poll tick); and the fingerprint scan ran once per policy per tick
+  instead of once per bundle.
   **Two fail-closed rules, both about the same Kea behaviour:** a class with
   no `test` matches *every* packet, so a policy compiling to nothing is
   dropped rather than rendered testless (in both renderers), and `text_to_hex`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -680,6 +680,54 @@ suggestion, free-space treemap.
 - ⬜ [**Lease histogram by hour**](https://github.com/spatiumddi/spatiumddi/issues/53)
 - ⬜ [**Option 82 (relay agent info) class matching**](https://github.com/spatiumddi/spatiumddi/issues/54)
 - ⬜ [**DHCP test client**](https://github.com/spatiumddi/spatiumddi/issues/55)
+- ✅ [**Fingerprint-driven DHCP policy — compile device profiles into Kea client-classes**](https://github.com/spatiumddi/spatiumddi/issues/700)
+  — device profiling told us what a device *is*; client classes let us treat
+  kinds of device differently; nothing joined them. Now `dhcp_device_policy`
+  (migration `f3b8d21c74ae`) + `services/dhcp/device_policy.py` compile an
+  operator's choice of fingerbank device classes into a real Kea client-class
+  `test`, carrying an option set, a per-class `valid-lifetime`, and a stable
+  generated class name a pool's `class_restriction` can bind to. NAC-lite with
+  no 802.1X and no switch config. 4 REST routes, 2 MCP tools
+  (`find_dhcp_device_policies`, `preview_dhcp_device_policy`, both read-only,
+  default on), a Device Policies tab. Permissions ride on `dhcp_client_class`
+  — a device policy *is* a client class, generated rather than typed — so the
+  builtin DHCP Editor role gains it with no role migration. Explicitly **not**
+  a feature module (non-negotiable #14): it adds no top-level family, and
+  "off" is already `enabled=false` on the row.
+  **The compiler cannot match the category, and says so.** Fingerbank
+  classifies by querying its corpus; Kea has no `device-class == IoT`
+  predicate. So it matches *the signatures observed and classified into the
+  selected classes* — which makes v1 honestly "classify on first lease, apply
+  on renewal", stated in the UI rather than implied away.
+  **The load-bearing safety property is ambiguity exclusion.** A parameter
+  request list like `1,3,6,15` comes from a doorbell and a rack server alike,
+  so a signature seen both inside and outside the selected classes is excluded
+  by default, counted and listed — otherwise the headline use ("quarantine
+  unknown devices") is also how the CEO's laptop gets quarantined.
+  `include_ambiguous` is the audited opt-in. Unclassified devices are
+  deliberately *not* treated as ambiguity evidence (that would make the
+  feature unusable before a fingerbank key is set) but are reported — and
+  only for signatures that survive filtering and the 128-term cap, so the
+  count reflects devices the rendered expression actually reaches.
+  **Nothing device-controlled reaches the config as a string:** option 60 is
+  chosen by the *device*, so both halves of every term are emitted as hex
+  (`option[60].hex == 0x4D5346…`), making a vendor class of `' or 1--` inert
+  bytes rather than syntax. An absent option 60 compiles to `not
+  option[60].exists` rather than being ignored, which would silently widen the
+  match to every device sharing the request list.
+  **Two fail-closed rules, both about the same Kea behaviour:** a class with
+  no `test` matches *every* packet, so a policy compiling to nothing is
+  dropped rather than rendered testless (in both renderers), and `text_to_hex`
+  returns None for empty rather than emitting `0x`, which is a parse error
+  that fails the WHOLE config. Kea's parser is *not* the term-cap constraint
+  (1024 terms / 32 KB loads fine) — per-packet cost and legibility are, and
+  hitting the cap is reported, never silent. Every expression form was
+  validated against a live kea-dhcp4 3.0.3, and the end-to-end path
+  (REST → bundle → wire → agent → on-disk `kea-dhcp4.conf`) was walked on the
+  dev stack rather than reasoned about. **v4-only by construction** — options
+  55/60 are DHCPv4 codes, and the v6 branch of both renderers builds its class
+  list from generic client classes alone. **Deferred:** auto-creating the
+  quarantine pool, DHCPv6, and rules keyed on fingerbank device *name*.
 
 #### Operational tooling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,6 +736,18 @@ suggestion, free-space treemap.
   compile site is the bundle build, and stamping there would write on every
   long-poll tick); and the fingerprint scan ran once per policy per tick
   instead of once per bundle.
+  **Validated against a live fingerbank key**, which corrected a wrong
+  assumption carried by the issue text and the first draft of the docs: there
+  is no plain `Printer` or `IoT` class. Fingerbank's `device_class` is its own
+  taxonomy at mixed granularity — real observed values are `HP Print Server`
+  (score 89), `Operating System` (78), `Generic Android` (60),
+  `Hardware Manufacturer` (29), `Generic IoT` (15). The last of those is the
+  interesting one: a low score means fingerbank *failed* to identify the
+  device and fell back to the MAC vendor, so that class groups unrelated
+  hardware and is a poor policy target however plausible the name reads in a
+  list. `fingerbank_score` was already stored and surfaced nowhere, so the
+  class picker now shows it per class and flags anything under 30, and the
+  compiler warns when the best score among matched devices is below that.
   **Two fail-closed rules, both about the same Kea behaviour:** a class with
   no `test` matches *every* packet, so a policy compiling to nothing is
   dropped rather than rendered testless (in both renderers), and `text_to_hex`

--- a/agent/dhcp/spatium_dhcp_agent/render_kea.py
+++ b/agent/dhcp/spatium_dhcp_agent/render_kea.py
@@ -467,6 +467,40 @@ def _phone_class(c: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
+def _device_policy_class(c: dict[str, Any]) -> dict[str, Any] | None:
+    """Render a fingerprint-driven device-policy class (#700).
+
+    Mirrors ``_render_device_policy_class`` in ``backend/app/drivers/dhcp/kea.py``.
+
+    **Dhcp4 only, by construction.** The compiled expressions test options
+    55 and 60, which are DHCPv4 option codes; under Dhcp6 those numbers
+    address entirely different options (and the v6 equivalents are the ORO
+    and vendor-class, options 6 and 16). The v6 branch below builds its
+    class list from the generic ``client_classes`` alone, so nothing here
+    reaches it — same as the v4-only DROP class, and same as the backend
+    driver.
+
+    Returns ``None`` — rather than a class with no ``test`` — when the
+    expression is missing. The control plane already drops these, so
+    reaching here means a hand-crafted or truncated bundle; a testless Kea
+    class matches every packet, which would hand this policy's option set
+    and lease time to the whole network. Failing closed is the only safe
+    reading of a malformed device policy.
+    """
+    expr = c.get("match_expression") or c.get("test")
+    if not expr:
+        _log.warning("kea_device_policy_class_no_test", policy_class=c.get("name"))
+        return None
+    out: dict[str, Any] = {"name": c["name"], "test": expr}
+    lease_time = c.get("lease_time")
+    if lease_time is not None:
+        out["valid-lifetime"] = lease_time
+    opts = _options_from_mapping(c.get("options"))
+    if opts:
+        out["option-data"] = opts
+    return out
+
+
 def _dynamic_pool(p: dict[str, Any], *, address_family: str) -> dict[str, Any]:
     """Render one dynamic address pool, with its per-pool option overrides.
 
@@ -1046,6 +1080,17 @@ def render(
     # client-classes in declaration order, so this is behaviour, not style.
     rendered_classes += [_pxe_class(p) for p in (bundle.get("pxe_classes") or [])]
     rendered_classes += [_phone_class(c) for c in (bundle.get("phone_classes") or [])]
+    # #700 — device policies last, matching the backend driver's order, so an
+    # operator's own class of the same shape is evaluated first. Kea stops at
+    # the first match, so this is precedence rather than presentation.
+    rendered_classes += [
+        rc
+        for rc in (
+            _device_policy_class(c)
+            for c in (bundle.get("device_policy_classes") or [])
+        )
+        if rc is not None
+    ]
 
     # MAC blocklist — render as Kea's reserved ``DROP`` class. Any packet
     # whose hardware address matches the OR-ed expression is silently

--- a/agent/dhcp/tests/test_render_kea_wire_coverage.py
+++ b/agent/dhcp/tests/test_render_kea_wire_coverage.py
@@ -299,3 +299,79 @@ def test_pxe_next_server_ip_is_kept() -> None:
         {"name": "pxe", "match_expression": "", "next_server": "10.0.0.5", "boot_file_name": "b"}
     )
     assert c["next-server"] == "10.0.0.5"
+
+
+# ── #700 device-policy classes ────────────────────────────────────
+
+
+def test_device_policy_class_renders_with_lease_time() -> None:
+    """The per-class ``valid-lifetime`` is the "short leases for unknown
+    devices" half of #700's NAC-lite outcome. Kea honours it per class —
+    checked against kea-dhcp4 3.0.3, because a silently-ignored lease time
+    is the difference between a quarantine that expires and one that does
+    not."""
+    out = render(
+        _bundle(
+            device_policy_classes=[
+                {
+                    "name": "spatium-device-IoT",
+                    "match_expression": "option[55].hex == 0x010306",
+                    "options": {"dns-servers": "10.0.0.53"},
+                    "lease_time": 600,
+                }
+            ]
+        )
+    )
+    classes = out["Dhcp4"]["client-classes"]
+    cls = next(c for c in classes if c["name"] == "spatium-device-IoT")
+    assert cls["test"] == "option[55].hex == 0x010306"
+    assert cls["valid-lifetime"] == 600
+    assert cls["option-data"]
+
+
+def test_device_policy_class_without_test_is_dropped_not_rendered() -> None:
+    """A Kea client-class with no ``test`` matches EVERY packet.
+
+    The control plane already drops these, so arriving here means a
+    hand-crafted or truncated bundle. Rendering it would hand a quarantine
+    option set and lease time to the whole network, so the only safe
+    reading is to fail closed."""
+    out = render(
+        _bundle(
+            device_policy_classes=[
+                {"name": "no-test", "match_expression": "", "lease_time": 300}
+            ]
+        )
+    )
+    names = [c["name"] for c in out["Dhcp4"].get("client-classes", [])]
+    assert "no-test" not in names
+
+
+def test_device_policy_classes_do_not_leak_into_dhcp6() -> None:
+    """Options 55 and 60 are DHCPv4 option codes; under Dhcp6 those numbers
+    address entirely different options. The v6 branch builds its class list
+    from the generic ``client_classes`` alone — same as the v4-only DROP
+    class."""
+    bundle = _bundle(
+        device_policy_classes=[
+            {
+                "name": "spatium-device-IoT",
+                "match_expression": "option[55].hex == 0x010306",
+                "lease_time": 600,
+            }
+        ]
+    )
+    bundle["scopes"] = list(bundle["scopes"]) + [
+        {
+            "subnet_cidr": "2001:db8::/64",
+            "address_family": "ipv6",
+            "is_active": True,
+            "lease_time": 3600,
+            "options": {},
+            "pools": [],
+            "statics": [],
+        }
+    ]
+    out = render(bundle)
+    v6_classes = out.get("Dhcp6", {}).get("client-classes", [])
+    assert "spatium-device-IoT" not in [c["name"] for c in v6_classes]

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -730,6 +730,7 @@ backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:138
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:139
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:140
 backend/alembic/versions/f3b6d914c072_dns_server_daemon_version.py:drop_column:46
+backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py:drop_table:105
 backend/alembic/versions/f3b8d24a1c70_appliance_evict_requested.py:drop_column:39
 backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py:drop_column:49
 backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_column:175

--- a/backend/alembic/migrations_lint_baseline.txt
+++ b/backend/alembic/migrations_lint_baseline.txt
@@ -730,7 +730,7 @@ backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:138
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:139
 backend/alembic/versions/f3a8c2d491e7_password_policy.py:drop_column:140
 backend/alembic/versions/f3b6d914c072_dns_server_daemon_version.py:drop_column:46
-backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py:drop_table:105
+backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py:drop_table:97
 backend/alembic/versions/f3b8d24a1c70_appliance_evict_requested.py:drop_column:39
 backend/alembic/versions/f3b9c1d6a274_dhcp_group_socket_mode.py:drop_column:49
 backend/alembic/versions/f3e8b1d72a9c_tls_cert_monitoring.py:drop_column:175

--- a/backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py
+++ b/backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py
@@ -69,7 +69,6 @@ def upgrade() -> None:
             sa.ForeignKey("user.id", ondelete="SET NULL"),
             nullable=True,
         ),
-        sa.Column("last_compiled_at", sa.DateTime(timezone=True), nullable=True),
         # TimestampMixin columns need an explicit server_default here: a
         # fresh install runs the migration, not create_all, and would
         # otherwise NULL-violate on the first insert.

--- a/backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py
+++ b/backend/alembic/versions/f3b8d21c74ae_dhcp_device_policy.py
@@ -1,0 +1,98 @@
+"""dhcp device policy — fingerprint-driven client classes (#700)
+
+Revision ID: f3b8d21c74ae
+Revises: a2e7f31c9b48
+Create Date: 2026-08-24
+
+Joins the two halves of device profiling: fingerbank device classes on
+one side, Kea client classes on the other. One row per policy; the
+compiled match expression is derived at bundle-build time from the
+observed ``dhcp_fingerprint`` rows rather than stored, so a newly
+classified device joins its policy without an operator edit.
+
+``class_name`` is stored rather than derived from ``name`` so a rename
+cannot silently detach the pools that reference it via
+``dhcp_pool.class_restriction``.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "f3b8d21c74ae"
+down_revision = "a2e7f31c9b48"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "dhcp_device_policy",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "group_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("dhcp_server_group.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False, server_default=""),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("class_name", sa.String(length=128), nullable=False),
+        sa.Column(
+            "device_classes",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column(
+            "options",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("lease_time", sa.Integer(), nullable=True),
+        sa.Column("match_override", sa.Text(), nullable=True),
+        sa.Column(
+            "include_ambiguous",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("priority", sa.Integer(), nullable=False, server_default=sa.text("100")),
+        sa.Column(
+            "created_by_user_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("user.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("last_compiled_at", sa.DateTime(timezone=True), nullable=True),
+        # TimestampMixin columns need an explicit server_default here: a
+        # fresh install runs the migration, not create_all, and would
+        # otherwise NULL-violate on the first insert.
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column(
+            "modified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint("group_id", "name", name="uq_dhcp_device_policy_group_name"),
+        sa.UniqueConstraint(
+            "group_id", "class_name", name="uq_dhcp_device_policy_group_class_name"
+        ),
+    )
+    op.create_index("ix_dhcp_device_policy_group", "dhcp_device_policy", ["group_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_dhcp_device_policy_group", table_name="dhcp_device_policy")
+    op.drop_table("dhcp_device_policy")

--- a/backend/app/api/v1/dhcp/__init__.py
+++ b/backend/app/api/v1/dhcp/__init__.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter
 
 from app.api.v1.dhcp.agents import router as agents_router
 from app.api.v1.dhcp.client_classes import router as client_classes_router
+from app.api.v1.dhcp.device_policies import router as device_policies_router
 from app.api.v1.dhcp.lease_history import router as lease_history_router
 from app.api.v1.dhcp.leases import router as leases_router
 from app.api.v1.dhcp.mac_blocks import router as mac_blocks_router
@@ -30,6 +31,9 @@ router.include_router(pxe_profiles_router)
 router.include_router(phone_profiles_router)
 router.include_router(statics_router)
 router.include_router(client_classes_router)
+# #700 — fingerprint-driven device policies, which compile into the same
+# Kea client-class list the router above manages by hand.
+router.include_router(device_policies_router)
 router.include_router(mac_blocks_router)
 router.include_router(option_codes_router)
 router.include_router(option_templates_router)

--- a/backend/app/api/v1/dhcp/agents.py
+++ b/backend/app/api/v1/dhcp/agents.py
@@ -681,6 +681,22 @@ async def agent_config_longpoll(
                             }
                             for c in bundle.phone_classes
                         ],
+                        # #700 — fingerprint-driven device policies. Serialized
+                        # here for the reason #858 documents one block up: a
+                        # class that is ETag-hashed and rendered by the
+                        # control-plane driver but absent from the wire cannot
+                        # reach agent-managed Kea, which is how both the
+                        # appliance and the Compose stack run DHCP — i.e. the
+                        # feature would work nowhere it actually runs.
+                        "device_policy_classes": [
+                            {
+                                "name": c.name,
+                                "match_expression": c.match_expression,
+                                "options": c.options,
+                                "lease_time": c.lease_time,
+                            }
+                            for c in bundle.device_policy_classes
+                        ],
                         # #858 — Kea types a raw ``code:NN`` option as BINARY,
                         # so an operator's string value ("not a valid string of
                         # hexadecimal digits") fails the WHOLE config. The real
@@ -697,6 +713,11 @@ async def agent_config_longpoll(
                             + [st.options_override for s in bundle.scopes for st in s.statics]
                             + [c.options for c in bundle.client_classes]
                             + [c.options for c in bundle.phone_classes]
+                            # #700 — a device policy can deliver a raw
+                            # ``code:NN`` vendor option just as a phone profile
+                            # can; without its definition Kea types the value
+                            # BINARY and rejects the WHOLE config.
+                            + [c.options for c in bundle.device_policy_classes]
                         ),
                         "mac_blocks": [
                             {

--- a/backend/app/api/v1/dhcp/device_policies.py
+++ b/backend/app/api/v1/dhcp/device_policies.py
@@ -18,15 +18,20 @@ asks for explicitly:
   silently matches nothing.
 
 Permissions ride on ``dhcp_client_class``: a device policy *is* a client
-class, generated rather than hand-written, so anyone trusted to author
-one by hand is trusted to author one this way. It also means the builtin
-DHCP Editor role picks this up with no role migration.
+class, generated rather than hand-written. Reads follow that resource
+permission, so the builtin DHCP Editor role gains them with no role
+migration.
+
+**Writes are superadmin**, matching the hand-authored client-class
+surface next door rather than quietly widening it — the two produce the
+same Kea object, and a policy that can move devices into a quarantine
+pool is not a smaller privilege than typing that class by hand.
 """
 
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 import structlog
@@ -59,6 +64,10 @@ router = APIRouter(
 # unbounded string is both a config-size problem and an easy way to make
 # the whole group's config unparseable. See ``_validate_override``.
 MAX_OVERRIDE_LENGTH = 8192
+
+# Matched MACs returned by the preview. The full count is always reported
+# separately, so this bounds the response without hiding the scale.
+PREVIEW_MAC_LIMIT = 500
 
 
 def _validate_override(expr: str | None) -> str | None:
@@ -185,7 +194,6 @@ class DevicePolicyResponse(BaseModel):
     match_override: str | None
     include_ambiguous: bool
     priority: int
-    last_compiled_at: datetime | None
     created_at: datetime
     modified_at: datetime
 
@@ -214,6 +222,7 @@ class DevicePolicyPreviewOut(BaseModel):
     truncated: int
     max_signature_terms: int
     matched_macs: list[str]
+    matched_macs_truncated: bool
     matched_device_count: int
     unclassified_matches: int
     warnings: list[str]
@@ -285,7 +294,7 @@ def _to_preview(policy: DHCPDevicePolicy, compiled: Any) -> DevicePolicyPreviewO
         class_name=policy.class_name,
         expression=compiled.expression,
         source=compiled.source,
-        compiled_expression=compiled.expression,
+        compiled_expression=compiled.compiled_expression,
         signature_count=len(compiled.signatures),
         signatures=[
             SignatureOut(option_55=s.option_55, option_60=s.option_60) for s in compiled.signatures
@@ -296,7 +305,11 @@ def _to_preview(policy: DHCPDevicePolicy, compiled: Any) -> DevicePolicyPreviewO
         ambiguous_excluded=bool(compiled.ambiguous) and not policy.include_ambiguous,
         truncated=compiled.truncated,
         max_signature_terms=MAX_SIGNATURE_TERMS,
-        matched_macs=compiled.matched_macs,
+        # Capped for transport; the count is the whole population, so a
+        # large estate reports honestly instead of returning a 50k-element
+        # array to a modal that renders chips.
+        matched_macs=compiled.matched_macs[:PREVIEW_MAC_LIMIT],
+        matched_macs_truncated=len(compiled.matched_macs) > PREVIEW_MAC_LIMIT,
         matched_device_count=len(compiled.matched_macs),
         unclassified_matches=compiled.unclassified_matches,
         warnings=compiled.warnings,
@@ -379,6 +392,31 @@ async def update_device_policy(
     row = await _get_policy(db, policy_id)
     changes = body.model_dump(exclude_unset=True)
 
+    # ``exclude_unset`` is deliberate — it is what lets an explicit null
+    # CLEAR a nullable field (``lease_time``, ``match_override``), which
+    # ``exclude_none`` would make impossible. But it also lets a null
+    # through to columns that are NOT NULL, where the blanket setattr below
+    # turns it into an unhandled 500 on commit. So nulls are rejected for
+    # exactly the non-nullable set, by name, rather than for everything.
+    non_nullable = {
+        "name",
+        "description",
+        "enabled",
+        "device_classes",
+        "options",
+        "include_ambiguous",
+        "priority",
+    }
+    nulled = sorted(k for k in changes if k in non_nullable and changes[k] is None)
+    if nulled:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{', '.join(nulled)} cannot be null. Omit the field to leave it "
+                "unchanged, or send a value."
+            ),
+        )
+
     if "options" in changes:
         validate_domain_options(changes["options"] or {}, previous=row.options or {})
     if "match_override" in changes:
@@ -447,14 +485,16 @@ async def preview_device_policy(
 ) -> DevicePolicyPreviewOut:
     """Show exactly what this policy compiles to, and who it catches.
 
-    Read-only and side-effect free apart from stamping
-    ``last_compiled_at`` — the operator needs to know how fresh the answer
-    is, because the underlying fingerprint set moves on its own.
+    Genuinely read-only. An earlier cut stamped ``last_compiled_at`` here,
+    which made a GET authorised by ``read`` perform an unaudited write that
+    maintenance mode does not gate (it only holds POST/PUT/PATCH/DELETE).
+    The column was dropped rather than moved: the only other place a
+    compile happens is the config-bundle build, and stamping there would
+    add a write to every agent long-poll tick. Compilation is stateless and
+    always current, so there was nothing worth recording.
     """
     row = await _get_policy(db, policy_id)
     compiled = await compile_device_policy(db, row)
-    row.last_compiled_at = datetime.now(UTC)
-    await db.commit()
     return _to_preview(row, compiled)
 
 

--- a/backend/app/api/v1/dhcp/device_policies.py
+++ b/backend/app/api/v1/dhcp/device_policies.py
@@ -1,0 +1,519 @@
+"""Fingerprint-driven device policy CRUD + preview (issue #700).
+
+Wires device profiling to Kea client classes: the operator picks
+fingerbank device classes and an outcome, and ``services.dhcp.device_policy``
+compiles it into a match expression over the signatures that produced
+those classifications.
+
+Two endpoints exist purely so this is not a black box, which the issue
+asks for explicitly:
+
+* ``GET …/device-policies/{id}/preview`` returns the compiled
+  expression, every signature that went into it, the ones excluded for
+  ambiguity, and the MACs that currently match — i.e. which existing
+  leases land in this class, before anything is applied.
+* ``GET …/server-groups/{gid}/device-observations`` lists the device
+  classes fingerbank has actually returned on this install, with counts,
+  so the class picker offers what exists rather than a free-text box that
+  silently matches nothing.
+
+Permissions ride on ``dhcp_client_class``: a device policy *is* a client
+class, generated rather than hand-written, so anyone trusted to author
+one by hand is trusted to author one this way. It also means the builtin
+DHCP Editor role picks this up with no role migration.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import func, select
+
+from app.api.deps import DB, CurrentUser, SuperAdmin
+from app.api.v1.dhcp._audit import write_audit
+from app.api.v1.dhcp.scopes import validate_domain_options
+from app.core.agent_wake import collect_wake, dhcp_group_channel
+from app.core.permissions import require_resource_permission
+from app.models.dhcp import DHCPServerGroup
+from app.models.dhcp_device_policy import DHCPDevicePolicy
+from app.models.dhcp_fingerprint import DHCPFingerprint
+from app.services.dhcp.device_policy import (
+    MAX_SIGNATURE_TERMS,
+    compile_device_policy,
+    slugify_class_name,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(
+    tags=["dhcp"],
+    dependencies=[Depends(require_resource_permission("dhcp_client_class"))],
+)
+
+# A manual override is interpolated verbatim into the Kea config, so an
+# unbounded string is both a config-size problem and an easy way to make
+# the whole group's config unparseable. See ``_validate_override``.
+MAX_OVERRIDE_LENGTH = 8192
+
+
+def _validate_override(expr: str | None) -> str | None:
+    """Structurally check an operator-supplied match expression.
+
+    This is deliberately *not* a Kea expression parser — operators need
+    the real language for the override to be a usable escape hatch, and
+    re-implementing Kea's grammar here would reject valid expressions
+    while still missing invalid ones.
+
+    What it does catch is the class of typo that takes the whole group
+    down rather than just this policy: Kea rejects a malformed config
+    *whole*, so an unbalanced parenthesis here stops every other class,
+    scope and reservation in the group converging. That blast radius is
+    the same one #876 and #899 documented for named.conf, and it is why
+    an obviously-broken expression is refused at the API instead of at
+    the agent.
+
+    The agent still runs Kea's own ``config-test`` before applying, and
+    #882's quarantine means a bundle Kea rejects is reverted rather than
+    re-applied in a loop — so this is the first gate, not the only one.
+    """
+    if expr is None:
+        return None
+    expr = expr.strip()
+    if not expr:
+        return None
+    if len(expr) > MAX_OVERRIDE_LENGTH:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Match expression is {len(expr)} characters; the limit is "
+                f"{MAX_OVERRIDE_LENGTH}."
+            ),
+        )
+    if expr.count("(") != expr.count(")"):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Unbalanced parentheses in the match expression. Kea rejects a "
+                "malformed configuration in full, so this would stop every scope "
+                "and class in this group from converging, not just this policy."
+            ),
+        )
+    if expr.count("'") % 2:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Unbalanced quote in the match expression. Kea rejects a "
+                "malformed configuration in full, so this would stop every scope "
+                "and class in this group from converging, not just this policy."
+            ),
+        )
+    return expr
+
+
+# ── Schemas ─────────────────────────────────────────────────────────────────
+
+
+class DevicePolicyCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str = ""
+    enabled: bool = True
+    device_classes: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Fingerbank device classes to match, e.g. "
+            '["Printer", "Internet of Things (IoT)"]. Use '
+            "GET /dhcp/server-groups/{id}/device-observations for the classes "
+            "actually seen on this install."
+        ),
+    )
+    options: dict[str, Any] = Field(default_factory=dict)
+    lease_time: int | None = Field(
+        default=None,
+        ge=60,
+        le=4294967295,
+        description=(
+            "Kea valid-lifetime for matched devices, in seconds. A short lease "
+            "is what makes a quarantine reversible."
+        ),
+    )
+    match_override: str | None = None
+    include_ambiguous: bool = False
+    priority: int = 100
+
+    @field_validator("device_classes")
+    @classmethod
+    def _clean_classes(cls, v: list[str]) -> list[str]:
+        # Deduplicate while preserving order, and drop blanks. A blank
+        # entry would silently match every unclassified fingerprint.
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in v:
+            item = (item or "").strip()
+            if item and item not in seen:
+                seen.add(item)
+                out.append(item)
+        return out
+
+
+class DevicePolicyUpdate(BaseModel):
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = None
+    enabled: bool | None = None
+    device_classes: list[str] | None = None
+    options: dict[str, Any] | None = None
+    lease_time: int | None = Field(None, ge=60, le=4294967295)
+    match_override: str | None = None
+    include_ambiguous: bool | None = None
+    priority: int | None = None
+
+
+class DevicePolicyResponse(BaseModel):
+    id: uuid.UUID
+    group_id: uuid.UUID
+    name: str
+    description: str
+    enabled: bool
+    class_name: str
+    device_classes: list[str]
+    options: dict[str, Any]
+    lease_time: int | None
+    match_override: str | None
+    include_ambiguous: bool
+    priority: int
+    last_compiled_at: datetime | None
+    created_at: datetime
+    modified_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SignatureOut(BaseModel):
+    option_55: str | None
+    option_60: str | None
+
+
+class DevicePolicyPreviewOut(BaseModel):
+    policy_id: uuid.UUID
+    class_name: str
+    # The expression that will be rendered — the operator's override when
+    # one is set, otherwise the compiled one.
+    expression: str
+    source: str = Field(description="compiled | override | empty")
+    # Always what the compiler produced, so an override can be compared
+    # against it. Equal to ``expression`` when no override is set.
+    compiled_expression: str
+    signature_count: int
+    signatures: list[SignatureOut]
+    ambiguous_signatures: list[SignatureOut]
+    ambiguous_excluded: bool
+    truncated: int
+    max_signature_terms: int
+    matched_macs: list[str]
+    matched_device_count: int
+    unclassified_matches: int
+    warnings: list[str]
+    renders: bool = Field(
+        description=(
+            "Whether this policy contributes a class to the next config bundle. "
+            "False when it is disabled or compiles to nothing."
+        )
+    )
+
+
+class DeviceObservationOut(BaseModel):
+    device_class: str
+    device_count: int
+    signature_count: int
+
+
+class DeviceObservationsOut(BaseModel):
+    classes: list[DeviceObservationOut]
+    unclassified_devices: int
+    total_devices: int
+    note: str
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+async def _get_group(db: DB, group_id: uuid.UUID) -> DHCPServerGroup:
+    grp = await db.get(DHCPServerGroup, group_id)
+    if grp is None:
+        raise HTTPException(status_code=404, detail="DHCP server group not found")
+    return grp
+
+
+async def _get_policy(db: DB, policy_id: uuid.UUID) -> DHCPDevicePolicy:
+    row = await db.get(DHCPDevicePolicy, policy_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Device policy not found")
+    return row
+
+
+async def _unique_class_name(db: DB, group_id: uuid.UUID, name: str) -> str:
+    """Pick a group-unique Kea class name derived from the policy name.
+
+    Collisions are resolved with a numeric suffix rather than by failing:
+    two policies called "Printers" and "printers" slugify identically, and
+    refusing the second would be a confusing way to say "pick a different
+    name" for something the operator never sees.
+    """
+    base = slugify_class_name(name)
+    candidate = base
+    n = 2
+    while True:
+        exists = await db.execute(
+            select(DHCPDevicePolicy.id).where(
+                DHCPDevicePolicy.group_id == group_id,
+                DHCPDevicePolicy.class_name == candidate,
+            )
+        )
+        if exists.scalar_one_or_none() is None:
+            return candidate
+        candidate = f"{base}-{n}"
+        n += 1
+
+
+def _to_preview(policy: DHCPDevicePolicy, compiled: Any) -> DevicePolicyPreviewOut:
+    return DevicePolicyPreviewOut(
+        policy_id=policy.id,
+        class_name=policy.class_name,
+        expression=compiled.expression,
+        source=compiled.source,
+        compiled_expression=compiled.expression,
+        signature_count=len(compiled.signatures),
+        signatures=[
+            SignatureOut(option_55=s.option_55, option_60=s.option_60) for s in compiled.signatures
+        ],
+        ambiguous_signatures=[
+            SignatureOut(option_55=s.option_55, option_60=s.option_60) for s in compiled.ambiguous
+        ],
+        ambiguous_excluded=bool(compiled.ambiguous) and not policy.include_ambiguous,
+        truncated=compiled.truncated,
+        max_signature_terms=MAX_SIGNATURE_TERMS,
+        matched_macs=compiled.matched_macs,
+        matched_device_count=len(compiled.matched_macs),
+        unclassified_matches=compiled.unclassified_matches,
+        warnings=compiled.warnings,
+        renders=bool(policy.enabled and compiled.expression),
+    )
+
+
+# ── Routes ──────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/server-groups/{group_id}/device-policies",
+    response_model=list[DevicePolicyResponse],
+)
+async def list_device_policies(
+    group_id: uuid.UUID, db: DB, _: CurrentUser
+) -> list[DHCPDevicePolicy]:
+    res = await db.execute(
+        select(DHCPDevicePolicy)
+        .where(DHCPDevicePolicy.group_id == group_id)
+        .order_by(DHCPDevicePolicy.priority, DHCPDevicePolicy.name)
+    )
+    return list(res.scalars().all())
+
+
+@router.post(
+    "/server-groups/{group_id}/device-policies",
+    response_model=DevicePolicyResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_device_policy(
+    group_id: uuid.UUID, body: DevicePolicyCreate, db: DB, user: SuperAdmin
+) -> DHCPDevicePolicy:
+    await _get_group(db, group_id)
+    dupe = await db.execute(
+        select(DHCPDevicePolicy.id).where(
+            DHCPDevicePolicy.group_id == group_id,
+            DHCPDevicePolicy.name == body.name,
+        )
+    )
+    if dupe.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="A device policy with that name exists")
+    validate_domain_options(body.options or {})  # #597
+    override = _validate_override(body.match_override)
+
+    payload = body.model_dump()
+    payload["match_override"] = override
+    row = DHCPDevicePolicy(
+        group_id=group_id,
+        class_name=await _unique_class_name(db, group_id, body.name),
+        created_by_user_id=user.id,
+        **payload,
+    )
+    db.add(row)
+    await db.flush()
+    write_audit(
+        db,
+        user=user,
+        action="create",
+        resource_type="dhcp_device_policy",
+        resource_id=str(row.id),
+        resource_display=row.name,
+        new_value=body.model_dump(mode="json"),
+    )
+    collect_wake(dhcp_group_channel(group_id))
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+@router.get("/device-policies/{policy_id}", response_model=DevicePolicyResponse)
+async def get_device_policy(policy_id: uuid.UUID, db: DB, _: CurrentUser) -> DHCPDevicePolicy:
+    return await _get_policy(db, policy_id)
+
+
+@router.put("/device-policies/{policy_id}", response_model=DevicePolicyResponse)
+async def update_device_policy(
+    policy_id: uuid.UUID, body: DevicePolicyUpdate, db: DB, user: SuperAdmin
+) -> DHCPDevicePolicy:
+    row = await _get_policy(db, policy_id)
+    changes = body.model_dump(exclude_unset=True)
+
+    if "options" in changes:
+        validate_domain_options(changes["options"] or {}, previous=row.options or {})
+    if "match_override" in changes:
+        changes["match_override"] = _validate_override(changes["match_override"])
+    if "device_classes" in changes:
+        seen: set[str] = set()
+        cleaned: list[str] = []
+        for item in changes["device_classes"] or []:
+            item = (item or "").strip()
+            if item and item not in seen:
+                seen.add(item)
+                cleaned.append(item)
+        changes["device_classes"] = cleaned
+    if "name" in changes and changes["name"] != row.name:
+        dupe = await db.execute(
+            select(DHCPDevicePolicy.id).where(
+                DHCPDevicePolicy.group_id == row.group_id,
+                DHCPDevicePolicy.name == changes["name"],
+                DHCPDevicePolicy.id != row.id,
+            )
+        )
+        if dupe.scalar_one_or_none():
+            raise HTTPException(status_code=409, detail="A device policy with that name exists")
+    # ``class_name`` is deliberately NOT recomputed on rename. Pools bind to
+    # a class by name, so regenerating it here would leave every pool with
+    # a ``client-class`` naming a class that no longer exists — which Kea
+    # accepts and which silently stops the pool serving anyone.
+    for k, v in changes.items():
+        setattr(row, k, v)
+
+    write_audit(
+        db,
+        user=user,
+        action="update",
+        resource_type="dhcp_device_policy",
+        resource_id=str(row.id),
+        resource_display=row.name,
+        changed_fields=list(changes.keys()),
+        new_value=body.model_dump(mode="json", exclude_unset=True),
+    )
+    collect_wake(dhcp_group_channel(row.group_id))
+    await db.commit()
+    await db.refresh(row)
+    return row
+
+
+@router.delete("/device-policies/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_device_policy(policy_id: uuid.UUID, db: DB, user: SuperAdmin) -> None:
+    row = await _get_policy(db, policy_id)
+    write_audit(
+        db,
+        user=user,
+        action="delete",
+        resource_type="dhcp_device_policy",
+        resource_id=str(row.id),
+        resource_display=row.name,
+    )
+    collect_wake(dhcp_group_channel(row.group_id))
+    await db.delete(row)
+    await db.commit()
+
+
+@router.get("/device-policies/{policy_id}/preview", response_model=DevicePolicyPreviewOut)
+async def preview_device_policy(
+    policy_id: uuid.UUID, db: DB, _: CurrentUser
+) -> DevicePolicyPreviewOut:
+    """Show exactly what this policy compiles to, and who it catches.
+
+    Read-only and side-effect free apart from stamping
+    ``last_compiled_at`` — the operator needs to know how fresh the answer
+    is, because the underlying fingerprint set moves on its own.
+    """
+    row = await _get_policy(db, policy_id)
+    compiled = await compile_device_policy(db, row)
+    row.last_compiled_at = datetime.now(UTC)
+    await db.commit()
+    return _to_preview(row, compiled)
+
+
+@router.get(
+    "/server-groups/{group_id}/device-observations",
+    response_model=DeviceObservationsOut,
+)
+async def list_device_observations(
+    group_id: uuid.UUID, db: DB, _: CurrentUser
+) -> DeviceObservationsOut:
+    """Fingerbank device classes actually observed, with device counts.
+
+    Feeds the class picker. Offering a free-text box instead would let an
+    operator build a policy against a class string that never appears,
+    which compiles to an empty expression and renders nothing — a policy
+    that looks configured and does nothing at all.
+
+    The fingerprint store is not group-scoped (one row per MAC,
+    platform-wide), so these counts are platform-wide too. ``group_id`` is
+    validated so the endpoint 404s consistently with its siblings rather
+    than answering for a group that does not exist.
+    """
+    await _get_group(db, group_id)
+
+    res = await db.execute(
+        select(
+            DHCPFingerprint.fingerbank_device_class,
+            func.count().label("device_count"),
+            func.count(
+                func.distinct(
+                    func.concat(
+                        func.coalesce(DHCPFingerprint.option_55, ""),
+                        "|",
+                        func.coalesce(DHCPFingerprint.option_60, ""),
+                    )
+                )
+            ).label("signature_count"),
+        )
+        .where(DHCPFingerprint.fingerbank_device_class.isnot(None))
+        .where(DHCPFingerprint.fingerbank_device_class != "")
+        .group_by(DHCPFingerprint.fingerbank_device_class)
+        .order_by(func.count().desc())
+    )
+    classes = [
+        DeviceObservationOut(device_class=row[0], device_count=row[1], signature_count=row[2])
+        for row in res.all()
+    ]
+
+    totals = await db.execute(select(func.count()).select_from(DHCPFingerprint))
+    total = int(totals.scalar() or 0)
+    classified = sum(c.device_count for c in classes)
+
+    return DeviceObservationsOut(
+        classes=classes,
+        unclassified_devices=total - classified,
+        total_devices=total,
+        note=(
+            "Classes come from fingerprints already observed and enriched. A "
+            "device class absent here has not been seen on this network yet, so "
+            "a policy naming it will match nothing until one appears."
+        ),
+    )

--- a/backend/app/api/v1/dhcp/device_policies.py
+++ b/backend/app/api/v1/dhcp/device_policies.py
@@ -34,7 +34,6 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-import structlog
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import func, select
@@ -52,8 +51,6 @@ from app.services.dhcp.device_policy import (
     compile_device_policy,
     slugify_class_name,
 )
-
-logger = structlog.get_logger(__name__)
 
 router = APIRouter(
     tags=["dhcp"],

--- a/backend/app/api/v1/dhcp/device_policies.py
+++ b/backend/app/api/v1/dhcp/device_policies.py
@@ -131,10 +131,13 @@ class DevicePolicyCreate(BaseModel):
     device_classes: list[str] = Field(
         default_factory=list,
         description=(
-            "Fingerbank device classes to match, e.g. "
-            '["Printer", "Internet of Things (IoT)"]. Use '
-            "GET /dhcp/server-groups/{id}/device-observations for the classes "
-            "actually seen on this install."
+            "Fingerbank device classes to match. These are fingerbank's own "
+            "taxonomy strings, which sit at mixed granularity and are rarely "
+            "the tidy category you would guess — real values include "
+            '"HP Print Server", "Generic IoT", "Generic Android" and '
+            '"Operating System". Always pick from GET '
+            "/dhcp/server-groups/{id}/device-observations rather than typing "
+            "one: a class string that does not appear there matches nothing."
         ),
     )
     options: dict[str, Any] = Field(default_factory=dict)
@@ -213,6 +216,7 @@ class DevicePolicyPreviewOut(BaseModel):
     # against it. Equal to ``expression`` when no override is set.
     compiled_expression: str
     signature_count: int
+    confidence: int | None
     signatures: list[SignatureOut]
     ambiguous_signatures: list[SignatureOut]
     ambiguous_excluded: bool
@@ -235,6 +239,13 @@ class DeviceObservationOut(BaseModel):
     device_class: str
     device_count: int
     signature_count: int
+    # Fingerbank's own 0-100 confidence, surfaced because the class name
+    # alone hides the difference between an identified device and a
+    # vendor-only fallback. "Hardware Manufacturer" at 29 is fingerbank
+    # saying it could not identify the device, which makes it a poor
+    # policy target however plausible the name looks in a list.
+    best_score: int | None
+    avg_score: int | None
 
 
 class DeviceObservationsOut(BaseModel):
@@ -293,6 +304,7 @@ def _to_preview(policy: DHCPDevicePolicy, compiled: Any) -> DevicePolicyPreviewO
         source=compiled.source,
         compiled_expression=compiled.compiled_expression,
         signature_count=len(compiled.signatures),
+        confidence=compiled.confidence,
         signatures=[
             SignatureOut(option_55=s.option_55, option_60=s.option_60) for s in compiled.signatures
         ],
@@ -529,6 +541,8 @@ async def list_device_observations(
                     )
                 )
             ).label("signature_count"),
+            func.max(DHCPFingerprint.fingerbank_score).label("best_score"),
+            func.avg(DHCPFingerprint.fingerbank_score).label("avg_score"),
         )
         .where(DHCPFingerprint.fingerbank_device_class.isnot(None))
         .where(DHCPFingerprint.fingerbank_device_class != "")
@@ -536,7 +550,13 @@ async def list_device_observations(
         .order_by(func.count().desc())
     )
     classes = [
-        DeviceObservationOut(device_class=row[0], device_count=row[1], signature_count=row[2])
+        DeviceObservationOut(
+            device_class=row[0],
+            device_count=row[1],
+            signature_count=row[2],
+            best_score=int(row[3]) if row[3] is not None else None,
+            avg_score=int(row[4]) if row[4] is not None else None,
+        )
         for row in res.all()
     ]
 
@@ -551,6 +571,9 @@ async def list_device_observations(
         note=(
             "Classes come from fingerprints already observed and enriched. A "
             "device class absent here has not been seen on this network yet, so "
-            "a policy naming it will match nothing until one appears."
+            "a policy naming it will match nothing until one appears. Scores are "
+            "fingerbank's own 0-100 confidence: a low one usually means it fell "
+            "back to the MAC vendor instead of identifying the device, so that "
+            "class groups unrelated hardware and makes a poor policy target."
         ),
     )

--- a/backend/app/drivers/dhcp/base.py
+++ b/backend/app/drivers/dhcp/base.py
@@ -132,6 +132,27 @@ class PhoneClassDef:
 
 
 @dataclass(frozen=True)
+class DevicePolicyClassDef:
+    """A rendered fingerprint-driven device-policy class (issue #700).
+
+    Kept distinct from :class:`ClientClassDef` because it carries a
+    ``lease_time`` that becomes Kea's per-class ``valid-lifetime`` — the
+    "short leases for unknown devices" half of the issue's NAC-lite
+    outcome, which a plain client class has no field for.
+
+    ``match_expression`` is already compiled (see
+    ``services.dhcp.device_policy``) and is never empty here: the
+    assembler drops a policy that compiles to nothing rather than
+    emitting a testless class, which Kea treats as *match everything*.
+    """
+
+    name: str
+    match_expression: str
+    options: dict[str, Any] = field(default_factory=dict)
+    lease_time: int | None = None
+
+
+@dataclass(frozen=True)
 class MACBlockDef:
     """A blocked MAC address — group-global deny entry.
 
@@ -261,6 +282,11 @@ class ConfigBundle:
     mac_blocks: tuple[MACBlockDef, ...] = ()
     pxe_classes: tuple[PXEClassDef, ...] = ()
     phone_classes: tuple[PhoneClassDef, ...] = ()
+    # #700 — fingerprint-driven device policies, already compiled to Kea
+    # match expressions. Ordered by (priority, name) at assembly time;
+    # Kea evaluates client-classes in declaration order, so the ordering
+    # is behaviour rather than presentation.
+    device_policy_classes: tuple[DevicePolicyClassDef, ...] = ()
     etag: str = ""
     # Populated when the server's group has ≥ 2 Kea members. The
     # agent's Kea renderer injects ``libdhcp_ha.so`` + the ``high-
@@ -299,6 +325,7 @@ class ConfigBundle:
             "mac_blocks": [asdict(m) for m in self.mac_blocks],
             "pxe_classes": [asdict(p) for p in self.pxe_classes],
             "phone_classes": [asdict(c) for c in self.phone_classes],
+            "device_policy_classes": [asdict(c) for c in self.device_policy_classes],
             "failover": asdict(self.failover) if self.failover else None,
             "dhcp_socket_type": self.dhcp_socket_type,
             "lease_cache_threshold": self.lease_cache_threshold,

--- a/backend/app/drivers/dhcp/kea.py
+++ b/backend/app/drivers/dhcp/kea.py
@@ -22,6 +22,7 @@ import structlog
 from app.drivers.dhcp.base import (
     ClientClassDef,
     ConfigBundle,
+    DevicePolicyClassDef,
     DHCPDriver,
     PhoneClassDef,
     PoolDef,
@@ -433,6 +434,27 @@ def _render_phone_class(p: PhoneClassDef) -> dict[str, Any]:
     return d
 
 
+def _render_device_policy_class(p: DevicePolicyClassDef) -> dict[str, Any]:
+    """Render a fingerprint-driven device-policy class (issue #700).
+
+    ``valid-lifetime`` on a client class is honoured by Kea per-class —
+    verified against kea-dhcp4 3.0.3 rather than assumed, because a
+    silently-ignored lease time is the difference between a quarantine
+    that expires and one that never does.
+
+    The ``test`` key is emitted unconditionally: the assembler never
+    produces a device-policy class with an empty expression, since a Kea
+    class with no ``test`` matches every packet — which for this feature
+    would apply a quarantine policy to the whole network.
+    """
+    d: dict[str, Any] = {"name": p.name, "test": p.match_expression}
+    if p.lease_time is not None:
+        d["valid-lifetime"] = p.lease_time
+    if p.options:
+        d["option-data"] = _render_option_data(p.options, address_family="ipv4")
+    return d
+
+
 def _render_pxe_class(p: PXEClassDef) -> dict[str, Any]:
     """Render a PXE / iPXE class for Dhcp4 ``client-classes`` (issue #51).
 
@@ -494,7 +516,11 @@ class KeaDriver(DHCPDriver):
                     _render_client_class(c, address_family="ipv4") for c in bundle.client_classes
                 ]
                 + [_render_pxe_class(p) for p in bundle.pxe_classes]
-                + [_render_phone_class(p) for p in bundle.phone_classes],
+                + [_render_phone_class(p) for p in bundle.phone_classes]
+                # #700 — last, so an operator's hand-written class of the
+                # same shape is evaluated first. Kea stops at the first
+                # match, so declaration order is precedence.
+                + [_render_device_policy_class(p) for p in bundle.device_policy_classes],
                 "option-data": _render_option_data(bundle.options.options, address_family="ipv4"),
             }
             # #856 — ship definitions for any non-standard option emitted above.

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -49,6 +49,7 @@ from app.models.dhcp import (
     DHCPServerGroup,
     DHCPStaticAssignment,
 )
+from app.models.dhcp_device_policy import DHCPDevicePolicy
 from app.models.dhcp_fingerprint import DHCPFingerprint
 from app.models.diagnostics import InternalError
 from app.models.dicom import DICOMApplicationEntity, DICOMPeer
@@ -234,6 +235,7 @@ __all__ = [
     "DHCPStaticAssignment",
     "DHCPClientClass",
     "DHCPMACBlock",
+    "DHCPDevicePolicy",
     "DHCPFingerprint",
     "DHCPLease",
     "DHCPLeaseHistory",

--- a/backend/app/models/dhcp.py
+++ b/backend/app/models/dhcp.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     Boolean,
@@ -36,6 +37,9 @@ from sqlalchemy.dialects.postgresql import INET, JSONB, MACADDR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, SoftDeleteMixin, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from app.models.dhcp_device_policy import DHCPDevicePolicy
 
 # ── Server Group / Server ────────────────────────────────────────────────────
 
@@ -144,6 +148,13 @@ class DHCPServerGroup(UUIDPrimaryKeyMixin, TimestampMixin, Base):
     )
     option_templates: Mapped[list[DHCPOptionTemplate]] = relationship(
         "DHCPOptionTemplate", back_populates="group", cascade="all, delete-orphan"
+    )
+    # #700 — fingerprint-driven device policies. Defined in its own module
+    # (``models.dhcp_device_policy``) because it depends on the fingerprint
+    # store rather than on anything in this file; the string target defers
+    # resolution until both are imported.
+    device_policies: Mapped[list[DHCPDevicePolicy]] = relationship(
+        "DHCPDevicePolicy", back_populates="group", cascade="all, delete-orphan"
     )
 
 

--- a/backend/app/models/dhcp_device_policy.py
+++ b/backend/app/models/dhcp_device_policy.py
@@ -39,12 +39,10 @@ accepts and which quietly stops the pool serving anyone.
 from __future__ import annotations
 
 import uuid
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     Boolean,
-    DateTime,
     ForeignKey,
     Index,
     Integer,
@@ -123,9 +121,6 @@ class DHCPDevicePolicy(UUIDPrimaryKeyMixin, TimestampMixin, Base):
         UUID(as_uuid=True),
         ForeignKey("user.id", ondelete="SET NULL"),
         nullable=True,
-    )
-    last_compiled_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
     )
 
     group: Mapped[DHCPServerGroup] = relationship(

--- a/backend/app/models/dhcp_device_policy.py
+++ b/backend/app/models/dhcp_device_policy.py
@@ -1,0 +1,136 @@
+"""Fingerprint-driven DHCP policy (issue #700).
+
+Device profiling (#—passive DHCP fingerprinting via the agent's scapy
+sniffer + fingerbank enrichment) tells us what a device *is*. Kea client
+classes let us treat classes of device differently. Nothing connected the
+two: the profile was read-only decoration on the IP row, and client
+classes were hand-authored match expressions.
+
+A ``DHCPDevicePolicy`` is the join. The operator picks fingerbank device
+*classes* ("Printer", "Internet of Things (IoT)") and an outcome — an
+option set, a lease time, and optionally a pool — and SpatiumDDI compiles
+that down to a real Kea client-class ``test`` expression over the
+option-55 / option-60 signatures that produced those classifications.
+
+**What the compiled expression actually matches, stated plainly.**
+Fingerbank's classification is a lookup against their corpus; there is no
+"device class == IoT" predicate a DHCP server can evaluate. So the
+compiler matches the *signatures we have observed and had classified into
+the selected classes* — not the abstract category. Two consequences the UI
+repeats rather than hides:
+
+1. A device whose signature we have never seen does not match, however
+   obviously it belongs to the category. It is classified on its first
+   lease and the policy applies from the next renewal. That is the
+   honest v1 boundary, and it is why nothing here should be described
+   as instant enforcement.
+2. The policy tracks observation. As new signatures land in a selected
+   class the expression grows on its own — which is the feature, but it
+   also means the rendered config changes without an operator edit.
+
+``class_name`` is deliberately a stored column rather than something
+derived from ``name`` at render time. Pools reference a class by name
+(``DHCPPool.class_restriction``), so a rename that silently moved the
+generated class name would detach every pool pointing at it — the pool
+would keep a restriction to a class that no longer exists, which Kea
+accepts and which quietly stops the pool serving anyone.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, UUIDPrimaryKeyMixin
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from app.models.dhcp import DHCPServerGroup
+
+
+class DHCPDevicePolicy(UUIDPrimaryKeyMixin, TimestampMixin, Base):
+    """One fingerprint-driven policy — group-scoped, compiled into a Kea class."""
+
+    __tablename__ = "dhcp_device_policy"
+    __table_args__ = (
+        UniqueConstraint("group_id", "name", name="uq_dhcp_device_policy_group_name"),
+        # The generated Kea class name has to be unique per group for the
+        # same reason ``name`` does: two classes with one name is a config
+        # Kea rejects outright, taking every other class down with it.
+        UniqueConstraint("group_id", "class_name", name="uq_dhcp_device_policy_group_class_name"),
+        Index("ix_dhcp_device_policy_group", "group_id"),
+    )
+
+    group_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("dhcp_server_group.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # The Kea client-class name this policy compiles to. Stable across
+    # renames (see the module docstring) and referenced by pools via
+    # ``DHCPPool.class_restriction`` to get the issue's "optionally this
+    # pool" outcome.
+    class_name: Mapped[str] = mapped_column(String(128), nullable=False)
+
+    # Fingerbank device classes the operator selected, e.g.
+    # ``["Printer", "Internet of Things (IoT)"]``. Matched against
+    # ``DHCPFingerprint.fingerbank_device_class``.
+    device_classes: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+
+    # The outcome. ``options`` mirrors ``DHCPClientClass.options``
+    # (``{name: value}``); ``lease_time`` becomes the class's
+    # ``valid-lifetime``, which Kea honours per-class — verified against
+    # kea-dhcp4 3.0.3, since a silently-ignored lease time would be the
+    # difference between a quarantine that expires and one that does not.
+    options: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    lease_time: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Operator escape hatch, required by the issue: the compiled
+    # expression must be visible AND overridable so nobody debugs a black
+    # box against kea-dhcp4.log. When set, this is rendered verbatim and
+    # the compiler's output is shown alongside it for comparison only.
+    match_override: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # A signature seen on devices BOTH inside and outside the selected
+    # classes is ambiguous: matching it would apply this policy to devices
+    # the operator did not select. Excluded by default; this is the
+    # explicit, audited opt-in. See ``services.dhcp.device_policy``.
+    include_ambiguous: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Kea evaluates client-classes in declaration order, so this is
+    # behaviour rather than presentation — the same reasoning as
+    # ``DHCPPXEArchMatch.priority``.
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=100)
+
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("user.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    last_compiled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    group: Mapped[DHCPServerGroup] = relationship(
+        "DHCPServerGroup", back_populates="device_policies"
+    )
+
+
+__all__ = ["DHCPDevicePolicy"]

--- a/backend/app/services/ai/tools/dhcp.py
+++ b/backend/app/services/ai/tools/dhcp.py
@@ -26,10 +26,12 @@ from app.models.dhcp import (
     DHCPServerGroup,
     DHCPStaticAssignment,
 )
+from app.models.dhcp_device_policy import DHCPDevicePolicy
 from app.models.dhcp_fingerprint import DHCPFingerprint
 from app.models.ipam import Subnet
 from app.models.metrics import DHCPMetricSample
 from app.services.ai.tools.base import register_tool
+from app.services.dhcp.device_policy import compile_device_policy
 from app.services.dhcp.stats import STATS_WINDOW_SECONDS, active_lease_count
 from app.services.oui import bulk_lookup_vendors, is_voip_phone_vendor, normalize_mac_key
 
@@ -998,3 +1000,100 @@ async def find_dhcp_lease_history(
         }
         for r in rows
     ]
+
+
+# ── Fingerprint-driven device policies (#700) ──────────────────────────────
+
+
+class ListDevicePoliciesArgs(BaseModel):
+    group_id: uuid.UUID | None = Field(default=None, description="Filter to one DHCP server group.")
+    enabled_only: bool = Field(default=False, description="Only policies that are switched on.")
+
+
+@register_tool(
+    name="find_dhcp_device_policies",
+    description=(
+        "List fingerprint-driven DHCP device policies (issue #700) — the rules "
+        "that give devices of a given fingerbank class (Printer, IoT, game "
+        "console, …) a specific option set, lease time and optionally a "
+        "restricted pool. Each row reports the Kea client-class it compiles to "
+        "and whether it currently matches anything."
+    ),
+    args_model=ListDevicePoliciesArgs,
+    category="dhcp",
+    default_enabled=True,
+)
+async def find_dhcp_device_policies(
+    db: AsyncSession, user: User, args: ListDevicePoliciesArgs
+) -> list[dict[str, Any]]:
+    stmt = select(DHCPDevicePolicy)
+    if args.group_id:
+        stmt = stmt.where(DHCPDevicePolicy.group_id == args.group_id)
+    if args.enabled_only:
+        stmt = stmt.where(DHCPDevicePolicy.enabled.is_(True))
+    stmt = stmt.order_by(DHCPDevicePolicy.priority, DHCPDevicePolicy.name)
+    rows = list((await db.execute(stmt)).scalars().all())
+    return [
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "group_id": str(r.group_id),
+            "enabled": r.enabled,
+            "kea_client_class": r.class_name,
+            "device_classes": list(r.device_classes or []),
+            "lease_time": r.lease_time,
+            "options": dict(r.options or {}),
+            "has_manual_override": bool(r.match_override),
+            "include_ambiguous": r.include_ambiguous,
+            "priority": r.priority,
+        }
+        for r in rows
+    ]
+
+
+class PreviewDevicePolicyArgs(BaseModel):
+    policy_id: uuid.UUID = Field(description="The device policy to compile.")
+
+
+@register_tool(
+    name="preview_dhcp_device_policy",
+    description=(
+        "Compile one fingerprint-driven DHCP device policy and report exactly "
+        "what it matches: the Kea expression, how many observed signatures went "
+        "into it, which devices it currently catches, and any signatures "
+        "excluded because devices outside the selected classes emit them too. "
+        "Read-only — it changes no configuration."
+    ),
+    args_model=PreviewDevicePolicyArgs,
+    category="dhcp",
+    default_enabled=True,
+)
+async def preview_dhcp_device_policy(
+    db: AsyncSession, user: User, args: PreviewDevicePolicyArgs
+) -> dict[str, Any]:
+    row = await db.get(DHCPDevicePolicy, args.policy_id)
+    if row is None:
+        return {"error": "Device policy not found", "policy_id": str(args.policy_id)}
+    compiled = await compile_device_policy(db, row)
+    return {
+        "id": str(row.id),
+        "name": row.name,
+        "kea_client_class": row.class_name,
+        "expression": compiled.expression,
+        "source": compiled.source,
+        "renders": bool(row.enabled and compiled.expression),
+        "signature_count": len(compiled.signatures),
+        "matched_device_count": len(compiled.matched_macs),
+        "matched_macs": compiled.matched_macs[:50],
+        "ambiguous_signature_count": len(compiled.ambiguous),
+        "ambiguous_excluded": bool(compiled.ambiguous) and not row.include_ambiguous,
+        "truncated_signatures": compiled.truncated,
+        "unclassified_matches": compiled.unclassified_matches,
+        "warnings": compiled.warnings,
+        "note": (
+            "Matching is over DHCP signatures already observed and classified. "
+            "A device whose signature has never been seen does not match until "
+            "it has leased once and been classified — policies apply from the "
+            "next renewal, not instantly."
+        ),
+    }

--- a/backend/app/services/backup/sections.py
+++ b/backend/app/services/backup/sections.py
@@ -281,6 +281,10 @@ SECTIONS: tuple[Section, ...] = (
             "dhcp_pxe_arch_match",
             "dhcp_phone_profile",
             "dhcp_phone_profile_scope",
+            # #700 — FKs into dhcp_server_group, so a selective restore of
+            # this section TRUNCATE-CASCADEs it. Absent from the list, it
+            # would be emptied and never repopulated.
+            "dhcp_device_policy",
             "dhcp_fingerprint",
             "dhcp_config_op",
         ),

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -48,7 +48,10 @@ from app.models.dhcp import (
 )
 from app.models.dhcp_device_policy import DHCPDevicePolicy
 from app.models.ipam import Subnet
-from app.services.dhcp.device_policy import compile_device_policy
+from app.services.dhcp.device_policy import (
+    compile_device_policy,
+    load_fingerprint_snapshot,
+)
 from app.services.dhcp.radvd import build_ra_config, render_radvd_conf
 from app.services.feature_modules import is_module_enabled
 
@@ -597,11 +600,16 @@ async def _assemble_device_policy_classes(
         .scalars()
         .all()
     )
+    enabled = [p for p in rows if p.enabled]
+    if not enabled:
+        return ()
+    # One read of the fingerprint store for the whole group. This runs on
+    # every agent long-poll tick, so a per-policy scan would multiply the
+    # hottest read path in the subsystem by the policy count.
+    snapshot = await load_fingerprint_snapshot(db)
     out: list[DevicePolicyClassDef] = []
-    for policy in rows:
-        if not policy.enabled:
-            continue
-        compiled = await compile_device_policy(db, policy)
+    for policy in enabled:
+        compiled = await compile_device_policy(db, policy, snapshot=snapshot)
         if not compiled.expression:
             log.info(
                 "dhcp_device_policy_no_match",

--- a/backend/app/services/dhcp/config_bundle.py
+++ b/backend/app/services/dhcp/config_bundle.py
@@ -14,6 +14,7 @@ Mirrors ``app.services.dns.config_bundle``.
 from __future__ import annotations
 
 import ipaddress
+import uuid
 from datetime import UTC, datetime
 
 import structlog
@@ -24,6 +25,7 @@ from sqlalchemy.orm import selectinload
 from app.drivers.dhcp.base import (
     ClientClassDef,
     ConfigBundle,
+    DevicePolicyClassDef,
     FailoverConfig,
     MACBlockDef,
     PhoneClassDef,
@@ -44,7 +46,9 @@ from app.models.dhcp import (
     DHCPServer,
     DHCPServerGroup,
 )
+from app.models.dhcp_device_policy import DHCPDevicePolicy
 from app.models.ipam import Subnet
+from app.services.dhcp.device_policy import compile_device_policy
 from app.services.dhcp.radvd import build_ra_config, render_radvd_conf
 from app.services.feature_modules import is_module_enabled
 
@@ -335,6 +339,7 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
 
     pxe_classes = await _assemble_pxe_classes(db, scope_rows)
     phone_classes = await _assemble_phone_classes(db, scope_rows)
+    device_policy_classes = await _assemble_device_policy_classes(db, group.id if group else None)
 
     # IPv6 Router Advertisements (issue #524) — one radvd stanza per
     # RA-enabled IPv6 subnet in the group. The rendered radvd.conf ships in
@@ -387,6 +392,7 @@ async def build_config_bundle(db: AsyncSession, server: DHCPServer) -> ConfigBun
         mac_blocks=mac_blocks,
         pxe_classes=pxe_classes,
         phone_classes=phone_classes,
+        device_policy_classes=device_policy_classes,
         generated_at=datetime.now(UTC),
         failover=failover,
         dhcp_socket_type=dhcp_socket_type,
@@ -551,6 +557,65 @@ async def _assemble_phone_classes(
                 name=f"voip-{str(prof.id)[:8]}",
                 match_expression=match_expr,
                 options=options,
+            )
+        )
+    return tuple(out)
+
+
+async def _assemble_device_policy_classes(
+    db: AsyncSession, group_id: uuid.UUID | None
+) -> tuple[DevicePolicyClassDef, ...]:
+    """Compile each enabled device policy into a Kea client-class (#700).
+
+    Two properties worth stating because both are load-bearing:
+
+    **A policy that compiles to nothing is dropped, not emitted empty.**
+    A Kea client-class with no ``test`` matches every packet, so shipping
+    an empty expression would apply a quarantine option-set and lease time
+    to the entire network. "Compiles to nothing" is the normal state for a
+    freshly-created policy whose device classes have not been observed
+    yet, so this is a routine path rather than an error one.
+
+    **The expression depends on observed fingerprints, so the bundle
+    changes without an operator edit.** That is the feature — a newly
+    classified device joins the policy on its next renewal — but it means
+    the ETag legitimately shifts when the fingerprint store grows. It is
+    bounded by *distinct signatures*, not device count, so it settles once
+    the estate has been seen; a fleet of 500 identical handsets adds one
+    term, not 500.
+    """
+    if group_id is None:
+        return ()
+    rows = list(
+        (
+            await db.execute(
+                select(DHCPDevicePolicy)
+                .where(DHCPDevicePolicy.group_id == group_id)
+                .order_by(DHCPDevicePolicy.priority, DHCPDevicePolicy.name)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    out: list[DevicePolicyClassDef] = []
+    for policy in rows:
+        if not policy.enabled:
+            continue
+        compiled = await compile_device_policy(db, policy)
+        if not compiled.expression:
+            log.info(
+                "dhcp_device_policy_no_match",
+                policy_id=str(policy.id),
+                policy=policy.name,
+                reason=compiled.source,
+            )
+            continue
+        out.append(
+            DevicePolicyClassDef(
+                name=policy.class_name,
+                match_expression=compiled.expression,
+                options=dict(policy.options or {}),
+                lease_time=policy.lease_time,
             )
         )
     return tuple(out)

--- a/backend/app/services/dhcp/device_policy.py
+++ b/backend/app/services/dhcp/device_policy.py
@@ -74,7 +74,7 @@ logger = structlog.get_logger(__name__)
 MAX_SIGNATURE_TERMS = 128
 
 
-@dataclass(frozen=True, order=True)
+@dataclass(frozen=True)
 class Signature:
     """One observed DHCP signature.
 
@@ -83,7 +83,30 @@ class Signature:
     vendor-class string. ``None`` means the device did not send that
     option, which is itself matchable and is *not* the same as an empty
     one — see ``_term``.
+
+    Deliberately **not** ``order=True``. A generated ``__lt__`` compares
+    the fields pairwise, and two signatures that agree on option 55 but
+    differ on whether option 60 is present then compare ``None`` against
+    ``str`` — a ``TypeError`` raised inside ``build_config_bundle``, which
+    would 500 the agent long-poll and stop the whole group converging.
+    Sorting goes through ``sort_key`` instead, which gives absence a
+    defined position rather than an accidental one.
     """
+
+    @property
+    def sort_key(self) -> tuple[bool, str, bool, str]:
+        """Total order that tolerates absent options.
+
+        Absent sorts after present for the same value, so ``(1,3,6, no
+        vendor class)`` and ``(1,3,6, "HP")`` have a stable relative
+        position instead of raising.
+        """
+        return (
+            self.option_55 is None,
+            self.option_55 or "",
+            self.option_60 is None,
+            self.option_60 or "",
+        )
 
     option_55: str | None
     option_60: str | None
@@ -96,6 +119,11 @@ class CompiledPolicy:
     class_name: str
     expression: str
     source: str  # "compiled" | "override" | "empty"
+    # What the compiler produced, ALWAYS — even when an override replaces
+    # it on the wire. Storing the override in both fields would make the
+    # documented "compare your override against the generated expression"
+    # impossible, which is the whole reason the override is visible.
+    compiled_expression: str = ""
     signatures: list[Signature] = field(default_factory=list)
     ambiguous: list[Signature] = field(default_factory=list)
     # Signatures dropped by MAX_SIGNATURE_TERMS. Never silent.
@@ -110,17 +138,6 @@ class CompiledPolicy:
     # them by name, so the count is surfaced rather than buried.
     unclassified_matches: int = 0
     warnings: list[str] = field(default_factory=list)
-
-    @property
-    def compiled_expression(self) -> str:
-        """The expression the compiler produced, override or not.
-
-        When an override is set the rendered ``expression`` is the
-        operator's, but the UI still shows what we would have generated so
-        the two can be compared — that comparison is the whole point of
-        making the override visible.
-        """
-        return self.expression
 
 
 def option55_to_hex(csv: str | None) -> str | None:
@@ -149,13 +166,24 @@ def option55_to_hex(csv: str | None) -> str | None:
 
 
 def text_to_hex(text: str | None) -> str | None:
-    """Encode a vendor-class string as hex bytes. ``None`` when empty.
+    """Encode a vendor-class string as hex bytes. ``None`` when unusable.
 
     Empty must return ``None``, not ``""``: ``option[60].hex == 0x`` is a
     parse error that fails the *entire* Kea config, taking every unrelated
     class down with it (verified against kea-dhcp4 3.0.3).
+
+    A value containing U+FFFD is also refused. ``DHCPFingerprint`` decodes
+    option 60 with ``errors="replace"``, so a device that sent non-UTF-8
+    bytes — plenty of IoT vendors do — is stored with the original bytes
+    already destroyed. Re-encoding that yields ``EF BF BD``, which is not
+    what the device puts on the wire, so the term could never match. Worse
+    than useless: the preview would list the device as matched while the
+    rendered class silently skipped it. Refusing is the honest answer
+    until the fingerprint store keeps the raw bytes.
     """
     if not text:
+        return None
+    if "\ufffd" in text:
         return None
     raw = text.encode("utf-8", errors="replace")
     return raw.hex().upper() or None
@@ -219,8 +247,37 @@ def slugify_class_name(name: str) -> str:
     return f"spatium-device-{slug}"
 
 
-async def _load_signatures(
-    db: AsyncSession, selected: set[str]
+@dataclass(frozen=True)
+class FingerprintSnapshot:
+    """Every observed fingerprint, read once.
+
+    ``compile_device_policy`` runs per policy, and a config bundle is
+    rebuilt on every agent long-poll tick — so scanning ``dhcp_fingerprint``
+    inside the compiler meant one full scan per policy per tick, on the
+    hottest read path in the DHCP subsystem. The scan is hoisted here and
+    the assembler passes one snapshot to every policy in the group.
+    """
+
+    rows: tuple[tuple[str, str | None, str | None, str | None], ...]
+
+
+async def load_fingerprint_snapshot(db: AsyncSession) -> FingerprintSnapshot:
+    """Read the fingerprint store once for a whole compilation pass."""
+    res = await db.execute(
+        select(
+            DHCPFingerprint.mac_address,
+            DHCPFingerprint.option_55,
+            DHCPFingerprint.option_60,
+            DHCPFingerprint.fingerbank_device_class,
+        )
+    )
+    return FingerprintSnapshot(
+        rows=tuple((str(m), o55, o60, cls) for m, o55, o60, cls in res.all())
+    )
+
+
+def _partition(
+    snapshot: FingerprintSnapshot, selected: set[str]
 ) -> tuple[dict[Signature, list[str]], set[Signature], dict[Signature, int]]:
     """Partition observed fingerprints by whether their class was selected.
 
@@ -243,18 +300,10 @@ async def _load_signatures(
     one would make the feature unusable before the fingerbank key is set.
     They are counted instead, and reported: they will receive the policy.
     """
-    res = await db.execute(
-        select(
-            DHCPFingerprint.mac_address,
-            DHCPFingerprint.option_55,
-            DHCPFingerprint.option_60,
-            DHCPFingerprint.fingerbank_device_class,
-        )
-    )
     inside: dict[Signature, list[str]] = {}
     outside: set[Signature] = set()
     unclassified: dict[Signature, int] = {}
-    for mac, opt55, opt60, device_class in res.all():
+    for mac, opt55, opt60, device_class in snapshot.rows:
         sig = Signature(option_55=opt55, option_60=opt60)
         if device_class is None or device_class == "":
             unclassified[sig] = unclassified.get(sig, 0) + 1
@@ -265,13 +314,22 @@ async def _load_signatures(
     return inside, outside, unclassified
 
 
-async def compile_device_policy(db: AsyncSession, policy: DHCPDevicePolicy) -> CompiledPolicy:
+async def compile_device_policy(
+    db: AsyncSession,
+    policy: DHCPDevicePolicy,
+    *,
+    snapshot: FingerprintSnapshot | None = None,
+) -> CompiledPolicy:
     """Compile one policy into its Kea client-class expression.
 
     Always returns a result — a policy that currently matches nothing is a
     normal state (no devices seen yet in the selected classes), not an
     error. The caller decides whether to render it; ``source == "empty"``
     means there is nothing to render.
+
+    Pass ``snapshot`` when compiling several policies together (the config
+    bundle does) so the fingerprint store is read once rather than once per
+    policy — see :class:`FingerprintSnapshot`.
     """
     selected = {c for c in (policy.device_classes or []) if isinstance(c, str) and c}
     result = CompiledPolicy(class_name=policy.class_name, expression="", source="empty")
@@ -280,9 +338,12 @@ async def compile_device_policy(db: AsyncSession, policy: DHCPDevicePolicy) -> C
         result.warnings.append(
             "No device classes selected — this policy matches nothing and is not rendered."
         )
-    inside, outside, unclassified = (
-        await _load_signatures(db, selected) if selected else ({}, set(), {})
-    )
+    if selected:
+        if snapshot is None:
+            snapshot = await load_fingerprint_snapshot(db)
+        inside, outside, unclassified = _partition(snapshot, selected)
+    else:
+        inside, outside, unclassified = {}, set(), {}
 
     usable: list[Signature] = []
     ambiguous: list[Signature] = []
@@ -298,8 +359,8 @@ async def compile_device_policy(db: AsyncSession, policy: DHCPDevicePolicy) -> C
         usable.append(sig)
 
     # Deterministic ordering — the expression rides the bundle ETag.
-    usable.sort()
-    ambiguous.sort()
+    usable.sort(key=lambda s: s.sort_key)
+    ambiguous.sort(key=lambda s: s.sort_key)
 
     if len(usable) > MAX_SIGNATURE_TERMS:
         result.truncated = len(usable) - MAX_SIGNATURE_TERMS
@@ -333,6 +394,7 @@ async def compile_device_policy(db: AsyncSession, policy: DHCPDevicePolicy) -> C
         )
 
     compiled = build_expression(usable)
+    result.compiled_expression = compiled
     override = (policy.match_override or "").strip()
     if override:
         result.expression = override
@@ -354,9 +416,11 @@ async def compile_device_policy(db: AsyncSession, policy: DHCPDevicePolicy) -> C
 __all__ = [
     "MAX_SIGNATURE_TERMS",
     "CompiledPolicy",
+    "FingerprintSnapshot",
     "Signature",
     "build_expression",
     "compile_device_policy",
+    "load_fingerprint_snapshot",
     "option55_to_hex",
     "slugify_class_name",
     "text_to_hex",

--- a/backend/app/services/dhcp/device_policy.py
+++ b/backend/app/services/dhcp/device_policy.py
@@ -1,0 +1,363 @@
+"""Compile fingerbank device classes into Kea client-class expressions (#700).
+
+The operator picks device *categories*; this module turns them into
+something a DHCP server can actually evaluate.
+
+**Why this is a compiler and not a lookup.** Fingerbank classifies a
+device by querying their corpus with the DHCP signature it emitted.
+Kea cannot do that mid-packet, and there is no ``device-class ==
+IoT`` predicate to render. What Kea *can* test is the signature
+itself — option 55 (parameter request list) and option 60 (vendor
+class identifier) — which is precisely the input that produced the
+classification. So the compiler collects every signature we have
+observed and had classified into the selected classes, and emits an
+OR over those signatures.
+
+The gap between "the category" and "signatures we have observed in
+the category" is the honest limit of the feature, and every surface
+states it rather than implying instant enforcement: a device whose
+signature is new to us matches nothing until it has been seen and
+classified once, which is why v1 is *classify on first lease, apply
+on renewal*.
+
+Three properties this module is responsible for, each of which is the
+difference between a working policy and a quiet misfire:
+
+**Ambiguous signatures are excluded by default.** DHCP signatures are
+not unique to a device class — a minimal parameter-request-list like
+``1,3,6,15`` is emitted by embedded Linux in a doorbell and by a rack
+server alike. If a signature appears on devices both inside and
+outside the selected classes, matching it applies the policy to
+devices the operator did not choose. For a feature whose headline use
+is "put unknown devices in a quarantine pool with a restricted
+resolver", silently including such a signature is how the CEO's
+laptop ends up quarantined. They are excluded, counted, and listed;
+``include_ambiguous`` is the explicit opt-in.
+
+**Nothing device-controlled is interpolated as a string.** Option 60
+is a value the *device* chooses, and it lands inside a config file
+whose syntax has quoting. Both halves of every term are emitted as
+hex literals (``option[60].hex == 0x4D5346...``), so a vendor-class
+of ``' or 1--`` becomes inert bytes rather than expression syntax.
+Verified against kea-dhcp4 3.0.3: the hex form parses and the same
+payload as a quoted string does not survive as syntax.
+
+**The output is deterministic.** Signatures are sorted before
+rendering, because the expression rides the config bundle's ETag —
+an unstable ordering would shift the ETag on every rebuild and make
+every agent in the group re-fetch and re-render identical config.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import structlog
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dhcp_device_policy import DHCPDevicePolicy
+from app.models.dhcp_fingerprint import DHCPFingerprint
+
+logger = structlog.get_logger(__name__)
+
+# Cap on signature terms in one compiled expression.
+#
+# Measured, not guessed: kea-dhcp4 3.0.3 parses a 1024-term / 32 KB
+# expression without complaint, so the parser is not the constraint.
+# The constraints are per-packet evaluation cost (every term is tested
+# against every DISCOVER until one matches) and an operator's ability to
+# read what we generated — the issue's own requirement that this not be a
+# black box. A policy that hits the cap is reported, never silently
+# truncated: ``CompiledPolicy.truncated`` carries the count and the API
+# surfaces it as a warning.
+MAX_SIGNATURE_TERMS = 128
+
+
+@dataclass(frozen=True, order=True)
+class Signature:
+    """One observed DHCP signature.
+
+    ``option_55`` is the comma-separated decimal parameter-request-list
+    exactly as ``DHCPFingerprint`` stores it; ``option_60`` is the decoded
+    vendor-class string. ``None`` means the device did not send that
+    option, which is itself matchable and is *not* the same as an empty
+    one — see ``_term``.
+    """
+
+    option_55: str | None
+    option_60: str | None
+
+
+@dataclass
+class CompiledPolicy:
+    """The result of compiling one policy — everything the UI must show."""
+
+    class_name: str
+    expression: str
+    source: str  # "compiled" | "override" | "empty"
+    signatures: list[Signature] = field(default_factory=list)
+    ambiguous: list[Signature] = field(default_factory=list)
+    # Signatures dropped by MAX_SIGNATURE_TERMS. Never silent.
+    truncated: int = 0
+    # MACs whose stored fingerprint matches a signature that made it into
+    # the expression. This is the "which existing leases land in which
+    # class" preview the issue asks for.
+    matched_macs: list[str] = field(default_factory=list)
+    # Devices fingerbank has NOT classified that share a matched
+    # signature. They will receive the policy — same signature, so almost
+    # certainly the same kind of device — but the operator did not pick
+    # them by name, so the count is surfaced rather than buried.
+    unclassified_matches: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def compiled_expression(self) -> str:
+        """The expression the compiler produced, override or not.
+
+        When an override is set the rendered ``expression`` is the
+        operator's, but the UI still shows what we would have generated so
+        the two can be compared — that comparison is the whole point of
+        making the override visible.
+        """
+        return self.expression
+
+
+def option55_to_hex(csv: str | None) -> str | None:
+    """``"1,3,6,15"`` → ``"0103060F"``. ``None`` when unusable.
+
+    Rejects rather than coerces: a byte outside 0-255 or a non-numeric
+    field means the stored fingerprint is not a parameter-request-list,
+    and guessing at it would emit an expression that matches the wrong
+    packets. Returns ``None`` so the caller drops the term.
+    """
+    if not csv:
+        return None
+    out: list[str] = []
+    for part in csv.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            value = int(part, 10)
+        except ValueError:
+            return None
+        if not 0 <= value <= 255:
+            return None
+        out.append(f"{value:02X}")
+    return "".join(out) or None
+
+
+def text_to_hex(text: str | None) -> str | None:
+    """Encode a vendor-class string as hex bytes. ``None`` when empty.
+
+    Empty must return ``None``, not ``""``: ``option[60].hex == 0x`` is a
+    parse error that fails the *entire* Kea config, taking every unrelated
+    class down with it (verified against kea-dhcp4 3.0.3).
+    """
+    if not text:
+        return None
+    raw = text.encode("utf-8", errors="replace")
+    return raw.hex().upper() or None
+
+
+def _term(sig: Signature) -> str | None:
+    """Render one signature as a Kea sub-expression, or ``None`` to skip.
+
+    A signature with neither option is unmatchable, and must never be
+    rendered: an empty term would collapse into an always-true expression
+    and apply the policy to every device on the network.
+
+    When the device sent no option 60 the term asserts that absence
+    (``not option[60].exists``) rather than ignoring it. Ignoring it would
+    silently widen the match to every device sharing the
+    parameter-request-list *including* ones that do send a vendor class —
+    the exact over-matching the ambiguity check exists to prevent.
+    """
+    hex55 = option55_to_hex(sig.option_55)
+    hex60 = text_to_hex(sig.option_60)
+    if hex55 and hex60:
+        return f"(option[55].hex == 0x{hex55} and option[60].hex == 0x{hex60})"
+    if hex55:
+        return f"(option[55].hex == 0x{hex55} and not option[60].exists)"
+    if hex60:
+        return f"(option[60].hex == 0x{hex60} and not option[55].exists)"
+    return None
+
+
+def build_expression(signatures: list[Signature]) -> str:
+    """OR the signature terms together. Empty input yields ``""``.
+
+    An empty string is meaningful downstream and is *not* the same as an
+    always-match: the renderers omit the ``test`` key entirely for a
+    falsy expression, and a Kea class with no test matches everything.
+    Callers must therefore skip rendering the class altogether rather than
+    emitting it testless — see ``assemble_device_policy_classes``.
+    """
+    terms = [t for t in (_term(s) for s in signatures) if t]
+    return " or ".join(terms)
+
+
+def slugify_class_name(name: str) -> str:
+    """Derive a Kea-safe, stable client-class name from a policy name.
+
+    Kept conservative — alphanumerics, dash and underscore — because the
+    result is both a Kea identifier and the value an operator types into a
+    pool's ``class_restriction``. A name that round-trips badly through
+    either would break the pool binding silently.
+    """
+    out = []
+    for ch in name.strip():
+        if ch.isalnum() or ch in "-_":
+            out.append(ch)
+        elif ch in " \t/.":
+            out.append("-")
+    slug = "".join(out).strip("-")
+    while "--" in slug:
+        slug = slug.replace("--", "-")
+    slug = slug[:100] or "policy"
+    return f"spatium-device-{slug}"
+
+
+async def _load_signatures(
+    db: AsyncSession, selected: set[str]
+) -> tuple[dict[Signature, list[str]], set[Signature], dict[Signature, int]]:
+    """Partition observed fingerprints by whether their class was selected.
+
+    Returns ``(inside, outside, unclassified)`` where ``inside`` maps each
+    in-class signature to the MACs that produced it and ``unclassified``
+    counts unenriched devices per signature.
+
+    The unclassified counts are returned per-signature rather than
+    pre-summed so the caller can tally them against the signatures that
+    actually survived ambiguity filtering and the term cap. Summing here
+    would count devices behind an *excluded* signature as ones the policy
+    will reach — an over-report in exactly the safety reporting an
+    operator is relying on to decide whether a quarantine is safe to
+    enable.
+
+    Rows fingerbank has not classified are deliberately NOT treated as
+    evidence of ambiguity. An unclassified device sharing a signature is
+    not a device known to be something else — it is a device we have not
+    asked about yet, and excluding an otherwise-clean signature because of
+    one would make the feature unusable before the fingerbank key is set.
+    They are counted instead, and reported: they will receive the policy.
+    """
+    res = await db.execute(
+        select(
+            DHCPFingerprint.mac_address,
+            DHCPFingerprint.option_55,
+            DHCPFingerprint.option_60,
+            DHCPFingerprint.fingerbank_device_class,
+        )
+    )
+    inside: dict[Signature, list[str]] = {}
+    outside: set[Signature] = set()
+    unclassified: dict[Signature, int] = {}
+    for mac, opt55, opt60, device_class in res.all():
+        sig = Signature(option_55=opt55, option_60=opt60)
+        if device_class is None or device_class == "":
+            unclassified[sig] = unclassified.get(sig, 0) + 1
+        elif device_class in selected:
+            inside.setdefault(sig, []).append(str(mac))
+        else:
+            outside.add(sig)
+    return inside, outside, unclassified
+
+
+async def compile_device_policy(db: AsyncSession, policy: DHCPDevicePolicy) -> CompiledPolicy:
+    """Compile one policy into its Kea client-class expression.
+
+    Always returns a result — a policy that currently matches nothing is a
+    normal state (no devices seen yet in the selected classes), not an
+    error. The caller decides whether to render it; ``source == "empty"``
+    means there is nothing to render.
+    """
+    selected = {c for c in (policy.device_classes or []) if isinstance(c, str) and c}
+    result = CompiledPolicy(class_name=policy.class_name, expression="", source="empty")
+
+    if not selected:
+        result.warnings.append(
+            "No device classes selected — this policy matches nothing and is not rendered."
+        )
+    inside, outside, unclassified = (
+        await _load_signatures(db, selected) if selected else ({}, set(), {})
+    )
+
+    usable: list[Signature] = []
+    ambiguous: list[Signature] = []
+    for sig in inside:
+        # A signature with nothing to match on is dropped here rather than
+        # in _term, so it never counts toward the cap or the preview.
+        if _term(sig) is None:
+            continue
+        if sig in outside:
+            ambiguous.append(sig)
+            if not policy.include_ambiguous:
+                continue
+        usable.append(sig)
+
+    # Deterministic ordering — the expression rides the bundle ETag.
+    usable.sort()
+    ambiguous.sort()
+
+    if len(usable) > MAX_SIGNATURE_TERMS:
+        result.truncated = len(usable) - MAX_SIGNATURE_TERMS
+        usable = usable[:MAX_SIGNATURE_TERMS]
+        result.warnings.append(
+            f"{result.truncated} signature(s) beyond the {MAX_SIGNATURE_TERMS}-term "
+            "cap were not compiled. Narrow the selected device classes, or split "
+            "this policy, so the match is complete."
+        )
+
+    result.signatures = usable
+    result.ambiguous = ambiguous
+    # Tallied against the signatures that survived filtering and the cap —
+    # not against every in-class signature — so this counts only devices the
+    # rendered expression will actually reach.
+    usable_set = set(usable)
+    unclassified_hits = sum(n for sig, n in unclassified.items() if sig in usable_set)
+    result.unclassified_matches = unclassified_hits
+    result.matched_macs = sorted(mac for sig in usable for mac in inside.get(sig, []))
+
+    if ambiguous and not policy.include_ambiguous:
+        result.warnings.append(
+            f"{len(ambiguous)} signature(s) were excluded because devices outside "
+            "the selected classes emit them too. Including them would apply this "
+            "policy to those devices as well."
+        )
+    if unclassified_hits:
+        result.warnings.append(
+            f"{unclassified_hits} device(s) fingerbank has not classified share a "
+            "matched signature and will also receive this policy."
+        )
+
+    compiled = build_expression(usable)
+    override = (policy.match_override or "").strip()
+    if override:
+        result.expression = override
+        result.source = "override"
+        result.warnings.append(
+            "A manual match expression is in force; the compiled expression below "
+            "is shown for comparison and is not rendered."
+        )
+    elif compiled:
+        result.expression = compiled
+        result.source = "compiled"
+    else:
+        result.expression = ""
+        result.source = "empty"
+
+    return result
+
+
+__all__ = [
+    "MAX_SIGNATURE_TERMS",
+    "CompiledPolicy",
+    "Signature",
+    "build_expression",
+    "compile_device_policy",
+    "option55_to_hex",
+    "slugify_class_name",
+    "text_to_hex",
+]

--- a/backend/app/services/dhcp/device_policy.py
+++ b/backend/app/services/dhcp/device_policy.py
@@ -70,6 +70,15 @@ from app.models.dhcp_fingerprint import DHCPFingerprint
 # surfaces it as a warning.
 MAX_SIGNATURE_TERMS = 128
 
+# Below this fingerbank score, a classification is usually the OUI vendor
+# rather than an identified device — its ``device_class`` comes back as a
+# taxonomy node like "Hardware Manufacturer" that groups unrelated
+# hardware. Observed rather than documented upstream: on a live key, an
+# exactly-identified print server scored 89 and an unidentified Apple
+# device fell back to the vendor at 29. Policies built on those are the
+# ones most likely to catch devices the operator did not mean.
+LOW_CONFIDENCE_SCORE = 30
+
 
 @dataclass(frozen=True)
 class Signature:
@@ -134,6 +143,9 @@ class CompiledPolicy:
     # certainly the same kind of device — but the operator did not pick
     # them by name, so the count is surfaced rather than buried.
     unclassified_matches: int = 0
+    # Best fingerbank score among the devices this policy matches, 0-100.
+    # None when nothing matched or no score was recorded.
+    confidence: int | None = None
     warnings: list[str] = field(default_factory=list)
 
 
@@ -193,14 +205,28 @@ def _term(sig: Signature) -> str | None:
     rendered: an empty term would collapse into an always-true expression
     and apply the policy to every device on the network.
 
-    When the device sent no option 60 the term asserts that absence
+    When the device sent no option 60 the term asserts that **absence**
     (``not option[60].exists``) rather than ignoring it. Ignoring it would
     silently widen the match to every device sharing the
     parameter-request-list *including* ones that do send a vendor class —
     the exact over-matching the ambiguity check exists to prevent.
+
+    Which is why "absent" and "present but unencodable" must not be
+    conflated. A vendor class destroyed by a lossy decode, or a malformed
+    parameter-request-list, cannot be encoded — but the device *did* send
+    one, so asserting its absence would state the opposite of the truth
+    and match a different population of devices entirely. Such a signature
+    is dropped whole. Degrading it to the other option alone would be
+    worse than not matching: it would match confidently, and wrongly.
     """
+    has55, has60 = bool(sig.option_55), bool(sig.option_60)
     hex55 = option55_to_hex(sig.option_55)
     hex60 = text_to_hex(sig.option_60)
+
+    # Present but unencodable → the signature cannot be expressed at all.
+    if (has55 and not hex55) or (has60 and not hex60):
+        return None
+
     if hex55 and hex60:
         return f"(option[55].hex == 0x{hex55} and option[60].hex == 0x{hex60})"
     if hex55:
@@ -255,7 +281,7 @@ class FingerprintSnapshot:
     the assembler passes one snapshot to every policy in the group.
     """
 
-    rows: tuple[tuple[str, str | None, str | None, str | None], ...]
+    rows: tuple[tuple[str, str | None, str | None, str | None, int | None], ...]
 
 
 async def load_fingerprint_snapshot(db: AsyncSession) -> FingerprintSnapshot:
@@ -266,16 +292,17 @@ async def load_fingerprint_snapshot(db: AsyncSession) -> FingerprintSnapshot:
             DHCPFingerprint.option_55,
             DHCPFingerprint.option_60,
             DHCPFingerprint.fingerbank_device_class,
+            DHCPFingerprint.fingerbank_score,
         )
     )
     return FingerprintSnapshot(
-        rows=tuple((str(m), o55, o60, cls) for m, o55, o60, cls in res.all())
+        rows=tuple((str(m), o55, o60, cls, score) for m, o55, o60, cls, score in res.all())
     )
 
 
 def _partition(
     snapshot: FingerprintSnapshot, selected: set[str]
-) -> tuple[dict[Signature, list[str]], set[Signature], dict[Signature, int]]:
+) -> tuple[dict[Signature, list[str]], set[Signature], dict[Signature, int], list[int]]:
     """Partition observed fingerprints by whether their class was selected.
 
     Returns ``(inside, outside, unclassified)`` where ``inside`` maps each
@@ -300,15 +327,18 @@ def _partition(
     inside: dict[Signature, list[str]] = {}
     outside: set[Signature] = set()
     unclassified: dict[Signature, int] = {}
-    for mac, opt55, opt60, device_class in snapshot.rows:
+    scores: list[int] = []
+    for mac, opt55, opt60, device_class, score in snapshot.rows:
         sig = Signature(option_55=opt55, option_60=opt60)
         if device_class is None or device_class == "":
             unclassified[sig] = unclassified.get(sig, 0) + 1
         elif device_class in selected:
             inside.setdefault(sig, []).append(str(mac))
+            if score is not None:
+                scores.append(int(score))
         else:
             outside.add(sig)
-    return inside, outside, unclassified
+    return inside, outside, unclassified, scores
 
 
 async def compile_device_policy(
@@ -338,9 +368,9 @@ async def compile_device_policy(
     if selected:
         if snapshot is None:
             snapshot = await load_fingerprint_snapshot(db)
-        inside, outside, unclassified = _partition(snapshot, selected)
+        inside, outside, unclassified, scores = _partition(snapshot, selected)
     else:
-        inside, outside, unclassified = {}, set(), {}
+        inside, outside, unclassified, scores = {}, set(), {}, []
 
     usable: list[Signature] = []
     ambiguous: list[Signature] = []
@@ -389,6 +419,17 @@ async def compile_device_policy(
             f"{unclassified_hits} device(s) fingerbank has not classified share a "
             "matched signature and will also receive this policy."
         )
+    if usable and scores:
+        best = max(scores)
+        result.confidence = best
+        if best < LOW_CONFIDENCE_SCORE:
+            result.warnings.append(
+                f"Fingerbank's confidence in these classifications is low "
+                f"(best score {best}/100). Below about {LOW_CONFIDENCE_SCORE} it "
+                "is usually falling back to the MAC vendor rather than "
+                "identifying the device, so the class may group unrelated "
+                "hardware. Check the matched devices before relying on this."
+            )
 
     compiled = build_expression(usable)
     result.compiled_expression = compiled

--- a/backend/app/services/dhcp/device_policy.py
+++ b/backend/app/services/dhcp/device_policy.py
@@ -52,14 +52,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import structlog
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.dhcp_device_policy import DHCPDevicePolicy
 from app.models.dhcp_fingerprint import DHCPFingerprint
-
-logger = structlog.get_logger(__name__)
 
 # Cap on signature terms in one compiled expression.
 #

--- a/backend/tests/test_dhcp_device_policy.py
+++ b/backend/tests/test_dhcp_device_policy.py
@@ -31,6 +31,7 @@ from app.models.dhcp_device_policy import DHCPDevicePolicy
 from app.models.dhcp_fingerprint import DHCPFingerprint
 from app.services.dhcp.config_bundle import build_config_bundle
 from app.services.dhcp.device_policy import (
+    LOW_CONFIDENCE_SCORE,
     MAX_SIGNATURE_TERMS,
     Signature,
     _term,
@@ -74,12 +75,19 @@ async def _make_group_with_server(
     return grp, srv
 
 
-def _fp(mac: str, opt55: str | None, opt60: str | None, klass: str | None) -> DHCPFingerprint:
+def _fp(
+    mac: str,
+    opt55: str | None,
+    opt60: str | None,
+    klass: str | None,
+    score: int | None = 90,
+) -> DHCPFingerprint:
     return DHCPFingerprint(
         mac_address=mac,
         option_55=opt55,
         option_60=opt60,
         fingerbank_device_class=klass,
+        fingerbank_score=score,
     )
 
 
@@ -163,7 +171,22 @@ def test_lossy_decoded_vendor_class_is_refused_not_mismatched() -> None:
     bytes the device never sent. Emitting it would list the device as
     matched in the preview while the rendered class silently skipped it."""
     assert text_to_hex("Acme\ufffdPrinter") is None
-    assert build_expression([Signature("1,3,6", "Acme\ufffdPrinter")]) == (
+
+
+def test_present_but_unencodable_option_drops_the_whole_signature() -> None:
+    """ "Absent" and "present but unencodable" must not be conflated.
+
+    The device DID send a vendor class, so falling back to
+    ``not option[60].exists`` would assert the opposite of the truth and
+    match a different population — devices that send this request list and
+    no vendor class at all. Matching confidently and wrongly is worse than
+    not matching, so the signature is dropped whole."""
+    assert _term(Signature("1,3,6", "Acme\ufffdPrinter")) is None
+    assert _term(Signature("1,3,junk", "HP")) is None
+    assert build_expression([Signature("1,3,6", "Acme\ufffdPrinter")]) == ""
+
+    # A genuinely absent option still compiles, asserting the absence.
+    assert _term(Signature("1,3,6", None)) == (
         "(option[55].hex == 0x010306 and not option[60].exists)"
     )
 
@@ -536,3 +559,41 @@ async def test_preview_does_not_write(db_session: AsyncSession, client: AsyncCli
     assert r.status_code == 200
     await db_session.refresh(policy)
     assert policy.modified_at == before
+
+
+@pytest.mark.asyncio
+async def test_low_fingerbank_confidence_is_warned(db_session: AsyncSession) -> None:
+    """A low score means fingerbank fell back to the MAC vendor instead of
+    identifying the device — verified against a live key, where an
+    unidentified Apple device came back as device_class "Hardware
+    Manufacturer" at 29 while an exactly-identified print server scored 89.
+    A class built from vendor fallbacks groups unrelated hardware, which is
+    the wrong thing to hang a quarantine on."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add(_fp("aa:bb:cc:00:0b:01", "1,3,6", None, "Hardware Manufacturer", score=29))
+    policy = _policy(grp.id, device_classes=["Hardware Manufacturer"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert out.confidence == 29
+    assert any("confidence" in w for w in out.warnings)
+    # Still compiles — this is advice, not a refusal. The operator may know
+    # their estate better than fingerbank does.
+    assert out.expression
+
+
+@pytest.mark.asyncio
+async def test_confident_classification_is_not_warned(
+    db_session: AsyncSession,
+) -> None:
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add(_fp("aa:bb:cc:00:0c:01", "1,3,6", None, "HP Print Server", score=89))
+    policy = _policy(grp.id, device_classes=["HP Print Server"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert out.confidence == 89
+    assert not any("confidence" in w for w in out.warnings)
+    assert out.confidence >= LOW_CONFIDENCE_SCORE

--- a/backend/tests/test_dhcp_device_policy.py
+++ b/backend/tests/test_dhcp_device_policy.py
@@ -1,0 +1,390 @@
+"""Fingerprint-driven DHCP device policies (issue #700).
+
+The tests that matter here are the ones guarding a *silent* misfire —
+a policy that renders, looks configured, and applies to the wrong
+devices or to none:
+
+* an unmatchable signature must never compile to an always-true term
+* an empty vendor class must never compile to ``0x``, which Kea rejects
+  whole, taking every unrelated class in the group down with it
+* a signature shared with devices outside the selected classes is
+  excluded unless the operator opts in
+* the expression is deterministic, because it rides the bundle ETag
+* nothing device-controlled reaches the config as a quoted string
+* a policy that compiles to nothing is dropped rather than rendered
+  testless, which in Kea means "match every packet"
+* device-policy classes reach the *wire*, per the #858 lesson
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dhcp import DHCPServer, DHCPServerGroup
+from app.models.dhcp_device_policy import DHCPDevicePolicy
+from app.models.dhcp_fingerprint import DHCPFingerprint
+from app.services.dhcp.config_bundle import build_config_bundle
+from app.services.dhcp.device_policy import (
+    MAX_SIGNATURE_TERMS,
+    Signature,
+    _term,
+    build_expression,
+    compile_device_policy,
+    option55_to_hex,
+    slugify_class_name,
+    text_to_hex,
+)
+
+
+async def _make_user(db: AsyncSession) -> tuple[User, str]:
+    user = User(
+        username=f"u-{uuid.uuid4().hex[:8]}",
+        email=f"{uuid.uuid4().hex[:8]}@example.com",
+        display_name="Test",
+        hashed_password=hash_password("x"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user, create_access_token(str(user.id))
+
+
+async def _make_group_with_server(
+    db: AsyncSession,
+) -> tuple[DHCPServerGroup, DHCPServer]:
+    grp = DHCPServerGroup(name=f"g-{uuid.uuid4().hex[:6]}", description="")
+    db.add(grp)
+    await db.flush()
+    srv = DHCPServer(
+        name=f"s-{uuid.uuid4().hex[:6]}",
+        driver="kea",
+        host="127.0.0.1",
+        port=67,
+        server_group_id=grp.id,
+    )
+    db.add(srv)
+    await db.flush()
+    return grp, srv
+
+
+def _fp(mac: str, opt55: str | None, opt60: str | None, klass: str | None) -> DHCPFingerprint:
+    return DHCPFingerprint(
+        mac_address=mac,
+        option_55=opt55,
+        option_60=opt60,
+        fingerbank_device_class=klass,
+    )
+
+
+def _policy(group_id, **kw) -> DHCPDevicePolicy:
+    base = {
+        "group_id": group_id,
+        "name": kw.pop("name", f"p-{uuid.uuid4().hex[:6]}"),
+        "class_name": kw.pop("class_name", f"spatium-device-{uuid.uuid4().hex[:6]}"),
+        "device_classes": kw.pop("device_classes", ["Printer"]),
+        "enabled": kw.pop("enabled", True),
+    }
+    base.update(kw)
+    return DHCPDevicePolicy(**base)
+
+
+# ── Encoding primitives ───────────────────────────────────────────
+
+
+def test_option55_to_hex_encodes_decimal_csv() -> None:
+    assert option55_to_hex("1,3,6,15") == "0103060F"
+    assert option55_to_hex("1, 3 ,6") == "010306"
+
+
+@pytest.mark.parametrize("bad", ["", None, "1,300", "1,-2", "1,x", "abc"])
+def test_option55_to_hex_rejects_unusable(bad: str | None) -> None:
+    """A byte outside 0-255 or a non-numeric field means the stored row is
+    not a parameter-request-list. Coercing it would emit an expression that
+    matches the wrong packets, so the term is dropped instead."""
+    assert option55_to_hex(bad) is None
+
+
+def test_text_to_hex_empty_is_none_not_empty_string() -> None:
+    """``option[60].hex == 0x`` is a parse error that fails the ENTIRE Kea
+    config, not just this class — verified against kea-dhcp4 3.0.3."""
+    assert text_to_hex("") is None
+    assert text_to_hex(None) is None
+    assert text_to_hex("MSFT 5.0") == "4D53465420352E30"
+
+
+def test_signature_with_nothing_to_match_is_never_rendered() -> None:
+    """The single most dangerous term this compiler could emit.
+
+    An empty term would collapse the OR into an always-true expression and
+    hand the policy's option set and lease time to every device on the
+    network."""
+    assert _term(Signature(None, None)) is None
+    assert build_expression([Signature(None, None)]) == ""
+
+
+def test_absent_vendor_class_is_asserted_not_ignored() -> None:
+    """A device that sent no option 60 compiles to ``not option[60].exists``.
+
+    Ignoring the absence would widen the match to every device sharing the
+    parameter-request-list, including ones that DO send a vendor class."""
+    term = _term(Signature("1,3,6", None))
+    assert term is not None
+    assert "not option[60].exists" in term
+
+
+def test_expression_is_deterministic_regardless_of_input_order() -> None:
+    """The expression rides the config-bundle ETag. An unstable ordering
+    would shift the ETag on every rebuild and make every agent in the group
+    re-fetch and re-render byte-identical config."""
+    a = [Signature("1,3,6", "A"), Signature("1,3", "B"), Signature("9", None)]
+    assert build_expression(sorted(a)) == build_expression(sorted(list(reversed(a))))
+
+
+def test_device_controlled_vendor_class_never_becomes_syntax() -> None:
+    """Option 60 is chosen by the *device*. Emitting it as hex means a
+    vendor class of ``' or 1--`` lands as inert bytes rather than as
+    expression syntax."""
+    expr = build_expression([Signature("1,3,6", "' or 1--")])
+    assert "'" not in expr
+    assert "or 1--" not in expr
+    assert expr.count("(") == expr.count(")")
+
+
+def test_slugify_class_name_is_kea_safe() -> None:
+    assert slugify_class_name("IoT Quarantine / v2") == "spatium-device-IoT-Quarantine-v2"
+    assert slugify_class_name("!!!") == "spatium-device-policy"
+
+
+# ── Compilation semantics ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_signature_excluded_by_default(db_session: AsyncSession) -> None:
+    """A signature emitted by devices inside AND outside the selected
+    classes is not matched by default.
+
+    This is the difference between quarantining the printers and
+    quarantining the laptop that happens to share their request list."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add_all(
+        [
+            _fp("aa:bb:cc:00:00:01", "1,3,6", None, "Printer"),
+            _fp("aa:bb:cc:00:00:02", "1,3,6", None, "Windows"),
+            _fp("aa:bb:cc:00:00:03", "1,3,6,15", None, "Printer"),
+        ]
+    )
+    policy = _policy(grp.id, device_classes=["Printer"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+
+    assert Signature("1,3,6", None) in out.ambiguous
+    assert Signature("1,3,6", None) not in out.signatures
+    assert Signature("1,3,6,15", None) in out.signatures
+    assert "aa:bb:cc:00:00:02" not in out.matched_macs
+    assert any("excluded" in w for w in out.warnings)
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_signature_included_on_explicit_opt_in(
+    db_session: AsyncSession,
+) -> None:
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add_all(
+        [
+            _fp("aa:bb:cc:00:01:01", "1,3,6", None, "Printer"),
+            _fp("aa:bb:cc:00:01:02", "1,3,6", None, "Windows"),
+        ]
+    )
+    policy = _policy(grp.id, device_classes=["Printer"], include_ambiguous=True)
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert Signature("1,3,6", None) in out.signatures
+
+
+@pytest.mark.asyncio
+async def test_unclassified_device_is_not_ambiguity_but_is_reported(
+    db_session: AsyncSession,
+) -> None:
+    """A device fingerbank has not answered on is not evidence of a
+    different class — excluding an otherwise-clean signature because of one
+    would make the feature unusable before an API key is set. It WILL
+    receive the policy, so the count is surfaced instead of buried."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add_all(
+        [
+            _fp("aa:bb:cc:00:02:01", "1,3,6", None, "Printer"),
+            _fp("aa:bb:cc:00:02:02", "1,3,6", None, None),
+        ]
+    )
+    policy = _policy(grp.id, device_classes=["Printer"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert Signature("1,3,6", None) in out.signatures
+    assert out.ambiguous == []
+    assert out.unclassified_matches == 1
+    assert any("not classified" in w for w in out.warnings)
+
+
+@pytest.mark.asyncio
+async def test_truncation_is_reported_never_silent(db_session: AsyncSession) -> None:
+    grp, _ = await _make_group_with_server(db_session)
+    for i in range(MAX_SIGNATURE_TERMS + 5):
+        db_session.add(
+            _fp(f"aa:bb:cc:{i // 256:02x}:{i % 256:02x}:01", f"1,{i % 250 + 1},6", str(i), "IoT")
+        )
+    policy = _policy(grp.id, device_classes=["IoT"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert len(out.signatures) == MAX_SIGNATURE_TERMS
+    assert out.truncated == 5
+    assert any("cap" in w for w in out.warnings)
+
+
+@pytest.mark.asyncio
+async def test_override_is_rendered_and_compiled_still_reported(
+    db_session: AsyncSession,
+) -> None:
+    """The issue requires the compiled expression stay visible so nobody
+    debugs a black box — an override must not hide what we would have
+    generated."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add(_fp("aa:bb:cc:00:03:01", "1,3,6", None, "Printer"))
+    policy = _policy(grp.id, device_classes=["Printer"], match_override="option[55].hex == 0xDEAD")
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert out.expression == "option[55].hex == 0xDEAD"
+    assert out.source == "override"
+    assert out.signatures  # the compiled input is still reported
+
+
+@pytest.mark.asyncio
+async def test_policy_with_no_observations_compiles_to_nothing(
+    db_session: AsyncSession,
+) -> None:
+    grp, _ = await _make_group_with_server(db_session)
+    policy = _policy(grp.id, device_classes=["Nothing Seen Yet"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert out.expression == ""
+    assert out.source == "empty"
+
+
+# ── Bundle + wire ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bundle_drops_policy_that_compiles_to_nothing(
+    db_session: AsyncSession,
+) -> None:
+    """A Kea class with no ``test`` matches EVERY packet. Rendering an
+    unmatched policy testless would apply its option set and lease time to
+    the whole network."""
+    grp, srv = await _make_group_with_server(db_session)
+    db_session.add(_policy(grp.id, device_classes=["Never Seen"]))
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.device_policy_classes == ()
+
+
+@pytest.mark.asyncio
+async def test_bundle_drops_disabled_policy(db_session: AsyncSession) -> None:
+    grp, srv = await _make_group_with_server(db_session)
+    db_session.add(_fp("aa:bb:cc:00:04:01", "1,3,6", None, "Printer"))
+    db_session.add(_policy(grp.id, device_classes=["Printer"], enabled=False))
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, srv)
+    assert bundle.device_policy_classes == ()
+
+
+@pytest.mark.asyncio
+async def test_bundle_renders_matching_policy_with_lease_time(
+    db_session: AsyncSession,
+) -> None:
+    grp, srv = await _make_group_with_server(db_session)
+    db_session.add(_fp("aa:bb:cc:00:05:01", "1,3,6", None, "Printer"))
+    db_session.add(
+        _policy(
+            grp.id,
+            device_classes=["Printer"],
+            class_name="spatium-device-printers",
+            lease_time=600,
+            options={"dns-servers": "10.0.0.53"},
+        )
+    )
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, srv)
+    assert len(bundle.device_policy_classes) == 1
+    cls = bundle.device_policy_classes[0]
+    assert cls.name == "spatium-device-printers"
+    assert cls.lease_time == 600
+    assert cls.options == {"dns-servers": "10.0.0.53"}
+    assert "option[55].hex" in cls.match_expression
+
+
+@pytest.mark.asyncio
+async def test_policy_change_moves_the_etag(db_session: AsyncSession) -> None:
+    """Without this the agent's long-poll never learns the class exists."""
+    grp, srv = await _make_group_with_server(db_session)
+    before = (await build_config_bundle(db_session, srv)).compute_etag()
+
+    db_session.add(_fp("aa:bb:cc:00:06:01", "1,3,6", None, "Printer"))
+    db_session.add(_policy(grp.id, device_classes=["Printer"]))
+    await db_session.flush()
+
+    after = (await build_config_bundle(db_session, srv)).compute_etag()
+    assert before != after
+
+
+@pytest.mark.asyncio
+async def test_unclassified_behind_an_excluded_signature_is_not_counted(
+    db_session: AsyncSession,
+) -> None:
+    """Only devices the RENDERED expression reaches are reported.
+
+    An unclassified device sharing a signature that was excluded for
+    ambiguity will not receive the policy, so counting it would overstate
+    the blast radius — in the one report an operator leans on to decide
+    whether a quarantine is safe to switch on."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add_all(
+        [
+            # `1,3,6` is emitted inside AND outside the selected class, so it
+            # is excluded — along with the unclassified device behind it.
+            _fp("aa:bb:cc:00:07:01", "1,3,6", None, "Printer"),
+            _fp("aa:bb:cc:00:07:02", "1,3,6", None, "Windows"),
+            _fp("aa:bb:cc:00:07:03", "1,3,6", None, None),
+            # A clean signature, with its own unclassified sharer.
+            _fp("aa:bb:cc:00:07:04", "1,3,6,15", None, "Printer"),
+            _fp("aa:bb:cc:00:07:05", "1,3,6,15", None, None),
+        ]
+    )
+    policy = _policy(grp.id, device_classes=["Printer"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+
+    assert Signature("1,3,6", None) in out.ambiguous
+    assert out.signatures == [Signature("1,3,6,15", None)]
+    # One, not two: the device behind the excluded signature does not count.
+    assert out.unclassified_matches == 1

--- a/backend/tests/test_dhcp_device_policy.py
+++ b/backend/tests/test_dhcp_device_policy.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.security import create_access_token, hash_password
@@ -35,6 +36,7 @@ from app.services.dhcp.device_policy import (
     _term,
     build_expression,
     compile_device_policy,
+    load_fingerprint_snapshot,
     option55_to_hex,
     slugify_class_name,
     text_to_hex,
@@ -137,12 +139,44 @@ def test_absent_vendor_class_is_asserted_not_ignored() -> None:
     assert "not option[60].exists" in term
 
 
+def test_signatures_sort_when_one_lacks_an_option() -> None:
+    """Regression: ``Signature`` used ``order=True``, whose generated
+    ``__lt__`` compares ``None`` against ``str`` as soon as two in-class
+    signatures agree on option 55 and differ on whether option 60 is
+    present. That raised TypeError inside ``build_config_bundle`` — a 500
+    on the agent long-poll that stops the entire group converging. Every
+    earlier fixture happened to differ on option 55, which is why nothing
+    caught it."""
+    rows = [
+        Signature("1,3,6", "HP"),
+        Signature("1,3,6", None),
+        Signature(None, "X"),
+        Signature(None, None),
+    ]
+    rows.sort(key=lambda s: s.sort_key)  # must not raise
+    assert len(rows) == 4
+
+
+def test_lossy_decoded_vendor_class_is_refused_not_mismatched() -> None:
+    """A non-UTF-8 option 60 is stored already destroyed (the fingerprint
+    row decodes with errors="replace"), so re-encoding yields EF BF BD —
+    bytes the device never sent. Emitting it would list the device as
+    matched in the preview while the rendered class silently skipped it."""
+    assert text_to_hex("Acme\ufffdPrinter") is None
+    assert build_expression([Signature("1,3,6", "Acme\ufffdPrinter")]) == (
+        "(option[55].hex == 0x010306 and not option[60].exists)"
+    )
+
+
 def test_expression_is_deterministic_regardless_of_input_order() -> None:
     """The expression rides the config-bundle ETag. An unstable ordering
     would shift the ETag on every rebuild and make every agent in the group
     re-fetch and re-render byte-identical config."""
     a = [Signature("1,3,6", "A"), Signature("1,3", "B"), Signature("9", None)]
-    assert build_expression(sorted(a)) == build_expression(sorted(list(reversed(a))))
+    key = lambda s: s.sort_key  # noqa: E731
+    assert build_expression(sorted(a, key=key)) == build_expression(
+        sorted(list(reversed(a)), key=key)
+    )
 
 
 def test_device_controlled_vendor_class_never_becomes_syntax() -> None:
@@ -388,3 +422,117 @@ async def test_unclassified_behind_an_excluded_signature_is_not_counted(
     assert out.signatures == [Signature("1,3,6,15", None)]
     # One, not two: the device behind the excluded signature does not count.
     assert out.unclassified_matches == 1
+
+
+@pytest.mark.asyncio
+async def test_bundle_survives_signatures_differing_only_on_absent_option(
+    db_session: AsyncSession,
+) -> None:
+    """End-to-end guard for the sort crash: this is the shape that reached
+    ``build_config_bundle`` and 500'd the agent config long-poll."""
+    grp, srv = await _make_group_with_server(db_session)
+    db_session.add_all(
+        [
+            _fp("aa:bb:cc:00:08:01", "1,3,6", "HP-Printer", "Printer"),
+            _fp("aa:bb:cc:00:08:02", "1,3,6", None, "Printer"),
+        ]
+    )
+    db_session.add(_policy(grp.id, device_classes=["Printer"]))
+    await db_session.flush()
+
+    bundle = await build_config_bundle(db_session, srv)  # must not raise
+    assert len(bundle.device_policy_classes) == 1
+
+
+@pytest.mark.asyncio
+async def test_override_reports_the_compiled_expression_separately(
+    db_session: AsyncSession,
+) -> None:
+    """``compiled_expression`` previously echoed the override, making the
+    documented comparison impossible."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add(_fp("aa:bb:cc:00:09:01", "1,3,6", None, "Printer"))
+    policy = _policy(grp.id, device_classes=["Printer"], match_override="option[55].hex == 0xDEAD")
+    db_session.add(policy)
+    await db_session.flush()
+
+    out = await compile_device_policy(db_session, policy)
+    assert out.expression == "option[55].hex == 0xDEAD"
+    assert out.compiled_expression != out.expression
+    assert "option[55].hex == 0x010306" in out.compiled_expression
+
+
+@pytest.mark.asyncio
+async def test_shared_snapshot_matches_a_per_policy_compile(
+    db_session: AsyncSession,
+) -> None:
+    """The bundle passes one fingerprint snapshot to every policy so the
+    store is read once per tick rather than once per policy. The hoisted
+    read must not change the answer."""
+    grp, _ = await _make_group_with_server(db_session)
+    db_session.add_all(
+        [
+            _fp("aa:bb:cc:00:0a:01", "1,3,6,15", None, "Printer"),
+            _fp("aa:bb:cc:00:0a:02", "1,3,6", None, "Windows"),
+        ]
+    )
+    policy = _policy(grp.id, device_classes=["Printer"])
+    db_session.add(policy)
+    await db_session.flush()
+
+    snap = await load_fingerprint_snapshot(db_session)
+    assert (await compile_device_policy(db_session, policy, snapshot=snap)).expression == (
+        await compile_device_policy(db_session, policy)
+    ).expression
+
+
+@pytest.mark.asyncio
+async def test_explicit_null_on_a_not_null_field_is_422_not_500(
+    db_session: AsyncSession, client: AsyncClient
+) -> None:
+    """``exclude_unset`` is kept so a null can CLEAR a nullable field, but
+    it also let a null reach NOT NULL columns, where the blanket setattr
+    turned it into an unhandled 500 on commit."""
+    _, token = await _make_user(db_session)
+    grp, _ = await _make_group_with_server(db_session)
+    policy = _policy(grp.id, device_classes=["Printer"])
+    db_session.add(policy)
+    await db_session.commit()
+
+    headers = {"Authorization": f"Bearer {token}"}
+    for field_name in ("options", "enabled", "priority", "device_classes"):
+        r = await client.put(
+            f"/api/v1/dhcp/device-policies/{policy.id}",
+            json={field_name: None},
+            headers=headers,
+        )
+        assert r.status_code == 422, f"{field_name} -> {r.status_code}"
+
+    # A null on a NULLABLE field still means "clear it".
+    r = await client.put(
+        f"/api/v1/dhcp/device-policies/{policy.id}",
+        json={"lease_time": None},
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["lease_time"] is None
+
+
+@pytest.mark.asyncio
+async def test_preview_does_not_write(db_session: AsyncSession, client: AsyncClient) -> None:
+    """A GET authorised by ``read`` must not commit — it would be an
+    unaudited write that maintenance mode does not gate."""
+    _, token = await _make_user(db_session)
+    grp, _ = await _make_group_with_server(db_session)
+    policy = _policy(grp.id, device_classes=["Printer"])
+    db_session.add(policy)
+    await db_session.commit()
+    before = policy.modified_at
+
+    r = await client.get(
+        f"/api/v1/dhcp/device-policies/{policy.id}/preview",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert r.status_code == 200
+    await db_session.refresh(policy)
+    assert policy.modified_at == before

--- a/backend/tests/test_dhcp_wire_bundle_coverage.py
+++ b/backend/tests/test_dhcp_wire_bundle_coverage.py
@@ -9,6 +9,10 @@ This boundary has now produced the same bug four times:
 * #858 — pool ``options_override``, ``pxe_classes`` and ``phone_classes``.
 * #858 — pool ``class_restriction``, shipped but never read by the agent.
 
+This test is why #700 wired ``device_policy_classes`` through the payload
+and the agent renderer in the same change: adding the dataclass field alone
+fails here.
+
 Every occurrence is silent: the UI shows the value, the API returns it, the
 ETag moves when it changes so the agent even re-syncs — and the rendered
 config is identical, because the payload never carried it.
@@ -40,6 +44,7 @@ SHIPPED: frozenset[str] = frozenset(
         "client_classes",
         "pxe_classes",
         "phone_classes",
+        "device_policy_classes",  # #700
         "mac_blocks",
         "failover",
         "dhcp_socket_type",  # → inside the synthesized "server" block

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -1425,7 +1425,21 @@ the cap is **reported**, never silent.
 
 Permissions ride on `dhcp_client_class` — a device policy *is* a
 client class, generated rather than hand-written — so the builtin DHCP
-Editor role picks it up with no role migration.
+Editor role gains **read** with no role migration. **Writes are
+superadmin**, matching the hand-authored client-class surface rather
+than quietly widening it: the two produce the same Kea object, and a
+policy that can move devices into a quarantine pool is not a smaller
+privilege than typing that class by hand.
+
+The preview is genuinely read-only — it commits nothing, so it cannot
+become an unaudited write on a path authorised by `read` and not gated
+by maintenance mode.
+
+A vendor class that was stored after a lossy decode (option 60 arrived
+as non-UTF-8 and `DHCPFingerprint` decodes with `errors="replace"`) is
+**refused**, not re-encoded: `EF BF BD` is not what the device puts on
+the wire, so the term could never match while the preview claimed the
+device was caught. It falls back to matching option 55 alone.
 
 MCP: `find_dhcp_device_policies` and `preview_dhcp_device_policy`,
 both read-only and default-enabled.

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -537,6 +537,11 @@ DHCPClientClass
 
 Classes are referenced by pool `class_restriction` field. The DHCP driver translates these to server-native syntax.
 
+Hand-authoring a match expression is not the only way to get a class:
+[§17a](#17a-fingerprint-driven-device-policies-issue-700) compiles one
+from fingerbank device classes, so "printers get a short lease and a
+restricted resolver" does not have to start from Kea syntax.
+
 ---
 
 ## 4a. DHCP MAC Blocklist
@@ -1290,6 +1295,148 @@ a "Raw signature" disclosure) the option-55 / option-60 strings.
 The same surface lets operators force a re-lookup if they think the
 fingerbank result is wrong (the dispatched task ignores the cache
 window for that one MAC).
+
+## 17a. Fingerprint-driven device policies (issue #700)
+
+Section 17 tells you what a device *is*. Section 4 lets you treat
+classes of device differently. This joins them: the operator picks
+fingerbank device classes and an outcome — an option set, a lease
+time, and optionally a pool — and SpatiumDDI compiles it into a real
+Kea client-class `test` expression.
+
+That produces NAC-lite outcomes with no 802.1X and no switch
+configuration: unknown and IoT devices get a short lease, a restricted
+resolver and a quarantine pool; corporate laptops get the normal
+treatment.
+
+### What the expression actually matches
+
+Fingerbank classifies by querying their corpus with the signature a
+device emitted. Kea cannot do that mid-packet, and there is no
+`device-class == IoT` predicate to render. So the compiler matches
+**the signatures we have observed and had classified into the
+selected classes** — not the abstract category.
+
+Two consequences, repeated in the UI rather than hidden:
+
+1. A device whose signature we have never seen matches nothing,
+   however obviously it belongs to the category. It is classified on
+   its first lease and the policy applies from the **next renewal**.
+   Nothing here is instant enforcement.
+2. The policy tracks observation. As new signatures land in a selected
+   class the expression grows on its own — which is the feature, but
+   it also means the rendered config changes with no operator edit,
+   and the bundle ETag legitimately shifts. It is bounded by *distinct
+   signatures*, not device count, so it settles once the estate has
+   been seen: a fleet of 500 identical handsets adds one term, not 500.
+
+### Ambiguous signatures are excluded by default
+
+DHCP signatures are not unique to a device class. A minimal parameter
+request list like `1,3,6,15` is emitted by embedded Linux in a
+doorbell and by a rack server alike. If a signature appears on devices
+both inside **and** outside the selected classes, matching it applies
+the policy to devices the operator did not choose — which for a
+feature whose headline use is "put unknown devices in a quarantine
+pool" is how the CEO's laptop ends up quarantined.
+
+Such signatures are excluded, counted, and listed in the preview.
+`include_ambiguous` is the explicit, audited opt-in.
+
+Devices fingerbank has **not** classified are treated differently:
+they are not evidence of a different class (excluding an otherwise
+clean signature because of one would make the feature unusable before
+an API key is set), so they do not trigger ambiguity. They *will*
+receive the policy, so the count is reported instead — and only for
+signatures that survived filtering and the term cap, so the number
+reflects devices the rendered expression actually reaches.
+
+### Nothing device-controlled becomes syntax
+
+Option 60 is a value the *device* chooses, and it lands inside a
+config file with quoting. Both halves of every term are emitted as hex
+literals:
+
+```
+(option[55].hex == 0x0103060F and option[60].hex == 0x4D53465420352E30)
+```
+
+so a vendor class of `' or 1--` becomes inert bytes rather than
+expression syntax. Verified against kea-dhcp4 3.0.3.
+
+A device that sent no option 60 compiles to `not option[60].exists`
+rather than omitting the test — ignoring the absence would widen the
+match to every device sharing the request list, including ones that
+*do* send a vendor class.
+
+### The compiled expression is visible and overridable
+
+`GET /dhcp/device-policies/{id}/preview` returns the expression, the
+signatures behind it, the excluded ones, and the MACs currently
+matched. `match_override` replaces the generated expression entirely,
+and the preview still shows what the compiler produced so the two can
+be compared. Nobody should end up debugging a black box against
+`kea-dhcp4.log`.
+
+An override is structurally checked at the API (balanced parentheses
+and quotes, length). This is deliberately not a Kea expression parser
+— operators need the real language for the escape hatch to be usable —
+but Kea rejects a malformed config **whole**, so an unbalanced paren
+would stop every other class, scope and reservation in the group
+converging, not just this policy. Same blast radius `named.conf`
+validation exists for in #876 / #899. The agent still runs Kea's own
+`config-test` before applying, and #882's quarantine means a rejected
+bundle is reverted rather than re-applied in a loop.
+
+### Rendering
+
+| Property | Value |
+|---|---|
+| Table | `dhcp_device_policy` (migration `f3b8d21c74ae`) |
+| Kea class name | `spatium-device-<slug>`, stored not derived |
+| Per-class lease | Kea `valid-lifetime` on the class |
+| Address family | **DHCPv4 only** — options 55/60 are v4 option codes |
+| Order | After operator, PXE and phone classes |
+
+`class_name` is a stored column rather than derived from `name` at
+render time. Pools bind to a class **by name** via
+`DHCPPool.class_restriction`, so regenerating it on rename would leave
+every pool restricted to a class that no longer exists — which Kea
+accepts, and which silently stops the pool serving anyone.
+
+A policy that compiles to nothing is **dropped**, never rendered with
+an empty `test`: a Kea client class with no test matches every packet,
+which would hand a quarantine's option set and lease time to the whole
+network. The agent renderer fails closed the same way.
+
+The maximum number of signature terms in one expression is 128. Kea's
+parser is not the constraint (a 1024-term / 32 KB expression loads
+fine); per-packet evaluation cost and operator legibility are. Hitting
+the cap is **reported**, never silent.
+
+### Endpoints
+
+| Method | Path |
+|---|---|
+| GET/POST | `/dhcp/server-groups/{gid}/device-policies` |
+| GET/PUT/DELETE | `/dhcp/device-policies/{id}` |
+| GET | `/dhcp/device-policies/{id}/preview` |
+| GET | `/dhcp/server-groups/{gid}/device-observations` |
+
+Permissions ride on `dhcp_client_class` — a device policy *is* a
+client class, generated rather than hand-written — so the builtin DHCP
+Editor role picks it up with no role migration.
+
+MCP: `find_dhcp_device_policies` and `preview_dhcp_device_policy`,
+both read-only and default-enabled.
+
+**Deferred:** auto-creating the quarantine pool alongside the policy
+(today the operator points a pool's class restriction at the generated
+class name); DHCPv6, which needs the option 16 / ORO equivalents and a
+different fingerbank input; and rules that key on fingerbank
+*device name* rather than class.
+
+---
 
 ## 18. PXE / iPXE provisioning profiles (issue #51)
 

--- a/docs/features/DHCP.md
+++ b/docs/features/DHCP.md
@@ -1304,6 +1304,35 @@ fingerbank device classes and an outcome — an option set, a lease
 time, and optionally a pool — and SpatiumDDI compiles it into a real
 Kea client-class `test` expression.
 
+### Device classes are fingerbank's strings, not tidy categories
+
+Worth setting expectations before the first policy: `device_class` is
+fingerbank's own taxonomy (the first parent of the matched device), and
+it sits at mixed granularity. Verified against a live key, real values
+look like:
+
+| `device_class` | `device_name` | score |
+|---|---|---|
+| `HP Print Server` | HP JetDirect Print Server | 89 |
+| `Operating System` | Windows OS | 78 |
+| `Generic Android` | Samsung Android | 60 |
+| `Hardware Manufacturer` | Apple, Inc. | 29 |
+| `Generic IoT` | Raspberry Pi | 15 |
+
+There is no plain `Printer` or `IoT` class to select. Always pick from
+`GET …/device-observations` rather than typing a string — one that does
+not appear there compiles to an empty expression and renders nothing,
+which looks configured and does nothing.
+
+**The score is part of the safety story, not decoration.** A low
+fingerbank score means it could not identify the device and fell back to
+the MAC vendor — which is exactly what `Hardware Manufacturer` at 29
+above is. A class like that groups unrelated hardware, so building a
+quarantine on it targets an arbitrary set of unidentified devices. The
+class picker shows the score per class and flags anything under 30, and
+the compiler adds a warning when the best score among matched devices is
+below that.
+
 That produces NAC-lite outcomes with no 802.1X and no switch
 configuration: unknown and IoT devices get a short lease, a restricted
 resolver and a quarantine pool; corporate laptops get the normal

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8387,6 +8387,37 @@ export const dhcpApi = {
   deleteClientClass: (_groupId: string, classId: string) =>
     api.delete(`/dhcp/client-classes/${classId}`),
 
+  // #700 — fingerprint-driven device policies. These COMPILE INTO client
+  // classes; they are not a parallel mechanism. The preview call is what
+  // keeps the generated match expression from being a black box.
+  listDevicePolicies: (groupId: string) =>
+    api
+      .get<DHCPDevicePolicy[]>(`/dhcp/server-groups/${groupId}/device-policies`)
+      .then((r) => r.data),
+  createDevicePolicy: (groupId: string, data: Partial<DHCPDevicePolicy>) =>
+    api
+      .post<DHCPDevicePolicy>(
+        `/dhcp/server-groups/${groupId}/device-policies`,
+        data,
+      )
+      .then((r) => r.data),
+  updateDevicePolicy: (policyId: string, data: Partial<DHCPDevicePolicy>) =>
+    api
+      .put<DHCPDevicePolicy>(`/dhcp/device-policies/${policyId}`, data)
+      .then((r) => r.data),
+  deleteDevicePolicy: (policyId: string) =>
+    api.delete(`/dhcp/device-policies/${policyId}`),
+  previewDevicePolicy: (policyId: string) =>
+    api
+      .get<DHCPDevicePolicyPreview>(`/dhcp/device-policies/${policyId}/preview`)
+      .then((r) => r.data),
+  listDeviceObservations: (groupId: string) =>
+    api
+      .get<DHCPDeviceObservations>(
+        `/dhcp/server-groups/${groupId}/device-observations`,
+      )
+      .then((r) => r.data),
+
   listOptionCodes: (q?: string) =>
     api
       .get<DHCPOptionCodeDef[]>("/dhcp/option-codes", {
@@ -8780,6 +8811,64 @@ export interface DHCPClientClass {
   options: Record<string, unknown>;
   created_at: string;
   modified_at: string;
+}
+
+// #700 — fingerprint-driven device policy. ``class_name`` is the Kea client
+// class this compiles to; a pool's ``class_restriction`` binds to that string,
+// which is why it is stable across renames rather than derived from ``name``.
+export interface DHCPDevicePolicy {
+  id: string;
+  group_id: string;
+  name: string;
+  description: string;
+  enabled: boolean;
+  class_name: string;
+  device_classes: string[];
+  options: Record<string, unknown>;
+  lease_time: number | null;
+  match_override: string | null;
+  include_ambiguous: boolean;
+  priority: number;
+  last_compiled_at: string | null;
+  created_at: string;
+  modified_at: string;
+}
+
+export interface DHCPDeviceSignature {
+  option_55: string | null;
+  option_60: string | null;
+}
+
+export interface DHCPDevicePolicyPreview {
+  policy_id: string;
+  class_name: string;
+  expression: string;
+  source: string;
+  compiled_expression: string;
+  signature_count: number;
+  signatures: DHCPDeviceSignature[];
+  ambiguous_signatures: DHCPDeviceSignature[];
+  ambiguous_excluded: boolean;
+  truncated: number;
+  max_signature_terms: number;
+  matched_macs: string[];
+  matched_device_count: number;
+  unclassified_matches: number;
+  warnings: string[];
+  renders: boolean;
+}
+
+export interface DHCPDeviceObservation {
+  device_class: string;
+  device_count: number;
+  signature_count: number;
+}
+
+export interface DHCPDeviceObservations {
+  classes: DHCPDeviceObservation[];
+  unclassified_devices: number;
+  total_devices: number;
+  note: string;
 }
 
 export interface DHCPOptionCodeDef {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8845,6 +8845,7 @@ export interface DHCPDevicePolicyPreview {
   source: string;
   compiled_expression: string;
   signature_count: number;
+  confidence: number | null;
   signatures: DHCPDeviceSignature[];
   ambiguous_signatures: DHCPDeviceSignature[];
   ambiguous_excluded: boolean;
@@ -8862,6 +8863,11 @@ export interface DHCPDeviceObservation {
   device_class: string;
   device_count: number;
   signature_count: number;
+  // Fingerbank's own 0-100 confidence. A low score usually means it fell
+  // back to the MAC vendor rather than identifying the device, so the
+  // class groups unrelated hardware — worth showing next to the name.
+  best_score: number | null;
+  avg_score: number | null;
 }
 
 export interface DHCPDeviceObservations {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8829,7 +8829,6 @@ export interface DHCPDevicePolicy {
   match_override: string | null;
   include_ambiguous: boolean;
   priority: number;
-  last_compiled_at: string | null;
   created_at: string;
   modified_at: string;
 }
@@ -8852,6 +8851,7 @@ export interface DHCPDevicePolicyPreview {
   truncated: number;
   max_signature_terms: number;
   matched_macs: string[];
+  matched_macs_truncated: boolean;
   matched_device_count: number;
   unclassified_matches: number;
   warnings: string[];

--- a/frontend/src/pages/dhcp/DHCPPage.tsx
+++ b/frontend/src/pages/dhcp/DHCPPage.tsx
@@ -64,6 +64,7 @@ import { CreateStaticAssignmentModal } from "./CreateStaticAssignmentModal";
 import { useFeatureModules } from "@/hooks/useFeatureModules";
 import { usePermissions } from "@/hooks/usePermissions";
 import { MacBlocksTab } from "./MacBlocksTab";
+import { DevicePoliciesTab } from "./DevicePoliciesTab";
 import { PhoneProfilesTab } from "./PhoneProfilesTab";
 import { DeleteConfirmModal, StatusDot } from "./_shared";
 import {
@@ -346,6 +347,7 @@ type GroupTab =
   | "option-templates"
   | "mac-blocks"
   | "phone-profiles"
+  | "device-policies"
   | "responders"
   | "router-advertisements";
 
@@ -506,6 +508,12 @@ function GroupDetailView({
               Phone Profiles
             </TabButton>
             <TabButton
+              active={tab === "device-policies"}
+              onClick={() => setTab("device-policies")}
+            >
+              Device Policies
+            </TabButton>
+            <TabButton
               active={tab === "responders"}
               onClick={() => setTab("responders")}
             >
@@ -547,6 +555,9 @@ function GroupDetailView({
         {isKea && tab === "mac-blocks" && <MacBlocksTab groupId={group.id} />}
         {isKea && tab === "phone-profiles" && (
           <PhoneProfilesTab groupId={group.id} />
+        )}
+        {isKea && tab === "device-policies" && (
+          <DevicePoliciesTab groupId={group.id} />
         )}
         {isKea && tab === "responders" && <RespondersTab groupId={group.id} />}
         {isKea && raEnabled && tab === "router-advertisements" && (

--- a/frontend/src/pages/dhcp/DevicePoliciesTab.tsx
+++ b/frontend/src/pages/dhcp/DevicePoliciesTab.tsx
@@ -1,0 +1,613 @@
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { AlertTriangle, Cpu, Eye, Pencil, Plus, Trash2 } from "lucide-react";
+
+import {
+  dhcpApi,
+  type DHCPDevicePolicy,
+  type DHCPDevicePolicyPreview,
+} from "@/lib/api";
+import {
+  Modal,
+  Field,
+  Btns,
+  inputCls,
+  errMsg,
+  DeleteConfirmModal,
+} from "./_shared";
+
+const KEY_BASE = "dhcp-device-policies";
+const OBS_KEY = "dhcp-device-observations";
+
+/**
+ * Device Policies tab (issue #700) — fingerbank device classes compiled
+ * into Kea client classes.
+ *
+ * The UI's main job beyond CRUD is to keep the compiled match expression
+ * visible. The issue is explicit that operators must not end up debugging
+ * a black box against kea-dhcp4.log, so the preview shows the generated
+ * expression, the signatures behind it, the ones excluded for ambiguity,
+ * and the devices currently caught — before anything is applied.
+ *
+ * It is also the surface that states the v1 boundary plainly: matching is
+ * over signatures already observed and classified, so a policy applies
+ * from a device's next renewal, not the moment it is saved.
+ */
+export function DevicePoliciesTab({ groupId }: { groupId: string }) {
+  const qc = useQueryClient();
+  const [showCreate, setShowCreate] = useState(false);
+  const [edit, setEdit] = useState<DHCPDevicePolicy | null>(null);
+  const [del, setDel] = useState<DHCPDevicePolicy | null>(null);
+  const [preview, setPreview] = useState<DHCPDevicePolicy | null>(null);
+
+  const { data: policies = [], isFetching } = useQuery({
+    queryKey: [KEY_BASE, groupId],
+    queryFn: () => dhcpApi.listDevicePolicies(groupId),
+    enabled: !!groupId,
+  });
+
+  const delMut = useMutation({
+    mutationFn: (id: string) => dhcpApi.deleteDevicePolicy(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [KEY_BASE, groupId] });
+      setDel(null);
+    },
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="flex items-center gap-2 text-sm font-semibold">
+            <Cpu className="h-4 w-4 shrink-0" />
+            Device Policies
+          </h3>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Give devices of a given fingerprint class their own options, lease
+            time and pool. Matching is over DHCP signatures already seen and
+            classified on this network, so a policy takes effect from a
+            device&rsquo;s next renewal &mdash; not instantly.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setShowCreate(true)}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-sm text-primary-foreground"
+        >
+          <Plus className="h-4 w-4" /> New Policy
+        </button>
+      </div>
+
+      {isFetching && policies.length === 0 ? (
+        <div className="text-sm text-muted-foreground">Loading&hellip;</div>
+      ) : policies.length === 0 ? (
+        <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+          No device policies yet. A policy turns &ldquo;printers get a short
+          lease and a restricted resolver&rdquo; into a Kea client class you can
+          read and override.
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[54rem] text-sm">
+            <thead>
+              <tr className="border-b text-left text-xs uppercase text-muted-foreground">
+                <th className="px-3 py-2">Name</th>
+                <th className="px-3 py-2">Device classes</th>
+                <th className="px-3 py-2">Lease</th>
+                <th className="px-3 py-2">Kea class</th>
+                <th className="px-3 py-2">State</th>
+                <th className="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {policies.map((p) => (
+                <tr key={p.id} className="border-b last:border-0">
+                  <td className="px-3 py-2">
+                    <div className="font-medium">{p.name}</div>
+                    {p.description && (
+                      <div className="text-xs text-muted-foreground">
+                        {p.description}
+                      </div>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex flex-wrap gap-1">
+                      {p.device_classes.length === 0 ? (
+                        <span className="text-xs text-muted-foreground">
+                          none selected
+                        </span>
+                      ) : (
+                        p.device_classes.map((c) => (
+                          <span
+                            key={c}
+                            className="rounded bg-muted px-1.5 py-0.5 text-xs"
+                          >
+                            {c}
+                          </span>
+                        ))
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-xs">
+                    {p.lease_time ? `${p.lease_time}s` : "inherit"}
+                  </td>
+                  <td className="px-3 py-2">
+                    {/* Shown because a pool's class restriction binds to this
+                        exact string — the operator needs to be able to copy it. */}
+                    <code className="break-all text-xs">{p.class_name}</code>
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex flex-wrap items-center gap-1">
+                      <span
+                        className={`rounded px-1.5 py-0.5 text-xs ${
+                          p.enabled
+                            ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400"
+                            : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {p.enabled ? "enabled" : "disabled"}
+                      </span>
+                      {p.match_override && (
+                        <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-xs text-amber-600 dark:text-amber-400">
+                          manual match
+                        </span>
+                      )}
+                      {p.include_ambiguous && (
+                        <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-xs text-amber-600 dark:text-amber-400">
+                          ambiguous included
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-1">
+                      <button
+                        type="button"
+                        title="Preview compiled match"
+                        onClick={() => setPreview(p)}
+                        className="rounded p-1 hover:bg-muted"
+                      >
+                        <Eye className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        title="Edit"
+                        onClick={() => setEdit(p)}
+                        className="rounded p-1 hover:bg-muted"
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </button>
+                      <button
+                        type="button"
+                        title="Delete"
+                        onClick={() => setDel(p)}
+                        className="rounded p-1 hover:bg-muted"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {showCreate && (
+        <DevicePolicyModal
+          groupId={groupId}
+          onClose={() => setShowCreate(false)}
+        />
+      )}
+      {edit && (
+        <DevicePolicyModal
+          groupId={groupId}
+          policy={edit}
+          onClose={() => setEdit(null)}
+        />
+      )}
+      {preview && (
+        <PreviewModal policy={preview} onClose={() => setPreview(null)} />
+      )}
+      {del && (
+        <DeleteConfirmModal
+          title="Delete device policy"
+          description={`Delete "${del.name}"? Pools restricted to ${del.class_name} will no longer match any class.`}
+          onConfirm={() => delMut.mutate(del.id)}
+          onClose={() => setDel(null)}
+          isPending={delMut.isPending}
+          error={delMut.isError ? errMsg(delMut.error) : null}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Create / edit. Device classes come from what fingerbank has actually
+ *  returned on this install — a free-text box would let an operator build a
+ *  policy against a class string that never appears, which compiles to an
+ *  empty expression and renders nothing at all. */
+function DevicePolicyModal({
+  groupId,
+  policy,
+  onClose,
+}: {
+  groupId: string;
+  policy?: DHCPDevicePolicy;
+  onClose: () => void;
+}) {
+  const qc = useQueryClient();
+  const isEdit = !!policy;
+  const [name, setName] = useState(policy?.name ?? "");
+  const [description, setDescription] = useState(policy?.description ?? "");
+  const [enabled, setEnabled] = useState(policy?.enabled ?? true);
+  const [selected, setSelected] = useState<string[]>(
+    policy?.device_classes ?? [],
+  );
+  const [leaseTime, setLeaseTime] = useState(
+    policy?.lease_time != null ? String(policy.lease_time) : "",
+  );
+  const [optionsText, setOptionsText] = useState(
+    JSON.stringify(policy?.options ?? {}, null, 2),
+  );
+  const [override, setOverride] = useState(policy?.match_override ?? "");
+  const [includeAmbiguous, setIncludeAmbiguous] = useState(
+    policy?.include_ambiguous ?? false,
+  );
+  const [optionsError, setOptionsError] = useState<string | null>(null);
+
+  const { data: obs } = useQuery({
+    queryKey: [OBS_KEY, groupId],
+    queryFn: () => dhcpApi.listDeviceObservations(groupId),
+    enabled: !!groupId,
+  });
+
+  // A class that was selected before but is no longer observed must stay
+  // visible and selected, or editing an existing policy would silently drop
+  // it just because the last device of that kind left the network.
+  const options = useMemo(() => {
+    const seen = new Map<string, number>();
+    for (const c of obs?.classes ?? [])
+      seen.set(c.device_class, c.device_count);
+    for (const c of selected) if (!seen.has(c)) seen.set(c, 0);
+    return [...seen.entries()].sort(
+      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+    );
+  }, [obs, selected]);
+
+  const mut = useMutation({
+    mutationFn: (body: Partial<DHCPDevicePolicy>) =>
+      isEdit
+        ? dhcpApi.updateDevicePolicy(policy!.id, body)
+        : dhcpApi.createDevicePolicy(groupId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: [KEY_BASE, groupId] });
+      onClose();
+    },
+  });
+
+  // Btns renders a type="submit" button, so the fields must sit inside a
+  // <form> for Enter-to-save and the click to reach this handler at all.
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    let parsedOptions: Record<string, unknown> = {};
+    if (optionsText.trim()) {
+      try {
+        parsedOptions = JSON.parse(optionsText);
+      } catch {
+        setOptionsError(
+          'Options must be valid JSON, e.g. {"dns-servers": "10.0.0.53"}',
+        );
+        return;
+      }
+    }
+    setOptionsError(null);
+    mut.mutate({
+      name,
+      description,
+      enabled,
+      device_classes: selected,
+      lease_time: leaseTime.trim() ? Number(leaseTime) : null,
+      options: parsedOptions,
+      match_override: override.trim() ? override : null,
+      include_ambiguous: includeAmbiguous,
+    });
+  };
+
+  return (
+    <Modal
+      title={
+        isEdit ? `Edit Device Policy — ${policy!.name}` : "New Device Policy"
+      }
+      onClose={onClose}
+      wide
+    >
+      <form onSubmit={submit} className="space-y-3">
+        <Field label="Name">
+          <input
+            className={inputCls}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="IoT quarantine"
+          />
+        </Field>
+        <Field label="Description">
+          <input
+            className={inputCls}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+        </Field>
+
+        <Field
+          label="Device classes"
+          hint={
+            obs && obs.total_devices === 0
+              ? "No fingerprints collected yet — enable passive fingerprinting first, or this policy will match nothing."
+              : "Classes fingerbank has returned on this network, with device counts."
+          }
+        >
+          <div className="max-h-44 space-y-1 overflow-y-auto rounded-md border p-2">
+            {options.length === 0 ? (
+              <div className="text-xs text-muted-foreground">
+                Nothing observed yet.
+              </div>
+            ) : (
+              options.map(([cls, count]) => (
+                <label key={cls} className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(cls)}
+                    onChange={(e) =>
+                      setSelected((prev) =>
+                        e.target.checked
+                          ? [...prev, cls]
+                          : prev.filter((c) => c !== cls),
+                      )
+                    }
+                  />
+                  <span className="min-w-0 flex-1 truncate">{cls}</span>
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {count} device{count === 1 ? "" : "s"}
+                  </span>
+                </label>
+              ))
+            )}
+          </div>
+        </Field>
+
+        <Field
+          label="Lease time (seconds)"
+          hint="Blank inherits the scope default. A short lease is what makes a quarantine reversible."
+        >
+          <input
+            className={inputCls}
+            value={leaseTime}
+            onChange={(e) => setLeaseTime(e.target.value)}
+            placeholder="600"
+            inputMode="numeric"
+          />
+        </Field>
+
+        <Field
+          label="Options (JSON)"
+          hint='Delivered to matched devices, e.g. {"dns-servers": "10.0.0.53"}'
+        >
+          <textarea
+            className={`${inputCls} h-24 font-mono text-xs`}
+            value={optionsText}
+            onChange={(e) => setOptionsText(e.target.value)}
+          />
+        </Field>
+        {optionsError && (
+          <div className="text-xs text-destructive">{optionsError}</div>
+        )}
+
+        <Field
+          label="Manual match expression (optional)"
+          hint="Overrides the compiled expression entirely. Leave blank to use the generated one — the preview always shows both."
+        >
+          <textarea
+            className={`${inputCls} h-20 font-mono text-xs`}
+            value={override}
+            onChange={(e) => setOverride(e.target.value)}
+            placeholder="option[60].hex == 0x4D53465420352E30"
+          />
+        </Field>
+
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            className="mt-0.5"
+            checked={includeAmbiguous}
+            onChange={(e) => setIncludeAmbiguous(e.target.checked)}
+          />
+          <span>
+            Include ambiguous signatures
+            <span className="block text-xs text-muted-foreground">
+              Signatures that devices outside the selected classes also send.
+              Including them applies this policy to those devices too.
+            </span>
+          </span>
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(e) => setEnabled(e.target.checked)}
+          />
+          Enabled
+        </label>
+
+        {mut.isError && (
+          <div className="text-xs text-destructive">{errMsg(mut.error)}</div>
+        )}
+        <Btns
+          onClose={onClose}
+          pending={mut.isPending}
+          label={isEdit ? "Save" : "Create"}
+          disabled={!name.trim()}
+        />
+      </form>
+    </Modal>
+  );
+}
+
+/** The anti-black-box surface the issue asks for. */
+function PreviewModal({
+  policy,
+  onClose,
+}: {
+  policy: DHCPDevicePolicy;
+  onClose: () => void;
+}) {
+  const { data, isFetching, isError, error } = useQuery({
+    queryKey: [KEY_BASE, "preview", policy.id],
+    queryFn: () => dhcpApi.previewDevicePolicy(policy.id),
+  });
+
+  return (
+    <Modal title={`Compiled match — ${policy.name}`} onClose={onClose} wide>
+      {isFetching ? (
+        <div className="text-sm text-muted-foreground">Compiling&hellip;</div>
+      ) : isError ? (
+        <div className="text-sm text-destructive">{errMsg(error)}</div>
+      ) : data ? (
+        <PreviewBody data={data} />
+      ) : null}
+    </Modal>
+  );
+}
+
+function PreviewBody({ data }: { data: DHCPDevicePolicyPreview }) {
+  return (
+    <div className="space-y-4 text-sm">
+      {data.warnings.length > 0 && (
+        <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/10 p-3">
+          {data.warnings.map((w) => (
+            <div key={w} className="flex items-start gap-2 text-xs">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <span>{w}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Stat label="Signatures" value={String(data.signature_count)} />
+        <Stat
+          label="Devices matched"
+          value={String(data.matched_device_count)}
+        />
+        <Stat
+          label="Ambiguous"
+          value={`${data.ambiguous_signatures.length}${
+            data.ambiguous_excluded ? " excluded" : ""
+          }`}
+        />
+        <Stat label="Renders" value={data.renders ? "yes" : "no"} />
+      </div>
+
+      <div>
+        <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">
+          Kea match expression ({data.source})
+        </div>
+        <pre className="max-h-40 overflow-auto rounded-md border bg-muted/40 p-2 font-mono text-xs whitespace-pre-wrap break-all">
+          {data.expression || "(matches nothing — no observed signatures yet)"}
+        </pre>
+      </div>
+
+      {data.signatures.length > 0 && (
+        <SignatureList title="Signatures matched" rows={data.signatures} />
+      )}
+      {data.ambiguous_signatures.length > 0 && (
+        <SignatureList
+          title={
+            data.ambiguous_excluded
+              ? "Excluded — also sent by devices outside these classes"
+              : "Ambiguous — included by your override"
+          }
+          rows={data.ambiguous_signatures}
+        />
+      )}
+
+      {data.matched_macs.length > 0 && (
+        <div>
+          <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">
+            Devices currently matched
+          </div>
+          <div className="flex max-h-28 flex-wrap gap-1 overflow-y-auto">
+            {data.matched_macs.map((m) => (
+              <code key={m} className="rounded bg-muted px-1.5 py-0.5 text-xs">
+                {m}
+              </code>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <p className="text-xs text-muted-foreground">
+        Matching is over signatures already observed and classified. A device
+        whose signature has never been seen here does not match until it has
+        leased once and been classified &mdash; policies apply from the next
+        renewal, not instantly.
+      </p>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border p-2">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="text-sm font-medium">{value}</div>
+    </div>
+  );
+}
+
+function SignatureList({
+  title,
+  rows,
+}: {
+  title: string;
+  rows: { option_55: string | null; option_60: string | null }[];
+}) {
+  return (
+    <div>
+      <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">
+        {title}
+      </div>
+      <div className="max-h-32 overflow-auto rounded-md border">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="px-2 py-1">Option 55 (request list)</th>
+              <th className="px-2 py-1">Option 60 (vendor class)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((s, i) => (
+              <tr
+                key={`${s.option_55}|${s.option_60}|${i}`}
+                className="border-b last:border-0"
+              >
+                <td className="px-2 py-1 font-mono break-all">
+                  {s.option_55 ?? (
+                    <span className="italic text-muted-foreground">absent</span>
+                  )}
+                </td>
+                <td className="px-2 py-1 font-mono break-all">
+                  {s.option_60 ?? (
+                    <span className="italic text-muted-foreground">absent</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/dhcp/DevicePoliciesTab.tsx
+++ b/frontend/src/pages/dhcp/DevicePoliciesTab.tsx
@@ -514,10 +514,26 @@ function PreviewBody({ data }: { data: DHCPDevicePolicyPreview }) {
         <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">
           Kea match expression ({data.source})
         </div>
-        <pre className="max-h-40 overflow-auto rounded-md border bg-muted/40 p-2 font-mono text-xs whitespace-pre-wrap break-all">
+        <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted/40 p-2 font-mono text-xs">
           {data.expression || "(matches nothing — no observed signatures yet)"}
         </pre>
       </div>
+
+      {/* The comparison is the whole reason the override is visible: without
+          it, a manual expression is exactly the black box the feature exists
+          to avoid. Only shown when the two actually differ. */}
+      {data.source === "override" &&
+        data.compiled_expression !== data.expression && (
+          <div>
+            <div className="mb-1 text-xs font-semibold uppercase text-muted-foreground">
+              What the compiler would have generated
+            </div>
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-all rounded-md border border-dashed bg-muted/20 p-2 font-mono text-xs text-muted-foreground">
+              {data.compiled_expression ||
+                "(nothing — no observed signatures in the selected classes)"}
+            </pre>
+          </div>
+        )}
 
       {data.signatures.length > 0 && (
         <SignatureList title="Signatures matched" rows={data.signatures} />
@@ -545,6 +561,11 @@ function PreviewBody({ data }: { data: DHCPDevicePolicyPreview }) {
               </code>
             ))}
           </div>
+          {data.matched_macs_truncated && (
+            <div className="mt-1 text-xs text-muted-foreground">
+              Showing {data.matched_macs.length} of {data.matched_device_count}.
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/dhcp/DevicePoliciesTab.tsx
+++ b/frontend/src/pages/dhcp/DevicePoliciesTab.tsx
@@ -267,12 +267,13 @@ function DevicePolicyModal({
   // visible and selected, or editing an existing policy would silently drop
   // it just because the last device of that kind left the network.
   const options = useMemo(() => {
-    const seen = new Map<string, number>();
+    const seen = new Map<string, { count: number; score: number | null }>();
     for (const c of obs?.classes ?? [])
-      seen.set(c.device_class, c.device_count);
-    for (const c of selected) if (!seen.has(c)) seen.set(c, 0);
+      seen.set(c.device_class, { count: c.device_count, score: c.best_score });
+    for (const c of selected)
+      if (!seen.has(c)) seen.set(c, { count: 0, score: null });
     return [...seen.entries()].sort(
-      (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+      (a, b) => b[1].count - a[1].count || a[0].localeCompare(b[0]),
     );
   }, [obs, selected]);
 
@@ -354,7 +355,7 @@ function DevicePolicyModal({
                 Nothing observed yet.
               </div>
             ) : (
-              options.map(([cls, count]) => (
+              options.map(([cls, meta]) => (
                 <label key={cls} className="flex items-center gap-2 text-sm">
                   <input
                     type="checkbox"
@@ -368,8 +369,27 @@ function DevicePolicyModal({
                     }
                   />
                   <span className="min-w-0 flex-1 truncate">{cls}</span>
+                  {/* A class name alone hides the difference between an
+                      identified device and a vendor-only fallback, which is
+                      what a low fingerbank score means. */}
+                  {meta.score != null && (
+                    <span
+                      className={`shrink-0 rounded px-1.5 py-0.5 text-xs ${
+                        meta.score < 30
+                          ? "bg-amber-500/15 text-amber-600 dark:text-amber-400"
+                          : "bg-muted text-muted-foreground"
+                      }`}
+                      title={
+                        meta.score < 30
+                          ? "Low confidence — fingerbank likely fell back to the MAC vendor rather than identifying the device, so this class may group unrelated hardware."
+                          : "Fingerbank confidence for this class"
+                      }
+                    >
+                      {meta.score}/100
+                    </span>
+                  )}
                   <span className="shrink-0 text-xs text-muted-foreground">
-                    {count} device{count === 1 ? "" : "s"}
+                    {meta.count} device{meta.count === 1 ? "" : "s"}
                   </span>
                 </label>
               ))


### PR DESCRIPTION
Closes #700

Device profiling told us what a device *is*; Kea client classes let us treat kinds of device differently; nothing joined the two. A `DHCPDevicePolicy` now compiles an operator's choice of fingerbank device classes into a real Kea client-class `test` expression, carrying an option set, a per-class `valid-lifetime`, and a stable generated class name a pool's `class_restriction` can bind to — NAC-lite with no 802.1X and no switch configuration.

## The compiler cannot match the category, and says so

Fingerbank classifies by querying its corpus; Kea has no `device-class == IoT` predicate to render. So the compiler matches **the signatures observed and classified into the selected classes** — which makes v1 honestly *classify on first lease, apply on renewal*, stated in the UI rather than implied away.

## Safety properties

**Ambiguous signatures are excluded by default.** A parameter request list like `1,3,6,15` comes from a doorbell and a rack server alike. A signature seen both inside and outside the selected classes is excluded, counted and listed — otherwise the headline use ("quarantine unknown devices") is also how the CEO's laptop gets quarantined. `include_ambiguous` is the audited opt-in. Unclassified devices are deliberately *not* treated as ambiguity evidence (that would make the feature unusable before a fingerbank key is set) but are reported — and only for signatures surviving filtering and the term cap, so the count reflects devices the rendered expression actually reaches.

**Nothing device-controlled becomes syntax.** Option 60 is chosen by the *device*, so both halves of every term are emitted as hex (`option[60].hex == 0x4D5346…`), making a vendor class of `' or 1--` inert bytes. An absent option 60 compiles to `not option[60].exists` rather than being ignored, which would widen the match to every device sharing the request list. "Absent" and "present but unencodable" are kept distinct — a lossy-decoded vendor class drops the signature whole rather than asserting an absence that is false.

**Two fail-closed rules, one Kea behaviour.** A class with no `test` matches *every* packet, so a policy compiling to nothing is dropped rather than rendered testless (in both renderers), and the option-60 encoder returns None for empty rather than emitting `0x`, a parse error that fails the whole config.

## Verified, not assumed

Every expression form was validated against a live `kea-dhcp4 3.0.3` before being designed around — which is how the `0x` parse error and per-class `valid-lifetime` support were established. Kea's parser is *not* the term-cap constraint (1024 terms / 32 KB loads fine); per-packet cost and legibility are, and hitting the cap is reported, never silent.

The full path was walked on a dev stack rather than reasoned about: REST → bundle → wire → agent → on-disk `kea-dhcp4.conf`, with Kea healthy. Then re-run against a **live fingerbank key**, which corrected a wrong assumption in the issue text and the first draft of the docs: there is no plain `Printer` or `IoT` class. Real values are `HP Print Server` (89), `Operating System` (78), `Generic Android` (60), `Hardware Manufacturer` (29), `Generic IoT` (15). The low scores matter — they mean fingerbank *failed* to identify the device and fell back to the MAC vendor, so such a class groups unrelated hardware. `fingerbank_score` was stored and surfaced nowhere; the picker now shows it and flags anything under 30, and the compiler warns accordingly. It warns rather than refuses.

## Scope

- Model + migration `f3b8d21c74ae`; compiler in `services/dhcp/device_policy.py`
- Rendering in both the control-plane driver and the agent renderer; wire serialization per the #858 lesson
- 4 REST routes + a preview and an observations endpoint (the anti-black-box surfaces the issue asks for)
- 2 MCP tools, read-only, default on
- Device Policies tab under DHCP
- **v4-only by construction** — options 55/60 are DHCPv4 codes, and the v6 branch of both renderers builds its class list from generic client classes alone
- Permissions ride on `dhcp_client_class`: reads follow it (DHCP Editor gains them with no role migration), writes stay superadmin, matching the hand-authored client-class surface rather than quietly widening it
- Explicitly **not** a feature module (non-negotiable #14): no new top-level family, and "off" is already `enabled=false` on the row

## Review

`/code-review` found nine issues; all nine reproduced and were fixed, two of them live 500s. The worst was `Signature(order=True)`, whose generated `__lt__` compares `None` against `str` as soon as two in-class signatures differ on whether option 60 is present — a `TypeError` raised *inside* `build_config_bundle`, i.e. a 500 on the agent long-poll that stops the whole group converging. Every fixture happened to differ on option 55, so the suite was green. Also fixed: explicit nulls reaching NOT NULL columns; the table missing from the backup catalogue (a test was already failing); `compiled_expression` echoing the override; a preview GET that committed; and a fingerprint full-scan running per policy per long-poll tick instead of once per bundle.

## Not covered

No real DHCP client has leased against one of these classes — config delivery and Kea's acceptance are verified, the resulting lease is not. DHCPv6, auto-creating the quarantine pool, and rules keyed on fingerbank *device name* are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)