### PR TITLE
feat(dns): move a server between server groups (#934)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -727,7 +727,28 @@ suggestion, free-space treemap.
   `/register` resolves the row by `agent_id` first, globally, and its
   update branch never writes `group_id`, so a stale `AGENT_GROUP` neither
   drags the server back nor forks a second row. Pinned by a test, and
-  `DNS_AGENT.md` now says so where that variable is documented.
+  `DNS_AGENT.md` now says so where that variable is documented. **The
+  appliance path needed the opposite treatment**, found in review: there
+  the agent is not configured from its own environment at all — the
+  supervisor derives `AGENT_GROUP` *and* the per-role nftables ports from
+  `Appliance.assigned_dns_group_id`, so that pointer is repointed by the
+  move (only when it names the group being left) and the supervisor
+  heartbeat woken. Otherwise the firewall keeps the OLD group's #50
+  DoT/DoH/DoQ ports open while the agent listens on the new group's —
+  every config file valid, the listener simply unreachable.
+  **Three more from review.** The op purge covers `in_flight` as well as
+  `pending`: an op already shipped is not finished with, because `ack_op`
+  returns a NACKed one to `pending` and that ack can land *after* the move,
+  re-queueing an old-group zone's update against the new group's daemon.
+  The derived TSIG key name is now folded to a safe identifier — it is
+  interpolated verbatim into `key "<name>" { … };`, so a group named
+  `edge"; };` made `named-checkconf` reject the file whole and the agent
+  decline the entire bundle, the #876 / #899 class again, newly reachable
+  because the move generates keys for operator-typed group names
+  (sanitised, not refused: the name is derived, and `Edge (DMZ)` is not a
+  mistake). And the frontend invalidated only the *source* group's server
+  list, so with a 30 s `staleTime` a moved server was invisible in both
+  groups if the operator navigated straight to the target.
   **Also fixed, found on the way:** `is_primary` was settable by **no API
   at all**, while three separate comments told operators to flip it "later
   via the API" — including the hint `record_ops` logs when it drops a write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -674,6 +674,76 @@ suggestion, free-space treemap.
   (#734); the lesson recorded in `DNS.md` §8.2 is to assert on the
   *rendered config*, not the stored row.
 
+- ✅ [**A DNS server cannot be moved between server groups**](https://github.com/spatiumddi/spatiumddi/issues/934)
+  — reported in discussion #933 the obvious way: an auto-registered BIND9
+  agent lands in `default`, the operator creates the group they actually
+  wanted, and the server is stuck there. `ServerUpdate` carried no
+  `group_id` and no move endpoint existed, while the DHCP side has had
+  `server_group_id` on its update payload since #430 — an asymmetry, not
+  a design decision. Now `group_id` on the server PUT, routed through
+  `services/dns/server_move.py` rather than the generic setattr loop, and
+  a **Server group** picker in the edit modal. No migration, no new table.
+  **The move is not a column write**, because a DNS server accumulates
+  group-scoped state that becomes false the instant its group changes.
+  `DNSServerZoneState` rows and pending `DNSRecordOp`s reference the OLD
+  group's zones — left behind, the Zone Sync pill reports convergence for
+  zones the server no longer serves, and queued RFC 2136 updates ship to a
+  daemon that has never heard of those zones. `config_apply_status` (#882)
+  means "the live config is the saved one", so carrying `ok` across a move
+  is false at commit; it resets to NULL, which is UNKNOWN and never `ok`.
+  The target group's TSIG key is generated if absent, since a group created
+  in the UI has never been through agent registration, where that
+  generation used to be inlined (now `ensure_group_tsig_key`, shared by
+  both paths). Both group channels **and the server's own** are woken — the
+  server channel is the load-bearing one, because an agent already parked
+  in a long-poll subscribed using its OLD group and a group wake alone
+  would never reach it.
+  **`is_primary` is the sharp edge, in both directions.** A group with none
+  drops every record write to its zones *silently* — a log line, no error
+  to the caller — so moving a primary out elects the oldest enabled,
+  unpaused survivor. A group with **two** is worse than a wrong pick: the
+  catalog-zone producer lookup in `build_config_bundle` used
+  `scalar_one_or_none` with no `LIMIT`, so a second primary raises
+  `MultipleResultsFound` *inside the agent long-poll* — a 500 that stops
+  the whole group converging. So the incoming server is elected in the
+  target only when it has none, an existing primary is never demoted, and
+  that query was capped defensively. **The election bug this class predicts
+  was in the first draft and caught by tests**: the departing server is
+  still `group_id == old_group` in-session when the election runs, so
+  without an explicit `exclude_id` the query re-elects the very server
+  being demoted — the flag stays on a member that has left AND the target
+  ends up with two.
+  Two refusals. A **name collision** in the target (409 — names are unique
+  per group; the constraint would fire anyway, but not say which name).
+  And a move that would leave the target **mixed-driver** (422): a group is
+  single-driver, which `DNS_DRIVERS.md` §5.1 has always asserted the
+  control plane enforces — it does not, it only 422s *later*, at DNSSEC-sign
+  or ALIAS time. A move is a new operation with no installs to break, so it
+  fails closed rather than manufacturing a state that breaks something
+  else afterwards; moving into an *empty* group is always allowed, whatever
+  its driver, which is the reported case.
+  **The move survives agent re-registration**, which is what makes it an
+  operator action rather than a setting the next restart undoes:
+  `/register` resolves the row by `agent_id` first, globally, and its
+  update branch never writes `group_id`, so a stale `AGENT_GROUP` neither
+  drags the server back nor forks a second row. Pinned by a test, and
+  `DNS_AGENT.md` now says so where that variable is documented.
+  **Also fixed, found on the way:** `is_primary` was settable by **no API
+  at all**, while three separate comments told operators to flip it "later
+  via the API" — including the hint `record_ops` logs when it drops a write
+  for want of a primary, i.e. the message shown at the exact moment the
+  advice was needed. It is now on `ServerUpdate`, demoting the incumbent
+  atomically; clearing the *last* primary is refused (422) rather than
+  silently re-creating the footgun create-time auto-election exists to
+  prevent. 1 MCP tool (`find_dns_servers`, read-only, default on) — the
+  copilot could list server *groups* and had no way to see the servers in
+  them, so "which group is ns1 in?" and "which group has no primary?" were
+  both unanswerable. Deliberately **no** `propose_move_*` write tool
+  (explicit decision per non-negotiable #13): the move re-renders two
+  groups' configs, which is the broad-blast-radius shape that guidance says
+  to keep off the copilot. Not a feature module (#14) — it extends an
+  existing resource rather than adding a top-level family.
+
 #### DHCP-specific
 
 - ✅ [**DHCPv6 stateful + SLAAC config UI**](https://github.com/spatiumddi/spatiumddi/issues/52) — shipped `2026.06.04-1`: `DHCPScope.v6_address_mode` + `ra_managed_flag` / `ra_other_flag`; the Kea driver renders `subnet6` by mode (stateful → pools + options; stateless / SLAAC → options only). Migration `e4c1a8f63b29`.

--- a/backend/app/api/v1/dns/agents.py
+++ b/backend/app/api/v1/dns/agents.py
@@ -51,6 +51,7 @@ from app.services.dns.agent_token import (
     verify_agent_token,
 )
 from app.services.dns.record_ops import ack_op
+from app.services.dns.tsig import ensure_group_tsig_key
 from app.services.feature_modules import is_module_enabled
 
 logger = structlog.get_logger(__name__)
@@ -233,13 +234,9 @@ async def agent_register(
 
     # Auto-generate group TSIG key on first registration if not set.
     # Used by the agent's RFC 2136 dynamic update path over loopback.
-    if not group.tsig_key_secret:
-        import base64
-        import secrets
-
-        group.tsig_key_name = f"spatium-{group.name}".replace(" ", "-").lower()
-        group.tsig_key_secret = base64.b64encode(secrets.token_bytes(32)).decode()
-        group.tsig_key_algorithm = "hmac-sha256"
+    # Shared with the #934 group-move path, which has the same need for a
+    # group the operator created in the UI and no agent has registered into.
+    ensure_group_tsig_key(group)
 
     # First server in the group is auto-elected primary so DDNS ops have
     # somewhere to land. Operator can flip later via API.

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -16,6 +16,7 @@ from fastapi.responses import JSONResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, or_, select
+from sqlalchemy import update as sa_update
 from sqlalchemy.orm import selectinload
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
@@ -108,6 +109,7 @@ from app.services.dns.resolver_presets import (
     find_forwarder_conflict,
 )
 from app.services.dns.serial import bump_zone_serial
+from app.services.dns.server_move import ServerMoveError, move_server_to_group
 from app.services.dns.zone_templates import (
     get_template,
     list_templates,
@@ -377,6 +379,21 @@ class ServerUpdate(BaseModel):
     status: str | None = None
     notes: str | None = None
     is_enabled: bool | None = None
+    # #934 — move this server to another server group. Same contract as the
+    # DHCP side's ``server_group_id``: omitted / null leaves it alone,
+    # re-sending the current group is a no-op. The handler routes it through
+    # ``move_server_to_group`` rather than the generic setattr loop, because
+    # the move has to purge old-group state and re-elect primaries.
+    group_id: uuid.UUID | None = None
+    # #934 — designate this server as the group's primary (the row DDNS /
+    # RFC 2136 writes are queued against). Setting it demotes whatever other
+    # member currently holds the flag: two primaries in one group is not a
+    # tie-break, it is a ``MultipleResultsFound`` inside the agent long-poll.
+    # Until now the flag was only ever set implicitly, on create and on first
+    # agent registration, while three separate comments — including the hint
+    # an operator sees when a record write is dropped for want of a primary —
+    # told them to flip it "later via the API".
+    is_primary: bool | None = None
     # Same contract as the DHCP side:
     #   * None → leave stored creds alone
     #   * {}   → clear stored creds (revert to Path A only)
@@ -1606,7 +1623,15 @@ async def update_server(
     server = await _require_server(group_id, server_id, db)
     changes = body.model_dump(
         exclude_none=True,
-        exclude={"api_key", "windows_credentials", "cloud_credentials"},
+        # ``group_id`` / ``is_primary`` (#934) are NOT plain column writes —
+        # each has cross-row consequences the generic loop below can't have.
+        exclude={
+            "api_key",
+            "windows_credentials",
+            "cloud_credentials",
+            "group_id",
+            "is_primary",
+        },
     )
     if body.api_key is not None:
         # Issue #210 — Fernet-encrypted at rest; matches the create
@@ -1699,6 +1724,64 @@ async def update_server(
             server.credentials_encrypted = encrypt_dict(merged)
             changes["cloud_credentials_set"] = True
 
+    # ── #934 group move ───────────────────────────────────────────────
+    # Deliberately AFTER the setattr loop: a payload that renames and moves
+    # in one request must have its name collision checked against the NEW
+    # name, and its driver homogeneity against the NEW driver.
+    move_result = None
+    if body.group_id is not None and body.group_id != server.group_id:
+        target_group = await _require_group(body.group_id, db)
+        try:
+            move_result = await move_server_to_group(db, server, target_group)
+        except ServerMoveError as exc:
+            raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        if move_result is not None:
+            changes["group_id"] = str(move_result.new_group_id)
+
+    # ── #934 explicit primary designation ─────────────────────────────
+    # Runs after the move so "put it in that group and make it primary" is
+    # one request, and so the demotion sweep targets the group the server
+    # ends up in rather than the one it left.
+    if body.is_primary is not None and body.is_primary != server.is_primary:
+        if body.is_primary:
+            await db.execute(
+                sa_update(DNSServer)
+                .where(
+                    DNSServer.group_id == server.group_id,
+                    DNSServer.id != server.id,
+                    DNSServer.is_primary.is_(True),
+                )
+                .values(is_primary=False)
+            )
+            server.is_primary = True
+        else:
+            # Clearing the LAST primary re-creates the footgun create-time
+            # auto-election exists to prevent: ``enqueue_record_op`` drops
+            # every write to the group's zones with only a log line — no
+            # error reaches whoever made the change. Promote a replacement
+            # instead; that demotes this one as a side effect.
+            others = await db.execute(
+                select(DNSServer.id)
+                .where(
+                    DNSServer.group_id == server.group_id,
+                    DNSServer.id != server.id,
+                    DNSServer.is_primary.is_(True),
+                )
+                .limit(1)
+            )
+            if others.first() is None:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "This is the only primary in its group; clearing it would "
+                        "silently drop every DNS record write to the group's zones. "
+                        "Mark another server in the group as primary instead — that "
+                        "demotes this one."
+                    ),
+                )
+            server.is_primary = False
+        changes["is_primary"] = server.is_primary
+
     db.add(
         AuditLog(
             user_id=current_user.id,
@@ -1709,6 +1792,7 @@ async def update_server(
             resource_id=str(server.id),
             resource_display=server.name,
             changed_fields=list(changes.keys()),
+            new_value=move_result.as_audit_value() if move_result else None,
             result="success",
         )
     )

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -20,6 +20,7 @@ from app.models.dns import (
     DNSPool,
     DNSPoolMember,
     DNSRecord,
+    DNSServer,
     DNSServerGroup,
     DNSServerOptions,
     DNSTSIGKey,
@@ -175,6 +176,86 @@ async def list_dns_server_groups(
             "is_recursive": g.is_recursive,
         }
         for g in rows
+    ]
+
+
+class FindDnsServersArgs(BaseModel):
+    group_id: str | None = Field(
+        default=None,
+        description="Restrict to one server group (UUID). Omit for the whole fleet.",
+    )
+    search: str | None = Field(
+        default=None,
+        description="Case-insensitive substring match on server name or host.",
+    )
+    primary_only: bool = Field(
+        default=False,
+        description=(
+            "Only the server each group applies DDNS / record writes at. "
+            "Use when asked which server is primary, or to find a group "
+            "that has none."
+        ),
+    )
+    limit: int = Field(default=200, ge=1, le=1000)
+
+
+@register_tool(
+    name="find_dns_servers",
+    description=(
+        "List individual DNS servers with the group each belongs to, its "
+        "driver, whether it is the group's primary, and its enabled / "
+        "maintenance / config-apply state. Answers 'which group is this "
+        "server in?', 'which server is primary for that group?' and "
+        "'which groups have no primary?' — the last of which silently "
+        "drops every record write to that group's zones. Read-only: "
+        "moving a server between groups is done over the REST API or the "
+        "DNS → Server Groups UI, not from here."
+    ),
+    args_model=FindDnsServersArgs,
+    category="dns",
+)
+async def find_dns_servers(
+    db: AsyncSession, user: User, args: FindDnsServersArgs
+) -> list[dict[str, Any]]:
+    stmt = (
+        select(DNSServer, DNSServerGroup.name)
+        .join(DNSServerGroup, DNSServer.group_id == DNSServerGroup.id)
+        .order_by(DNSServerGroup.name.asc(), DNSServer.name.asc())
+        .limit(args.limit)
+    )
+    if args.group_id:
+        try:
+            stmt = stmt.where(DNSServer.group_id == uuid.UUID(args.group_id))
+        except ValueError:
+            return []
+    if args.search:
+        term = f"%{args.search.strip()}%"
+        stmt = stmt.where(or_(DNSServer.name.ilike(term), DNSServer.host.ilike(term)))
+    if args.primary_only:
+        stmt = stmt.where(DNSServer.is_primary.is_(True))
+
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "id": str(s.id),
+            "name": s.name,
+            "group_id": str(s.group_id),
+            "group_name": group_name,
+            "driver": s.driver,
+            "host": s.host,
+            "port": s.port,
+            "is_primary": s.is_primary,
+            "is_enabled": s.is_enabled,
+            "maintenance_mode": s.maintenance_mode,
+            "status": s.status,
+            # NULL means the agent has never reported a verdict (a pre-#882
+            # agent, or an agentless driver with no apply loop). UNKNOWN,
+            # never "ok" — a silently reverted config is exactly what would
+            # hide behind that assumption.
+            "config_apply_status": s.config_apply_status,
+            "last_seen_at": s.last_seen_at.isoformat() if s.last_seen_at else None,
+        }
+        for s, group_name in rows
     ]
 
 

--- a/backend/app/services/dns/agent_config.py
+++ b/backend/app/services/dns/agent_config.py
@@ -608,11 +608,21 @@ async def build_config_bundle(db: AsyncSession, server: DNSServer) -> ConfigBund
     ):
         producer = (
             await db.execute(
-                select(DNSServer).where(
+                select(DNSServer)
+                .where(
                     DNSServer.group_id == server.group_id,
                     DNSServer.driver == server.driver,
                     DNSServer.is_primary.is_(True),
                 )
+                # ``.limit(1)`` is load-bearing, not tidiness: without it a
+                # group that somehow holds two primaries raises
+                # MultipleResultsFound from ``scalar_one_or_none`` — INSIDE
+                # the agent long-poll, so the failure is a 500 that stops the
+                # whole group converging rather than a mis-picked producer.
+                # Ordered so the pick is at least deterministic if it happens.
+                # Every other primary lookup in the codebase already caps at 1.
+                .order_by(DNSServer.created_at, DNSServer.id)
+                .limit(1)
             )
         ).scalar_one_or_none()
 

--- a/backend/app/services/dns/server_move.py
+++ b/backend/app/services/dns/server_move.py
@@ -1,0 +1,282 @@
+"""Move a DNS server row from one server group to another (issue #934).
+
+A DNS server was addressable only under its group (``/dns/groups/{gid}/
+servers/{sid}``) and had no way to change groups, while the DHCP side has
+carried ``server_group_id`` on its update payload since #430. Discussion
+#933 hit the gap the obvious way: an auto-registered agent lands in
+``default``, the operator creates the group they actually wanted, and the
+server is stuck.
+
+The move is not a column write. A DNS server accumulates group-scoped
+state that becomes a lie the moment its group changes:
+
+  * ``DNSServerZoneState`` rows are per ``(server, zone)`` against the OLD
+    group's zones — left behind, the Zone Sync pill reports convergence
+    for zones this server no longer serves.
+  * pending ``DNSRecordOp`` rows are RFC 2136 updates queued for old-group
+    zones. Shipping them after the move sends the new group's daemon
+    updates for zones it has never heard of.
+  * ``config_apply_status`` (#882) says whether the LIVE config is the
+    SAVED one. A move changes the saved one, so a carried-over ``ok`` is
+    false at the instant of commit — and NULL means UNKNOWN, never ok.
+  * ``is_primary`` is per-group and load-bearing: ``resolve_primary_server``
+    drops every record write for a group with no primary, and
+    ``build_config_bundle`` fetches the primary with ``scalar_one_or_none``,
+    so a group with TWO would 500 the agent long-poll rather than merely
+    pick wrong.
+
+So the move is a small transaction rather than an assignment, and it lives
+here rather than in the router so it can be tested without HTTP.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+
+import structlog
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_wake import collect_wake, dns_group_channel, dns_server_channel
+from app.models.dns import (
+    DNSRecordOp,
+    DNSServer,
+    DNSServerGroup,
+    DNSServerZoneState,
+)
+from app.services.dns.tsig import ensure_group_tsig_key
+
+logger = structlog.get_logger(__name__)
+
+
+class ServerMoveError(Exception):
+    """A move the control plane refuses.
+
+    Carries the HTTP status the router should answer with, so the reason
+    survives the service → router boundary instead of collapsing into one
+    generic 400.
+    """
+
+    def __init__(self, detail: str, status_code: int = 409) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class ServerMoveResult:
+    """What the move actually did — folded into the audit row so the
+    trail says more than "group_id changed"."""
+
+    old_group_id: uuid.UUID
+    new_group_id: uuid.UUID
+    zone_state_purged: int
+    pending_ops_dropped: int
+    demoted: bool
+    old_group_new_primary_id: uuid.UUID | None
+    elected_primary: bool
+    target_tsig_key_generated: bool
+
+    def as_audit_value(self) -> dict[str, object]:
+        return {
+            "old_group_id": str(self.old_group_id),
+            "new_group_id": str(self.new_group_id),
+            "zone_state_purged": self.zone_state_purged,
+            "pending_ops_dropped": self.pending_ops_dropped,
+            "demoted_from_primary": self.demoted,
+            "old_group_new_primary_id": (
+                str(self.old_group_new_primary_id) if self.old_group_new_primary_id else None
+            ),
+            "elected_primary_in_target": self.elected_primary,
+            "target_tsig_key_generated": self.target_tsig_key_generated,
+        }
+
+
+async def _elect_primary(
+    db: AsyncSession, group_id: uuid.UUID, *, exclude_id: uuid.UUID
+) -> DNSServer | None:
+    """Pick a replacement primary for a group that has just lost one.
+
+    Prefers a server that can actually accept writes: enabled, not paused
+    for maintenance (``record_ops`` excludes paused servers from
+    primary cluster-math), oldest first so the choice is deterministic
+    and stable across repeated moves rather than whatever the planner
+    returns.
+
+    ``exclude_id`` is load-bearing rather than defensive. The election runs
+    while the departing server is still ``group_id == group_id`` in this
+    session — the reassignment has not been flushed — so without it the
+    query re-elects the very server being demoted. The move then silently
+    does nothing: the old group's flag sits on a member that has left, and
+    the target group ends up with two primaries, which is the shape that
+    500s the agent long-poll rather than merely picking wrong.
+    """
+    base = (
+        select(DNSServer)
+        .where(DNSServer.group_id == group_id, DNSServer.id != exclude_id)
+        .order_by(DNSServer.created_at, DNSServer.id)
+        .limit(1)
+    )
+    candidate = (
+        await db.execute(
+            base.where(
+                DNSServer.is_enabled.is_(True),
+                DNSServer.maintenance_mode.is_(False),
+            )
+        )
+    ).scalar_one_or_none()
+    if candidate is None:
+        # Every remaining server is disabled or paused. Fall back to any
+        # member rather than leaving the group primary-less: a paused
+        # primary still beats none, because ``resolve_primary_server``
+        # returning None drops record writes SILENTLY (a log line, no
+        # error to the caller), whereas a paused one is visible in the UI.
+        candidate = (await db.execute(base)).scalar_one_or_none()
+    if candidate is not None:
+        candidate.is_primary = True
+    return candidate
+
+
+async def move_server_to_group(
+    db: AsyncSession, server: DNSServer, target_group: DNSServerGroup
+) -> ServerMoveResult | None:
+    """Re-home ``server`` into ``target_group``.
+
+    Returns ``None`` when the server is already in the target group (an
+    idempotent PUT re-sending the current ``group_id`` is a no-op, not an
+    error). Raises ``ServerMoveError`` when the move is refused.
+
+    The caller commits. Nothing here flushes state the caller cannot roll
+    back, so a later failure in the same handler discards the whole move.
+    """
+    old_group_id = server.group_id
+    if old_group_id == target_group.id:
+        return None
+
+    # ── Refusals ──────────────────────────────────────────────────────
+    #
+    # Name collision: ``uq_dns_server_group_name`` would raise anyway, but
+    # as a bare integrity error naming a constraint rather than telling the
+    # operator which name clashed.
+    clash = await db.execute(
+        select(DNSServer.id).where(
+            DNSServer.group_id == target_group.id,
+            DNSServer.name == server.name,
+        )
+    )
+    if clash.first() is not None:
+        raise ServerMoveError(
+            f"Group {target_group.name!r} already has a server named "
+            f"{server.name!r}. Rename one of them first.",
+            status_code=409,
+        )
+
+    # Driver homogeneity. A group is single-driver (docs/drivers/
+    # DNS_DRIVERS.md §5.1): its rendered config, catalog-zone semantics and
+    # AXFR shape all assume one driver, and the driver-gated operations
+    # (DNSSEC signing, ALIAS records) 422 on a mixed group. Today that is
+    # enforced lazily, at operation time, so a mixed group is reachable and
+    # only fails later on an unrelated action. A move is a NEW operation
+    # with no existing installs to break, so it fails closed here instead
+    # of manufacturing a state that breaks something else afterwards.
+    res = await db.execute(
+        select(DNSServer.driver)
+        .where(DNSServer.group_id == target_group.id, DNSServer.driver != server.driver)
+        .distinct()
+    )
+    foreign_drivers = sorted({d for d in res.scalars().all() if d})
+    if foreign_drivers:
+        raise ServerMoveError(
+            f"Group {target_group.name!r} runs {foreign_drivers}; this server runs "
+            f"{server.driver!r}. A server group is single-driver — move it to a "
+            f"{server.driver}-only group, or an empty one.",
+            status_code=422,
+        )
+
+    # ── Purge state that belongs to the old group ─────────────────────
+    zone_state_purged = (
+        await db.execute(
+            sa_delete(DNSServerZoneState).where(DNSServerZoneState.server_id == server.id)
+        )
+    ).rowcount or 0
+    pending_ops_dropped = (
+        await db.execute(
+            sa_delete(DNSRecordOp).where(
+                DNSRecordOp.server_id == server.id,
+                DNSRecordOp.state == "pending",
+            )
+        )
+    ).rowcount or 0
+
+    # #882 verdict refers to a bundle from the old group. NULL = UNKNOWN.
+    server.config_apply_status = None
+    server.config_apply_error = None
+    server.config_failed_etag = None
+    server.config_apply_at = None
+
+    # ── Primary bookkeeping, on both sides ────────────────────────────
+    demoted = server.is_primary
+    old_group_new_primary_id: uuid.UUID | None = None
+    if demoted:
+        server.is_primary = False
+        replacement = await _elect_primary(db, old_group_id, exclude_id=server.id)
+        old_group_new_primary_id = replacement.id if replacement else None
+
+    server.group_id = target_group.id
+
+    # Elect in the target only if it has none — never demote a primary the
+    # operator already chose there.
+    target_primaries = (
+        await db.execute(
+            select(func.count())
+            .select_from(DNSServer)
+            .where(
+                DNSServer.group_id == target_group.id,
+                DNSServer.is_primary.is_(True),
+                DNSServer.id != server.id,
+            )
+        )
+    ).scalar_one()
+    elected_primary = target_primaries == 0
+    if elected_primary:
+        server.is_primary = True
+
+    # The agent renders the group's TSIG key into ``tsig/ddns.key`` and
+    # signs its loopback RFC 2136 updates with it. A group created through
+    # the UI has never been through agent registration, so it may have no
+    # key at all — generate one now rather than shipping a bundle whose
+    # dynamic-update path cannot authenticate.
+    target_tsig_key_generated = ensure_group_tsig_key(target_group)
+
+    # Both groups' bundles change shape (a member left one and joined the
+    # other), and the server's own channel is what reaches an agent already
+    # parked in a long-poll — its subscription was built from the OLD group,
+    # so the group wake alone would not reach it.
+    collect_wake(
+        dns_group_channel(old_group_id),
+        dns_group_channel(target_group.id),
+        dns_server_channel(server.id),
+    )
+
+    logger.info(
+        "dns_server_moved_group",
+        server_id=str(server.id),
+        server_name=server.name,
+        old_group_id=str(old_group_id),
+        new_group_id=str(target_group.id),
+        zone_state_purged=zone_state_purged,
+        pending_ops_dropped=pending_ops_dropped,
+    )
+
+    return ServerMoveResult(
+        old_group_id=old_group_id,
+        new_group_id=target_group.id,
+        zone_state_purged=zone_state_purged,
+        pending_ops_dropped=pending_ops_dropped,
+        demoted=demoted,
+        old_group_new_primary_id=old_group_new_primary_id,
+        elected_primary=elected_primary,
+        target_tsig_key_generated=target_tsig_key_generated,
+    )

--- a/backend/app/services/dns/server_move.py
+++ b/backend/app/services/dns/server_move.py
@@ -39,7 +39,13 @@ from sqlalchemy import delete as sa_delete
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.agent_wake import collect_wake, dns_group_channel, dns_server_channel
+from app.core.agent_wake import (
+    appliance_channel,
+    collect_wake,
+    dns_group_channel,
+    dns_server_channel,
+)
+from app.models.appliance import Appliance
 from app.models.dns import (
     DNSRecordOp,
     DNSServer,
@@ -78,6 +84,7 @@ class ServerMoveResult:
     old_group_new_primary_id: uuid.UUID | None
     elected_primary: bool
     target_tsig_key_generated: bool
+    appliance_repointed_id: uuid.UUID | None
 
     def as_audit_value(self) -> dict[str, object]:
         return {
@@ -91,6 +98,9 @@ class ServerMoveResult:
             ),
             "elected_primary_in_target": self.elected_primary,
             "target_tsig_key_generated": self.target_tsig_key_generated,
+            "appliance_repointed_id": (
+                str(self.appliance_repointed_id) if self.appliance_repointed_id else None
+            ),
         }
 
 
@@ -201,11 +211,18 @@ async def move_server_to_group(
             sa_delete(DNSServerZoneState).where(DNSServerZoneState.server_id == server.id)
         )
     ).rowcount or 0
+    # ``in_flight`` as well as ``pending``: an op already shipped in a bundle
+    # is not finished with. ``ack_op`` resets a NACKed one back to ``pending``
+    # (fewer than 5 attempts), and that ack can arrive AFTER the move — which
+    # would put an RFC 2136 update for an old-group zone back in the queue and
+    # ship it to the new group's daemon, exactly what this purge exists to
+    # prevent. ``build_config_bundle`` already treats the two states as one
+    # live set when it retires ops for an agentless server.
     pending_ops_dropped = (
         await db.execute(
             sa_delete(DNSRecordOp).where(
                 DNSRecordOp.server_id == server.id,
-                DNSRecordOp.state == "pending",
+                DNSRecordOp.state.in_(("pending", "in_flight")),
             )
         )
     ).rowcount or 0
@@ -250,6 +267,33 @@ async def move_server_to_group(
     # dynamic-update path cannot authenticate.
     target_tsig_key_generated = ensure_group_tsig_key(target_group)
 
+    # ── Appliance-registered servers: repoint the parent appliance ─────
+    #
+    # On the #170 appliance path the DNS agent is not configured from its own
+    # environment — the supervisor derives it from ``Appliance.
+    # assigned_dns_group_id``. That pointer feeds ``_build_role_assignment``,
+    # which hands the supervisor both the ``AGENT_GROUP`` written into
+    # ``role-compose.env`` AND the #50 DoT/DoH/DoQ ports opened in the
+    # per-role nftables drop-in. Leaving it on the old group means the
+    # firewall keeps the OLD group's encrypted-transport ports: move into a
+    # group serving DoT on 8853 and the agent listens on a port nftables
+    # never opens — a silent, config-clean failure. And because the same
+    # pointer supplies AGENT_GROUP, an agent whose volume is later wiped
+    # would re-register into the old group as a duplicate row.
+    #
+    # Only repointed when it currently names the group being left: an
+    # appliance deliberately assigned elsewhere is not ours to redirect.
+    appliance_repointed_id: uuid.UUID | None = None
+    if server.appliance_id is not None:
+        appliance = await db.get(Appliance, server.appliance_id)
+        if appliance is not None and appliance.assigned_dns_group_id == old_group_id:
+            appliance.assigned_dns_group_id = target_group.id
+            appliance_repointed_id = appliance.id
+            # Per-appliance desired state changed, so wake the supervisor's
+            # heartbeat long-poll rather than making it wait out its interval
+            # for a firewall rule its agent already needs.
+            collect_wake(appliance_channel(appliance.id))
+
     # Both groups' bundles change shape (a member left one and joined the
     # other), and the server's own channel is what reaches an agent already
     # parked in a long-poll — its subscription was built from the OLD group,
@@ -279,4 +323,5 @@ async def move_server_to_group(
         old_group_new_primary_id=old_group_new_primary_id,
         elected_primary=elected_primary,
         target_tsig_key_generated=target_tsig_key_generated,
+        appliance_repointed_id=appliance_repointed_id,
     )

--- a/backend/app/services/dns/tsig.py
+++ b/backend/app/services/dns/tsig.py
@@ -19,6 +19,7 @@ rather than only after someone creates a key.
 from __future__ import annotations
 
 import base64
+import re
 import secrets
 import uuid
 
@@ -102,6 +103,34 @@ async def resolve_group_transfer_key(db: AsyncSession, group_id: uuid.UUID) -> T
 __all__ = ["resolve_group_transfer_key", "transfer_needs_tsig"]
 
 
+#: Characters legal in a derived TSIG key name. Everything else is folded to
+#: a hyphen — see ``_safe_key_label``.
+_UNSAFE_KEY_CHARS_RE = re.compile(r"[^a-z0-9_-]+")
+
+
+def _safe_key_label(group: DNSServerGroup) -> str:
+    """Fold a group name into a key name that is safe in ``named.conf``.
+
+    The result is interpolated VERBATIM into ``key "<name>" { … };`` by both
+    agent renderers, so a group named ``edge"; };`` would close the statement
+    early and inject the rest. That is not a cosmetic break: BIND rejects the
+    file whole, ``named-checkconf`` fails, and the agent declines the entire
+    bundle — so one badly-named group stops its whole group converging, with
+    the same blast radius as the #876 / #899 findings.
+
+    Sanitising rather than rejecting is deliberate. The key name is DERIVED,
+    not typed: an operator naming a group ``Edge (DMZ)`` has done nothing
+    wrong and should not be refused because of how we build an identifier
+    from it. Group names are not unique per rendered config either — a
+    bundle carries one legacy key, its own group's — so folding two names
+    together cannot collide in practice.
+    """
+    label = _UNSAFE_KEY_CHARS_RE.sub("-", (group.name or "").strip().lower()).strip("-")
+    # Nothing survived (a name that is entirely punctuation or non-ASCII).
+    # Fall back to the id, which is always a safe identifier and unique.
+    return f"spatium-{label}" if label else f"spatium-{group.id}"
+
+
 def ensure_group_tsig_key(group: DNSServerGroup) -> bool:
     """Give ``group`` a legacy group TSIG key if it has none yet.
 
@@ -118,7 +147,7 @@ def ensure_group_tsig_key(group: DNSServerGroup) -> bool:
     """
     if group.tsig_key_secret:
         return False
-    group.tsig_key_name = f"spatium-{group.name}".replace(" ", "-").lower()
+    group.tsig_key_name = _safe_key_label(group)
     group.tsig_key_secret = base64.b64encode(secrets.token_bytes(32)).decode()
     group.tsig_key_algorithm = "hmac-sha256"
     return True

--- a/backend/app/services/dns/tsig.py
+++ b/backend/app/services/dns/tsig.py
@@ -18,6 +18,8 @@ rather than only after someone creates a key.
 
 from __future__ import annotations
 
+import base64
+import secrets
 import uuid
 
 import structlog
@@ -98,3 +100,25 @@ async def resolve_group_transfer_key(db: AsyncSession, group_id: uuid.UUID) -> T
 
 
 __all__ = ["resolve_group_transfer_key", "transfer_needs_tsig"]
+
+
+def ensure_group_tsig_key(group: DNSServerGroup) -> bool:
+    """Give ``group`` a legacy group TSIG key if it has none yet.
+
+    The agent renders this key into ``tsig/ddns.key`` and signs its
+    loopback RFC 2136 updates with it; ``resolve_group_transfer_key``
+    above prefers it for AXFR because it exists on every agent-managed
+    group without operator action. Historically it was generated inline
+    on first agent registration, which meant a group created through the
+    UI — or one a server is MOVED into (#934) — could reach an agent with
+    no key at all.
+
+    Returns True when a key was generated, False when one already existed.
+    Mutates the row; the caller commits.
+    """
+    if group.tsig_key_secret:
+        return False
+    group.tsig_key_name = f"spatium-{group.name}".replace(" ", "-").lower()
+    group.tsig_key_secret = base64.b64encode(secrets.token_bytes(32)).decode()
+    group.tsig_key_algorithm = "hmac-sha256"
+    return True

--- a/backend/tests/test_dns_server_group_move.py
+++ b/backend/tests/test_dns_server_group_move.py
@@ -211,6 +211,19 @@ async def test_move_purges_zone_state_and_pending_ops(
             state="pending",
         )
     )
+    # Already shipped in a bundle but not yet acked. NOT finished with:
+    # ``ack_op`` puts a NACKed op back to ``pending``, and that ack can
+    # arrive after the move — re-queueing an old-group zone's update against
+    # the new group's daemon.
+    db_session.add(
+        DNSRecordOp(
+            server_id=srv.id,
+            zone_name="example.com.",
+            op="create",
+            record={"name": "inflight", "type": "A", "value": "10.0.0.3"},
+            state="in_flight",
+        )
+    )
     # An already-applied op is history, not queued work — it stays.
     db_session.add(
         DNSRecordOp(
@@ -721,3 +734,156 @@ async def test_move_survives_agent_re_registration_with_a_stale_group_name(
 
     await db_session.refresh(srv)
     assert srv.group_id == target.id, "re-registration must not undo the operator's move"
+
+
+# ── Code-review follow-ups ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_repoints_the_parent_appliance_dns_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """On the #170 appliance path the agent is not configured from its own
+    environment — the supervisor derives ``AGENT_GROUP`` *and* the #50
+    DoT/DoH/DoQ firewall ports from ``Appliance.assigned_dns_group_id``.
+    Left on the old group, nftables keeps the old group's encrypted-transport
+    ports open while the agent listens on the new group's: config-clean, and
+    silently unreachable."""
+    from app.models.appliance import Appliance
+
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    appliance = Appliance(
+        hostname="ddi1",
+        public_key_der=b"\x00" * 32,
+        public_key_fingerprint="fp-ddi1",
+        state="approved",
+        assigned_roles=["dns_bind9"],
+        assigned_dns_group_id=default.id,
+    )
+    db_session.add(appliance)
+    await db_session.flush()
+    srv = await _server(db_session, default, "ns1", appliance_id=appliance.id)
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(appliance)
+    assert appliance.assigned_dns_group_id == target.id
+
+
+@pytest.mark.asyncio
+async def test_move_leaves_an_appliance_assigned_elsewhere_alone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Only repoint when the appliance currently names the group being
+    left. One deliberately assigned somewhere else is not ours to redirect
+    on the strength of one server row moving."""
+    from app.models.appliance import Appliance
+
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    elsewhere = await _group(db_session, "elsewhere")
+    appliance = Appliance(
+        hostname="ddi1",
+        public_key_der=b"\x00" * 32,
+        public_key_fingerprint="fp-ddi1",
+        state="approved",
+        assigned_roles=["dns_bind9"],
+        assigned_dns_group_id=elsewhere.id,
+    )
+    db_session.add(appliance)
+    await db_session.flush()
+    srv = await _server(db_session, default, "ns1", appliance_id=appliance.id)
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(appliance)
+    assert appliance.assigned_dns_group_id == elsewhere.id
+
+
+@pytest.mark.asyncio
+async def test_derived_tsig_key_name_is_safe_in_named_conf(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The key name is interpolated VERBATIM into ``key "<name>" { … };`` by
+    both agent renderers. A group name that closes the statement early makes
+    ``named-checkconf`` reject the file WHOLE, so the agent declines the
+    entire bundle — one badly-named group stops its group converging.
+
+    Sanitised rather than refused: the name is derived, not typed, and an
+    operator naming a group ``Edge (DMZ)`` has done nothing wrong."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    hostile = await _group(db_session, 'edge"; }; key "evil')
+    srv = await _server(db_session, default, "ns1")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(hostile.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(hostile)
+    name = hostile.tsig_key_name
+    assert name
+    assert set(name) <= set("abcdefghijklmnopqrstuvwxyz0123456789_-"), name
+    # Specifically: nothing that could terminate or open a BIND statement.
+    for ch in '";{}\n\\':
+        assert ch not in name
+
+
+@pytest.mark.asyncio
+async def test_derived_tsig_key_name_falls_back_to_the_group_id(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A name that is entirely punctuation leaves no label to fold, and an
+    empty ``key "" { … }`` is not valid BIND either."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    punct = await _group(db_session, "!!! ***")
+    srv = await _server(db_session, default, "ns1")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(punct.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(punct)
+    assert punct.tsig_key_name == f"spatium-{punct.id}"
+
+
+@pytest.mark.asyncio
+async def test_derived_tsig_key_name_keeps_the_readable_form(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Sanitising must not make ordinary names unrecognisable — spaces and
+    parentheses fold to single hyphens, not to the id fallback."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    normal = await _group(db_session, "Edge (DMZ)")
+    srv = await _server(db_session, default, "ns1")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(normal.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(normal)
+    assert normal.tsig_key_name == "spatium-edge-dmz"

--- a/backend/tests/test_dns_server_group_move.py
+++ b/backend/tests/test_dns_server_group_move.py
@@ -1,0 +1,723 @@
+"""Moving a DNS server between server groups (issue #934).
+
+Discussion #933: an auto-registered agent lands in ``default``, the
+operator creates the group they actually wanted, and there was no way to
+move the server into it — while the DHCP side has carried
+``server_group_id`` on its update payload since #430.
+
+The interesting assertions here are not "the column changed". They are the
+cross-row consequences a naive assignment would leave behind: stale
+per-server zone state, record ops queued for the old group's zones, a
+``config_apply_status`` that means "the live config is the saved one" and
+stops being true at the instant of commit, and the primary flag — which
+drops every record write when a group has none and 500s the agent
+long-poll when a group has two.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import (
+    DNSRecordOp,
+    DNSServer,
+    DNSServerGroup,
+    DNSServerZoneState,
+    DNSZone,
+)
+
+
+async def _superadmin(db: AsyncSession, username: str = "root934") -> str:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+async def _group(db: AsyncSession, name: str, **kw: object) -> DNSServerGroup:
+    g = DNSServerGroup(name=name, description="", **kw)
+    db.add(g)
+    await db.flush()
+    return g
+
+
+async def _server(
+    db: AsyncSession,
+    group: DNSServerGroup,
+    name: str,
+    *,
+    is_primary: bool = False,
+    driver: str = "bind9",
+    **kw: object,
+) -> DNSServer:
+    s = DNSServer(
+        group_id=group.id,
+        name=name,
+        driver=driver,
+        host=name,
+        port=53,
+        roles=["authoritative"],
+        status="active",
+        is_primary=is_primary,
+        **kw,
+    )
+    db.add(s)
+    await db.flush()
+    return s
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _url(group_id: uuid.UUID, server_id: uuid.UUID) -> str:
+    return f"/api/v1/dns/groups/{group_id}/servers/{server_id}"
+
+
+# ── The move itself ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_reassigns_group_and_reports_it(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The discussion's exact case: one agent in ``default``, move it to
+    the group the operator actually made."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal-resolvers")
+    srv = await _server(db_session, default, "ns1", is_primary=True)
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["group_id"] == str(target.id)
+
+    await db_session.refresh(srv)
+    assert srv.group_id == target.id
+
+
+@pytest.mark.asyncio
+async def test_move_is_addressable_under_the_old_group_url(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The server is still addressed under the group it is LEAVING — the
+    URL names where it is, the body names where it is going. A caller who
+    guesses the reverse gets a 404 rather than a silent no-op."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(db_session, default, "ns1")
+
+    wrong = await client.put(
+        _url(target.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert wrong.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_resending_the_current_group_is_a_no_op(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """An idempotent PUT that echoes the whole row back must not be
+    treated as a move — it would purge zone state and re-run elections
+    for no reason."""
+    token = await _superadmin(db_session)
+    grp = await _group(db_session, "default")
+    srv = await _server(db_session, grp, "ns1", is_primary=True)
+    zone = DNSZone(group_id=grp.id, name="example.com.", zone_type="primary")
+    db_session.add(zone)
+    await db_session.flush()
+    db_session.add(DNSServerZoneState(server_id=srv.id, zone_id=zone.id, current_serial=7))
+    await db_session.flush()
+
+    resp = await client.put(
+        _url(grp.id, srv.id),
+        json={"group_id": str(grp.id), "notes": "unchanged"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    rows = (
+        (
+            await db_session.execute(
+                select(DNSServerZoneState).where(DNSServerZoneState.server_id == srv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1, "a no-op move must not purge per-server zone state"
+
+
+@pytest.mark.asyncio
+async def test_move_to_unknown_group_404s(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _superadmin(db_session)
+    grp = await _group(db_session, "default")
+    srv = await _server(db_session, grp, "ns1")
+
+    resp = await client.put(
+        _url(grp.id, srv.id),
+        json={"group_id": str(uuid.uuid4())},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 404
+
+
+# ── State that belongs to the old group ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_purges_zone_state_and_pending_ops(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Both reference the OLD group's zones. Left behind, the Zone Sync
+    pill reports convergence for zones this server no longer serves, and
+    the queued RFC 2136 updates would be shipped to a daemon that has
+    never heard of those zones."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(db_session, default, "ns1")
+    zone = DNSZone(group_id=default.id, name="example.com.", zone_type="primary")
+    db_session.add(zone)
+    await db_session.flush()
+    db_session.add(DNSServerZoneState(server_id=srv.id, zone_id=zone.id, current_serial=42))
+    db_session.add(
+        DNSRecordOp(
+            server_id=srv.id,
+            zone_name="example.com.",
+            op="create",
+            record={"name": "www", "type": "A", "value": "10.0.0.1"},
+            state="pending",
+        )
+    )
+    # An already-applied op is history, not queued work — it stays.
+    db_session.add(
+        DNSRecordOp(
+            server_id=srv.id,
+            zone_name="example.com.",
+            op="create",
+            record={"name": "old", "type": "A", "value": "10.0.0.2"},
+            state="applied",
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    zone_state = (
+        (
+            await db_session.execute(
+                select(DNSServerZoneState).where(DNSServerZoneState.server_id == srv.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert zone_state == []
+
+    ops = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == srv.id)))
+        .scalars()
+        .all()
+    )
+    assert [o.state for o in ops] == ["applied"]
+
+
+@pytest.mark.asyncio
+async def test_move_clears_config_apply_verdict(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``config_apply_status`` (#882) means "the LIVE config is the SAVED
+    one". A move changes the saved one, so carrying ``ok`` across it is a
+    false statement at the instant of commit. NULL is UNKNOWN, never ok."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(
+        db_session,
+        default,
+        "ns1",
+        config_apply_status="ok",
+        config_apply_error=None,
+        config_failed_etag="deadbeef",
+        config_apply_at=datetime.now(UTC),
+    )
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(srv)
+    assert srv.config_apply_status is None
+    assert srv.config_failed_etag is None
+    assert srv.config_apply_at is None
+
+
+@pytest.mark.asyncio
+async def test_move_generates_a_tsig_key_for_a_ui_created_target_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A group created in the UI has never been through agent
+    registration, where the legacy group key was historically generated —
+    so without this the moved agent gets a bundle whose loopback RFC 2136
+    path has no key to sign with."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal resolvers")
+    assert target.tsig_key_secret is None
+    srv = await _server(db_session, default, "ns1")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(target)
+    assert target.tsig_key_secret
+    assert target.tsig_key_algorithm == "hmac-sha256"
+    # Spaces are not legal in a BIND key name.
+    assert target.tsig_key_name == "spatium-internal-resolvers"
+
+
+@pytest.mark.asyncio
+async def test_move_leaves_an_existing_target_tsig_key_alone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Regenerating it would invalidate every agent in the target group
+    that is already signing with the current secret."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(
+        db_session,
+        "internal",
+        tsig_key_name="spatium-internal",
+        tsig_key_secret="Zm9vYmFy",
+        tsig_key_algorithm="hmac-sha256",
+    )
+    srv = await _server(db_session, default, "ns1")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(target)
+    assert target.tsig_key_secret == "Zm9vYmFy"
+
+
+# ── Primary bookkeeping, both sides ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_moving_the_primary_elects_a_replacement_in_the_old_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A group with no primary drops every record write to its zones with
+    only a log line — no error reaches whoever made the change."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    primary = await _server(db_session, default, "ns1", is_primary=True)
+    survivor = await _server(db_session, default, "ns2")
+
+    resp = await client.put(
+        _url(default.id, primary.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(survivor)
+    assert survivor.is_primary is True
+
+
+@pytest.mark.asyncio
+async def test_election_prefers_an_enabled_unpaused_survivor(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A disabled or paused server is skipped by the record-op dispatcher,
+    so electing one would leave the group nominally covered and actually
+    dead. Insertion order deliberately puts the unusable candidate first."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    primary = await _server(db_session, default, "ns1", is_primary=True)
+    paused = await _server(db_session, default, "ns2", maintenance_mode=True)
+    usable = await _server(db_session, default, "ns3")
+
+    resp = await client.put(
+        _url(default.id, primary.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(paused)
+    await db_session.refresh(usable)
+    assert usable.is_primary is True
+    assert paused.is_primary is False
+
+
+@pytest.mark.asyncio
+async def test_moving_the_only_server_leaves_the_old_group_without_a_primary(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Nothing to elect. The move still succeeds — an empty group with no
+    primary is a consistent state, and refusing would make the discussion's
+    single-agent case unfixable."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(db_session, default, "ns1", is_primary=True)
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(srv)
+    assert srv.group_id == target.id
+    # Elected in the target, which had none.
+    assert srv.is_primary is True
+
+
+@pytest.mark.asyncio
+async def test_move_into_a_group_that_has_a_primary_does_not_make_two(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Two primaries in one group is not a tie-break — ``build_config_bundle``
+    fetches the catalog-zone producer with ``scalar_one_or_none``, so a
+    second one raises inside the agent long-poll and stops the WHOLE group
+    converging."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    incoming = await _server(db_session, default, "ns1", is_primary=True)
+    sitting = await _server(db_session, target, "ns2", is_primary=True)
+
+    resp = await client.put(
+        _url(default.id, incoming.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(incoming)
+    await db_session.refresh(sitting)
+    assert sitting.is_primary is True, "the operator's existing choice wins"
+    assert incoming.is_primary is False
+
+    count = (
+        (
+            await db_session.execute(
+                select(DNSServer).where(
+                    DNSServer.group_id == target.id, DNSServer.is_primary.is_(True)
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(count) == 1
+
+
+# ── Refusals ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_refused_on_name_collision(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``uq_dns_server_group_name`` would raise anyway; the point is that
+    the operator is told which name clashed."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(db_session, default, "ns1")
+    await _server(db_session, target, "ns1")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 409
+    assert "ns1" in resp.json()["detail"]
+
+    await db_session.refresh(srv)
+    assert srv.group_id == default.id
+
+
+@pytest.mark.asyncio
+async def test_rename_and_move_in_one_request_checks_the_new_name(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The collision check runs after the rename, so renaming out of the
+    way and moving is a single request — and renaming INTO a clash is
+    still caught."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(db_session, default, "ns1")
+    await _server(db_session, target, "ns1")
+
+    ok = await client.put(
+        _url(default.id, srv.id),
+        json={"name": "ns9", "group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert ok.status_code == 200, ok.text
+    await db_session.refresh(srv)
+    assert srv.group_id == target.id and srv.name == "ns9"
+
+
+@pytest.mark.asyncio
+async def test_move_refused_when_it_would_mix_drivers(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A server group is single-driver: its rendered config, catalog-zone
+    semantics and AXFR shape all assume one. Mixing is only caught today
+    at operation time (DNSSEC sign / ALIAS), i.e. long after the mistake."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "pdns")
+    srv = await _server(db_session, default, "ns1", driver="bind9")
+    await _server(db_session, target, "pdns1", driver="powerdns")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 422
+    assert "single-driver" in resp.json()["detail"]
+
+    await db_session.refresh(srv)
+    assert srv.group_id == default.id
+
+
+@pytest.mark.asyncio
+async def test_move_into_an_empty_group_of_any_driver_is_allowed(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The discussion's case — the operator makes a fresh group precisely
+    to move a server into it. Nothing to disagree with."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "brand-new")
+    srv = await _server(db_session, default, "ns1", driver="powerdns")
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.asyncio
+async def test_move_requires_superadmin(client: AsyncClient, db_session: AsyncSession) -> None:
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    srv = await _server(db_session, default, "ns1")
+    user = User(
+        username="plain934",
+        email="plain934@example.com",
+        display_name="plain",
+        hashed_password=hash_password("password123"),
+        is_superadmin=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+
+    resp = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(create_access_token(str(user.id))),
+    )
+    assert resp.status_code == 403
+
+
+# ── Explicit primary designation ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_promoting_a_server_demotes_the_incumbent(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Three separate comments told operators to flip this flag "later via
+    the API" and no endpoint accepted it — including the hint shown when a
+    record write is dropped for want of a primary."""
+    token = await _superadmin(db_session)
+    grp = await _group(db_session, "default")
+    incumbent = await _server(db_session, grp, "ns1", is_primary=True)
+    challenger = await _server(db_session, grp, "ns2")
+
+    resp = await client.put(
+        _url(grp.id, challenger.id),
+        json={"is_primary": True},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(incumbent)
+    await db_session.refresh(challenger)
+    assert challenger.is_primary is True
+    assert incumbent.is_primary is False
+
+
+@pytest.mark.asyncio
+async def test_promotion_only_demotes_within_the_same_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    grp = await _group(db_session, "default")
+    other = await _group(db_session, "internal")
+    challenger = await _server(db_session, grp, "ns1")
+    untouched = await _server(db_session, other, "ns2", is_primary=True)
+
+    resp = await client.put(
+        _url(grp.id, challenger.id),
+        json={"is_primary": True},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(untouched)
+    assert untouched.is_primary is True
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_only_primary_is_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """It re-creates exactly the footgun create-time auto-election exists
+    to prevent, and the resulting write drops are silent."""
+    token = await _superadmin(db_session)
+    grp = await _group(db_session, "default")
+    only = await _server(db_session, grp, "ns1", is_primary=True)
+    await _server(db_session, grp, "ns2")
+
+    resp = await client.put(
+        _url(grp.id, only.id),
+        json={"is_primary": False},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 422
+    assert "only primary" in resp.json()["detail"]
+
+    await db_session.refresh(only)
+    assert only.is_primary is True
+
+
+@pytest.mark.asyncio
+async def test_move_and_promote_in_one_request_promotes_in_the_target(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The demotion sweep must target the group the server ENDS UP in."""
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    mover = await _server(db_session, default, "ns1")
+    await _server(db_session, default, "ns0", is_primary=True)
+    sitting = await _server(db_session, target, "ns2", is_primary=True)
+
+    resp = await client.put(
+        _url(default.id, mover.id),
+        json={"group_id": str(target.id), "is_primary": True},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(mover)
+    await db_session.refresh(sitting)
+    assert mover.group_id == target.id
+    assert mover.is_primary is True
+    assert sitting.is_primary is False
+
+
+# ── Durability against the agent ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_survives_agent_re_registration_with_a_stale_group_name(
+    client: AsyncClient, db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The agent's ``AGENT_GROUP`` env still names the group it LEFT.
+
+    This is what makes the move a real operator action rather than a
+    setting the next agent restart undoes: ``/register`` resolves an
+    existing row by ``agent_id`` first — globally, with no group filter —
+    and its update branch deliberately never writes ``group_id``. Without
+    that, a token expiry or a container restart would silently drag the
+    server back into ``default``, and the operator would have no way to
+    tell why.
+    """
+    monkeypatch.setenv("DNS_AGENT_KEY", "psk-934")
+    token = await _superadmin(db_session)
+    default = await _group(db_session, "default")
+    target = await _group(db_session, "internal")
+    agent_id = uuid.uuid4()
+    srv = await _server(db_session, default, "ns1", agent_id=agent_id)
+
+    moved = await client.put(
+        _url(default.id, srv.id),
+        json={"group_id": str(target.id)},
+        headers=_auth(token),
+    )
+    assert moved.status_code == 200, moved.text
+
+    # The agent re-bootstraps (401 / 404 path) still advertising the OLD
+    # group name, exactly as its unchanged env var says.
+    reg = await client.post(
+        "/api/v1/dns/agents/register",
+        headers={"X-DNS-Agent-Key": "psk-934"},
+        json={
+            "hostname": "ns1",
+            "fingerprint": "fp-1",
+            "driver": "bind9",
+            "roles": ["authoritative"],
+            "agent_id": str(agent_id),
+            "group_name": "default",
+        },
+    )
+    assert reg.status_code == 200, reg.text
+    assert reg.json()["server_id"] == str(srv.id), "must reuse the row, not fork a new one"
+
+    await db_session.refresh(srv)
+    assert srv.group_id == target.id, "re-registration must not undo the operator's move"

--- a/docs/deployment/DNS_AGENT.md
+++ b/docs/deployment/DNS_AGENT.md
@@ -574,6 +574,17 @@ dns-bind9-ns1:
 > the control plane fans record ops out to every enabled agent-based
 > server in the group regardless of role.
 
+> **`AGENT_GROUP` only decides where a BRAND-NEW agent lands.** On
+> re-registration the control plane resolves the existing row by `agent_id`
+> and never rewrites its `group_id`, so editing this variable does not move
+> a server that has already registered — and leaving it stale does not drag
+> a moved one back. To change a registered server's group, move it in the
+> control plane (`group_id` on the server PUT, or the **Server group**
+> picker in its edit modal — see
+> [`DNS.md` §1](../features/DNS.md)). Naming a group that does not exist
+> still auto-creates an empty one, so a stale value here is untidy rather
+> than harmful.
+
 ---
 
 ## 9. Deliverables for Wave 2 Implementation

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -160,10 +160,26 @@ operations only notice at DNSSEC-sign / ALIAS time, long after the mistake.
 Moving into an *empty* group is always allowed, whatever its driver — that is
 the common case.
 
-The move survives agent re-registration. `/register` resolves an existing row
-by `agent_id` first, with no group filter, and never writes `group_id` on an
-existing row — so a stale `AGENT_GROUP` on the container does not drag the
-server back. There is no need to edit the agent's environment after moving it.
+The move survives agent re-registration, on both deployment shapes — but for
+two different reasons, and the difference matters if you are debugging one.
+
+On a **standalone agent** (Docker / Kubernetes), the group comes from the
+container's own `AGENT_GROUP`. `/register` resolves an existing row by
+`agent_id` first, with no group filter, and never writes `group_id` on a row
+it finds — so a stale `AGENT_GROUP` neither drags the server back nor forks a
+second row in the old group. There is no need to edit the agent's environment
+after moving it, though leaving it accurate is tidier.
+
+On an **appliance** (#170), the agent is not configured from its own
+environment at all: the supervisor derives both `AGENT_GROUP` and the per-role
+nftables ports from `Appliance.assigned_dns_group_id`. The move therefore
+**repoints that field too**, and wakes the supervisor's heartbeat so it
+re-applies rather than waiting out its interval. Without that the firewall
+would keep the *old* group's DoT/DoH/DoQ ports open while the agent listens on
+the new group's — a failure that leaves every config valid and the listener
+simply unreachable. The pointer is only moved when it currently names the
+group being left; an appliance deliberately assigned elsewhere is not
+redirected on the strength of one server row moving.
 
 ### Designating the group primary (#934)
 

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -115,6 +115,67 @@ Groups:
 
 A server may belong to only one group but may have **multiple roles** (e.g., both authoritative and recursive).
 
+### Moving a server between groups (#934)
+
+An auto-registered agent lands in the group its `AGENT_GROUP` names, or in
+`default` when it names none — which is rarely the group the operator wants
+it in permanently. Send `group_id` on
+`PUT /api/v1/dns/groups/{current_group_id}/servers/{server_id}`, or use the
+**Server group** picker in the server's edit modal. Note the URL names the
+group the server is *leaving* and the body the one it is joining; addressing
+it under the target group is a 404.
+
+Re-sending the server's current `group_id` is a no-op, so an idempotent PUT
+that echoes the whole row back is safe.
+
+The move is not just a column write. It also:
+
+* **Purges the server's `DNSServerZoneState` rows and its pending
+  `DNSRecordOp`s.** Both reference the *old* group's zones — left behind, the
+  Zone Sync pill reports convergence for zones this server no longer serves,
+  and the queued RFC 2136 updates would be shipped to a daemon that has never
+  heard of those zones. Already-applied ops are history and stay.
+* **Clears the `config_apply_*` verdict (#882).** `ok` means "the live config
+  is the saved one"; a move changes the saved one, so carrying it across is
+  false at the instant of commit. NULL is UNKNOWN, never ok.
+* **Re-elects primaries on both sides.** Moving a group's primary out elects
+  the oldest enabled, unpaused survivor — a group with none silently drops
+  every record write to its zones. In the target the server is elected only
+  if there is no primary already; an existing one is never demoted, because
+  two primaries in one group is not a tie-break, it raises inside the agent
+  long-poll and stops the whole group converging.
+* **Generates the target group's TSIG key if it has none.** A group created
+  in the UI has never been through agent registration, where that key was
+  historically generated.
+* **Wakes both groups and the server's own channel.** The server channel is
+  what reaches an agent already parked in a long-poll — its subscription was
+  built from the old group, so a group wake alone would not reach it.
+
+Two refusals: a **name collision** in the target group (409 — server names are
+unique per group), and a move that would leave the target **mixed-driver**
+(422). The second fails closed here even though a mixed group is still
+reachable by other paths: a group is single-driver (see
+[`DNS_DRIVERS.md` §5.1](../drivers/DNS_DRIVERS.md)) and the driver-gated
+operations only notice at DNSSEC-sign / ALIAS time, long after the mistake.
+Moving into an *empty* group is always allowed, whatever its driver — that is
+the common case.
+
+The move survives agent re-registration. `/register` resolves an existing row
+by `agent_id` first, with no group filter, and never writes `group_id` on an
+existing row — so a stale `AGENT_GROUP` on the container does not drag the
+server back. There is no need to edit the agent's environment after moving it.
+
+### Designating the group primary (#934)
+
+`is_primary` marks the one server per group that DDNS and record writes are
+applied at. It is auto-elected on create and on first agent registration when
+the group has none; send `is_primary: true` on the same PUT to move it, which
+demotes whichever server currently holds it. **Clearing the last primary is
+refused (422)** — it re-creates the footgun the auto-election exists to
+prevent, and the resulting dropped writes are silent (a log line; no error
+reaches whoever made the change). Promote a replacement instead; that demotes
+the incumbent as a side effect.
+
 ---
 
 ## 2. DNS Views (Split-Horizon)

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1259,7 +1259,15 @@ function ServerModal({
         ? dnsApi.updateServer(groupId, server.id, d)
         : dnsApi.createServer(groupId, d),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["dns-servers", groupId] });
+      // Prefix-invalidate EVERY group's server list, not just this one.
+      // A #934 move writes rows in two groups (the server leaves one and
+      // joins the other) and primary re-election touches a sibling in each,
+      // so scoping this to `groupId` left the target group's cached list
+      // wrong for the full 30 s `staleTime` — the moved server invisible in
+      // both places if the operator navigated straight there.
+      qc.invalidateQueries({ queryKey: ["dns-servers"] });
+      // Group rows carry `server_count`, which a move changes on both sides.
+      qc.invalidateQueries({ queryKey: ["dns-groups"] });
       onClose();
     },
     onError: (e: ApiError) => setError(formatApiError(e)),

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1166,7 +1166,21 @@ function ServerModal({
   const [notes, setNotes] = useState(server?.notes ?? "");
   const [apiKey, setApiKey] = useState("");
   const [isEnabled, setIsEnabled] = useState(server?.is_enabled ?? true);
+  // #934 — move this server to another group, and designate the group's
+  // primary. Edit-only: on create the group is the one you are creating it
+  // in, and the primary flag is auto-elected when the group has none.
+  const [targetGroupId, setTargetGroupId] = useState(
+    server?.group_id ?? groupId,
+  );
+  const [isPrimary, setIsPrimary] = useState(server?.is_primary ?? false);
   const [error, setError] = useState("");
+
+  // Only needed for the move picker, so don't fetch it on the create path.
+  const { data: allGroups = [] } = useQuery({
+    queryKey: ["dns-groups"],
+    queryFn: () => dnsApi.listGroups(),
+    enabled: editing,
+  });
 
   // Windows credential state — same contract as the DHCP modal:
   //   * On edit with creds: leave blank to keep, type to replace.
@@ -1274,6 +1288,15 @@ function ServerModal({
       notes,
       is_enabled: isEnabled,
       ...(apiKey && !cloud ? { api_key: apiKey } : {}),
+      // #934 — only on edit, and only when actually changed. Sending an
+      // unchanged group_id is a server-side no-op, but sending is_primary
+      // unchanged would still take the demotion path on every save.
+      ...(editing && targetGroupId !== server!.group_id
+        ? { group_id: targetGroupId }
+        : {}),
+      ...(editing && isPrimary !== server!.is_primary
+        ? { is_primary: isPrimary }
+        : {}),
     };
 
     if (credFields) {
@@ -1561,6 +1584,50 @@ function ServerModal({
             placeholder="Optional notes"
           />
         </Field>
+        {editing && (
+          <>
+            <Field label="Server group">
+              <select
+                className={inputCls}
+                value={targetGroupId}
+                onChange={(e) => setTargetGroupId(e.target.value)}
+              >
+                {allGroups.map((g) => (
+                  <option key={g.id} value={g.id}>
+                    {g.name}
+                  </option>
+                ))}
+              </select>
+              {targetGroupId !== server!.group_id && (
+                <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                  Moving this server re-renders both groups&rsquo; config. Its
+                  per-zone sync state and any queued record updates for the old
+                  group&rsquo;s zones are discarded, and the agent picks up the
+                  new group&rsquo;s config on its next poll. A group is
+                  single-driver, so the target must be empty or already running{" "}
+                  <code>{driver}</code>.
+                </p>
+              )}
+            </Field>
+            <label className="flex items-start gap-2 text-sm">
+              <input
+                type="checkbox"
+                className="mt-0.5"
+                checked={isPrimary}
+                onChange={(e) => setIsPrimary(e.target.checked)}
+              />
+              <span>
+                <span className="font-medium">Primary for this group</span>
+                <span className="block text-xs text-muted-foreground">
+                  The server DDNS and record writes are applied at. Exactly one
+                  per group &mdash; ticking this demotes whichever server holds
+                  it now. A group with no primary silently drops every record
+                  write to its zones, so it can only be moved, not cleared.
+                </span>
+              </span>
+            </label>
+          </>
+        )}
         <label className="flex items-start gap-2 text-sm">
           <input
             type="checkbox"


### PR DESCRIPTION
Reported in [discussion #933](https://github.com/spatiumddi/spatiumddi/discussions/933): a freshly auto-registered BIND9 agent lands in `default`, the operator creates the group they actually wanted, and there is no way to move the server into it. The DHCP side has carried `server_group_id` on its update payload since #430 and handles the move properly — an asymmetry, not a design decision.

Now `group_id` on `PUT /api/v1/dns/groups/{current}/servers/{id}`, routed through a new `services/dns/server_move.py`, plus a **Server group** picker in the edit modal. No migration.

## The move is not a column write

A DNS server accumulates group-scoped state that becomes false the instant its group changes:

- **`DNSServerZoneState` rows and live `DNSRecordOp`s are purged.** Both reference the *old* group's zones — left behind, the Zone Sync pill reports convergence for zones the server no longer serves, and queued RFC 2136 updates ship to a daemon that has never heard of those zones. The delete covers `in_flight` as well as `pending`: an op already shipped is not finished with, because `ack_op` returns a NACKed one to `pending` and that ack can land *after* the move.
- **`config_apply_status` (#882) is cleared.** It means "the live config is the saved one"; a move changes the saved one, so carrying `ok` across is false at the instant of commit. NULL is UNKNOWN, never `ok`.
- **The target group's TSIG key is generated if absent.** A group created in the UI has never been through agent registration, where that generation used to be inlined — now `ensure_group_tsig_key`, shared by both paths.
- **Both group channels and the server's own are woken.** The server channel is the load-bearing one: an agent already parked in a long-poll subscribed using its *old* group, so a group wake alone would never reach it.
- **On the appliance path, `Appliance.assigned_dns_group_id` is repointed** and the supervisor heartbeat woken. There the agent is not configured from its own environment at all — `_build_role_assignment` derives both the `AGENT_GROUP` written into `role-compose.env` and the #50 DoT/DoH/DoQ ports opened in the per-role nftables drop-in from that field. Left stale, a move into a group serving DoT on 8853 leaves the firewall closed while the agent listens: every config file valid, the listener simply unreachable. Only repointed when it names the group being left.

## `is_primary` is the sharp edge, in both directions

A group with **none** drops every record write to its zones *silently* — a log line, no error to the caller — so moving a primary out elects the oldest enabled, unpaused survivor.

A group with **two** is worse than a wrong pick. The catalog-zone producer lookup in `build_config_bundle` used `scalar_one_or_none()` with no `LIMIT`, so a second primary raises `MultipleResultsFound` *inside the agent long-poll* — a 500 that stops the whole group converging rather than merely picking wrong. So the incoming server is elected in the target only when it has none, an existing primary is never demoted, and that query was capped defensively.

**The election bug this class predicts was in the first draft and caught by the tests.** The departing server is still `group_id == old_group` in-session when the election runs, so without an explicit `exclude_id` the query re-elects the very server being demoted — the flag stays on a member that has left *and* the target ends up with two.

## Two refusals

- **Name collision** in the target (409). `uq_dns_server_group_name` would fire anyway, but as a constraint name rather than telling the operator which name clashed.
- **Mixed-driver** target (422). A group is single-driver, which `DNS_DRIVERS.md` §5.1 has always asserted the control plane enforces — **it does not**; it only 422s later, at DNSSEC-sign or ALIAS time. A move is a new operation with no installs to break, so it fails closed rather than manufacturing a state that breaks something else afterwards. Moving into an *empty* group is always allowed, whatever its driver, which is the reported case.

## The move survives agent re-registration

`/register` resolves the row by `agent_id` first, globally, and its update branch never writes `group_id` — so a stale `AGENT_GROUP` neither drags the server back nor forks a second row. That is what makes this an operator action rather than a setting the next container restart undoes. Pinned by a test, and `DNS_AGENT.md` now says so where that variable is documented.

## Also fixed, found on the way

**`is_primary` was settable by no API at all**, while three separate comments told operators to flip it "later via the API" — including the hint `record_ops` logs when it drops a write for want of a primary, i.e. the message shown at the exact moment the advice was needed. It is now on `ServerUpdate`, demoting the incumbent atomically. Clearing the *last* primary is refused (422) rather than silently re-creating the footgun create-time auto-election exists to prevent.

**The derived TSIG key name reached `named.conf` unvalidated.** It is interpolated verbatim into `key "<name>" { … };` by both agent renderers, so a group named `edge"; };` would close the statement early — and BIND rejects the file *whole*, so `named-checkconf` fails and the agent declines the entire bundle. One badly-named group stopping its group converging: the #876 / #899 class, newly reachable because the move generates keys for operator-typed group names. Sanitised rather than refused — the name is derived, not typed, and `Edge (DMZ)` is not a mistake — falling back to the group id when nothing survives, since `key "" { … }` is not valid either.

## MCP

1 tool: **`find_dns_servers`** (read-only, default on). The copilot could list server *groups* and had no way to see the servers in them, so "which group is ns1 in?" and "which group has no primary?" were both unanswerable.

Deliberately **no** `propose_move_*` write tool — explicit decision per non-negotiable #13: the move re-renders two groups' configs, which is the broad-blast-radius shape that guidance says to keep off the copilot. Not a feature module (#14) either: it extends an existing resource rather than adding a top-level family.

## Verification

27 tests in the new suite; 122 across the DNS regression batch (ACLs, dynamic-update ACLs, encrypted transports, config-apply status, TSIG transfer, PSK gate, MCP execution smoke); 27 supervisor tests. `make ci`, the migration linter and the untyped-route guard all clean.

Walked end to end on the dev stack against a **live BIND9 agent**, not reasoned about:

- Move into an empty group → 7 zones → 0, clean `structural_reload_applied`, agent re-reported `ok`; move back → 0 → 7, zone resolving again.
- All three refusals returned their real status codes and messages against the running API.
- With a deliberately punctuated group name (`Edge (DMZ) 934`), the key rendered as `spatium-edge-dmz-934` into the agent's own `ddns.key` and `named-checkconf` exited 0.

Dev stack restored to its original state afterwards; no test groups left behind.

Closes #934

🤖 Generated with [Claude Code](https://claude.com/claude-code)
