### PR TITLE
fix(dns): filter the group-move picker by driver, drop a false comment (#937)

### DIFF
--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -292,10 +292,58 @@ class ServerGroupResponse(BaseModel):
     catalog_zones_enabled: bool
     catalog_zone_name: str
     is_public_facing: bool = False
+    # #934 follow-up — the distinct drivers of the servers currently in this
+    # group. Empty means an empty group, which is compatible with anything.
+    # A group is single-driver, so one entry is the normal case; two or more
+    # is a group that got mixed through the create path, which does not
+    # enforce homogeneity (only the move and the driver-gated operations do).
+    # Exposed so a client can tell which groups a given server may move into
+    # without fetching every group's server list to find out.
+    server_drivers: list[str] = []
     created_at: datetime
     modified_at: datetime
 
     model_config = {"from_attributes": True}
+
+    @classmethod
+    def from_model(cls, g: DNSServerGroup, drivers: list[str] | None = None) -> ServerGroupResponse:
+        return cls(
+            id=g.id,
+            name=g.name,
+            description=g.description,
+            group_type=g.group_type,
+            default_view=g.default_view,
+            is_recursive=g.is_recursive,
+            catalog_zones_enabled=g.catalog_zones_enabled,
+            catalog_zone_name=g.catalog_zone_name,
+            is_public_facing=g.is_public_facing,
+            server_drivers=sorted(drivers or []),
+            created_at=g.created_at,
+            modified_at=g.modified_at,
+        )
+
+
+async def _drivers_by_group(db: DB, group_ids: list[uuid.UUID]) -> dict[uuid.UUID, list[str]]:
+    """Distinct server drivers per group, in ONE query.
+
+    Aggregated rather than fetched per group: the group list is rendered on
+    every visit to the DNS page, and a per-group lookup would be an N+1 that
+    grows with the estate.
+    """
+    if not group_ids:
+        return {}
+    rows = (
+        await db.execute(
+            select(DNSServer.group_id, DNSServer.driver)
+            .where(DNSServer.group_id.in_(group_ids))
+            .distinct()
+        )
+    ).all()
+    out: dict[uuid.UUID, list[str]] = {}
+    for gid, driver in rows:
+        if driver:
+            out.setdefault(gid, []).append(driver)
+    return out
 
 
 # ── Server schemas ──────────────────────────────────────────────────────────
@@ -1340,13 +1388,17 @@ def _validate_address_record_value(record_type: str, value: str) -> None:
 
 
 @router.get("/groups", response_model=list[ServerGroupResponse])
-async def list_groups(db: DB, _: CurrentUser) -> list[DNSServerGroup]:
+async def list_groups(db: DB, _: CurrentUser) -> list[ServerGroupResponse]:
     result = await db.execute(select(DNSServerGroup).order_by(DNSServerGroup.name))
-    return list(result.scalars().all())
+    groups = list(result.scalars().all())
+    drivers = await _drivers_by_group(db, [g.id for g in groups])
+    return [ServerGroupResponse.from_model(g, drivers.get(g.id)) for g in groups]
 
 
 @router.post("/groups", response_model=ServerGroupResponse, status_code=status.HTTP_201_CREATED)
-async def create_group(body: ServerGroupCreate, db: DB, current_user: SuperAdmin) -> DNSServerGroup:
+async def create_group(
+    body: ServerGroupCreate, db: DB, current_user: SuperAdmin
+) -> ServerGroupResponse:
     existing = await db.execute(select(DNSServerGroup).where(DNSServerGroup.name == body.name))
     if existing.scalar_one_or_none():
         raise HTTPException(status_code=409, detail="A server group with that name already exists")
@@ -1373,21 +1425,23 @@ async def create_group(body: ServerGroupCreate, db: DB, current_user: SuperAdmin
     await db.commit()
     await db.refresh(group)
     logger.info("dns_group_created", group_id=str(group.id), name=group.name)
-    return group
+    # A group is empty at creation, so no aggregate query is needed here.
+    return ServerGroupResponse.from_model(group, [])
 
 
 @router.get("/groups/{group_id}", response_model=ServerGroupResponse)
-async def get_group(group_id: uuid.UUID, db: DB, _: CurrentUser) -> DNSServerGroup:
+async def get_group(group_id: uuid.UUID, db: DB, _: CurrentUser) -> ServerGroupResponse:
     group = await db.get(DNSServerGroup, group_id)
     if not group:
         raise HTTPException(status_code=404, detail="Server group not found")
-    return group
+    drivers = await _drivers_by_group(db, [group.id])
+    return ServerGroupResponse.from_model(group, drivers.get(group.id))
 
 
 @router.put("/groups/{group_id}", response_model=ServerGroupResponse)
 async def update_group(
     group_id: uuid.UUID, body: ServerGroupUpdate, db: DB, current_user: SuperAdmin
-) -> DNSServerGroup:
+) -> ServerGroupResponse:
     group = await db.get(DNSServerGroup, group_id)
     if not group:
         raise HTTPException(status_code=404, detail="Server group not found")
@@ -1412,7 +1466,8 @@ async def update_group(
     collect_wake(dns_group_channel(group.id))
     await db.commit()
     await db.refresh(group)
-    return group
+    drivers = await _drivers_by_group(db, [group.id])
+    return ServerGroupResponse.from_model(group, drivers.get(group.id))
 
 
 @router.delete("/groups/{group_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/tests/test_dns_server_group_move.py
+++ b/backend/tests/test_dns_server_group_move.py
@@ -887,3 +887,87 @@ async def test_derived_tsig_key_name_keeps_the_readable_form(
 
     await db_session.refresh(normal)
     assert normal.tsig_key_name == "spatium-edge-dmz"
+
+
+# ── `server_drivers` on the group response (#934 follow-up) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_group_response_reports_its_server_drivers(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The move picker needs to know which groups a server may go to. Without
+    this it would have to fetch every group's server list to find out, so it
+    offered groups the move then refused with a 422 on save."""
+    token = await _superadmin(db_session)
+    await _group(db_session, "empty")
+    bind = await _group(db_session, "bind-only")
+    pdns = await _group(db_session, "pdns-only")
+    await _server(db_session, bind, "ns1", driver="bind9")
+    await _server(db_session, bind, "ns2", driver="bind9")
+    await _server(db_session, pdns, "pdns1", driver="powerdns")
+
+    resp = await client.get("/api/v1/dns/groups", headers=_auth(token))
+    assert resp.status_code == 200, resp.text
+    by_name = {g["name"]: g["server_drivers"] for g in resp.json()}
+
+    # Empty group: compatible with anything, so no drivers to report.
+    assert by_name["empty"] == []
+    # Distinct, not one entry per server.
+    assert by_name["bind-only"] == ["bind9"]
+    assert by_name["pdns-only"] == ["powerdns"]
+
+
+@pytest.mark.asyncio
+async def test_group_response_reports_a_mixed_group_honestly(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A group is single-driver, but only the MOVE and the driver-gated
+    operations enforce it — the create path does not, so mixed groups are
+    reachable. Reporting one driver would let the picker offer it as
+    compatible when the move will refuse."""
+    token = await _superadmin(db_session)
+    mixed = await _group(db_session, "mixed")
+    await _server(db_session, mixed, "a", driver="bind9")
+    await _server(db_session, mixed, "b", driver="powerdns")
+
+    resp = await client.get(f"/api/v1/dns/groups/{mixed.id}", headers=_auth(token))
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["server_drivers"] == ["bind9", "powerdns"]
+
+
+@pytest.mark.asyncio
+async def test_newly_created_group_reports_no_drivers(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The create response is the one the UI puts straight into its cache."""
+    token = await _superadmin(db_session)
+    resp = await client.post(
+        "/api/v1/dns/groups",
+        json={"name": "fresh", "description": "", "group_type": "custom"},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["server_drivers"] == []
+
+
+@pytest.mark.asyncio
+async def test_group_drivers_track_a_move(client: AsyncClient, db_session: AsyncSession) -> None:
+    """The field has to move with the server, or the picker keeps offering
+    (or blocking) groups on the strength of where servers used to be."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    srv = await _server(db_session, src, "ns1", driver="bind9")
+
+    resp = await client.put(
+        _url(src.id, srv.id),
+        json={"group_id": str(dst.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 200, resp.text
+
+    listing = await client.get("/api/v1/dns/groups", headers=_auth(token))
+    by_name = {g["name"]: g["server_drivers"] for g in listing.json()}
+    assert by_name["src"] == []
+    assert by_name["dst"] == ["bind9"]

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4810,6 +4810,12 @@ export interface DNSServerGroup {
   // operator binds a private IP into a zone in this group, forcing a
   // typed-CIDR confirm.
   is_public_facing?: boolean;
+  /** Distinct drivers of the servers currently in this group (#934
+   *  follow-up). Empty = an empty group, compatible with anything. A group
+   *  is single-driver, so one entry is normal; two or more means the group
+   *  was mixed through the create path, which doesn't enforce homogeneity.
+   *  Lets the move picker tell which groups a server can actually go to. */
+  server_drivers?: string[];
   created_at: string;
   modified_at: string;
 }

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -1266,7 +1266,10 @@ function ServerModal({
       // wrong for the full 30 s `staleTime` — the moved server invisible in
       // both places if the operator navigated straight there.
       qc.invalidateQueries({ queryKey: ["dns-servers"] });
-      // Group rows carry `server_count`, which a move changes on both sides.
+      // Also the group list: since #934 a group row carries `server_drivers`,
+      // which a move changes on BOTH sides — and that field is what decides
+      // which groups this picker offers, so a stale one would keep offering
+      // a group the move now refuses (or hide one it would now accept).
       qc.invalidateQueries({ queryKey: ["dns-groups"] });
       onClose();
     },
@@ -1600,20 +1603,33 @@ function ServerModal({
                 value={targetGroupId}
                 onChange={(e) => setTargetGroupId(e.target.value)}
               >
-                {allGroups.map((g) => (
-                  <option key={g.id} value={g.id}>
-                    {g.name}
-                  </option>
-                ))}
+                {allGroups.map((g) => {
+                  // A group is single-driver, so the server can only move to
+                  // one that is empty or already runs its driver. Incompatible
+                  // groups are shown DISABLED with the reason rather than
+                  // hidden: an operator looking for a group they can see in
+                  // the sidebar should find out why it isn't available here,
+                  // not conclude it has vanished. The server's current group
+                  // always stays selectable, whatever it contains — otherwise
+                  // an already-mixed group could not render its own value.
+                  const drivers = g.server_drivers ?? [];
+                  const foreign = drivers.filter((d) => d !== driver);
+                  const isCurrent = g.id === server!.group_id;
+                  const blocked = !isCurrent && foreign.length > 0;
+                  return (
+                    <option key={g.id} value={g.id} disabled={blocked}>
+                      {g.name}
+                      {blocked ? ` — runs ${foreign.join(", ")}` : ""}
+                    </option>
+                  );
+                })}
               </select>
               {targetGroupId !== server!.group_id && (
                 <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
                   Moving this server re-renders both groups&rsquo; config. Its
                   per-zone sync state and any queued record updates for the old
                   group&rsquo;s zones are discarded, and the agent picks up the
-                  new group&rsquo;s config on its next poll. A group is
-                  single-driver, so the target must be empty or already running{" "}
-                  <code>{driver}</code>.
+                  new group&rsquo;s config on its next poll.
                 </p>
               )}
             </Field>


### PR DESCRIPTION
Two follow-ups on the #934 group move, both surfaced by the screenshot on [discussion #933](https://github.com/spatiumddi/spatiumddi/discussions/933).

## The picker offered groups the move refuses

The **Server group** dropdown listed every group. A group is single-driver, so a BIND9 server cannot move into a `powerdns` / `technitium` / `windows_dns` one — the move refused with a clear 422, but only **on save**, after the operator had already chosen. In the reported install that was 4 of 7 groups offered and unusable.

The picker had no way to tell: `ServerGroupResponse` carried no driver information, so filtering client-side would have meant fetching every group's server list — an N+1 on a control that renders on every visit to the DNS page.

`ServerGroupResponse` now carries **`server_drivers`**, the *distinct* drivers of the servers currently in the group, aggregated in one query:

- `[]` — an empty group, compatible with anything
- `["bind9"]` — the normal single-driver case
- `["bind9", "powerdns"]` — a group mixed through the create path, which does **not** enforce homogeneity (only the move and the driver-gated operations do)

Reporting the set rather than a single driver is the part that matters: collapsing a mixed group to one value would let the picker offer a group the move then refuses, which is the bug being fixed. There's a test pinning the mixed case for exactly that reason.

Incompatible entries render **disabled with the reason inline** (`default-powerdns — runs powerdns`) rather than hidden — a group the operator can see in the sidebar should explain why it's unavailable, not appear to have vanished. The server's own current group stays selectable regardless, or an already-mixed group could not render its own value. The warning text below the picker loses its sentence about matching drivers, since the control now says it per row.

## A comment merged in #936 was wrong

`DNSPage.tsx` invalidates `["dns-groups"]` after a server save, justified as *"Group rows carry `server_count`, which a move changes on both sides."* That `server_count` belongs to `DNSClientWindow` (DNS threat analytics); `DNSServerGroup` has no server-derived field at all, so the refetch was pointless and its reason false.

The first half of this PR **makes it load-bearing** — a move changes `server_drivers` on both sides, and that field decides what the picker offers, so a stale group list would keep offering a group the move now refuses. So the call stays and the comment now states the real reason rather than being deleted with it.

## Verification

4 new tests (31 in the suite); 125 across the group-endpoint regression batch (API-token resource grants, agentless soft-delete, dynamic-update ACLs, ACL rendering, import/export, modern record types, bulk create, encrypted transports, pool reverse zones, plus the response-media-type and model-attribute guards). `make ci` and the untyped-route guard clean.

Checked against the live dev stack — the same 7 groups as the screenshot, now correctly split for a `bind9` server:

```
default              drivers=['bind9']         -> selectable
default-powerdns     drivers=['powerdns']      -> DISABLED — runs powerdns
default-technitium   drivers=['technitium']    -> DISABLED — runs technitium
pdns-p3-5a533        drivers=['powerdns']      -> DISABLED — runs powerdns
preset-test-877      drivers=[]                -> selectable
test                 drivers=[]                -> selectable
windows              drivers=['windows_dns']   -> DISABLED — runs windows_dns
```

Closes #937

🤖 Generated with [Claude Code](https://claude.com/claude-code)
