### PR TITLE
feat(dns): move a zone between server groups (#935)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -765,6 +765,74 @@ suggestion, free-space treemap.
   to keep off the copilot. Not a feature module (#14) — it extends an
   existing resource rather than adding a top-level family.
 
+- ✅ [**A DNS zone cannot be moved between server groups**](https://github.com/spatiumddi/spatiumddi/issues/935)
+  — the other half of discussion #933, and a much sharper tool than the
+  #934 server move. A server carries state *about* a group; a zone
+  carries references *into* one — `DNSView`, `DNSTSIGKey`, `DNSAcl`,
+  `DNSPool` are all group-scoped. Preview → commit at
+  `POST …/zones/{id}/move/{preview,commit}`, service in
+  `services/dns/zone_move.py`, Move button on the zone detail. No
+  migration.
+  **The design turns on one property: clearing a view WIDENS exposure.**
+  Under split-horizon a record with `view_id` set renders in exactly that
+  view; one with NULL is *shared* and renders in **every** view
+  (`pool_geo.records_for_view`). So dropping a reference the target cannot
+  resolve does not remove the zone from a view, it adds it to all of them —
+  a zone that answered only on `internal` starts answering on `external`,
+  with no operator-visible symptom. Views and TSIG keys therefore remap
+  **by name** (a view called `internal` in each group is the operator's own
+  statement that the two mean the same thing), and where they cannot, the
+  move refuses until the widening is acknowledged. The issue text as filed
+  had this wrong — it treated clearing as a neutral tidy-up.
+  **Three acknowledgements, each its own checkbox** rather than one blanket
+  "I understand", or the DNSSEC warning gets accepted by someone who only
+  read the view one: `view_widening`; `dnssec_rollover` (the private keys
+  live on the *current* group's servers and do not move, so the target
+  signs from scratch and the DS at the registrar is wrong until
+  republished); `lost_update_grants` (a grant naming a TSIG key absent from
+  the target cannot be kept — `num_nonnulls(tsig_key_id, ip_cidr) = 1`
+  forbids clearing the key — so the row is deleted, which fails *closed*,
+  the safe direction, but not silently). Plus the zone name typed back, as
+  the IPAM block move takes a typed CIDR.
+  **The collision check runs against the RESOLVED view.** The constraint is
+  `(group_id, view_id, name)`, so a zone whose view is cleared lands at
+  `(target, NULL, name)` and can collide with an unviewed zone a
+  `(group, name)` check would have missed — while the same name in two
+  different views is not a collision at all, which is the entire point of
+  split-horizon.
+  Pools follow the zone (attached by `zone_id`, health-checked from the
+  control plane rather than the group's agents); per-server zone state and
+  queued ops are purged; a driver change **warns rather than refuses**,
+  unlike the server move, because a zone is data and BIND9 → PowerDNS is a
+  legitimate migration.
+  **Eight findings from /code-review, all confirmed, and they clustered:**
+  the move reassigned `group_id` but skipped validations every *other* path
+  into a group performs. An integration-owned zone could be moved out from
+  under its reconciler; agentless groups (`windows_dns` / cloud /
+  `technitium_api`) were driven at neither end, leaving the zone live and
+  unmanaged on the old server and absent from the new (now create-first,
+  so a failure leaves it in both places rather than in neither); a signed
+  zone could land on a group that cannot sign and read as signed forever
+  while served unsigned; a named ACL the target does not define becomes an
+  undefined symbol that makes BIND reject the file *whole*, stopping the
+  entire target group — and the module docstring had claimed `DNSAcl` was
+  handled when it was never imported; a forwarders-less forward zone could
+  reach a Technitium group (the #743 failure). Plus: the DNSSEC purge left
+  `dnssec_ds_records` stale, so the UI would name a DS for keys no server
+  holds (now `clear_dnssec_key_state`, the helper every other flag-off path
+  uses); and the view-remap SELECT was soft-delete filtered, so a deleted
+  record kept a source-group `view_id` — whose test then caught the fix
+  going into the plan scan but not the commit loop, i.e. the preview
+  counting rows the commit did not rewrite. The two new refusals are
+  deliberately **not** acknowledgement-waivable: an acknowledgement is for
+  a consequence the operator can see and accept, and neither of those
+  leaves a state they could inspect afterwards.
+  1 MCP tool (`preview_dns_zone_move`, read-only, default on) —
+  deliberately **no** commit tool per non-negotiable #13, since the
+  operation's safety rests on a human reading three consequences and typing
+  the zone name back, none of which survives being driven from a chat
+  window.
+
 #### DHCP-specific
 
 - ✅ [**DHCPv6 stateful + SLAAC config UI**](https://github.com/spatiumddi/spatiumddi/issues/52) — shipped `2026.06.04-1`: `DHCPScope.v6_address_mode` + `ra_managed_flag` / `ra_other_flag`; the Kea driver renders `subnet6` by mode (stateful → pools + options; stateless / SLAAC → options only). Migration `e4c1a8f63b29`.

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -5575,6 +5575,9 @@ class ZoneMovePreviewResponse(BaseModel):
     source_drivers: list[str]
     target_drivers: list[str]
     name_collision: bool
+    dnssec_unsupported_drivers: list[str]
+    acl_names_remapped: list[str]
+    acl_names_lost: list[str]
     warnings: list[str]
     required_acknowledgements: list[str]
 
@@ -5607,6 +5610,9 @@ class ZoneMovePreviewResponse(BaseModel):
             source_drivers=plan.source_drivers,
             target_drivers=plan.target_drivers,
             name_collision=plan.name_collision,
+            dnssec_unsupported_drivers=plan.dnssec_unsupported_drivers,
+            acl_names_remapped=plan.acl_names_remapped,
+            acl_names_lost=plan.acl_names_lost,
             warnings=plan.warnings,
             required_acknowledgements=plan.required_acknowledgements,
         )
@@ -5645,6 +5651,10 @@ async def move_zone_preview(
     lock rather than trusting this one.
     """
     zone = await _require_zone(group_id, zone_id, db, current_user)
+    # Refused here as well as on commit: an operator should learn that an
+    # integration owns this zone while reading the plan, not after filling
+    # the modal in.
+    _reject_if_synthesised_zone(zone, "move")
     target_group = await _require_group(body.target_group_id, db)
     try:
         plan = await preview_zone_move(db, zone, target_group)
@@ -5665,7 +5675,16 @@ async def move_zone_commit(
     current_user: SuperAdmin,
 ) -> ZoneMoveCommitResponse:
     zone = await _require_zone(group_id, zone_id, db, current_user)
+    # A reconciler-owned zone is not the operator's to re-home — the next
+    # sync would recreate it in the group the integration is bound to.
+    _reject_if_synthesised_zone(zone, "move")
     target_group = await _require_group(body.target_group_id, db)
+    # The same serviceability guard every create / update runs, applied to
+    # the group the zone is landing in: a forwarders-less forward zone on a
+    # Technitium group is accepted and then silently never created on the
+    # daemon (#743). A move is just another way to arrive there.
+    await _assert_forward_zone_serviceable(target_group.id, zone.zone_type, zone.forwarders, db)
+    source_group_id = zone.group_id
     try:
         plan = await commit_zone_move(
             db,
@@ -5676,6 +5695,19 @@ async def move_zone_commit(
         )
     except ZoneMoveError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    # Agentless drivers (windows_dns / cloud / technitium_api) hold the zone
+    # in a system the ConfigBundle never reaches, so the move has to be
+    # driven at both ends or the zone is left live-and-unmanaged on the old
+    # server and absent from the new one.
+    #
+    # CREATE FIRST, then delete. Either call failing raises 502 before the
+    # commit below, so the DB rolls back — and on that path a create-then-
+    # fail leaves the zone existing in both places (visible, fixable) where
+    # delete-then-fail would have removed it from the old server with the
+    # database still saying it lives there.
+    await _push_zone_to_agentless_servers(db, zone, "create", group_id=target_group.id)
+    await _push_zone_to_agentless_servers(db, zone, "delete", group_id=source_group_id)
 
     db.add(
         AuditLog(
@@ -6021,7 +6053,9 @@ async def apply_delegation(
     return created
 
 
-async def _push_zone_to_agentless_servers(db: DB, zone: DNSZone, op: str) -> None:
+async def _push_zone_to_agentless_servers(
+    db: DB, zone: DNSZone, op: str, group_id: uuid.UUID | None = None
+) -> None:
     """Push ``create`` / ``delete`` to every agentless-with-creds server.
 
     "Agentless" means ``windows_dns`` (WinRM Path B), the cloud DNS drivers
@@ -6038,9 +6072,13 @@ async def _push_zone_to_agentless_servers(db: DB, zone: DNSZone, op: str) -> Non
     """
     from app.drivers.dns import get_driver, is_agentless  # noqa: PLC0415
 
+    # ``group_id`` overrides the zone's own when the caller needs to drive
+    # a group the zone is not (yet / no longer) in — the #935 move pushes a
+    # create into the TARGET and a delete into the SOURCE, and the row can
+    # only be in one of them at a time.
     servers_res = await db.execute(
         select(DNSServer).where(
-            DNSServer.group_id == zone.group_id,
+            DNSServer.group_id == (group_id if group_id is not None else zone.group_id),
             DNSServer.credentials_encrypted.isnot(None),
         )
     )

--- a/backend/app/api/v1/dns/router.py
+++ b/backend/app/api/v1/dns/router.py
@@ -8,7 +8,7 @@ import re
 import uuid
 import zipfile
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Self
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -110,6 +110,12 @@ from app.services.dns.resolver_presets import (
 )
 from app.services.dns.serial import bump_zone_serial
 from app.services.dns.server_move import ServerMoveError, move_server_to_group
+from app.services.dns.zone_move import (
+    ZoneMoveError,
+    ZoneMovePlan,
+)
+from app.services.dns.zone_move import commit_move as commit_zone_move
+from app.services.dns.zone_move import preview_move as preview_zone_move
 from app.services.dns.zone_templates import (
     get_template,
     list_templates,
@@ -5529,6 +5535,178 @@ async def rollover_zone_dnssec_key(
     )
     await db.commit()
     return {"status": "queued", "zone_id": str(zone.id), "key_tag": body.key_tag}
+
+
+# ── Zone move between server groups (issue #935) ────────────────────────────
+#
+# Preview → commit, like the IPAM block move, because none of the
+# consequences are guessable from the request. The heavy lifting lives in
+# ``app.services.dns.zone_move``; the handlers parse, call, audit, commit.
+
+
+class ZoneMovePreviewRequest(BaseModel):
+    target_group_id: uuid.UUID
+
+
+class ZoneMovePreviewResponse(BaseModel):
+    zone_id: uuid.UUID
+    zone_name: str
+    source_group_id: uuid.UUID
+    source_group_name: str
+    target_group_id: uuid.UUID
+    target_group_name: str
+    source_has_views: bool
+    target_has_views: bool
+    zone_view_action: str
+    zone_view_from: str | None
+    records_total: int
+    records_remapped: int
+    records_widened: int
+    records_cleared_inert: int
+    records_widened_by_view: dict[str, int]
+    acl_rows_remapped: int
+    acl_keys_lost: list[str]
+    pools_repointed: int
+    zone_state_rows: int
+    pending_ops: int
+    dnssec_signed: bool
+    dnssec_key_count: int
+    acme_accounts: int
+    source_drivers: list[str]
+    target_drivers: list[str]
+    name_collision: bool
+    warnings: list[str]
+    required_acknowledgements: list[str]
+
+    @classmethod
+    def from_plan(cls, plan: ZoneMovePlan) -> Self:
+        return cls(
+            zone_id=plan.zone_id,
+            zone_name=plan.zone_name,
+            source_group_id=plan.source_group_id,
+            source_group_name=plan.source_group_name,
+            target_group_id=plan.target_group_id,
+            target_group_name=plan.target_group_name,
+            source_has_views=plan.source_has_views,
+            target_has_views=plan.target_has_views,
+            zone_view_action=plan.zone_view_action,
+            zone_view_from=plan.zone_view_from,
+            records_total=plan.records_total,
+            records_remapped=plan.records_remapped,
+            records_widened=plan.records_widened,
+            records_cleared_inert=plan.records_cleared_inert,
+            records_widened_by_view=plan.records_widened_by_view,
+            acl_rows_remapped=plan.acl_rows_remapped,
+            acl_keys_lost=plan.acl_keys_lost,
+            pools_repointed=plan.pools_repointed,
+            zone_state_rows=plan.zone_state_rows,
+            pending_ops=plan.pending_ops,
+            dnssec_signed=plan.dnssec_signed,
+            dnssec_key_count=plan.dnssec_key_count,
+            acme_accounts=plan.acme_accounts,
+            source_drivers=plan.source_drivers,
+            target_drivers=plan.target_drivers,
+            name_collision=plan.name_collision,
+            warnings=plan.warnings,
+            required_acknowledgements=plan.required_acknowledgements,
+        )
+
+
+class ZoneMoveCommitRequest(ZoneMovePreviewRequest):
+    #: Must equal the zone name. Guards against a mis-clicked row, the
+    #: same way the IPAM block move takes a typed CIDR.
+    confirmation_zone_name: str
+    #: Consequences the operator has accepted — the keys the preview
+    #: returned in ``required_acknowledgements``. Anything the plan
+    #: demands and this omits is a 422 rather than a silent apply.
+    acknowledgements: list[str] = []
+
+
+class ZoneMoveCommitResponse(ZoneMovePreviewResponse):
+    moved: bool = True
+    target_tsig_key_generated: bool = False
+
+
+@router.post(
+    "/groups/{group_id}/zones/{zone_id}/move/preview",
+    response_model=ZoneMovePreviewResponse,
+)
+async def move_zone_preview(
+    group_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    body: ZoneMovePreviewRequest,
+    db: DB,
+    current_user: SuperAdmin,
+) -> ZoneMovePreviewResponse:
+    """Report exactly what moving this zone to another group would do.
+
+    Pure read — nothing is written, so it is safe to call repeatedly while
+    the operator decides. The commit re-derives the same plan inside its
+    lock rather than trusting this one.
+    """
+    zone = await _require_zone(group_id, zone_id, db, current_user)
+    target_group = await _require_group(body.target_group_id, db)
+    try:
+        plan = await preview_zone_move(db, zone, target_group)
+    except ZoneMoveError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    return ZoneMovePreviewResponse.from_plan(plan)
+
+
+@router.post(
+    "/groups/{group_id}/zones/{zone_id}/move/commit",
+    response_model=ZoneMoveCommitResponse,
+)
+async def move_zone_commit(
+    group_id: uuid.UUID,
+    zone_id: uuid.UUID,
+    body: ZoneMoveCommitRequest,
+    db: DB,
+    current_user: SuperAdmin,
+) -> ZoneMoveCommitResponse:
+    zone = await _require_zone(group_id, zone_id, db, current_user)
+    target_group = await _require_group(body.target_group_id, db)
+    try:
+        plan = await commit_zone_move(
+            db,
+            zone,
+            target_group,
+            confirmation_zone_name=body.confirmation_zone_name,
+            acknowledgements=set(body.acknowledgements),
+        )
+    except ZoneMoveError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+
+    db.add(
+        AuditLog(
+            user_id=current_user.id,
+            user_display_name=current_user.display_name,
+            auth_source=current_user.auth_source,
+            action="move",
+            resource_type="dns_zone",
+            resource_id=str(zone.id),
+            resource_display=zone.name,
+            old_value={"group_id": str(plan.source_group_id)},
+            new_value={
+                "group_id": str(plan.target_group_id),
+                "zone_view_action": plan.zone_view_action,
+                "records_remapped": plan.records_remapped,
+                "records_widened": plan.records_widened,
+                "records_cleared_inert": plan.records_cleared_inert,
+                "acl_rows_remapped": plan.acl_rows_remapped,
+                "acl_keys_lost": plan.acl_keys_lost,
+                "pools_repointed": plan.pools_repointed,
+                "dnssec_signed": plan.dnssec_signed,
+                "acknowledgements": sorted(body.acknowledgements),
+            },
+            result="success",
+        )
+    )
+    await db.commit()
+    await db.refresh(zone)
+    resp = ZoneMoveCommitResponse.from_plan(plan)
+    resp.target_tsig_key_generated = plan.target_tsig_key_generated
+    return resp
 
 
 @router.delete("/groups/{group_id}/zones/{zone_id}", status_code=204, response_model=None)

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -259,6 +259,77 @@ async def find_dns_servers(
     ]
 
 
+class PreviewZoneMoveArgs(BaseModel):
+    zone_id: str = Field(..., description="UUID of the zone to move.")
+    target_group_id: str = Field(..., description="UUID of the destination server group.")
+
+
+@register_tool(
+    name="preview_dns_zone_move",
+    description=(
+        "Report what moving a DNS zone to another server group would do, "
+        "WITHOUT doing it. Answers 'can this zone move to that group, and "
+        "what breaks?' — view scoping that would be lost or widened, "
+        "dynamic-update grants whose TSIG keys don't exist in the target, "
+        "whether the zone is DNSSEC-signed (a move re-signs it with new "
+        "keys, so the DS at the registrar goes stale), name collisions, "
+        "and ACME delegations whose NS records would still point at the "
+        "old group. Read-only. The move itself is deliberately not "
+        "available here — run it from the DNS UI or the REST API, where "
+        "the operator confirms the zone name and acknowledges each "
+        "consequence."
+    ),
+    args_model=PreviewZoneMoveArgs,
+    category="dns",
+)
+async def preview_dns_zone_move(
+    db: AsyncSession, user: User, args: PreviewZoneMoveArgs
+) -> dict[str, Any]:
+    from app.services.dns.zone_move import ZoneMoveError, preview_move
+
+    try:
+        zone_uuid = uuid.UUID(args.zone_id)
+        group_uuid = uuid.UUID(args.target_group_id)
+    except ValueError as exc:
+        return {"error": f"Invalid UUID: {exc}"}
+
+    zone = await db.get(DNSZone, zone_uuid)
+    if zone is None:
+        return {"error": "Zone not found"}
+    target = await db.get(DNSServerGroup, group_uuid)
+    if target is None:
+        return {"error": "Target server group not found"}
+
+    try:
+        plan = await preview_move(db, zone, target)
+    except ZoneMoveError as exc:
+        return {"error": exc.detail, "status": exc.status_code}
+
+    return {
+        "zone_name": plan.zone_name,
+        "source_group": plan.source_group_name,
+        "target_group": plan.target_group_name,
+        "zone_view_action": plan.zone_view_action,
+        "zone_view_from": plan.zone_view_from,
+        "records_total": plan.records_total,
+        "records_remapped": plan.records_remapped,
+        # The dangerous one: an unscoped record answers in EVERY view, so
+        # dropping a view reference widens exposure rather than removing it.
+        "records_widened": plan.records_widened,
+        "records_widened_by_view": plan.records_widened_by_view,
+        "acl_rows_remapped": plan.acl_rows_remapped,
+        "acl_keys_lost": plan.acl_keys_lost,
+        "pools_repointed": plan.pools_repointed,
+        "dnssec_signed": plan.dnssec_signed,
+        "acme_accounts": plan.acme_accounts,
+        "source_drivers": plan.source_drivers,
+        "target_drivers": plan.target_drivers,
+        "name_collision": plan.name_collision,
+        "warnings": plan.warnings,
+        "required_acknowledgements": plan.required_acknowledgements,
+    }
+
+
 # ── Live DNS lookup tools ───────────────────────────────────────────
 #
 # ``forward_dns`` and ``reverse_dns`` wrap dnspython so the operator

--- a/backend/app/services/ai/tools/dns.py
+++ b/backend/app/services/ai/tools/dns.py
@@ -325,6 +325,10 @@ async def preview_dns_zone_move(
         "source_drivers": plan.source_drivers,
         "target_drivers": plan.target_drivers,
         "name_collision": plan.name_collision,
+        # Hard refusals: neither is waivable by acknowledgement, because
+        # neither leaves a state the operator could inspect and fix after.
+        "dnssec_unsupported_drivers": plan.dnssec_unsupported_drivers,
+        "acl_names_lost": plan.acl_names_lost,
         "warnings": plan.warnings,
         "required_acknowledgements": plan.required_acknowledgements,
     }

--- a/backend/app/services/dns/zone_move.py
+++ b/backend/app/services/dns/zone_move.py
@@ -30,16 +30,18 @@ from __future__ import annotations
 import uuid
 import zlib
 from dataclasses import dataclass, field
+from typing import Any
 
 import structlog
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.agent_wake import collect_wake, dns_group_channel
 from app.models.acme import ACMEAccount
 from app.models.dns import (
+    DNSAcl,
     DNSKey,
     DNSPool,
     DNSRecord,
@@ -52,7 +54,9 @@ from app.models.dns import (
     DNSZone,
     DNSZoneUpdateAcl,
 )
+from app.services.dns.named_conf_validation import is_name_reference
 from app.services.dns.pool_geo import build_geo_steering
+from app.services.dns.record_ops import clear_dnssec_key_state
 from app.services.dns.tsig import ensure_group_tsig_key
 
 logger = structlog.get_logger(__name__)
@@ -67,6 +71,13 @@ _LOCK_NS_ZONE_MOVE = 0x5A4D  # "ZM"
 ACK_VIEW_WIDENING = "view_widening"
 ACK_DNSSEC_ROLLOVER = "dnssec_rollover"
 ACK_LOST_UPDATE_GRANTS = "lost_update_grants"
+
+#: Drivers whose agents can actually sign a zone. Mirrors the router's
+#: ``_DRIVER_GATED_OPERATIONS["dnssec_sign"]`` gate, which every other
+#: path into a signed zone goes through — a move that skipped it would
+#: leave the row saying ``dnssec_enabled`` while the zone is served
+#: unsigned, indefinitely and with nothing to notice it.
+DNSSEC_SIGN_DRIVERS = frozenset({"bind9", "powerdns"})
 
 
 class ZoneMoveError(Exception):
@@ -153,6 +164,18 @@ class ZoneMovePlan:
 
     name_collision: bool = False
     target_tsig_key_generated: bool = False
+    #: Target drivers that cannot sign, when the zone is signed. A move
+    #: onto one is refused rather than warned: the row keeps saying
+    #: ``dnssec_enabled`` while the zone is served unsigned forever.
+    dnssec_unsupported_drivers: list[str] = field(default_factory=list)
+    #: Named ACLs cited in the zone's own address-match lists
+    #: (``allow_query`` / ``allow_transfer`` / ``also_notify``). ``DNSAcl``
+    #: is group-scoped, so a name that exists in the source and not the
+    #: target becomes an undefined symbol in the target's named.conf —
+    #: which BIND rejects WHOLE, so the agent declines the entire bundle
+    #: and the group stops converging (the #882 / #899 failure).
+    acl_names_remapped: list[str] = field(default_factory=list)
+    acl_names_lost: list[str] = field(default_factory=list)
 
     warnings: list[str] = field(default_factory=list)
     #: Acknowledgement keys the commit will demand.
@@ -260,14 +283,32 @@ async def assemble_move_plan(
 
     plan.zone_view_action, plan.zone_view_to_id, plan.zone_view_from = _resolve(zone.view_id)
 
-    records = (
-        (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id))).scalars().all()
-    )
-    plan.records_total = len(records)
-    for r in records:
-        if r.view_id is None:
-            continue
-        action, _new_id, old_name = _resolve(r.view_id)
+    # ``records_total`` is what the operator is moving, so it counts LIVE
+    # rows only. The view scan below deliberately does not — see there.
+    plan.records_total = (
+        await db.execute(
+            select(func.count()).select_from(DNSRecord).where(DNSRecord.zone_id == zone.id)
+        )
+    ).scalar_one()
+
+    # Only view-scoped rows need looking at, and only their ``view_id`` —
+    # so this selects two columns rather than hydrating every DNSRecord in
+    # the zone, which the modal would otherwise do on every dropdown change.
+    #
+    # ``include_deleted=True`` is load-bearing: DNSRecord is soft-deleted,
+    # so the default filter would leave a deleted row pointing at a
+    # SOURCE-group view. Restoring it later resurrects a dangling reference
+    # into a group the zone has left — and under split-horizon that row
+    # then renders into no operator view at all rather than into one.
+    scoped = (
+        await db.execute(
+            select(DNSRecord.id, DNSRecord.view_id)
+            .where(DNSRecord.zone_id == zone.id, DNSRecord.view_id.isnot(None))
+            .execution_options(include_deleted=True)
+        )
+    ).all()
+    for _rid, view_id in scoped:
+        action, _new_id, old_name = _resolve(view_id)
         if action == "remapped":
             plan.records_remapped += 1
         elif action == "cleared_widening":
@@ -336,27 +377,86 @@ async def assemble_move_plan(
                 plan.acl_keys_lost.append(name or "(unknown key)")
 
     # ── Everything else ───────────────────────────────────────────────
-    plan.pools_repointed = len(
-        (await db.execute(select(DNSPool.id).where(DNSPool.zone_id == zone.id))).all()
-    )
-    plan.zone_state_rows = len(
-        (
-            await db.execute(
-                select(DNSServerZoneState.id).where(DNSServerZoneState.zone_id == zone.id)
-            )
-        ).all()
+    source_acls = {
+        a.name
+        for a in (await db.execute(select(DNSAcl).where(DNSAcl.group_id == zone.group_id)))
+        .scalars()
+        .all()
+    }
+    target_acls = {
+        a.name
+        for a in (await db.execute(select(DNSAcl).where(DNSAcl.group_id == target_group.id)))
+        .scalars()
+        .all()
+    }
+
+    plan.pools_repointed = await _count(db, DNSPool, DNSPool.zone_id == zone.id)
+    plan.zone_state_rows = await _count(
+        db, DNSServerZoneState, DNSServerZoneState.zone_id == zone.id
     )
     plan.pending_ops = await _count_pending_ops(db, zone)
-    plan.dnssec_key_count = len(
-        (await db.execute(select(DNSKey.id).where(DNSKey.zone_id == zone.id))).all()
-    )
+    plan.dnssec_key_count = await _count(db, DNSKey, DNSKey.zone_id == zone.id)
     plan.dnssec_signed = bool(zone.dnssec_enabled) or plan.dnssec_key_count > 0
-    plan.acme_accounts = len(
-        (await db.execute(select(ACMEAccount.id).where(ACMEAccount.zone_id == zone.id))).all()
-    )
+    plan.acme_accounts = await _count(db, ACMEAccount, ACMEAccount.zone_id == zone.id)
+
+    # ── DNSSEC support in the target (a refusal, not a warning) ───────
+    if plan.dnssec_signed:
+        allowed = DNSSEC_SIGN_DRIVERS
+        plan.dnssec_unsupported_drivers = sorted(set(plan.target_drivers) - allowed)
+
+    # ── Named ACLs cited by the zone's own address-match lists ────────
+    _scan_acl_references(plan, zone, source_acls, target_acls)
 
     _fill_warnings(plan)
     return plan
+
+
+async def _count(db: AsyncSession, model: type, *criteria: Any) -> int:
+    """``SELECT count(*)`` rather than hydrating rows to call ``len()`` on.
+
+    The preview runs on every change of the destination dropdown, so the
+    difference between counting in Postgres and materialising every record,
+    pool and key in the zone is the difference between a snappy modal and
+    one that stalls on a large zone.
+    """
+    return int(
+        (await db.execute(select(func.count()).select_from(model).where(*criteria))).scalar_one()
+    )
+
+
+def _acl_references(zone: DNSZone) -> set[str]:
+    """Named ACLs the zone's own address-match lists refer to.
+
+    ``allow_query`` / ``allow_transfer`` / ``also_notify`` are interpolated
+    into the rendered zone statement, and a bare identifier in one of them
+    is a reference to an ``acl "<name>" { … };`` block — which is defined
+    PER GROUP (#899). ``is_name_reference`` is the same helper the bundle
+    builder and the ACL ordering pass use, so the three cannot disagree
+    about what counts as a reference.
+    """
+    names: set[str] = set()
+    for values in (zone.allow_query, zone.allow_transfer, zone.also_notify):
+        for element in values or []:
+            name = is_name_reference(str(element))
+            if name:
+                names.add(name)
+    return names
+
+
+def _scan_acl_references(
+    plan: ZoneMovePlan, zone: DNSZone, source_acls: set[str], target_acls: set[str]
+) -> None:
+    for name in sorted(_acl_references(zone)):
+        # Only a name the SOURCE group actually defines is something the
+        # move can break. An unknown name is already broken (or is a
+        # built-in this helper does not classify) and is not ours to
+        # report as a consequence of moving.
+        if name not in source_acls:
+            continue
+        if name in target_acls:
+            plan.acl_names_remapped.append(name)
+        else:
+            plan.acl_names_lost.append(name)
 
 
 async def _count_pending_ops(db: AsyncSession, zone: DNSZone) -> int:
@@ -433,6 +533,15 @@ def _fill_warnings(plan: ZoneMovePlan) -> None:
         )
         plan.required_acknowledgements.append(ACK_LOST_UPDATE_GRANTS)
 
+    if plan.acl_names_lost:
+        plan.warnings.append(
+            f"The zone's address-match lists name ACL(s) that do not exist in the target group "
+            f"({', '.join(plan.acl_names_lost)}). A named ACL is defined per group, so the "
+            f"target's named.conf would carry an undefined symbol — BIND rejects the file "
+            f"whole, which stops the WHOLE target group converging, not just this zone. "
+            f"Create ACLs with the same names in the target first."
+        )
+
     if plan.acme_accounts:
         plan.warnings.append(
             f"{plan.acme_accounts} ACME DNS-01 delegation account(s) use this zone. Their TXT "
@@ -505,6 +614,25 @@ async def commit_move(
 
     plan = await assemble_move_plan(db, zone, target_group)
 
+    # Two hard refusals that no acknowledgement can waive, because neither
+    # produces a state the operator could inspect and fix afterwards.
+    if plan.dnssec_unsupported_drivers:
+        raise ZoneMoveError(
+            f"This zone is DNSSEC-signed and '{target_group.name}' runs "
+            f"{plan.dnssec_unsupported_drivers}, which cannot sign. The zone would keep "
+            f"reporting as signed while being served unsigned. Unsign it first, or pick a "
+            f"group running one of {sorted(DNSSEC_SIGN_DRIVERS)}.",
+            status_code=422,
+        )
+    if plan.acl_names_lost:
+        raise ZoneMoveError(
+            f"The zone names ACL(s) the target group does not define "
+            f"({', '.join(plan.acl_names_lost)}). Moving it would leave an undefined symbol in "
+            f"the target's named.conf, which BIND rejects whole — the entire target group "
+            f"would stop converging, not just this zone. Create ACLs with those names in "
+            f"'{target_group.name}' first.",
+            status_code=422,
+        )
     if plan.name_collision:
         where = f"view '{plan.zone_view_from}'" if plan.zone_view_to_id is not None else "no view"
         raise ZoneMoveError(
@@ -544,10 +672,17 @@ async def commit_move(
 
     # ── Views ─────────────────────────────────────────────────────────
     zone.view_id = _new_view_id(zone.view_id)
+    # ``include_deleted=True`` for the same reason the plan scan uses it:
+    # DNSRecord is soft-deleted, and a deleted row left pointing at a
+    # SOURCE-group view is a dangling reference the moment someone restores
+    # it. The plan counts those rows, so the commit has to actually rewrite
+    # them or the preview and the outcome disagree.
     records = (
         (
             await db.execute(
-                select(DNSRecord).where(DNSRecord.zone_id == zone.id, DNSRecord.view_id.isnot(None))
+                select(DNSRecord)
+                .where(DNSRecord.zone_id == zone.id, DNSRecord.view_id.isnot(None))
+                .execution_options(include_deleted=True)
             )
         )
         .scalars()
@@ -619,10 +754,14 @@ async def commit_move(
                 DNSRecordOp.state.in_(("pending", "in_flight")),
             )
         )
-    # DNSSEC key state is a read-only mirror of what the OLD group's
-    # agents reported. The target signs from scratch, so leaving these
-    # would show the operator keys that no server holds.
-    await db.execute(sa_delete(DNSKey).where(DNSKey.zone_id == zone.id))
+    # DNSSEC key state is a read-only mirror of what the OLD group's agents
+    # reported. The target signs from scratch, so leaving it would show the
+    # operator keys that no server holds — and, worse, a cached
+    # ``dnssec_ds_records`` telling them to publish the OLD group's DS.
+    # ``clear_dnssec_key_state`` is the one helper every other flag-off path
+    # uses, and it clears both halves; deleting the DNSKey rows alone left
+    # the stale DS behind.
+    await clear_dnssec_key_state(db, zone)
 
     zone.group_id = target_group.id
 

--- a/backend/app/services/dns/zone_move.py
+++ b/backend/app/services/dns/zone_move.py
@@ -1,0 +1,646 @@
+"""Move a DNS zone from one server group to another (issue #935).
+
+The sibling of the #934 server move, and a much sharper tool. A server
+carries state ABOUT a group; a zone carries references INTO one. Every
+one of these is group-scoped, so a bare ``group_id`` reassignment leaves
+cross-group dangling references: ``DNSView``, ``DNSTSIGKey``, ``DNSAcl``,
+``DNSServerOptions``, ``DNSPool``.
+
+**The load-bearing property is that clearing a view widens exposure.**
+
+Under split-horizon (#24) a record with ``view_id IS NOT NULL`` renders in
+exactly that view; a record with ``view_id IS NULL`` is *shared* and
+renders in EVERY view (``pool_geo.records_for_view``, and the zone-level
+equivalent in ``agent_config``). So dropping a view reference that cannot
+be resolved in the target is not a neutral tidy-up — it takes a zone or a
+record that answered only on the internal view and starts answering on the
+external one. That is a data-exposure change with no operator-visible
+symptom, which is why it is surfaced as its own acknowledgement rather
+than folded into a generic warning list.
+
+Preview → commit, like the IPAM block move, because none of this is
+guessable from the request: the operator has to see which views remap by
+name, which do not, what happens to their dynamic-update grants, and that
+a signed zone changes groups by ROLLING ITS KEYS rather than by moving
+them.
+"""
+
+from __future__ import annotations
+
+import uuid
+import zlib
+from dataclasses import dataclass, field
+
+import structlog
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select, text
+from sqlalchemy import update as sa_update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.agent_wake import collect_wake, dns_group_channel
+from app.models.acme import ACMEAccount
+from app.models.dns import (
+    DNSKey,
+    DNSPool,
+    DNSRecord,
+    DNSRecordOp,
+    DNSServer,
+    DNSServerGroup,
+    DNSServerZoneState,
+    DNSTSIGKey,
+    DNSView,
+    DNSZone,
+    DNSZoneUpdateAcl,
+)
+from app.services.dns.pool_geo import build_geo_steering
+from app.services.dns.tsig import ensure_group_tsig_key
+
+logger = structlog.get_logger(__name__)
+
+#: Advisory-lock namespace for zone moves. Distinct from the IPAM block
+#: move's namespace so the two never contend on a colliding CRC.
+_LOCK_NS_ZONE_MOVE = 0x5A4D  # "ZM"
+
+#: Acknowledgement keys. Each names a consequence the operator has to
+#: accept explicitly, because none of them is reversible by re-running
+#: the move in the other direction.
+ACK_VIEW_WIDENING = "view_widening"
+ACK_DNSSEC_ROLLOVER = "dnssec_rollover"
+ACK_LOST_UPDATE_GRANTS = "lost_update_grants"
+
+
+class ZoneMoveError(Exception):
+    """A move the control plane refuses, carrying the HTTP status the
+    router should answer with."""
+
+    def __init__(self, detail: str, status_code: int = 409) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.status_code = status_code
+
+
+@dataclass
+class ZoneMovePlan:
+    """Everything the preview reports and the commit re-derives.
+
+    Assembled by ``assemble_move_plan`` and re-assembled INSIDE the
+    commit's advisory lock, so a view created (or deleted) between
+    preview and commit changes the answer rather than being applied
+    against a stale reading.
+    """
+
+    zone_id: uuid.UUID
+    zone_name: str
+    source_group_id: uuid.UUID
+    source_group_name: str
+    target_group_id: uuid.UUID
+    target_group_name: str
+
+    # Split-horizon posture of each side. ``has_views`` is true when the
+    # group renders inside ``view { … }`` blocks at all — which geo
+    # steering (#530) forces on even for a group with no operator views.
+    source_has_views: bool = False
+    target_has_views: bool = False
+
+    # What happens to the zone's own pinned view.
+    #   kept_none        — it had none; nothing to do
+    #   remapped         — the target has a view of the same name
+    #   cleared_widening — no name match AND the target renders in views
+    #                      mode, so the zone goes from one view to all
+    #   cleared_inert    — no name match and the target has no views, so
+    #                      the reference was going to be ignored anyway
+    zone_view_action: str = "kept_none"
+    zone_view_from: str | None = None
+    zone_view_to_id: uuid.UUID | None = None
+
+    # Per-record view scoping, same three outcomes.
+    records_total: int = 0
+    records_remapped: int = 0
+    records_widened: int = 0
+    records_cleared_inert: int = 0
+    #: view name → count, for the operator to see WHICH scoping is lost.
+    records_widened_by_view: dict[str, int] = field(default_factory=dict)
+
+    # Dynamic-update (#641) grants. A ``tsig_key`` ACL row cannot simply
+    # be cleared: ``num_nonnulls(tsig_key_id, ip_cidr) = 1`` forbids a row
+    # with neither. So it is remapped by key name, or DELETED.
+    acl_rows_remapped: int = 0
+    acl_keys_lost: list[str] = field(default_factory=list)
+
+    # Pools follow their zone (they are attached by ``zone_id``, and their
+    # health checks run from the control plane rather than the group's
+    # agents, so nothing about them is bound to the old group).
+    pools_repointed: int = 0
+
+    # Purged: both refer to the OLD group's servers.
+    zone_state_rows: int = 0
+    pending_ops: int = 0
+
+    # DNSSEC. The private keys live on the old group's servers and do not
+    # travel; the target re-signs from scratch under its own policy.
+    dnssec_signed: bool = False
+    dnssec_key_count: int = 0
+
+    # ACME DNS-01 delegations (#28) pointing at this zone. The provider
+    # writes TXT through ``enqueue_record_op``, which resolves the primary
+    # from ``zone.group_id`` at call time — so after the move those writes
+    # land on the target's servers while the NS delegation at the
+    # registrar still points at the old group's hosts.
+    acme_accounts: int = 0
+
+    source_drivers: list[str] = field(default_factory=list)
+    target_drivers: list[str] = field(default_factory=list)
+
+    name_collision: bool = False
+    target_tsig_key_generated: bool = False
+
+    warnings: list[str] = field(default_factory=list)
+    #: Acknowledgement keys the commit will demand.
+    required_acknowledgements: list[str] = field(default_factory=list)
+
+
+def _advisory_lock_key(zone_id: uuid.UUID) -> tuple[int, int]:
+    key = zlib.crc32(str(zone_id).encode("utf-8"))
+    if key >= 2**31:
+        key -= 2**32
+    return (_LOCK_NS_ZONE_MOVE, key)
+
+
+async def _try_advisory_lock(db: AsyncSession, zone_id: uuid.UUID) -> bool:
+    ns, key = _advisory_lock_key(zone_id)
+    return bool(
+        (
+            await db.execute(
+                text("SELECT pg_try_advisory_xact_lock(:ns, :key)"),
+                {"ns": ns, "key": key},
+            )
+        ).scalar_one()
+    )
+
+
+async def _group_has_views(db: AsyncSession, group_id: uuid.UUID) -> bool:
+    """True when this group renders inside ``view { … }`` blocks.
+
+    Operator views (#24) OR synthesized geo views (#530) — the second is
+    easy to forget and matters here, because a group with geo steering and
+    no operator views still renders in views mode, so a cleared reference
+    still widens.
+    """
+    has_operator = (
+        await db.execute(select(DNSView.id).where(DNSView.group_id == group_id).limit(1))
+    ).first() is not None
+    if has_operator:
+        return True
+    return bool((await build_geo_steering(db, group_id)).active)
+
+
+async def _drivers_of(db: AsyncSession, group_id: uuid.UUID) -> list[str]:
+    rows = (
+        (
+            await db.execute(
+                select(DNSServer.driver).where(DNSServer.group_id == group_id).distinct()
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return sorted(d for d in rows if d)
+
+
+async def assemble_move_plan(
+    db: AsyncSession, zone: DNSZone, target_group: DNSServerGroup
+) -> ZoneMovePlan:
+    """Work out exactly what moving ``zone`` into ``target_group`` does.
+
+    Pure read — nothing here mutates. Called for the preview AND again
+    inside the commit's lock so the applied plan is never a stale one.
+    """
+    source_group = await db.get(DNSServerGroup, zone.group_id)
+    plan = ZoneMovePlan(
+        zone_id=zone.id,
+        zone_name=zone.name,
+        source_group_id=zone.group_id,
+        source_group_name=source_group.name if source_group else "(deleted)",
+        target_group_id=target_group.id,
+        target_group_name=target_group.name,
+    )
+
+    plan.source_has_views = await _group_has_views(db, zone.group_id)
+    plan.target_has_views = await _group_has_views(db, target_group.id)
+    plan.source_drivers = await _drivers_of(db, zone.group_id)
+    plan.target_drivers = await _drivers_of(db, target_group.id)
+
+    # ── Views, by NAME ────────────────────────────────────────────────
+    # Name is the only stable identity across groups: ids are per-group
+    # rows and a "internal" view in each group is the operator's own
+    # statement that the two mean the same thing.
+    target_views = {
+        v.name: v.id
+        for v in (await db.execute(select(DNSView).where(DNSView.group_id == target_group.id)))
+        .scalars()
+        .all()
+    }
+    source_views = {
+        v.id: v.name
+        for v in (await db.execute(select(DNSView).where(DNSView.group_id == zone.group_id)))
+        .scalars()
+        .all()
+    }
+
+    def _resolve(view_id: uuid.UUID | None) -> tuple[str, uuid.UUID | None, str | None]:
+        """(action, new_view_id, old_view_name) for one view reference."""
+        if view_id is None:
+            return ("kept_none", None, None)
+        old_name = source_views.get(view_id)
+        if old_name is not None and old_name in target_views:
+            return ("remapped", target_views[old_name], old_name)
+        if plan.target_has_views:
+            return ("cleared_widening", None, old_name)
+        return ("cleared_inert", None, old_name)
+
+    plan.zone_view_action, plan.zone_view_to_id, plan.zone_view_from = _resolve(zone.view_id)
+
+    records = (
+        (await db.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id))).scalars().all()
+    )
+    plan.records_total = len(records)
+    for r in records:
+        if r.view_id is None:
+            continue
+        action, _new_id, old_name = _resolve(r.view_id)
+        if action == "remapped":
+            plan.records_remapped += 1
+        elif action == "cleared_widening":
+            plan.records_widened += 1
+            key = old_name or "(unknown view)"
+            plan.records_widened_by_view[key] = plan.records_widened_by_view.get(key, 0) + 1
+        elif action == "cleared_inert":
+            plan.records_cleared_inert += 1
+
+    # ── Name collision, against the RESOLVED view ─────────────────────
+    # The constraint is ``(group_id, view_id, name)``, not
+    # ``(group_id, name)`` — so whether this collides depends on where the
+    # view resolves to. A zone whose view is cleared lands at
+    # ``(target, NULL, name)``, which can collide with an unviewed zone a
+    # (group_id, name) check would have missed.
+    effective_view_id = plan.zone_view_to_id
+    clash = await db.execute(
+        select(DNSZone.id).where(
+            DNSZone.group_id == target_group.id,
+            DNSZone.name == zone.name,
+            (
+                DNSZone.view_id.is_(None)
+                if effective_view_id is None
+                else DNSZone.view_id == effective_view_id
+            ),
+            DNSZone.id != zone.id,
+        )
+    )
+    plan.name_collision = clash.first() is not None
+
+    # ── Dynamic-update grants ─────────────────────────────────────────
+    acl_rows = (
+        (
+            await db.execute(
+                select(DNSZoneUpdateAcl).where(
+                    DNSZoneUpdateAcl.zone_id == zone.id,
+                    DNSZoneUpdateAcl.tsig_key_id.isnot(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if acl_rows:
+        source_keys = {
+            k.id: k.name
+            for k in (
+                await db.execute(select(DNSTSIGKey).where(DNSTSIGKey.group_id == zone.group_id))
+            )
+            .scalars()
+            .all()
+        }
+        target_keys = {
+            k.name
+            for k in (
+                await db.execute(select(DNSTSIGKey).where(DNSTSIGKey.group_id == target_group.id))
+            )
+            .scalars()
+            .all()
+        }
+        for row in acl_rows:
+            name = source_keys.get(row.tsig_key_id) if row.tsig_key_id else None
+            if name is not None and name in target_keys:
+                plan.acl_rows_remapped += 1
+            else:
+                plan.acl_keys_lost.append(name or "(unknown key)")
+
+    # ── Everything else ───────────────────────────────────────────────
+    plan.pools_repointed = len(
+        (await db.execute(select(DNSPool.id).where(DNSPool.zone_id == zone.id))).all()
+    )
+    plan.zone_state_rows = len(
+        (
+            await db.execute(
+                select(DNSServerZoneState.id).where(DNSServerZoneState.zone_id == zone.id)
+            )
+        ).all()
+    )
+    plan.pending_ops = await _count_pending_ops(db, zone)
+    plan.dnssec_key_count = len(
+        (await db.execute(select(DNSKey.id).where(DNSKey.zone_id == zone.id))).all()
+    )
+    plan.dnssec_signed = bool(zone.dnssec_enabled) or plan.dnssec_key_count > 0
+    plan.acme_accounts = len(
+        (await db.execute(select(ACMEAccount.id).where(ACMEAccount.zone_id == zone.id))).all()
+    )
+
+    _fill_warnings(plan)
+    return plan
+
+
+async def _count_pending_ops(db: AsyncSession, zone: DNSZone) -> int:
+    """Live record ops queued for this zone against the OLD group's servers.
+
+    Keyed by ``(server_id, zone_name)`` rather than by zone id — that is
+    how ``DNSRecordOp`` is shaped — so it is scoped to the source group's
+    servers to avoid touching an identically-named zone's ops elsewhere.
+    """
+    return len(
+        (
+            await db.execute(
+                select(DNSRecordOp.id)
+                .join(DNSServer, DNSServer.id == DNSRecordOp.server_id)
+                .where(
+                    DNSServer.group_id == zone.group_id,
+                    DNSRecordOp.zone_name == zone.name,
+                    DNSRecordOp.state.in_(("pending", "in_flight")),
+                )
+            )
+        ).all()
+    )
+
+
+def _fill_warnings(plan: ZoneMovePlan) -> None:
+    """Turn the measured plan into operator-readable warnings and the set
+    of acknowledgements the commit will demand."""
+    if plan.zone_view_action == "cleared_widening":
+        plan.warnings.append(
+            f"The zone is pinned to view '{plan.zone_view_from}', which does not exist in "
+            f"'{plan.target_group_name}'. It will be UNPINNED — and an unpinned zone renders "
+            f"into EVERY view in the target group, not none. Create a view named "
+            f"'{plan.zone_view_from}' in the target first to keep the current scoping."
+        )
+    if plan.records_widened:
+        detail = ", ".join(
+            f"{n} from '{v}'" for v, n in sorted(plan.records_widened_by_view.items())
+        )
+        plan.warnings.append(
+            f"{plan.records_widened} record(s) are scoped to views the target group does not "
+            f"have ({detail}). They will become unscoped, which means they start answering in "
+            f"EVERY view in the target rather than in one."
+        )
+    if plan.zone_view_action == "cleared_widening" or plan.records_widened:
+        plan.required_acknowledgements.append(ACK_VIEW_WIDENING)
+
+    if plan.zone_view_action == "cleared_inert":
+        plan.warnings.append(
+            f"The zone's view pin ('{plan.zone_view_from}') will be dropped. The target group "
+            f"does not render views, so this changes nothing today — but the pin is not "
+            f"recoverable by moving the zone back."
+        )
+    if plan.records_cleared_inert:
+        plan.warnings.append(
+            f"{plan.records_cleared_inert} record view-scoping(s) will be dropped. The target "
+            f"group does not render views, so this changes nothing today."
+        )
+
+    if plan.dnssec_signed:
+        plan.warnings.append(
+            "This zone is DNSSEC-signed. The private keys live on the CURRENT group's servers "
+            "and do not move — the target group signs from scratch with new keys, so this is a "
+            "key rollover. The DS record at the registrar/parent will be wrong until you "
+            "publish the new one, and the zone will fail validation in the interval."
+        )
+        plan.required_acknowledgements.append(ACK_DNSSEC_ROLLOVER)
+
+    if plan.acl_keys_lost:
+        plan.warnings.append(
+            f"{len(plan.acl_keys_lost)} dynamic-update grant(s) reference TSIG keys that do not "
+            f"exist in the target group ({', '.join(sorted(set(plan.acl_keys_lost)))}). Those "
+            f"grants will be DELETED — the clients using them lose the ability to update this "
+            f"zone. Create keys with the same names in the target first to keep them."
+        )
+        plan.required_acknowledgements.append(ACK_LOST_UPDATE_GRANTS)
+
+    if plan.acme_accounts:
+        plan.warnings.append(
+            f"{plan.acme_accounts} ACME DNS-01 delegation account(s) use this zone. Their TXT "
+            f"records will be written by the target group's servers, but the NS delegation at "
+            f"your registrar still points at the current group's — certificate issuance will "
+            f"fail until you repoint it."
+        )
+
+    if plan.target_drivers and plan.source_drivers and plan.target_drivers != plan.source_drivers:
+        plan.warnings.append(
+            f"Driver change: this zone is served by {plan.source_drivers} today and would be "
+            f"served by {plan.target_drivers}. Driver-specific features (ALIAS records, "
+            f"DNSSEC signing, per-driver record types) may not survive."
+        )
+    if not plan.target_drivers:
+        plan.warnings.append(
+            f"'{plan.target_group_name}' has no servers, so the zone will not be served by "
+            f"anything until one is added."
+        )
+
+    if plan.pending_ops:
+        plan.warnings.append(
+            f"{plan.pending_ops} queued record update(s) for this zone will be discarded — they "
+            f"target the current group's servers."
+        )
+
+
+async def preview_move(
+    db: AsyncSession, zone: DNSZone, target_group: DNSServerGroup
+) -> ZoneMovePlan:
+    if zone.group_id == target_group.id:
+        raise ZoneMoveError(
+            f"Zone '{zone.name}' is already in group '{target_group.name}'.",
+            status_code=422,
+        )
+    return await assemble_move_plan(db, zone, target_group)
+
+
+async def commit_move(
+    db: AsyncSession,
+    zone: DNSZone,
+    target_group: DNSServerGroup,
+    *,
+    confirmation_zone_name: str,
+    acknowledgements: set[str],
+) -> ZoneMovePlan:
+    """Apply the move. The caller commits.
+
+    Re-assembles the plan inside an advisory xact-lock so a view or key
+    created between preview and commit is reflected, and re-checks every
+    refusal against that fresh reading rather than the operator's stale
+    one.
+    """
+    if zone.group_id == target_group.id:
+        raise ZoneMoveError(
+            f"Zone '{zone.name}' is already in group '{target_group.name}'.",
+            status_code=422,
+        )
+    if confirmation_zone_name.strip().rstrip(".") != zone.name.rstrip("."):
+        raise ZoneMoveError(
+            f"Confirmation '{confirmation_zone_name}' does not match the zone name "
+            f"'{zone.name}'.",
+            status_code=422,
+        )
+    if not await _try_advisory_lock(db, zone.id):
+        raise ZoneMoveError(
+            "Another move is in progress for this zone. Try again shortly.",
+            status_code=423,
+        )
+
+    plan = await assemble_move_plan(db, zone, target_group)
+
+    if plan.name_collision:
+        where = f"view '{plan.zone_view_from}'" if plan.zone_view_to_id is not None else "no view"
+        raise ZoneMoveError(
+            f"Group '{target_group.name}' already has a zone named '{zone.name}' in {where}. "
+            f"Delete or rename it first.",
+            status_code=409,
+        )
+
+    missing = [a for a in plan.required_acknowledgements if a not in acknowledgements]
+    if missing:
+        raise ZoneMoveError(
+            "This move needs explicit acknowledgement of: "
+            + ", ".join(sorted(missing))
+            + ". Re-run the preview to see why, then resend with those acknowledgements.",
+            status_code=422,
+        )
+
+    old_group_id = zone.group_id
+    source_views = {
+        v.id: v.name
+        for v in (await db.execute(select(DNSView).where(DNSView.group_id == old_group_id)))
+        .scalars()
+        .all()
+    }
+    target_views = {
+        v.name: v.id
+        for v in (await db.execute(select(DNSView).where(DNSView.group_id == target_group.id)))
+        .scalars()
+        .all()
+    }
+
+    def _new_view_id(view_id: uuid.UUID | None) -> uuid.UUID | None:
+        if view_id is None:
+            return None
+        name = source_views.get(view_id)
+        return target_views.get(name) if name else None
+
+    # ── Views ─────────────────────────────────────────────────────────
+    zone.view_id = _new_view_id(zone.view_id)
+    records = (
+        (
+            await db.execute(
+                select(DNSRecord).where(DNSRecord.zone_id == zone.id, DNSRecord.view_id.isnot(None))
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for r in records:
+        r.view_id = _new_view_id(r.view_id)
+
+    # ── Dynamic-update grants ─────────────────────────────────────────
+    # Remap by key name where possible; delete what cannot be expressed.
+    # The CHECK constraint forbids a row with neither identity column, so
+    # "clear the key" is not an option — and deleting a grant fails
+    # CLOSED, which is the safe direction for an authorisation rule.
+    acl_rows = (
+        (
+            await db.execute(
+                select(DNSZoneUpdateAcl).where(
+                    DNSZoneUpdateAcl.zone_id == zone.id,
+                    DNSZoneUpdateAcl.tsig_key_id.isnot(None),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if acl_rows:
+        source_keys = {
+            k.id: k.name
+            for k in (
+                await db.execute(select(DNSTSIGKey).where(DNSTSIGKey.group_id == old_group_id))
+            )
+            .scalars()
+            .all()
+        }
+        target_keys = {
+            k.name: k.id
+            for k in (
+                await db.execute(select(DNSTSIGKey).where(DNSTSIGKey.group_id == target_group.id))
+            )
+            .scalars()
+            .all()
+        }
+        for row in acl_rows:
+            name = source_keys.get(row.tsig_key_id) if row.tsig_key_id else None
+            replacement = target_keys.get(name) if name else None
+            if replacement is not None:
+                row.tsig_key_id = replacement
+            else:
+                await db.delete(row)
+
+    # ── Pools follow the zone ─────────────────────────────────────────
+    if plan.pools_repointed:
+        await db.execute(
+            sa_update(DNSPool).where(DNSPool.zone_id == zone.id).values(group_id=target_group.id)
+        )
+
+    # ── Purge state belonging to the old group ────────────────────────
+    await db.execute(sa_delete(DNSServerZoneState).where(DNSServerZoneState.zone_id == zone.id))
+    old_server_ids = (
+        (await db.execute(select(DNSServer.id).where(DNSServer.group_id == old_group_id)))
+        .scalars()
+        .all()
+    )
+    if old_server_ids:
+        await db.execute(
+            sa_delete(DNSRecordOp).where(
+                DNSRecordOp.server_id.in_(old_server_ids),
+                DNSRecordOp.zone_name == zone.name,
+                DNSRecordOp.state.in_(("pending", "in_flight")),
+            )
+        )
+    # DNSSEC key state is a read-only mirror of what the OLD group's
+    # agents reported. The target signs from scratch, so leaving these
+    # would show the operator keys that no server holds.
+    await db.execute(sa_delete(DNSKey).where(DNSKey.zone_id == zone.id))
+
+    zone.group_id = target_group.id
+
+    # A group created in the UI may never have been through agent
+    # registration, where the legacy group TSIG key is generated. Same
+    # reasoning as the #934 server move.
+    plan.target_tsig_key_generated = ensure_group_tsig_key(target_group)
+
+    collect_wake(dns_group_channel(old_group_id), dns_group_channel(target_group.id))
+
+    logger.info(
+        "dns_zone_moved_group",
+        zone_id=str(zone.id),
+        zone_name=zone.name,
+        old_group_id=str(old_group_id),
+        new_group_id=str(target_group.id),
+        records_widened=plan.records_widened,
+        acl_keys_lost=len(plan.acl_keys_lost),
+        dnssec_signed=plan.dnssec_signed,
+    )
+    return plan

--- a/backend/tests/test_dns_zone_group_move.py
+++ b/backend/tests/test_dns_zone_group_move.py
@@ -15,6 +15,7 @@ pin that it cannot happen without the operator saying so.
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
@@ -74,12 +75,13 @@ async def _zone(
     name: str = "example.com.",
     *,
     view: DNSView | None = None,
+    zone_type: str = "primary",
     **kw: object,
 ) -> DNSZone:
     z = DNSZone(
         group_id=group.id,
         name=name,
-        zone_type="primary",
+        zone_type=zone_type,
         view_id=view.id if view else None,
         **kw,
     )
@@ -779,3 +781,254 @@ async def test_zone_addressed_under_the_wrong_group_404s(
         headers=_auth(token),
     )
     assert resp.status_code == 404
+
+
+# ── Code-review follow-ups ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_integration_owned_zone_cannot_be_moved(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A reconciler-owned zone is not the operator's to re-home — the next
+    sync recreates it in the group the integration is bound to. Refused on
+    the PREVIEW too, so it is learned before the modal is filled in."""
+    from app.models.ipam import IPSpace
+    from app.models.tailscale import TailscaleTenant
+
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    space = IPSpace(name="ts-space")
+    db_session.add(space)
+    await db_session.flush()
+    tenant = TailscaleTenant(name="tailnet", ipam_space_id=space.id)
+    db_session.add(tenant)
+    await db_session.flush()
+    zone = await _zone(db_session, src, "ts.net.", tailscale_tenant_id=tenant.id)
+
+    prev = await _preview(client, token, zone, dst)
+    assert prev.status_code == 422
+    assert "Tailscale" in prev.json()["detail"]
+
+    resp = await _commit(client, token, zone, dst, name="ts.net.")
+    assert resp.status_code == 422
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+@pytest.mark.asyncio
+async def test_signed_zone_refused_on_a_group_that_cannot_sign(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Not waivable by acknowledgement: the row would keep saying
+    ``dnssec_enabled`` while the zone is served unsigned, indefinitely,
+    with nothing to notice it. Every other path into a signed zone goes
+    through the same driver gate."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    await _server(db_session, src, "ns1")
+    win = DNSServer(
+        group_id=dst.id,
+        name="win1",
+        driver="windows_dns",
+        host="win1",
+        port=53,
+        roles=["authoritative"],
+        status="active",
+    )
+    db_session.add(win)
+    await db_session.flush()
+    zone = await _zone(db_session, src, dnssec_enabled=True)
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["dnssec_unsupported_drivers"] == ["windows_dns"]
+
+    # Even WITH the rollover acknowledgement — this one is a hard refusal.
+    resp = await _commit(client, token, zone, dst, acks=["dnssec_rollover"])
+    assert resp.status_code == 422
+    assert "cannot sign" in resp.json()["detail"]
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+@pytest.mark.asyncio
+async def test_signed_zone_moves_to_a_signing_capable_group(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The gate must not block the legitimate case."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    await _server(db_session, src, "ns1")
+    await _server(db_session, dst, "ns2")
+    zone = await _zone(db_session, src, dnssec_enabled=True)
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["dnssec_unsupported_drivers"] == []
+    assert (await _commit(client, token, zone, dst, acks=["dnssec_rollover"])).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_move_clears_the_cached_ds_records(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Deleting the DNSKey rows alone left ``dnssec_ds_records`` at the old
+    group's values — so the UI would tell the operator to publish a DS for
+    keys that no server in the new group holds."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(
+        db_session,
+        src,
+        dnssec_enabled=True,
+        dnssec_ds_records=[{"key_tag": 12345, "digest": "abc"}],
+    )
+
+    assert (await _commit(client, token, zone, dst, acks=["dnssec_rollover"])).status_code == 200
+    await db_session.refresh(zone)
+    assert zone.dnssec_ds_records is None
+
+
+@pytest.mark.asyncio
+async def test_forward_zone_without_forwarders_refused_on_technitium(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The #743 guard every create/update runs, applied to the group the
+    zone lands in. Technitium has no global-forwarder fallback, so the zone
+    would be accepted and then silently never created on the daemon."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    tech = DNSServer(
+        group_id=dst.id,
+        name="tech1",
+        driver="technitium",
+        host="tech1",
+        port=53,
+        roles=["authoritative"],
+        status="active",
+    )
+    db_session.add(tech)
+    await db_session.flush()
+    zone = await _zone(db_session, src, "fwd.example.", zone_type="forward", forwarders=[])
+
+    resp = await _commit(client, token, zone, dst, name="fwd.example.")
+    assert resp.status_code == 422
+    assert "forwarder" in resp.json()["detail"]
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+@pytest.mark.asyncio
+async def test_named_acl_reference_the_target_lacks_is_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``DNSAcl`` is per-group (#899). A name the target does not define is
+    an undefined symbol in its named.conf — and BIND rejects the file
+    WHOLE, so the entire target group stops converging, not just this
+    zone. Refused rather than warned for that reason."""
+    from app.models.dns import DNSAcl
+
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    db_session.add(DNSAcl(group_id=src.id, name="trusted"))
+    await db_session.flush()
+    zone = await _zone(db_session, src, allow_transfer=["trusted"])
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["acl_names_lost"] == ["trusted"]
+
+    resp = await _commit(client, token, zone, dst)
+    assert resp.status_code == 422
+    assert "trusted" in resp.json()["detail"]
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+@pytest.mark.asyncio
+async def test_named_acl_present_in_the_target_is_fine(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Same name in both groups is the operator saying they mean the same
+    thing — the view / TSIG rule applied to ACLs."""
+    from app.models.dns import DNSAcl
+
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    db_session.add(DNSAcl(group_id=src.id, name="trusted"))
+    db_session.add(DNSAcl(group_id=dst.id, name="trusted"))
+    await db_session.flush()
+    zone = await _zone(db_session, src, allow_transfer=["trusted"])
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["acl_names_remapped"] == ["trusted"]
+    assert body["acl_names_lost"] == []
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_builtin_match_list_values_are_not_acl_references(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``any`` / ``none`` / a CIDR / an address are not names, so they must
+    not be reported as ACLs the target is missing — that would refuse
+    almost every zone."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(
+        db_session,
+        src,
+        allow_query=["any"],
+        allow_transfer=["none", "10.0.0.0/8", "192.168.1.1"],
+    )
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["acl_names_lost"] == []
+    assert body["acl_names_remapped"] == []
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_records_have_their_view_remapped_too(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """DNSRecord is soft-deleted, so the default query filter hides deleted
+    rows. Left behind, a restored record points at a view in a group the
+    zone has left — and under split-horizon that renders it into no
+    operator view at all."""
+    from sqlalchemy import update as sa_update
+
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_internal = await _view(db_session, src, "internal")
+    dst_internal = await _view(db_session, dst, "internal")
+    zone = await _zone(db_session, src)
+    gone = await _record(db_session, zone, "old", view=src_internal)
+    await db_session.execute(
+        sa_update(DNSRecord)
+        .where(DNSRecord.id == gone.id)
+        .values(deleted_at=datetime.now(UTC))
+        .execution_options(include_deleted=True)
+    )
+    await db_session.flush()
+
+    # It is not part of "records moving" — that count is live rows.
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["records_total"] == 0
+    assert body["records_remapped"] == 1
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+    row = (
+        await db_session.execute(
+            select(DNSRecord).where(DNSRecord.id == gone.id).execution_options(include_deleted=True)
+        )
+    ).scalar_one()
+    assert row.view_id == dst_internal.id, "a soft-deleted row must not keep a stale view"

--- a/backend/tests/test_dns_zone_group_move.py
+++ b/backend/tests/test_dns_zone_group_move.py
@@ -1,0 +1,781 @@
+"""Moving a DNS zone between server groups (issue #935).
+
+The sibling of the #934 server move and a much sharper tool. A server
+carries state ABOUT a group; a zone carries references INTO one, and the
+sharpest of those is the view.
+
+**Clearing a view widens exposure.** Under split-horizon a record with
+``view_id IS NOT NULL`` renders in exactly that view; one with
+``view_id IS NULL`` is shared and renders in EVERY view. So dropping a
+reference the target cannot resolve does not remove the zone from a view —
+it adds it to all of them. Most of this file exists to pin that, and to
+pin that it cannot happen without the operator saying so.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import create_access_token, hash_password
+from app.models.auth import User
+from app.models.dns import (
+    DNSKey,
+    DNSPool,
+    DNSRecord,
+    DNSServer,
+    DNSServerGroup,
+    DNSServerZoneState,
+    DNSTSIGKey,
+    DNSView,
+    DNSZone,
+    DNSZoneUpdateAcl,
+)
+
+
+async def _superadmin(db: AsyncSession, username: str = "root935") -> str:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        display_name=username,
+        hashed_password=hash_password("password123"),
+        is_superadmin=True,
+    )
+    db.add(user)
+    await db.flush()
+    return create_access_token(str(user.id))
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def _group(db: AsyncSession, name: str) -> DNSServerGroup:
+    g = DNSServerGroup(name=name, description="")
+    db.add(g)
+    await db.flush()
+    return g
+
+
+async def _view(db: AsyncSession, group: DNSServerGroup, name: str) -> DNSView:
+    v = DNSView(group_id=group.id, name=name, match_clients=["any"])
+    db.add(v)
+    await db.flush()
+    return v
+
+
+async def _zone(
+    db: AsyncSession,
+    group: DNSServerGroup,
+    name: str = "example.com.",
+    *,
+    view: DNSView | None = None,
+    **kw: object,
+) -> DNSZone:
+    z = DNSZone(
+        group_id=group.id,
+        name=name,
+        zone_type="primary",
+        view_id=view.id if view else None,
+        **kw,
+    )
+    db.add(z)
+    await db.flush()
+    return z
+
+
+async def _record(
+    db: AsyncSession, zone: DNSZone, name: str, *, view: DNSView | None = None
+) -> DNSRecord:
+    r = DNSRecord(
+        zone_id=zone.id,
+        name=name,
+        record_type="A",
+        value="10.0.0.1",
+        ttl=300,
+        view_id=view.id if view else None,
+    )
+    db.add(r)
+    await db.flush()
+    return r
+
+
+async def _server(db: AsyncSession, group: DNSServerGroup, name: str) -> DNSServer:
+    s = DNSServer(
+        group_id=group.id,
+        name=name,
+        driver="bind9",
+        host=name,
+        port=53,
+        roles=["authoritative"],
+        status="active",
+        is_primary=True,
+    )
+    db.add(s)
+    await db.flush()
+    return s
+
+
+def _preview_url(z: DNSZone) -> str:
+    return f"/api/v1/dns/groups/{z.group_id}/zones/{z.id}/move/preview"
+
+
+def _commit_url(z: DNSZone) -> str:
+    return f"/api/v1/dns/groups/{z.group_id}/zones/{z.id}/move/commit"
+
+
+async def _preview(client: AsyncClient, token: str, zone: DNSZone, target: DNSServerGroup):
+    return await client.post(
+        _preview_url(zone),
+        json={"target_group_id": str(target.id)},
+        headers=_auth(token),
+    )
+
+
+async def _commit(
+    client: AsyncClient,
+    token: str,
+    zone: DNSZone,
+    target: DNSServerGroup,
+    *,
+    acks: list[str] | None = None,
+    name: str | None = None,
+):
+    return await client.post(
+        _commit_url(zone),
+        json={
+            "target_group_id": str(target.id),
+            "confirmation_zone_name": name if name is not None else zone.name,
+            "acknowledgements": acks or [],
+        },
+        headers=_auth(token),
+    )
+
+
+# ── The plain case ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_move_a_plain_zone(client: AsyncClient, db_session: AsyncSession) -> None:
+    """No views, no DNSSEC, no grants — the discussion's actual ask."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+    await _record(db_session, zone, "www")
+
+    prev = await _preview(client, token, zone, dst)
+    assert prev.status_code == 200, prev.text
+    assert prev.json()["required_acknowledgements"] == []
+    assert prev.json()["records_total"] == 1
+
+    resp = await _commit(client, token, zone, dst)
+    assert resp.status_code == 200, resp.text
+
+    await db_session.refresh(zone)
+    assert zone.group_id == dst.id
+
+
+@pytest.mark.asyncio
+async def test_preview_writes_nothing(client: AsyncClient, db_session: AsyncSession) -> None:
+    """It is called repeatedly while the operator reads the warnings."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+
+    for _ in range(3):
+        assert (await _preview(client, token, zone, dst)).status_code == 200
+
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+@pytest.mark.asyncio
+async def test_commit_requires_the_zone_name(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+
+    bad = await _commit(client, token, zone, dst, name="wrong.example.")
+    assert bad.status_code == 422
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+    # A trailing dot is a formatting detail, not a different zone.
+    ok = await _commit(client, token, zone, dst, name="example.com")
+    assert ok.status_code == 200, ok.text
+
+
+@pytest.mark.asyncio
+async def test_move_to_the_same_group_is_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Unlike the server move's silent no-op: this endpoint exists to be
+    given a DIFFERENT group, so the same one is a mistake worth naming."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    zone = await _zone(db_session, src)
+
+    assert (await _preview(client, token, zone, src)).status_code == 422
+    assert (await _commit(client, token, zone, src)).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_move_requires_superadmin(client: AsyncClient, db_session: AsyncSession) -> None:
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+    user = User(
+        username="plain935",
+        email="plain935@example.com",
+        display_name="plain",
+        hashed_password=hash_password("password123"),
+        is_superadmin=False,
+    )
+    db_session.add(user)
+    await db_session.flush()
+    token = create_access_token(str(user.id))
+
+    assert (await _preview(client, token, zone, dst)).status_code == 403
+    assert (await _commit(client, token, zone, dst)).status_code == 403
+
+
+# ── Views: the widening property ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_view_remaps_by_name(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Name is the only identity a view has across groups — two views
+    called ``internal`` are the operator saying they mean the same thing."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_internal = await _view(db_session, src, "internal")
+    dst_internal = await _view(db_session, dst, "internal")
+    zone = await _zone(db_session, src, view=src_internal)
+    rec = await _record(db_session, zone, "www", view=src_internal)
+
+    prev = await _preview(client, token, zone, dst)
+    body = prev.json()
+    assert body["zone_view_action"] == "remapped"
+    assert body["records_remapped"] == 1
+    assert body["records_widened"] == 0
+    # A remap preserves intent, so it needs no acknowledgement.
+    assert body["required_acknowledgements"] == []
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+    await db_session.refresh(zone)
+    await db_session.refresh(rec)
+    assert zone.view_id == dst_internal.id
+    assert rec.view_id == dst_internal.id
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_view_is_reported_as_widening(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """THE property. The target renders views but has no ``internal``, so
+    clearing the pin does not remove the zone from a view — it puts the
+    zone into every view the target has."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_internal = await _view(db_session, src, "internal")
+    await _view(db_session, dst, "external")  # target renders views, but not "internal"
+    zone = await _zone(db_session, src, view=src_internal)
+    await _record(db_session, zone, "secret", view=src_internal)
+
+    prev = await _preview(client, token, zone, dst)
+    body = prev.json()
+    assert body["zone_view_action"] == "cleared_widening"
+    assert body["records_widened"] == 1
+    assert body["records_widened_by_view"] == {"internal": 1}
+    assert "view_widening" in body["required_acknowledgements"]
+    assert any("EVERY view" in w for w in body["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_widening_move_is_refused_without_acknowledgement(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """It is a data-exposure change with no operator-visible symptom, so
+    it does not happen by default."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_internal = await _view(db_session, src, "internal")
+    await _view(db_session, dst, "external")
+    zone = await _zone(db_session, src, view=src_internal)
+
+    refused = await _commit(client, token, zone, dst)
+    assert refused.status_code == 422
+    assert "view_widening" in refused.json()["detail"]
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id, "refused move must not have applied"
+
+    allowed = await _commit(client, token, zone, dst, acks=["view_widening"])
+    assert allowed.status_code == 200, allowed.text
+    await db_session.refresh(zone)
+    assert zone.group_id == dst.id
+    assert zone.view_id is None
+
+
+@pytest.mark.asyncio
+async def test_clearing_a_view_into_a_viewless_group_is_inert(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Same row change, different consequence: with no views in the target
+    the reference was going to be ignored anyway, so it is reported but
+    needs no acknowledgement."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")  # no views at all
+    src_internal = await _view(db_session, src, "internal")
+    zone = await _zone(db_session, src, view=src_internal)
+    await _record(db_session, zone, "www", view=src_internal)
+
+    prev = await _preview(client, token, zone, dst)
+    body = prev.json()
+    assert body["zone_view_action"] == "cleared_inert"
+    assert body["records_cleared_inert"] == 1
+    assert body["records_widened"] == 0
+    assert body["required_acknowledgements"] == []
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_unscoped_records_are_left_alone(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A record with no view is already shared. Nothing to remap, and it
+    must not be counted as widened — it was never narrow."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    await _view(db_session, dst, "external")
+    zone = await _zone(db_session, src)
+    await _record(db_session, zone, "www")
+    await _record(db_session, zone, "mail")
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["records_total"] == 2
+    assert body["records_widened"] == 0
+    assert body["records_remapped"] == 0
+    assert body["required_acknowledgements"] == []
+
+
+# ── Name collision, against the RESOLVED view ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_collision_refused(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+    await _zone(db_session, dst)  # same name, same (NULL) view
+
+    assert (await _preview(client, token, zone, dst)).json()["name_collision"] is True
+    resp = await _commit(client, token, zone, dst)
+    assert resp.status_code == 409
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+@pytest.mark.asyncio
+async def test_same_name_in_a_different_view_is_not_a_collision(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The constraint is ``(group_id, view_id, name)``. A naive
+    ``(group, name)`` check would refuse this legitimate split-horizon
+    move — the whole point of views is the same zone name twice."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    await _view(db_session, src, "internal")
+    dst_internal = await _view(db_session, dst, "internal")
+    dst_external = await _view(db_session, dst, "external")
+    # The incoming zone resolves into dst/internal; the sitting one is in
+    # dst/external. Different rows under the constraint.
+    await _zone(db_session, dst, view=dst_external)
+    src_internal = (
+        await db_session.execute(
+            select(DNSView).where(DNSView.group_id == src.id, DNSView.name == "internal")
+        )
+    ).scalar_one()
+    zone = await _zone(db_session, src, view=src_internal)
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["zone_view_action"] == "remapped"
+    assert body["name_collision"] is False
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200, "legitimate move"
+    await db_session.refresh(zone)
+    assert zone.view_id == dst_internal.id
+
+
+@pytest.mark.asyncio
+async def test_collision_is_checked_against_the_cleared_view(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The subtle one. The zone's view does not exist in the target, so it
+    lands at ``(target, NULL, name)`` — which collides with an unviewed
+    zone that a check against the ORIGINAL view id would have missed."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_internal = await _view(db_session, src, "internal")
+    await _view(db_session, dst, "external")
+    await _zone(db_session, dst)  # unviewed, same name
+    zone = await _zone(db_session, src, view=src_internal)
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["zone_view_action"] == "cleared_widening"
+    assert body["name_collision"] is True
+
+    resp = await _commit(client, token, zone, dst, acks=["view_widening"])
+    assert resp.status_code == 409
+    await db_session.refresh(zone)
+    assert zone.group_id == src.id
+
+
+# ── DNSSEC ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_signed_zone_requires_rollover_acknowledgement(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The private keys live on the old group's servers and do not travel.
+    Moving a delegated signed zone takes it off the internet until the DS
+    is republished, so it cannot happen silently."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src, dnssec_enabled=True)
+    db_session.add(DNSKey(zone_id=zone.id, key_tag=12345, key_type="ksk", algorithm=13))
+    await db_session.flush()
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["dnssec_signed"] is True
+    assert body["dnssec_key_count"] == 1
+    assert "dnssec_rollover" in body["required_acknowledgements"]
+    assert any("DS record" in w for w in body["warnings"])
+
+    assert (await _commit(client, token, zone, dst)).status_code == 422
+
+    ok = await _commit(client, token, zone, dst, acks=["dnssec_rollover"])
+    assert ok.status_code == 200, ok.text
+
+    # The key mirror describes keys no server in the new group holds.
+    remaining = (
+        (await db_session.execute(select(DNSKey).where(DNSKey.zone_id == zone.id))).scalars().all()
+    )
+    assert remaining == []
+
+
+# ── Dynamic-update grants ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_grant_remaps_by_key_name(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_key = DNSTSIGKey(
+        group_id=src.id, name="dhcp-ddns", algorithm="hmac-sha256", secret_encrypted=b"x"
+    )
+    dst_key = DNSTSIGKey(
+        group_id=dst.id, name="dhcp-ddns", algorithm="hmac-sha256", secret_encrypted=b"y"
+    )
+    db_session.add_all([src_key, dst_key])
+    await db_session.flush()
+    zone = await _zone(db_session, src)
+    acl = DNSZoneUpdateAcl(
+        zone_id=zone.id, seq=0, action="grant", match_kind="tsig_key", tsig_key_id=src_key.id
+    )
+    db_session.add(acl)
+    await db_session.flush()
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["acl_rows_remapped"] == 1
+    assert body["acl_keys_lost"] == []
+    assert body["required_acknowledgements"] == []
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+    await db_session.refresh(acl)
+    assert acl.tsig_key_id == dst_key.id
+
+
+@pytest.mark.asyncio
+async def test_unmappable_update_grant_is_deleted_with_acknowledgement(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``num_nonnulls(tsig_key_id, ip_cidr) = 1`` forbids clearing the key,
+    so the row has to go. Deleting an authorisation rule fails CLOSED,
+    which is the safe direction — but losing a grant silently is not, so
+    it takes an acknowledgement."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    src_key = DNSTSIGKey(
+        group_id=src.id, name="dhcp-ddns", algorithm="hmac-sha256", secret_encrypted=b"x"
+    )
+    db_session.add(src_key)
+    await db_session.flush()
+    zone = await _zone(db_session, src)
+    db_session.add(
+        DNSZoneUpdateAcl(
+            zone_id=zone.id, seq=0, action="grant", match_kind="tsig_key", tsig_key_id=src_key.id
+        )
+    )
+    await db_session.flush()
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["acl_keys_lost"] == ["dhcp-ddns"]
+    assert "lost_update_grants" in body["required_acknowledgements"]
+
+    assert (await _commit(client, token, zone, dst)).status_code == 422
+
+    ok = await _commit(client, token, zone, dst, acks=["lost_update_grants"])
+    assert ok.status_code == 200, ok.text
+    rows = (
+        (
+            await db_session.execute(
+                select(DNSZoneUpdateAcl).where(DNSZoneUpdateAcl.zone_id == zone.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_ip_based_grants_are_untouched(client: AsyncClient, db_session: AsyncSession) -> None:
+    """An IP grant references nothing group-scoped, so it survives."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+    acl = DNSZoneUpdateAcl(
+        zone_id=zone.id, seq=0, action="grant", match_kind="ip", ip_cidr="10.0.0.0/24"
+    )
+    db_session.add(acl)
+    await db_session.flush()
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["acl_keys_lost"] == []
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+    await db_session.refresh(acl)
+    assert acl.ip_cidr == "10.0.0.0/24"
+
+
+# ── Everything else that points at the zone ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_pools_follow_the_zone(client: AsyncClient, db_session: AsyncSession) -> None:
+    """A pool is attached by ``zone_id`` and its health checks run from the
+    control plane, not the group's agents — so it follows rather than
+    being detached, which is the point of a move over export/import."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+    pool = DNSPool(group_id=src.id, zone_id=zone.id, name="web", record_name="www")
+    db_session.add(pool)
+    await db_session.flush()
+
+    assert (await _preview(client, token, zone, dst)).json()["pools_repointed"] == 1
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+    await db_session.refresh(pool)
+    assert pool.group_id == dst.id
+
+
+@pytest.mark.asyncio
+async def test_zone_state_and_queued_ops_are_purged(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Both describe the OLD group's servers."""
+    from app.models.dns import DNSRecordOp
+
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    srv = await _server(db_session, src, "ns1")
+    await _server(db_session, dst, "ns2")
+    zone = await _zone(db_session, src)
+    db_session.add(DNSServerZoneState(server_id=srv.id, zone_id=zone.id, current_serial=7))
+    for state in ("pending", "in_flight"):
+        db_session.add(
+            DNSRecordOp(
+                server_id=srv.id,
+                zone_name=zone.name,
+                op="create",
+                record={"name": "www", "type": "A", "value": "10.0.0.1"},
+                state=state,
+            )
+        )
+    # History, not queued work.
+    db_session.add(
+        DNSRecordOp(
+            server_id=srv.id,
+            zone_name=zone.name,
+            op="create",
+            record={"name": "old", "type": "A", "value": "10.0.0.2"},
+            state="applied",
+        )
+    )
+    await db_session.flush()
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["zone_state_rows"] == 1
+    assert body["pending_ops"] == 2
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+    states = (
+        (
+            await db_session.execute(
+                select(DNSServerZoneState).where(DNSServerZoneState.zone_id == zone.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert states == []
+    ops = (
+        (await db_session.execute(select(DNSRecordOp).where(DNSRecordOp.server_id == srv.id)))
+        .scalars()
+        .all()
+    )
+    assert [o.state for o in ops] == ["applied"]
+
+
+@pytest.mark.asyncio
+async def test_records_move_with_the_zone(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Records hang off ``zone_id``, so they need no rewrite — but the
+    move is worthless if they don't actually come along."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+    for n in ("www", "mail", "ftp"):
+        await _record(db_session, zone, n)
+
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+    await db_session.refresh(zone)
+    recs = (
+        (await db_session.execute(select(DNSRecord).where(DNSRecord.zone_id == zone.id)))
+        .scalars()
+        .all()
+    )
+    assert len(recs) == 3
+    assert zone.group_id == dst.id
+
+
+@pytest.mark.asyncio
+async def test_target_group_gets_a_tsig_key(client: AsyncClient, db_session: AsyncSession) -> None:
+    """Same reasoning as the #934 server move: a group created in the UI
+    has never been through agent registration."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    assert dst.tsig_key_secret is None
+    zone = await _zone(db_session, src)
+
+    resp = await _commit(client, token, zone, dst)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["target_tsig_key_generated"] is True
+
+    await db_session.refresh(dst)
+    assert dst.tsig_key_secret
+
+
+@pytest.mark.asyncio
+async def test_driver_change_and_empty_target_are_warned_not_refused(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Unlike the #934 server move, a zone is not itself driver-bound —
+    it is data. Moving it to a group of another driver is a legitimate
+    migration, so it warns rather than refuses."""
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    await _server(db_session, src, "ns1")
+    pdns = DNSServer(
+        group_id=dst.id,
+        name="pdns1",
+        driver="powerdns",
+        host="pdns1",
+        port=53,
+        roles=["authoritative"],
+        status="active",
+    )
+    db_session.add(pdns)
+    await db_session.flush()
+    zone = await _zone(db_session, src)
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert body["source_drivers"] == ["bind9"]
+    assert body["target_drivers"] == ["powerdns"]
+    assert any("Driver change" in w for w in body["warnings"])
+    assert body["required_acknowledgements"] == []
+    assert (await _commit(client, token, zone, dst)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_empty_target_group_is_warned(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    await _server(db_session, src, "ns1")
+    zone = await _zone(db_session, src)
+
+    body = (await _preview(client, token, zone, dst)).json()
+    assert any("no servers" in w for w in body["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_unknown_target_group_404s(client: AsyncClient, db_session: AsyncSession) -> None:
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    zone = await _zone(db_session, src)
+
+    resp = await client.post(
+        _preview_url(zone),
+        json={"target_group_id": str(uuid.uuid4())},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_zone_addressed_under_the_wrong_group_404s(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token = await _superadmin(db_session)
+    src = await _group(db_session, "src")
+    dst = await _group(db_session, "dst")
+    zone = await _zone(db_session, src)
+
+    resp = await client.post(
+        f"/api/v1/dns/groups/{dst.id}/zones/{zone.id}/move/preview",
+        json={"target_group_id": str(dst.id)},
+        headers=_auth(token),
+    )
+    assert resp.status_code == 404

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -181,6 +181,70 @@ simply unreachable. The pointer is only moved when it currently names the
 group being left; an appliance deliberately assigned elsewhere is not
 redirected on the strength of one server row moving.
 
+### Moving a zone between groups (#935)
+
+Zones are group-bound too, but a zone is a much sharper thing to move than a
+server: it holds references **into** its group, and the sharpest of those is
+the view. Preview → commit rather than a single call, at
+`POST /api/v1/dns/groups/{gid}/zones/{zid}/move/{preview,commit}` or the
+**Move** button on the zone detail. The preview writes nothing and is safe to
+re-run; the commit re-derives the same plan inside an advisory lock, so a view
+or key created in between changes the answer rather than being applied against
+a stale reading.
+
+**Clearing a view widens exposure — this is the property to understand.**
+Under split-horizon a record with a view set renders in exactly that view; one
+with no view is *shared* and renders in **every** view. So when the target
+group has no view of the same name, dropping the reference does not remove the
+zone from a view, it adds it to all of them. A zone that answered only on
+`internal` starts answering on `external`, with no operator-visible symptom.
+Views are therefore remapped **by name** wherever the target has a match
+(a view called `internal` in each group is the operator's own statement that
+the two mean the same thing), and where it does not, the move refuses until
+the operator acknowledges the widening explicitly.
+
+Three acknowledgements exist, each its own checkbox rather than one blanket
+"I understand", so the DNSSEC warning cannot be accepted by someone who only
+read the view one:
+
+| Key | When | Why it is not just a warning |
+|---|---|---|
+| `view_widening` | a view reference cannot be resolved in the target, which renders views | the zone or record goes from answering in one view to answering in all of them |
+| `dnssec_rollover` | the zone is signed | the private keys live on the **current** group's servers and do not move; the target signs from scratch, so the DS at the registrar is wrong until republished and validation fails in the interval |
+| `lost_update_grants` | a dynamic-update grant names a TSIG key absent from the target | the row cannot be kept (`num_nonnulls(tsig_key_id, ip_cidr) = 1` forbids clearing the key) so it is deleted, and the clients using it lose the ability to update the zone |
+
+The commit also requires the zone name typed back, the way the IPAM block move
+requires a typed CIDR.
+
+What the move does besides reassigning the row:
+
+* **Views and TSIG keys remap by name**, per the above. Dynamic-update grants
+  matched to a same-named key in the target keep working with no operator
+  action.
+* **Pools follow the zone.** They are attached by `zone_id` and their health
+  checks run from the control plane rather than the group's agents, so nothing
+  about them is bound to the old group.
+* **Per-server zone state and queued record updates are purged** — both
+  describe the old group's servers.
+* **DNSSEC key state is deleted.** It is a read-only mirror of what the old
+  group's agents reported; leaving it would show the operator keys that no
+  server holds.
+* **Both group channels are woken** so each side converges immediately.
+
+Two refusals: a **name collision** in the target (409) and a move to the group
+the zone is already in (422). The collision check runs against the *resolved*
+view, not the original one — the constraint is `(group_id, view_id, name)`, so
+a zone whose view is cleared lands at `(target, NULL, name)` and can collide
+with an unviewed zone that a `(group, name)` check would have missed.
+
+A **driver change warns rather than refuses**, unlike the server move: a zone
+is data, not a driver-bound thing, so moving one from a BIND9 group to a
+PowerDNS group is a legitimate migration — but driver-specific features
+(ALIAS, DNSSEC signing, per-driver record types) may not survive, so it says
+so. An **ACME DNS-01 delegation** on the zone is also flagged: its TXT records
+will be written by the target's servers while the NS delegation at the
+registrar still points at the old group's, so issuance fails until repointed.
+
 ### Designating the group primary (#934)
 
 `is_primary` marks the one server per group that DDNS and record writes are

--- a/docs/features/DNS.md
+++ b/docs/features/DNS.md
@@ -231,11 +231,39 @@ What the move does besides reassigning the row:
   server holds.
 * **Both group channels are woken** so each side converges immediately.
 
-Two refusals: a **name collision** in the target (409) and a move to the group
-the zone is already in (422). The collision check runs against the *resolved*
-view, not the original one — the constraint is `(group_id, view_id, name)`, so
-a zone whose view is cleared lands at `(target, NULL, name)` and can collide
-with an unviewed zone that a `(group, name)` check would have missed.
+Refusals, none of them waivable by acknowledgement — each would leave a state
+the operator could not inspect and fix afterwards:
+
+* a **name collision** in the target (409), checked against the *resolved*
+  view rather than the original: the constraint is `(group_id, view_id, name)`,
+  so a zone whose view is cleared lands at `(target, NULL, name)` and can
+  collide with an unviewed zone a `(group, name)` check would have missed —
+  while the same name in two different views is not a collision at all;
+* a move to the group the zone is already in (422);
+* a **signed zone onto a group that cannot sign** (422). The row would keep
+  reporting `dnssec_enabled` while the zone is served unsigned, indefinitely,
+  with nothing to notice — the same driver gate every other path into a signed
+  zone goes through;
+* a **named ACL** cited in the zone's `allow_query` / `allow_transfer` /
+  `also_notify` that the target group does not define (422). `DNSAcl` is
+  per-group, so the name becomes an undefined symbol — and BIND rejects the
+  file *whole*, which stops the entire target group converging rather than
+  just this zone;
+* a **forwarders-less forward zone onto a Technitium group** (422), the same
+  #743 guard every create and update runs.
+
+A zone owned by an integration reconciler (Tailscale, NetBird) cannot be moved
+at all — the next sync would recreate it in the group the integration is bound
+to. That one is refused on the *preview* as well, so it is learned before the
+modal is filled in.
+
+**Agentless groups are driven at both ends.** When either side runs
+`windows_dns`, a cloud driver or `technitium_api`, the zone lives in a system
+the ConfigBundle never reaches, so the move creates it on the target's servers
+and deletes it from the source's. Create runs first: if either call fails the
+whole move rolls back, and a failed create leaves nothing changed where a
+failed delete would have removed the zone from the old server while the
+database still said it lived there.
 
 A **driver change warns rather than refuses**, unlike the server move: a zone
 is data, not a driver-bound thing, so moving one from a BIND9 group to a

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4826,6 +4826,14 @@ export interface ZoneMovePreview {
   source_drivers: string[];
   target_drivers: string[];
   name_collision: boolean;
+  /** Target drivers that cannot sign, when the zone is signed. Non-empty
+   *  means the commit refuses — not waivable by acknowledgement. */
+  dnssec_unsupported_drivers: string[];
+  acl_names_remapped: string[];
+  /** Named ACLs the zone cites that the target group doesn't define.
+   *  Non-empty means the commit refuses: an undefined symbol makes BIND
+   *  reject the whole file, stopping the entire target group. */
+  acl_names_lost: string[];
   warnings: string[];
   /** Keys the commit will demand: view_widening | dnssec_rollover |
    *  lost_update_grants. */

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4793,6 +4793,46 @@ export const customFieldsApi = {
 
 // ── DNS ────────────────────────────────────────────────────────────────────
 
+/** #935 — what moving a zone to another group would do. Returned by both
+ *  the preview and the commit, so the UI can show the same figures after
+ *  the fact. */
+export interface ZoneMovePreview {
+  zone_id: string;
+  zone_name: string;
+  source_group_id: string;
+  source_group_name: string;
+  target_group_id: string;
+  target_group_name: string;
+  source_has_views: boolean;
+  target_has_views: boolean;
+  /** kept_none | remapped | cleared_widening | cleared_inert */
+  zone_view_action: string;
+  zone_view_from: string | null;
+  records_total: number;
+  records_remapped: number;
+  /** Records whose view scoping is lost while the TARGET renders views —
+   *  they go from answering in one view to answering in every one. */
+  records_widened: number;
+  records_cleared_inert: number;
+  records_widened_by_view: Record<string, number>;
+  acl_rows_remapped: number;
+  acl_keys_lost: string[];
+  pools_repointed: number;
+  zone_state_rows: number;
+  pending_ops: number;
+  dnssec_signed: boolean;
+  dnssec_key_count: number;
+  acme_accounts: number;
+  source_drivers: string[];
+  target_drivers: string[];
+  name_collision: boolean;
+  warnings: string[];
+  /** Keys the commit will demand: view_widening | dnssec_rollover |
+   *  lost_update_grants. */
+  required_acknowledgements: string[];
+  target_tsig_key_generated?: boolean;
+}
+
 export interface DNSServerGroup {
   id: string;
   name: string;
@@ -5712,6 +5752,32 @@ export const dnsApi = {
     api
       .put<DNSServer>(`/dns/groups/${groupId}/servers/${serverId}`, data)
       .then((r) => r.data),
+  // #935 — move a zone to another server group. Preview is a pure read
+  // and safe to call repeatedly; commit demands the typed zone name plus
+  // an acknowledgement for each consequence the preview flagged.
+  previewZoneMove: (groupId: string, zoneId: string, targetGroupId: string) =>
+    api
+      .post<ZoneMovePreview>(
+        `/dns/groups/${groupId}/zones/${zoneId}/move/preview`,
+        { target_group_id: targetGroupId },
+      )
+      .then((r) => r.data),
+  commitZoneMove: (
+    groupId: string,
+    zoneId: string,
+    body: {
+      target_group_id: string;
+      confirmation_zone_name: string;
+      acknowledgements: string[];
+    },
+  ) =>
+    api
+      .post<ZoneMovePreview>(
+        `/dns/groups/${groupId}/zones/${zoneId}/move/commit`,
+        body,
+      )
+      .then((r) => r.data),
+
   deleteServer: (groupId: string, serverId: string) =>
     api.delete(`/dns/groups/${groupId}/servers/${serverId}`),
   // Issue #182: per-server maintenance mode.

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -3128,10 +3128,15 @@ function MoveZoneModal({
   const allAcked = required.every((k) => acks[k]);
   const nameOk =
     confirmName.trim().replace(/\.$/, "") === zone.name.replace(/\.$/, "");
+  const blocked =
+    !!preview &&
+    (preview.name_collision ||
+      preview.dnssec_unsupported_drivers.length > 0 ||
+      preview.acl_names_lost.length > 0);
   const canSubmit =
     !!targetGroupId &&
     !!preview &&
-    !preview.name_collision &&
+    !blocked &&
     allAcked &&
     nameOk &&
     !mut.isPending;
@@ -3169,6 +3174,29 @@ function MoveZoneModal({
                 <strong>{preview.target_group_name}</strong> already has a zone
                 named <code>{preview.zone_name}</code> in the view this one
                 would land in. Rename or delete it first.
+              </div>
+            )}
+            {/* Two blockers no acknowledgement can waive — neither leaves a
+                state the operator could inspect and fix afterwards. */}
+            {preview.dnssec_unsupported_drivers.length > 0 && (
+              <div className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-700 dark:text-rose-300">
+                This zone is DNSSEC-signed and{" "}
+                <strong>{preview.target_group_name}</strong> runs{" "}
+                <code>{preview.dnssec_unsupported_drivers.join(", ")}</code>,
+                which cannot sign. It would keep reporting as signed while being
+                served unsigned. Unsign it first, or pick a BIND9 / PowerDNS
+                group.
+              </div>
+            )}
+            {preview.acl_names_lost.length > 0 && (
+              <div className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-700 dark:text-rose-300">
+                This zone names ACL(s){" "}
+                <code>{preview.acl_names_lost.join(", ")}</code> that{" "}
+                <strong>{preview.target_group_name}</strong> does not define.
+                Moving it would leave an undefined symbol in that group&rsquo;s{" "}
+                <code>named.conf</code>, which BIND rejects whole &mdash; the
+                entire target group would stop converging, not just this zone.
+                Create ACLs with those names there first.
               </div>
             )}
 

--- a/frontend/src/pages/dns/DNSPage.tsx
+++ b/frontend/src/pages/dns/DNSPage.tsx
@@ -39,6 +39,7 @@ import {
   Clipboard,
   Cloud,
   ExternalLink,
+  ArrowRightLeft,
 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { ConfigApplyChip } from "@/components/ConfigApplyChip";
@@ -3061,6 +3062,221 @@ function ZoneSyncPill({ state }: { state: ZoneServerState }) {
   );
 }
 
+// ── Move a zone to another server group (#935) ─────────────────────────────
+//
+// Preview → commit rather than a one-click action, because none of the
+// consequences are visible from the zone page: which view scoping survives,
+// which dynamic-update grants do, and that a signed zone changes groups by
+// rolling its keys. Each consequence is its own checkbox — a single "I
+// understand" would let the DNSSEC warning be accepted by someone who only
+// read the view one.
+
+const ACK_LABELS: Record<string, string> = {
+  view_widening:
+    "I understand these records will answer in EVERY view in the target group, not just the one they are scoped to today.",
+  dnssec_rollover:
+    "I understand this zone will be re-signed with new keys, and DNSSEC validation fails until I publish the new DS record at the registrar.",
+  lost_update_grants:
+    "I understand the listed dynamic-update grants will be deleted, and the clients using them can no longer update this zone.",
+};
+
+function MoveZoneModal({
+  zone,
+  onClose,
+  onMoved,
+}: {
+  zone: DNSZone;
+  onClose: () => void;
+  onMoved: (targetGroupId: string) => void;
+}) {
+  const [targetGroupId, setTargetGroupId] = useState("");
+  const [acks, setAcks] = useState<Record<string, boolean>>({});
+  const [confirmName, setConfirmName] = useState("");
+  const [error, setError] = useState("");
+
+  const { data: groups = [] } = useQuery({
+    queryKey: ["dns-groups"],
+    queryFn: () => dnsApi.listGroups(),
+  });
+
+  // Preview is a pure read, so it re-runs freely as the target changes.
+  const { data: preview, isFetching: previewing } = useQuery({
+    queryKey: ["zone-move-preview", zone.id, targetGroupId],
+    queryFn: () =>
+      dnsApi.previewZoneMove(zone.group_id, zone.id, targetGroupId),
+    enabled: !!targetGroupId,
+  });
+
+  // Clear stale acknowledgements when the target changes — a box ticked
+  // for one group's consequences must not carry over to another's.
+  useEffect(() => {
+    setAcks({});
+  }, [targetGroupId]);
+
+  const mut = useMutation({
+    mutationFn: () =>
+      dnsApi.commitZoneMove(zone.group_id, zone.id, {
+        target_group_id: targetGroupId,
+        confirmation_zone_name: confirmName,
+        acknowledgements: Object.keys(acks).filter((k) => acks[k]),
+      }),
+    onSuccess: () => onMoved(targetGroupId),
+    onError: (e: ApiError) => setError(formatApiError(e)),
+  });
+
+  const required = preview?.required_acknowledgements ?? [];
+  const allAcked = required.every((k) => acks[k]);
+  const nameOk =
+    confirmName.trim().replace(/\.$/, "") === zone.name.replace(/\.$/, "");
+  const canSubmit =
+    !!targetGroupId &&
+    !!preview &&
+    !preview.name_collision &&
+    allAcked &&
+    nameOk &&
+    !mut.isPending;
+
+  return (
+    <Modal title={`Move ${zone.name}`} onClose={onClose} wide>
+      <div className="space-y-4">
+        <Field label="Destination server group">
+          <select
+            className={inputCls}
+            value={targetGroupId}
+            onChange={(e) => setTargetGroupId(e.target.value)}
+          >
+            <option value="">Select a group…</option>
+            {groups
+              .filter((g) => g.id !== zone.group_id)
+              .map((g) => (
+                <option key={g.id} value={g.id}>
+                  {g.name}
+                </option>
+              ))}
+          </select>
+        </Field>
+
+        {previewing && (
+          <p className="text-sm text-muted-foreground">
+            Checking what this move would do…
+          </p>
+        )}
+
+        {preview && (
+          <>
+            {preview.name_collision && (
+              <div className="rounded-md border border-rose-500/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-700 dark:text-rose-300">
+                <strong>{preview.target_group_name}</strong> already has a zone
+                named <code>{preview.zone_name}</code> in the view this one
+                would land in. Rename or delete it first.
+              </div>
+            )}
+
+            <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs">
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1">
+                <span className="text-muted-foreground">Records moving</span>
+                <span>{preview.records_total}</span>
+                {preview.records_remapped > 0 && (
+                  <>
+                    <span className="text-muted-foreground">
+                      View scoping preserved
+                    </span>
+                    <span>
+                      {preview.records_remapped} record(s) remapped by view name
+                    </span>
+                  </>
+                )}
+                {preview.acl_rows_remapped > 0 && (
+                  <>
+                    <span className="text-muted-foreground">
+                      Update grants preserved
+                    </span>
+                    <span>
+                      {preview.acl_rows_remapped} remapped by key name
+                    </span>
+                  </>
+                )}
+                {preview.pools_repointed > 0 && (
+                  <>
+                    <span className="text-muted-foreground">
+                      Pools following
+                    </span>
+                    <span>{preview.pools_repointed}</span>
+                  </>
+                )}
+                {preview.pending_ops > 0 && (
+                  <>
+                    <span className="text-muted-foreground">
+                      Queued updates discarded
+                    </span>
+                    <span>{preview.pending_ops}</span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {preview.warnings.length > 0 && (
+              <ul className="space-y-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-800 dark:text-amber-300">
+                {preview.warnings.map((w, i) => (
+                  <li key={i}>• {w}</li>
+                ))}
+              </ul>
+            )}
+
+            {required.length > 0 && (
+              <div className="space-y-2">
+                {required.map((key) => (
+                  <label key={key} className="flex items-start gap-2 text-xs">
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={!!acks[key]}
+                      onChange={(e) =>
+                        setAcks((prev) => ({
+                          ...prev,
+                          [key]: e.target.checked,
+                        }))
+                      }
+                    />
+                    <span>{ACK_LABELS[key] ?? key}</span>
+                  </label>
+                ))}
+              </div>
+            )}
+
+            <Field label={`Type the zone name to confirm (${zone.name})`}>
+              <input
+                className={inputCls}
+                value={confirmName}
+                onChange={(e) => setConfirmName(e.target.value)}
+                placeholder={zone.name}
+              />
+            </Field>
+          </>
+        )}
+
+        {error && (
+          <p className="text-sm text-rose-600 dark:text-rose-400">{error}</p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-1">
+          <HeaderButton onClick={onClose}>Cancel</HeaderButton>
+          <HeaderButton
+            variant="destructive"
+            disabled={!canSubmit}
+            onClick={() => {
+              setError("");
+              mut.mutate();
+            }}
+          >
+            {mut.isPending ? "Moving…" : "Move zone"}
+          </HeaderButton>
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
 // Sub-tabs on the zone detail surface. Mirrored in the ``subtab`` URL param
 // (``records`` is the default and is left out of the URL entirely).
 type ZoneSubtab = "records" | "pools" | "certs" | "drift";
@@ -3077,6 +3293,7 @@ function ZoneDetailView({
   onDeleted: () => void;
 }) {
   const qc = useQueryClient();
+  const navigate = useNavigate();
   const [showAddRecord, setShowAddRecord] = useState(false);
   const [editRecord, setEditRecord] = useState<DNSRecord | null>(null);
   const [propagationRecord, setPropagationRecord] = useState<DNSRecord | null>(
@@ -3087,6 +3304,7 @@ function ZoneDetailView({
   const [showDelegate, setShowDelegate] = useState(false);
   const [showUpdateAcl, setShowUpdateAcl] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [showMoveZone, setShowMoveZone] = useState(false);
   const [deleteNotice, setDeleteNotice] = useState<string | null>(null);
   const [showImport, setShowImport] = useState(false);
   const [showRecFilters, setShowRecFilters] = useState(false);
@@ -3454,6 +3672,18 @@ function ZoneDetailView({
             }
           >
             Edit Zone
+          </HeaderButton>
+          <HeaderButton
+            icon={ArrowRightLeft}
+            onClick={() => setShowMoveZone(true)}
+            disabled={!!zone.tailscale_tenant_id}
+            title={
+              zone.tailscale_tenant_id
+                ? "This zone is synthesised by the Tailscale integration; it is bound to that tenant's group."
+                : "Move this zone to another server group"
+            }
+          >
+            Move
           </HeaderButton>
           <HeaderButton
             variant="destructive"
@@ -4132,6 +4362,23 @@ function ZoneDetailView({
             bulkDeleteRecords.mutate(Array.from(selectedRecords))
           }
           onClose={() => setConfirmBulkDelete(false)}
+        />
+      )}
+      {showMoveZone && (
+        <MoveZoneModal
+          zone={zone}
+          onClose={() => setShowMoveZone(false)}
+          onMoved={(targetGroupId) => {
+            setShowMoveZone(false);
+            // Both groups' zone lists changed, and the zone's own URL is
+            // keyed on the group it is in — so navigate to it under the new
+            // group rather than leaving the page on a 404.
+            qc.invalidateQueries({ queryKey: ["dns-zones"] });
+            qc.invalidateQueries({ queryKey: ["dns-groups"] });
+            navigate(`/dns?group=${targetGroupId}&zone=${zone.id}`, {
+              replace: true,
+            });
+          }}
         />
       )}
       {showEditZone && (


### PR DESCRIPTION
The other half of [discussion #933](https://github.com/spatiumddi/spatiumddi/discussions/933), and a much sharper tool than the #934 server move. A server carries state *about* a group; a zone carries references *into* one — `DNSView`, `DNSTSIGKey`, `DNSAcl` and `DNSPool` are all group-scoped, so a bare `group_id` reassignment leaves cross-group dangling references.

Preview → commit at `POST …/zones/{id}/move/{preview,commit}`, service in `services/dns/zone_move.py`, **Move** button on the zone detail. No migration.

## The design turns on one property: clearing a view WIDENS exposure

Under split-horizon a record with `view_id` set renders in exactly that view; one with `view_id IS NULL` is *shared* and renders in **every** view ([`pool_geo.records_for_view`](backend/app/services/dns/pool_geo.py#L342-L348)). So dropping a reference the target group cannot resolve does not remove the zone from a view — **it adds it to all of them.** A zone that answered only on `internal` starts answering on `external`, with no operator-visible symptom.

Views and TSIG keys therefore remap **by name** wherever the target has a match — a view called `internal` in each group is the operator's own statement that the two mean the same thing — and where they cannot, the move refuses until the widening is acknowledged.

*The issue text as I filed it had this wrong*: it described clearing the view as a neutral tidy-up ("cleared, or remapped to a same-named view"). It isn't, and that's most of why this needed a preview at all.

## Three acknowledgements, each its own checkbox

Not one blanket "I understand" — otherwise the DNSSEC warning gets accepted by someone who only read the view one.

| Key | When | Why it isn't just a warning |
|---|---|---|
| `view_widening` | a view reference can't be resolved in a target that renders views | the zone/record goes from one view to all of them |
| `dnssec_rollover` | the zone is signed | private keys live on the **current** group's servers and don't move; the target signs from scratch, so the DS at the registrar is wrong until republished and validation fails in the interval |
| `lost_update_grants` | a grant names a TSIG key absent from the target | `num_nonnulls(tsig_key_id, ip_cidr) = 1` forbids clearing the key, so the row is deleted — which fails *closed*, the safe direction, but not silently |

Plus the zone name typed back, the way the IPAM block move takes a typed CIDR.

## The collision check runs against the RESOLVED view

The constraint is `(group_id, view_id, name)`, not `(group_id, name)`. A zone whose view is cleared lands at `(target, NULL, name)` and can collide with an unviewed zone a naive check would have missed — while the same name in two *different* views is not a collision at all, which is the entire point of split-horizon. Both directions have a test.

## What else it does

Pools follow the zone (attached by `zone_id`, health-checked from the control plane rather than the group's agents). Per-server zone state and queued record ops are purged — both describe the old group's servers. DNSSEC key state is cleared rather than left showing keys no server holds. Both group channels are woken. A **driver change warns rather than refuses**, unlike the server move: a zone is data, so BIND9 → PowerDNS is a legitimate migration. An ACME DNS-01 delegation is flagged, because its TXT records would be written by the target's servers while the NS delegation at the registrar still points at the old group's.

## Code review — 8 findings, all confirmed and fixed

They clustered in one place: **the move reassigned `group_id` but skipped validations every *other* path into a group performs.**

- An **integration-owned zone** (Tailscale, NetBird) could be moved out from under its reconciler, which would recreate it in the bound group on the next sync. Now refused — on the *preview* too, so it's learned before the modal is filled in.
- **Agentless groups were driven at neither end.** `windows_dns` / cloud / `technitium_api` hold the zone in a system the ConfigBundle never reaches, so moving out left it live and unmanaged on the old server and moving in never created it. Now both ends, **create first**: if either call fails the move rolls back, and a failed create leaves nothing changed where a failed delete would have removed the zone from the old server with the database still saying it lived there.
- A **signed zone could land on a group that cannot sign**, and would read as signed forever while being served unsigned.
- A **named ACL** the target doesn't define becomes an undefined symbol in its `named.conf` — and BIND rejects the file *whole*, so that stops the **entire target group** converging, not just this zone. The module docstring had claimed `DNSAcl` was handled; it was never even imported.
- A **forwarders-less forward zone** could reach a Technitium group — the exact #743 failure the create/update guard exists to prevent.
- The DNSSEC purge deleted the `DNSKey` rows but left **`dnssec_ds_records` stale**, so the UI would tell the operator to publish a DS for keys no server in the new group holds. Now `clear_dnssec_key_state`, the one helper every other flag-off path uses.
- The view-remap SELECT was **soft-delete filtered**, so a deleted record kept a source-group `view_id` and restoring it later resurrected a dangling reference. *The test for this caught a second instance of the same bug*: my first fix went into the plan scan only, so the preview counted rows the commit did not rewrite.
- The preview **hydrated every `DNSRecord`** in the zone to produce two counts, and the modal fires it on every dropdown change. Counts now happen in Postgres; the view scan selects two columns.

The two new refusals (unsignable target, undefined ACL) are deliberately **not** acknowledgement-waivable, unlike the three above: an acknowledgement is for a consequence the operator can see and accept, and neither of these leaves a state they could inspect afterwards.

## MCP

1 tool: `preview_dns_zone_move` (read-only, default on). Deliberately **no** commit tool per non-negotiable #13 — the operation's safety rests on a human reading three consequences and typing the zone name back, none of which survives being driven from a chat window.

## Verification

34 tests in the new suite; 117 across the regression batch. `make ci`, the untyped-route guard and the migration linter all clean.

Walked end to end on the dev stack against a live BIND9 agent:

- Preview on a real zone reported its actual queued ops and empty-target warning.
- A view-pinned zone moving to a group whose views don't match was detected as `cleared_widening`, **refused without the acknowledgement**, refused again on a wrong confirmation name, and applied correctly with both — ending with `group_id` moved and `view_id` cleared as predicted.

Dev stack restored afterwards; no test data left behind.

Closes #935

🤖 Generated with [Claude Code](https://claude.com/claude-code)
