### PR TITLE
test(dns): pin the effective-blocklist exception set by equality

### DIFF
--- a/backend/tests/test_dns_blocklists.py
+++ b/backend/tests/test_dns_blocklists.py
@@ -301,7 +301,12 @@ async def test_effective_blocklist_for_group(db_session: AsyncSession) -> None:
     eff = await build_effective_for_group(db_session, group.id)
     assert eff.scope == "group"
     assert any(e.domain == "bad.example.com" for e in eff.entries)
-    assert "good.example.com" in eff.exceptions
+    # Equality, not membership: the group has one list carrying one exception,
+    # so pinning the whole set also catches an exception leaking in from a list
+    # that is not in scope. (It additionally keeps CodeQL's
+    # py/incomplete-url-substring-sanitization off a `"host" in <set[str]>`
+    # test it mistakes for a substring check on an unparsed URL.)
+    assert eff.exceptions == {"good.example.com"}
     assert bl.id in eff.lists
 
 


### PR DESCRIPTION
Closes CodeQL alert [93](https://github.com/spatiumddi/spatiumddi/security/code-scanning/93) (`py/incomplete-url-substring-sanitization`, severity **high**) — the only open code-scanning alert on the repo.

## The alert is a false positive

`backend/tests/test_dns_blocklists.py:304` asserted:

```python
assert "good.example.com" in eff.exceptions
```

`EffectiveBlocklist.exceptions` is declared `set[str]` (`backend/app/services/dns_blocklist.py:56`), so that `in` is **set membership**, not a substring check on an unparsed URL. The query does not resolve the attribute's type — it sees a domain-shaped literal on the left of `in` and assumes a URL on the right. There is no URL, no redirect and no sanitization anywhere in that test, and the alert is itself classified `test`.

## Why tighten the assertion instead of dismissing

The membership check was also weaker than what the test means to assert. The group under test has exactly one blocklist carrying exactly one exception, so:

```python
assert eff.exceptions == {"good.example.com"}
```

additionally catches an exception leaking in from a list that is **not** in scope — a real regression in `_collect_lists` that the `in` form would pass straight through. The alert clears as a side effect, since the query fires only on `in` / `startswith` / `endswith`, never on equality. A comment records both reasons so it does not get reverted back to membership.

Test-only. No migration, no endpoint, no MCP change.

## Verification

- `tests/test_dns_blocklists.py` — **14 passed** (run serially in the dev container).
- `ruff check`, `ruff format --check`, `black --check` — clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)