### PR TITLE
fix(ui): dashboard sweep — an RPKI signal that fired on 100% of rows, plus seven more defects (#942)

### DIFF
--- a/backend/app/api/v1/dashboards/network.py
+++ b/backend/app/api/v1/dashboards/network.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from fastapi import APIRouter
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from app.api.deps import DB, CurrentUser  # noqa: F401 — auth via dep
 from app.models.asn import ASN, ASNRpkiRoa
@@ -95,6 +95,10 @@ class NetworkDashboardSummary(BaseModel):
     asn_drift_count: int
     rpki_expiring_count: int
     rpki_expired_count: int
+    # Total ROAs tracked + when the pull last touched one. Lets the panel
+    # distinguish a real all-clear from stale or absent data (#942).
+    rpki_total_count: int
+    rpki_last_checked_at: datetime | None
     circuit_term_expiring_count: int
     circuit_status_changed_count: int
     service_orphan_count: int
@@ -178,6 +182,15 @@ async def network_summary(
     expired_rows = (
         (await db.execute(select(ASNRpkiRoa).where(ASNRpkiRoa.state == "expired"))).scalars().all()
     )
+    # Freshness of the underlying pull (#942). Without this the panel
+    # cannot tell "nothing is expiring" from "the refresh task died
+    # three weeks ago and these counts are fiction" — and those want
+    # opposite responses from the operator. Reported, never inferred:
+    # the frontend decides what counts as stale.
+    rpki_total_count = (await db.execute(select(func.count()).select_from(ASNRpkiRoa))).scalar_one()
+    rpki_last_checked_at = (
+        await db.execute(select(func.max(ASNRpkiRoa.last_checked_at)))
+    ).scalar_one()
     rpki_expiring: list[RpkiRoaRow] = []
     for r in expiring_rows[:_DETAIL_LIMIT]:
         asn_number = await _resolve_asn_number(db, r.asn_id)
@@ -344,6 +357,8 @@ async def network_summary(
         asn_drift_count=asn_drift_count,
         rpki_expiring_count=len(expiring_rows),
         rpki_expired_count=len(expired_rows),
+        rpki_total_count=rpki_total_count,
+        rpki_last_checked_at=rpki_last_checked_at,
         circuit_term_expiring_count=circuit_term_expiring_count,
         circuit_status_changed_count=circuit_status_changed_count,
         service_orphan_count=service_orphan_count,

--- a/backend/app/api/v1/dhcp/pools.py
+++ b/backend/app/api/v1/dhcp/pools.py
@@ -499,9 +499,20 @@ async def fleet_pool_occupancy(
     """Dynamic pools across every scope, fullest first.
 
     Answers the DHCP dashboard's headline question — "can clients still
-    get an address anywhere" — in one round trip whose cost does not grow
-    with the number of scopes: the pool fetch, one batched lease +
-    reservation pass, and name resolution for the returned slice only.
+    get an address anywhere" — in one round trip and a fixed number of
+    queries: the pool fetch, one batched lease + reservation pass, the
+    lease count, and name resolution for the returned slice only.
+
+    Fixed query *count*, not fixed *work*: the batched pass reads every
+    active lease and reservation in the scopes that own a dynamic pool,
+    so it scales with the lease table rather than with ``limit``, which
+    bounds only the rendered slice. That is deliberate — it is the same
+    scan ``compute_pool_occupancy_batch`` already performs for the
+    per-scope endpoint and for the ``dhcp_pool_exhaustion`` evaluator on
+    its own tick, and re-deriving occupancy in SQL here would be a
+    fourth implementation of the range arithmetic that could disagree
+    with the other three. If this becomes hot, push the range containment
+    into the shared helper so every caller benefits.
     """
     pools = list(
         (await db.execute(select(DHCPPool).where(DHCPPool.pool_type == _OCCUPANCY_POOL_TYPE)))

--- a/backend/app/api/v1/dhcp/pools.py
+++ b/backend/app/api/v1/dhcp/pools.py
@@ -7,17 +7,17 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, field_validator
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.api.deps import DB, CurrentUser, SuperAdmin
 from app.api.v1.dhcp._audit import write_audit
 from app.core.agent_wake import collect_wake, dhcp_group_channel
 from app.core.permissions import require_resource_permission
-from app.models.dhcp import DHCPPool, DHCPScope
-from app.models.ipam import IPAddress
+from app.models.dhcp import DHCPLease, DHCPPool, DHCPScope, DHCPServerGroup
+from app.models.ipam import IPAddress, Subnet
 from app.services.dhcp.pool_occupancy import (
     PoolOccupancy,
     compute_pool_occupancy_batch,
@@ -436,6 +436,163 @@ async def pool_occupancy(pool_id: uuid.UUID, db: DB, _: CurrentUser) -> PoolOccu
         raise HTTPException(status_code=422, detail=_not_applicable(pool.pool_type))
     occ = (await compute_pool_occupancy_batch(db, [pool]))[pool.id]
     return _occupancy_row(pool, occ, datetime.now(UTC))
+
+
+# ── Fleet-wide occupancy (issue #942) ────────────────────────────────
+#
+# The dashboard's DHCP tab needs "which pools are fullest, across every
+# scope" and must not answer it by fanning out one call per scope. The
+# filters here are deliberately IDENTICAL to the per-scope endpoint and
+# to the ``dhcp_pool_exhaustion`` alert evaluator: dynamic pools only,
+# and no ``is_active`` filter on the parent scope. That last one is a
+# choice, not an oversight — the evaluator does not filter on it either,
+# and a surface that quietly dropped rows the alerting still fires on is
+# precisely how an operator ends up reading "the pool is fine" about a
+# pool that is paging someone. Inactive scopes are flagged in the row
+# instead, so the UI can annotate without the API deciding for it.
+
+
+class FleetPoolOccupancyRow(PoolOccupancyResponse):
+    """One pool, plus the context needed to identify it without a
+    follow-up call — a pool name alone is frequently empty, and a
+    ``pool_id`` is not something an operator can act on."""
+
+    scope_name: str
+    scope_is_active: bool
+    subnet_network: str | None
+    group_id: uuid.UUID
+    group_name: str
+
+
+class FleetPoolOccupancyResponse(BaseModel):
+    computed_at: datetime
+    #: Every dynamic pool considered, not just the returned slice — so a
+    #: caller can say "3 of 47" rather than implying the top-N is all of
+    #: them.
+    pool_count: int
+    pools_warning: int
+    pools_critical: int
+    #: Distinct ``(scope, address)`` pairs in an active lease, fleet-wide.
+    #: DISTINCT, not COUNT(*): ``dhcp_lease`` is per-server and a Kea HA
+    #: pair mirrors every lease twice, so a row count reports 2x on
+    #: exactly the deployments where the number matters — and would
+    #: disagree with both ``pool_occupancy.py`` and the #889 InfluxDB
+    #: exporter, which dedupe for the same reason. Pairing with the scope
+    #: keeps this equal to the sum of that exporter's per-scope series.
+    active_lease_count: int
+    pools: list[FleetPoolOccupancyRow]
+
+
+#: Occupancy bands for the fleet rollup. Same numbers the subnet
+#: utilization heatmap uses, so "amber" means the same thing wherever an
+#: operator sees it on this dashboard.
+_POOL_WARNING_PERCENT = 80.0
+_POOL_CRITICAL_PERCENT = 95.0
+
+
+@router.get("/pools/occupancy", response_model=FleetPoolOccupancyResponse)
+async def fleet_pool_occupancy(
+    db: DB,
+    _: CurrentUser,
+    limit: int = Query(10, ge=1, le=200),
+) -> FleetPoolOccupancyResponse:
+    """Dynamic pools across every scope, fullest first.
+
+    Answers the DHCP dashboard's headline question — "can clients still
+    get an address anywhere" — in one round trip whose cost does not grow
+    with the number of scopes: the pool fetch, one batched lease +
+    reservation pass, and name resolution for the returned slice only.
+    """
+    pools = list(
+        (await db.execute(select(DHCPPool).where(DHCPPool.pool_type == _OCCUPANCY_POOL_TYPE)))
+        .scalars()
+        .all()
+    )
+    computed_at = datetime.now(UTC)
+    occ_by_pool = await compute_pool_occupancy_batch(db, pools)
+
+    # A zero-size pool (malformed or inverted range) reports 0/0 at 0%.
+    # It is counted in ``pool_count`` — it exists and is misconfigured —
+    # but must never outrank a genuinely full pool in the ranking.
+    ranked = sorted(
+        pools,
+        key=lambda p: (occ_by_pool[p.id].percent, occ_by_pool[p.id].assigned),
+        reverse=True,
+    )
+    pools_warning = sum(1 for p in pools if occ_by_pool[p.id].percent >= _POOL_WARNING_PERCENT)
+    pools_critical = sum(1 for p in pools if occ_by_pool[p.id].percent >= _POOL_CRITICAL_PERCENT)
+
+    lease_pairs = (
+        select(DHCPLease.scope_id, DHCPLease.ip_address)
+        .where(DHCPLease.scope_id.is_not(None), DHCPLease.state == "active")
+        .distinct()
+        .subquery()
+    )
+    active_lease_count = (
+        await db.execute(select(func.count()).select_from(lease_pairs))
+    ).scalar_one()
+
+    top = ranked[:limit]
+    # Resolve display context for the returned slice only — three
+    # queries, independent of how many pools the fleet has.
+    scope_ids = {p.scope_id for p in top}
+    scopes: dict[uuid.UUID, DHCPScope] = {}
+    if scope_ids:
+        scopes = {
+            s.id: s
+            for s in (await db.execute(select(DHCPScope).where(DHCPScope.id.in_(scope_ids))))
+            .scalars()
+            .all()
+        }
+    subnet_ids = {s.subnet_id for s in scopes.values()}
+    networks: dict[uuid.UUID, str] = {}
+    if subnet_ids:
+        networks = {
+            row[0]: str(row[1])
+            for row in (
+                await db.execute(select(Subnet.id, Subnet.network).where(Subnet.id.in_(subnet_ids)))
+            ).all()
+        }
+    group_ids = {s.group_id for s in scopes.values()}
+    group_names: dict[uuid.UUID, str] = {}
+    if group_ids:
+        group_names = {
+            row[0]: row[1]
+            for row in (
+                await db.execute(
+                    select(DHCPServerGroup.id, DHCPServerGroup.name).where(
+                        DHCPServerGroup.id.in_(group_ids)
+                    )
+                )
+            ).all()
+        }
+
+    rows: list[FleetPoolOccupancyRow] = []
+    for pool in top:
+        scope = scopes.get(pool.scope_id)
+        base = _occupancy_row(pool, occ_by_pool[pool.id], computed_at)
+        rows.append(
+            FleetPoolOccupancyRow(
+                **base.model_dump(),
+                scope_name=(scope.name if scope else "") or "",
+                scope_is_active=scope.is_active if scope else False,
+                subnet_network=networks.get(scope.subnet_id) if scope else None,
+                # A pool always has a scope (FK, CASCADE) and a scope always
+                # has a group. The fallbacks exist only so a row mid-delete
+                # degrades instead of 500-ing the whole panel.
+                group_id=scope.group_id if scope else uuid.UUID(int=0),
+                group_name=(group_names.get(scope.group_id, "") if scope else "") or "",
+            )
+        )
+
+    return FleetPoolOccupancyResponse(
+        computed_at=computed_at,
+        pool_count=len(pools),
+        pools_warning=pools_warning,
+        pools_critical=pools_critical,
+        active_lease_count=int(active_lease_count),
+        pools=rows,
+    )
 
 
 @router.get("/scopes/{scope_id}/pools/occupancy", response_model=list[PoolOccupancyResponse])

--- a/backend/app/api/v1/metrics/router.py
+++ b/backend/app/api/v1/metrics/router.py
@@ -30,6 +30,11 @@ from app.models.metrics import DHCPMetricSample, DNSMetricSample
 router = APIRouter()
 
 
+#: The cadence agents report counters at. One ``metric_sample`` row per
+#: server per minute, so a point's covered time span is this times the
+#: number of distinct buckets folded into it.
+_AGENT_BUCKET_SECONDS = 60
+
 WINDOW_SECONDS = {
     "1h": 3600,
     "6h": 6 * 3600,
@@ -56,6 +61,17 @@ def _window_start(window: str) -> datetime:
 
 class DNSTimePoint(BaseModel):
     t: datetime
+    #: Seconds of sampling this point actually covers — ``60 x`` the number
+    #: of distinct agent buckets folded into it, NOT ``bucket_seconds``.
+    #: Rates must be derived from this or the newest point is systematically
+    #: wrong: the current 5-minute bucket has only had one or two 60 s
+    #: samples reported into it, and dividing that partial sum by a full 300
+    #: renders a 70%+ phantom dip at the right-hand edge of every chart, on
+    #: every refresh. The leading bucket is partial for the same reason (the
+    #: window start does not align to a bucket boundary), and a bucket
+    #: missing a sample because an agent was briefly down is the same
+    #: problem in the middle of the series.
+    covered_seconds: int
     queries_total: int
     noerror: int
     nxdomain: int
@@ -73,6 +89,17 @@ class DNSTimeseries(BaseModel):
 
 class DHCPTimePoint(BaseModel):
     t: datetime
+    #: Seconds of sampling this point actually covers — ``60 x`` the number
+    #: of distinct agent buckets folded into it, NOT ``bucket_seconds``.
+    #: Rates must be derived from this or the newest point is systematically
+    #: wrong: the current 5-minute bucket has only had one or two 60 s
+    #: samples reported into it, and dividing that partial sum by a full 300
+    #: renders a 70%+ phantom dip at the right-hand edge of every chart, on
+    #: every refresh. The leading bucket is partial for the same reason (the
+    #: window start does not align to a bucket boundary), and a bucket
+    #: missing a sample because an agent was briefly down is the same
+    #: problem in the middle of the series.
+    covered_seconds: int
     discover: int
     offer: int
     request: int
@@ -120,6 +147,12 @@ async def dns_timeseries(
 
     stmt = select(
         bucket_col,
+        # Distinct agent buckets folded into this point. Counting DISTINCT
+        # bucket_at (not rows) is what makes this the covered TIME SPAN
+        # rather than a sample count: with several servers reporting, N
+        # rows share one minute, and the aggregate rate for that minute is
+        # still measured over 60 seconds.
+        func.count(func.distinct(DNSMetricSample.bucket_at)).label("sample_buckets"),
         func.sum(DNSMetricSample.queries_total).label("queries_total"),
         func.sum(DNSMetricSample.noerror).label("noerror"),
         func.sum(DNSMetricSample.nxdomain).label("nxdomain"),
@@ -136,6 +169,7 @@ async def dns_timeseries(
     points = [
         DNSTimePoint(
             t=row._mapping["t"],
+            covered_seconds=int(row.sample_buckets or 0) * _AGENT_BUCKET_SECONDS,
             queries_total=int(row.queries_total or 0),
             noerror=int(row.noerror or 0),
             nxdomain=int(row.nxdomain or 0),
@@ -168,6 +202,7 @@ async def dhcp_timeseries(
 
     stmt = select(
         bucket_col,
+        func.count(func.distinct(DHCPMetricSample.bucket_at)).label("sample_buckets"),
         func.sum(DHCPMetricSample.discover).label("discover"),
         func.sum(DHCPMetricSample.offer).label("offer"),
         func.sum(DHCPMetricSample.request).label("request"),
@@ -185,6 +220,7 @@ async def dhcp_timeseries(
     points = [
         DHCPTimePoint(
             t=row._mapping["t"],
+            covered_seconds=int(row.sample_buckets or 0) * _AGENT_BUCKET_SECONDS,
             discover=int(row.discover or 0),
             offer=int(row.offer or 0),
             request=int(row.request or 0),

--- a/backend/app/api/v1/metrics/router.py
+++ b/backend/app/api/v1/metrics/router.py
@@ -7,9 +7,12 @@ the agents (see `app.api.v1.{dns,dhcp}.agents.agent_metrics`); this
 module is read-only.
 
 Window → bucket selection is auto-scaled so charts stay readable:
-short windows (≤ 24 h) return raw 60 s rows, longer windows aggregate
-server-side into 5 min buckets. That keeps 7-day charts under 2k
-points without losing shape.
+short windows (< 24 h) return raw 60 s rows, 24 h and longer aggregate
+server-side into 5 min buckets. The ceiling is the chart's pixel width,
+not a row budget — 24 h of raw 60 s rows is 1,440 points into a
+~1,300 px plot, i.e. more points than pixels, which paints a jittery
+low-rate series as a solid filled band rather than a line. At 300 s
+that window is 288 points and legible; 7 d is 2,016.
 """
 
 from __future__ import annotations
@@ -36,8 +39,13 @@ WINDOW_SECONDS = {
 
 
 def _bucket_seconds_for(window: str) -> int:
-    """Pick an aggregation bucket that keeps charts under ~2k points."""
-    if WINDOW_SECONDS[window] > 24 * 3600:
+    """Pick an aggregation bucket that keeps a window under ~300 plotted points.
+
+    The bound that matters is the chart's pixel width, not a row budget:
+    more points than pixels renders a line as a solid band. 24 h is the
+    crossover — at raw 60 s it is 1,440 points, at 300 s it is 288.
+    """
+    if WINDOW_SECONDS[window] >= 24 * 3600:
         return 300  # 5 min
     return 60
 

--- a/backend/app/models/asn.py
+++ b/backend/app/models/asn.py
@@ -193,12 +193,16 @@ class ASNRpkiRoa(UUIDPrimaryKeyMixin, Base):
     )
     prefix: Mapped[str] = mapped_column(CIDR, nullable=False)
     max_length: Mapped[int] = mapped_column(Integer, nullable=False)
-    # Some public ROA mirrors (Cloudflare's ``rpki.json`` in particular)
-    # don't surface per-ROA validity windows — the JSON only has
-    # ``(asn, prefix, maxLength, ta)`` quads. We relax these to nullable
-    # in Phase 2 so the pull job can land what it has; ``state`` falls
-    # back to ``valid`` when the window is unknown so the alert
+    # Nullable because not every mirror exposes a validity window, and
+    # ``state`` falls back to ``valid`` when it is unknown so the alert
     # evaluator doesn't fire spurious "expired" events.
+    #
+    # Cloudflare's ``rpki.json`` DOES ship a per-row ``expires`` (an
+    # earlier comment here said it did not) — but it is the validity of
+    # the VRP cache entry, not of the ROA, and every row in the global
+    # dump carries one under a week out. It is landed for the record and
+    # deliberately not read as a lifetime; see
+    # ``_LIFETIME_VALIDITY_SOURCES`` in ``tasks/rpki_roa_refresh.py``.
     valid_from: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     valid_to: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 

--- a/backend/app/tasks/rpki_roa_refresh.py
+++ b/backend/app/tasks/rpki_roa_refresh.py
@@ -22,9 +22,12 @@ evaluator + the manual "Refresh now" path use the same logic:
 * ``valid_to is None`` (the public mirrors don't expose validity
   windows) → ``valid``. We don't fire spurious "expired" events on
   unknown windows.
-* ``valid_to <= now`` → ``expired``.
-* ``valid_to <= now + 30d`` → ``expiring_soon``.
-* otherwise → ``valid``.
+* a source whose validity field is a short-cycle cache expiry rather
+  than a per-ROA lifetime → always ``valid``, for the same reason. This
+  is the Cloudflare case and it is the common one; see
+  ``_LIFETIME_VALIDITY_SOURCES``.
+* otherwise: ``valid_to <= now`` → ``expired``; ``valid_to <= now + 30d``
+  → ``expiring_soon``; else ``valid``.
 
 Every additive / removed / state-transitioned row gets an audit-log
 entry. We deliberately don't audit "still valid, ticked" — that's
@@ -54,12 +57,38 @@ _SINGLETON_ID = 1
 _VALID_SOURCES = frozenset({"cloudflare", "ripe"})
 
 
-def _derive_roa_state(valid_to: datetime | None, now: datetime) -> str:
-    """Map ``valid_to`` → ROA state. ``None`` (unknown window) maps
-    to ``valid`` so we don't fire spurious alerts on mirrors that
-    don't expose the X.509 notAfter field.
+# Sources whose validity field is a per-ROA LIFETIME, and can therefore
+# carry an "expiring soon" signal.
+#
+# Cloudflare's ``rpki.json`` is deliberately absent (#942). Its
+# ``expires`` is the validity of the VRP cache entry — derived from the
+# shortest-lived object in the validation chain (EE cert / manifest /
+# CRL), all of which RPKI CAs re-sign on a rolling cycle of hours. It is
+# not a statement about the ROA's lifetime and does not decay towards a
+# renewal deadline. Measured against the live global dump on 2026-08-31:
+# of 997,298 ROAs, 100% expired within 7 days and 79% within 2 — so a
+# 30-day threshold flags literally every ROA that will ever exist,
+# permanently. That is not a noisy signal, it is a constant, and it fed
+# the ``rpki_roa_expiring`` alert rule one event PER ROA.
+#
+# For this source, presence in the dump is the signal: a ROA the AS
+# holder actually pulled disappears, and the reconcile below DELETEs it.
+# RIPE's ``notAfter`` is a genuine EE-certificate notAfter and keeps the
+# ladder. If you add a source, measure its distribution before listing
+# it here — the failure mode is silent and total.
+_LIFETIME_VALIDITY_SOURCES = frozenset({"ripe"})
+
+
+def _derive_roa_state(valid_to: datetime | None, now: datetime, source: str) -> str:
+    """Map ``valid_to`` → ROA state.
+
+    ``None`` (unknown window) maps to ``valid`` so we don't fire
+    spurious alerts on mirrors that don't expose the X.509 notAfter
+    field. A source whose validity field is a short-cycle cache expiry
+    rather than a lifetime is treated the same way, and for the same
+    reason — see :data:`_LIFETIME_VALIDITY_SOURCES`.
     """
-    if valid_to is None:
+    if valid_to is None or source not in _LIFETIME_VALIDITY_SOURCES:
         return "valid"
     if valid_to <= now:
         return "expired"
@@ -111,7 +140,7 @@ async def _refresh_one_asn(
 
         key = (str(prefix), int(max_length), trust_anchor or None)
         seen_keys.add(key)
-        new_state = _derive_roa_state(valid_to, now)
+        new_state = _derive_roa_state(valid_to, now, source)
 
         existing = existing_index.get(key)
         if existing is None:

--- a/backend/tests/test_dhcp_pool_occupancy_api.py
+++ b/backend/tests/test_dhcp_pool_occupancy_api.py
@@ -250,3 +250,172 @@ async def test_occupancy_404s_for_unknown_ids(
     assert (
         await client.get(f"/api/v1/dhcp/scopes/{missing}/pools/occupancy", headers=headers)
     ).status_code == 404
+
+
+# ── Fleet-wide rollup (issue #942) ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fleet_occupancy_ranks_fullest_first_and_carries_context(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The dashboard's question is "which pools are fullest", across every
+    scope, in one call — and each row must identify itself without a
+    follow-up, since a pool name is frequently empty."""
+    scope, _ = await _scope(db_session)
+    roomy = DHCPPool(
+        scope_id=scope.id,
+        name="roomy",
+        start_ip="10.61.0.10",
+        end_ip="10.61.0.109",  # 100 addresses
+        pool_type="dynamic",
+    )
+    tight = DHCPPool(
+        scope_id=scope.id,
+        name="tight",
+        start_ip="10.61.0.200",
+        end_ip="10.61.0.209",  # 10 addresses
+        pool_type="dynamic",
+    )
+    db_session.add_all([roomy, tight])
+    await db_session.flush()
+    # 1/100 vs 8/10 — the smaller absolute count is the bigger problem,
+    # so ranking must be on percent, not on assigned.
+    db_session.add(
+        DHCPStaticAssignment(
+            scope_id=scope.id, ip_address="10.61.0.11", mac_address="aa:bb:cc:00:00:01"
+        )
+    )
+    for i in range(8):
+        db_session.add(
+            DHCPStaticAssignment(
+                scope_id=scope.id,
+                ip_address=f"10.61.0.{200 + i}",
+                mac_address=f"aa:bb:cc:00:01:{i:02x}",
+            )
+        )
+    await db_session.flush()
+
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    res = await client.get("/api/v1/dhcp/pools/occupancy", headers=headers)
+    assert res.status_code == 200, res.text
+    body = res.json()
+
+    assert [p["pool_name"] for p in body["pools"]][:2] == ["tight", "roomy"]
+    assert body["pool_count"] == 2
+    assert body["pools_warning"] == 1  # tight at 80%
+    assert body["pools_critical"] == 0
+    top = body["pools"][0]
+    assert top["percent"] == 80.0
+    # Context that saves a follow-up call.
+    assert top["scope_name"] == "scope-a"
+    assert top["subnet_network"] == CIDR
+    assert top["group_name"]
+    assert top["scope_is_active"] is True
+
+
+@pytest.mark.asyncio
+async def test_fleet_occupancy_omits_non_dynamic_pools(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Same filter as the per-scope endpoint and the exhaustion alert
+    evaluator. An excluded range is never offered to a client and a
+    reserved one is supposed to fill up, so either would render as a red
+    exhaustion bar for behaving correctly."""
+    scope, _ = await _scope(db_session)
+    db_session.add_all(
+        [
+            DHCPPool(
+                scope_id=scope.id,
+                name="dyn",
+                start_ip="10.61.0.10",
+                end_ip="10.61.0.19",
+                pool_type="dynamic",
+            ),
+            DHCPPool(
+                scope_id=scope.id,
+                name="excl",
+                start_ip="10.61.0.20",
+                end_ip="10.61.0.29",
+                pool_type="excluded",
+            ),
+            DHCPPool(
+                scope_id=scope.id,
+                name="resv",
+                start_ip="10.61.0.30",
+                end_ip="10.61.0.39",
+                pool_type="reserved",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    body = (await client.get("/api/v1/dhcp/pools/occupancy", headers=headers)).json()
+    assert [p["pool_name"] for p in body["pools"]] == ["dyn"]
+    assert body["pool_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fleet_lease_count_dedupes_ha_mirrored_leases(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """``dhcp_lease`` is per-server and a Kea HA pair mirrors every lease,
+    so COUNT(*) reports 2x on exactly the deployments where the number
+    matters — and would disagree with pool_occupancy.py and the #889
+    InfluxDB exporter, both of which dedupe."""
+    scope, server_a = await _scope(db_session)
+    server_b = DHCPServer(name=f"kea-{uuid.uuid4().hex[:6]}", host="10.0.0.2", driver="kea")
+    db_session.add(server_b)
+    await db_session.flush()
+    # The SAME address, mirrored by both HA partners.
+    for srv in (server_a, server_b):
+        db_session.add(
+            DHCPLease(
+                server_id=srv.id,
+                scope_id=scope.id,
+                ip_address="10.61.0.50",
+                mac_address="aa:bb:cc:dd:ee:ff",
+                state="active",
+            )
+        )
+    # Plus one address only one partner has seen, and one expired row that
+    # must not count at all.
+    db_session.add(
+        DHCPLease(
+            server_id=server_a.id,
+            scope_id=scope.id,
+            ip_address="10.61.0.51",
+            mac_address="aa:bb:cc:dd:ee:01",
+            state="active",
+        )
+    )
+    db_session.add(
+        DHCPLease(
+            server_id=server_a.id,
+            scope_id=scope.id,
+            ip_address="10.61.0.52",
+            mac_address="aa:bb:cc:dd:ee:02",
+            state="expired",
+        )
+    )
+    await db_session.flush()
+
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    body = (await client.get("/api/v1/dhcp/pools/occupancy", headers=headers)).json()
+    assert body["active_lease_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_fleet_occupancy_empty_estate_is_not_an_error(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """A fresh install has no pools; the panel needs a shape to render,
+    not a 404."""
+    headers = {"Authorization": f"Bearer {await _token(db_session)}"}
+    res = await client.get("/api/v1/dhcp/pools/occupancy", headers=headers)
+    assert res.status_code == 200
+    body = res.json()
+    assert body["pool_count"] == 0
+    assert body["pools"] == []
+    assert body["active_lease_count"] == 0

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -144,7 +144,7 @@ async def test_dhcp_timeseries_returns_empty_when_no_data(
     assert resp.status_code == 200
     body = resp.json()
     assert body["points"] == []
-    assert body["bucket_seconds"] == 60
+    assert body["bucket_seconds"] == 300
 
 
 @pytest.mark.asyncio
@@ -157,6 +157,42 @@ async def test_7d_window_uses_5min_buckets(client: AsyncClient, db_session: Asyn
     )
     assert resp.status_code == 200
     assert resp.json()["bucket_seconds"] == 300
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("window", "expected_bucket", "max_points"),
+    [
+        ("1h", 60, 60),
+        ("6h", 60, 360),
+        # 24 h is the crossover (#942). At raw 60 s it is 1,440 points
+        # into a ~1,300 px chart — more points than pixels, which paints
+        # a low-rate series as a solid band instead of a line.
+        ("24h", 300, 288),
+        ("7d", 300, 2016),
+    ],
+)
+async def test_window_bucketing_keeps_points_plottable(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    window: str,
+    expected_bucket: int,
+    max_points: int,
+) -> None:
+    """Every window must resolve to a bucket that keeps it under a
+    screen's worth of points. Guards both directions: shrinking a bucket
+    reintroduces the smear, growing one throws away shape."""
+    _, token = await _make_user(db_session)
+    resp = await client.get(
+        f"/api/v1/metrics/dns/timeseries?window={window}",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["bucket_seconds"] == expected_bucket
+    from app.api.v1.metrics.router import WINDOW_SECONDS
+
+    assert WINDOW_SECONDS[window] // body["bucket_seconds"] == max_points
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_metrics.py
+++ b/backend/tests/test_metrics.py
@@ -246,3 +246,87 @@ async def test_dhcp_agent_metrics_ingest_roundtrip(
     assert len(body["points"]) == 1
     assert body["points"][0]["discover"] == 7
     assert body["points"][0]["ack"] == 5
+
+
+@pytest.mark.asyncio
+async def test_partial_bucket_reports_the_seconds_it_actually_covers(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """The newest 5-minute bucket has only had one or two 60 s samples
+    reported into it (#942).
+
+    Dividing that partial sum by a full 300 renders a 70%+ phantom dip at
+    the right-hand edge of every chart, on every refresh — measured on the
+    dev estate as 0.027 against a steady 0.093. ``covered_seconds`` is what
+    makes the rate honest, so it must reflect distinct agent buckets, not
+    the nominal bucket width.
+    """
+    _, token = await _make_user(db_session)
+    server = await _make_dns_server(db_session)
+
+    now = datetime.now(UTC).replace(second=0, microsecond=0)
+    # A complete 5-minute bucket, then a partial one holding a single
+    # sample. date_bin anchors on 2000-01-01, so :00 and :05 are boundaries.
+    base = now.replace(minute=(now.minute // 10) * 10) - timedelta(minutes=20)
+    for i in range(5):
+        db_session.add(
+            DNSMetricSample(
+                server_id=server.id,
+                bucket_at=base + timedelta(minutes=i),
+                queries_total=10,
+            )
+        )
+    db_session.add(
+        DNSMetricSample(
+            server_id=server.id,
+            bucket_at=base + timedelta(minutes=5),
+            queries_total=10,
+        )
+    )
+    await db_session.commit()
+
+    body = (
+        await client.get(
+            "/api/v1/metrics/dns/timeseries?window=24h",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    ).json()
+    assert body["bucket_seconds"] == 300
+    points = {p["t"]: p for p in body["points"]}
+    full, partial = sorted(points.values(), key=lambda p: p["t"])[:2]
+
+    assert full["covered_seconds"] == 300
+    assert partial["covered_seconds"] == 60
+    # The rate the chart draws. Same underlying qps; without the fix the
+    # partial point would render at a fifth of it.
+    assert full["queries_total"] / full["covered_seconds"] == pytest.approx(
+        partial["queries_total"] / partial["covered_seconds"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_covered_seconds_is_a_time_span_not_a_row_count(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    """Two servers reporting the same minute cover 60 seconds, not 120.
+
+    Counting rows would halve the aggregate rate on every multi-server
+    deployment — i.e. on exactly the ones with enough traffic to look at.
+    """
+    _, token = await _make_user(db_session)
+    s1 = await _make_dns_server(db_session)
+    s2 = await _make_dns_server(db_session)
+    now = datetime.now(UTC).replace(second=0, microsecond=0)
+    for srv in (s1, s2):
+        db_session.add(DNSMetricSample(server_id=srv.id, bucket_at=now, queries_total=30))
+    await db_session.commit()
+
+    body = (
+        await client.get(
+            "/api/v1/metrics/dns/timeseries?window=1h",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    ).json()
+    point = body["points"][0]
+    assert point["queries_total"] == 60
+    assert point["covered_seconds"] == 60

--- a/backend/tests/test_rpki_roa_state.py
+++ b/backend/tests/test_rpki_roa_state.py
@@ -1,0 +1,98 @@
+"""ROA state derivation — source-awareness of the validity window (#942).
+
+The bug this pins: ``expiring_soon`` was derived from ``valid_to`` with
+a 30-day threshold regardless of what the source's validity field
+actually means. Cloudflare's ``rpki.json`` — the DEFAULT source — ships
+``expires``, which is the validity of the VRP cache entry rather than of
+the ROA. Measured against the live global dump on 2026-08-31: of 997,298
+ROAs, 100% expired within 7 days and 79% within 2, because RPKI CAs
+re-sign the objects in the validation chain on a rolling cycle of hours.
+
+So the threshold matched every ROA, permanently. That is not a noisy
+signal — it is a constant, and it fed the ``rpki_roa_expiring`` alert
+rule one event per ROA (928 open events on a small dev estate).
+
+These are pure-function tests on purpose: the failure was silent and
+total, and a unit test on the ladder is the cheapest thing that catches
+the next source being added without measuring its distribution first.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.tasks.rpki_roa_refresh import _LIFETIME_VALIDITY_SOURCES, _derive_roa_state
+
+NOW = datetime(2026, 8, 31, 12, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize("source", ["cloudflare", "ripe"])
+def test_unknown_window_is_valid(source: str) -> None:
+    """A mirror that exposes no window must not produce expiry events."""
+    assert _derive_roa_state(None, NOW, source) == "valid"
+
+
+@pytest.mark.parametrize(
+    "valid_to",
+    [
+        NOW + timedelta(hours=6),
+        NOW + timedelta(days=1),
+        NOW + timedelta(days=2),
+        NOW + timedelta(days=6),
+    ],
+)
+def test_cloudflare_short_cycle_expiry_is_not_expiring_soon(valid_to: datetime) -> None:
+    """The whole Cloudflare dump sits in this range at any moment.
+
+    Reading it as a lifetime made the KPI equal to the total ROA count
+    and stormed the alert rule. These windows are the *normal* steady
+    state for that source, not a deadline.
+    """
+    assert _derive_roa_state(valid_to, NOW, "cloudflare") == "valid"
+
+
+def test_cloudflare_past_window_is_not_expired_either() -> None:
+    """A lapsed cache entry is not a lapsed ROA.
+
+    Presence in the dump is the signal for this source — a ROA the AS
+    holder actually pulled disappears and the reconcile DELETEs it. A
+    ``valid_to`` in the past only means our snapshot went stale, and
+    reading it as ``expired`` would turn a dead refresh task into a
+    fleet-wide "every ROA expired" alert storm.
+    """
+    assert _derive_roa_state(NOW - timedelta(days=3), NOW, "cloudflare") == "valid"
+
+
+def test_ripe_lifetime_window_keeps_the_full_ladder() -> None:
+    """RIPE's ``notAfter`` is a genuine EE-certificate lifetime."""
+    assert _derive_roa_state(NOW - timedelta(days=1), NOW, "ripe") == "expired"
+    assert _derive_roa_state(NOW + timedelta(days=10), NOW, "ripe") == "expiring_soon"
+    assert _derive_roa_state(NOW + timedelta(days=29), NOW, "ripe") == "expiring_soon"
+    assert _derive_roa_state(NOW + timedelta(days=200), NOW, "ripe") == "valid"
+
+
+def test_ripe_boundary_is_inclusive_at_30_days() -> None:
+    assert _derive_roa_state(NOW + timedelta(days=30), NOW, "ripe") == "expiring_soon"
+    assert _derive_roa_state(NOW + timedelta(days=30, seconds=1), NOW, "ripe") == "valid"
+
+
+def test_unknown_source_fails_closed_to_valid() -> None:
+    """An unrecognised source must not manufacture expiry events.
+
+    ``refresh_due_roas`` already coerces the setting to a known value,
+    so this is defence in depth for a future source added to the
+    settings enum but not measured and listed here.
+    """
+    assert _derive_roa_state(NOW + timedelta(hours=1), NOW, "routinator") == "valid"
+
+
+def test_cloudflare_is_not_a_lifetime_source() -> None:
+    """Pins the decision itself, so re-adding it is a deliberate act.
+
+    Anything listed here must have had its expiry distribution measured
+    against the live source first — see the module docstring.
+    """
+    assert "cloudflare" not in _LIFETIME_VALIDITY_SOURCES
+    assert "ripe" in _LIFETIME_VALIDITY_SOURCES

--- a/frontend/src/components/MetricsCharts.tsx
+++ b/frontend/src/components/MetricsCharts.tsx
@@ -174,13 +174,18 @@ export function DNSQueryRateCard({
           <WindowPicker value={win} onChange={setWin} />
         </div>
       </div>
-      <div className="h-64 p-3">
+      {/* Collapse to a slim strip when there is nothing to plot (#942).
+          A full 256 px of empty state pushed the panels that DO have
+          something to say below the fold — and on a fresh install, or any
+          deployment with no agent reporting counters, that is the normal
+          case rather than the exception. */}
+      <div className={hasData || isLoading ? "h-64 p-3" : "px-4 py-3"}>
         {isLoading ? (
           <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
             Loading…
           </div>
         ) : !hasData ? (
-          <div className="flex h-full flex-col items-center justify-center gap-1 text-center text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
             <span>No query data yet.</span>
             <span className="text-[11px]">
               BIND9 agents report counters every 60&nbsp;s.
@@ -307,13 +312,18 @@ export function DHCPTrafficCard({
           <WindowPicker value={win} onChange={setWin} />
         </div>
       </div>
-      <div className="h-64 p-3">
+      {/* Collapse to a slim strip when there is nothing to plot (#942).
+          A full 256 px of empty state pushed the panels that DO have
+          something to say below the fold — and on a fresh install, or any
+          deployment with no agent reporting counters, that is the normal
+          case rather than the exception. */}
+      <div className={hasData || isLoading ? "h-64 p-3" : "px-4 py-3"}>
         {isLoading ? (
           <div className="flex h-full items-center justify-center text-xs text-muted-foreground">
             Loading…
           </div>
         ) : !hasData ? (
-          <div className="flex h-full flex-col items-center justify-center gap-1 text-center text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
             <span>No DHCP traffic yet.</span>
             <span className="text-[11px]">
               Kea agents report packet counters every 60&nbsp;s.

--- a/frontend/src/components/MetricsCharts.tsx
+++ b/frontend/src/components/MetricsCharts.tsx
@@ -61,9 +61,16 @@ function formatT(iso: string, win: MetricsWindow): string {
   return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function perSecond(value: number, bucketSeconds: number): number {
-  if (bucketSeconds <= 0) return 0;
-  return +(value / bucketSeconds).toFixed(2);
+// Rates divide by the seconds a point ACTUALLY covers, not by the nominal
+// bucket width (#942). The newest 5-minute bucket has only had one or two
+// 60 s samples reported into it, so dividing its partial sum by a full 300
+// drew a 70%+ phantom dip at the right-hand edge of every chart — the
+// leading bucket is partial for the same reason, and so is any bucket an
+// agent was down for. Falls back to the nominal width for a server too old
+// to report the field.
+function perSecond(value: number, coveredSeconds: number): number {
+  if (coveredSeconds <= 0) return 0;
+  return +(value / coveredSeconds).toFixed(2);
 }
 
 function WindowPicker({
@@ -136,10 +143,22 @@ export function DNSQueryRateCard({
 
   const points = (data?.points ?? []).map((p) => ({
     t: formatT(p.t, win),
-    queries: perSecond(p.queries_total, data?.bucket_seconds ?? 60),
-    noerror: perSecond(p.noerror, data?.bucket_seconds ?? 60),
-    nxdomain: perSecond(p.nxdomain, data?.bucket_seconds ?? 60),
-    servfail: perSecond(p.servfail, data?.bucket_seconds ?? 60),
+    queries: perSecond(
+      p.queries_total,
+      p.covered_seconds || (data?.bucket_seconds ?? 60),
+    ),
+    noerror: perSecond(
+      p.noerror,
+      p.covered_seconds || (data?.bucket_seconds ?? 60),
+    ),
+    nxdomain: perSecond(
+      p.nxdomain,
+      p.covered_seconds || (data?.bucket_seconds ?? 60),
+    ),
+    servfail: perSecond(
+      p.servfail,
+      p.covered_seconds || (data?.bucket_seconds ?? 60),
+    ),
   }));
 
   // The API returns one zero-filled sample per bucket even when no
@@ -276,10 +295,16 @@ export function DHCPTrafficCard({
 
   const points = (data?.points ?? []).map((p) => ({
     t: formatT(p.t, win),
-    discover: perSecond(p.discover, data?.bucket_seconds ?? 60),
-    request: perSecond(p.request, data?.bucket_seconds ?? 60),
-    ack: perSecond(p.ack, data?.bucket_seconds ?? 60),
-    nak: perSecond(p.nak, data?.bucket_seconds ?? 60),
+    discover: perSecond(
+      p.discover,
+      p.covered_seconds || (data?.bucket_seconds ?? 60),
+    ),
+    request: perSecond(
+      p.request,
+      p.covered_seconds || (data?.bucket_seconds ?? 60),
+    ),
+    ack: perSecond(p.ack, p.covered_seconds || (data?.bucket_seconds ?? 60)),
+    nak: perSecond(p.nak, p.covered_seconds || (data?.bucket_seconds ?? 60)),
   }));
 
   // The API returns one zero-filled sample per bucket even when no

--- a/frontend/src/components/MetricsCharts.tsx
+++ b/frontend/src/components/MetricsCharts.tsx
@@ -44,9 +44,13 @@ const WINDOWS: { key: MetricsWindow; label: string }[] = [
 
 const ALL_SERVERS = "__all__";
 
-function formatT(iso: string, bucketSeconds: number): string {
+// Tick labels key off the WINDOW, not the bucket size: a 24 h window
+// aggregated into 5 min buckets is still one day of data, and stamping
+// the date on every tick there is noise. Only the multi-day window
+// needs it to disambiguate.
+function formatT(iso: string, win: MetricsWindow): string {
   const d = new Date(iso);
-  if (bucketSeconds >= 300) {
+  if (win === "7d") {
     return d.toLocaleString([], {
       month: "short",
       day: "numeric",
@@ -131,7 +135,7 @@ export function DNSQueryRateCard({
   });
 
   const points = (data?.points ?? []).map((p) => ({
-    t: formatT(p.t, data?.bucket_seconds ?? 60),
+    t: formatT(p.t, win),
     queries: perSecond(p.queries_total, data?.bucket_seconds ?? 60),
     noerror: perSecond(p.noerror, data?.bucket_seconds ?? 60),
     nxdomain: perSecond(p.nxdomain, data?.bucket_seconds ?? 60),
@@ -266,7 +270,7 @@ export function DHCPTrafficCard({
   });
 
   const points = (data?.points ?? []).map((p) => ({
-    t: formatT(p.t, data?.bucket_seconds ?? 60),
+    t: formatT(p.t, win),
     discover: perSecond(p.discover, data?.bucket_seconds ?? 60),
     request: perSecond(p.request, data?.bucket_seconds ?? 60),
     ack: perSecond(p.ack, data?.bucket_seconds ?? 60),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10745,6 +10745,11 @@ export type MetricsWindow = "1h" | "6h" | "24h" | "7d";
 
 export interface DNSMetricsPoint {
   t: string;
+  /** Seconds this point actually covers (60 x distinct agent buckets), NOT
+   *  `bucket_seconds`. Derive rates from this: the newest bucket is always
+   *  partial, and dividing it by the nominal width draws a phantom dip at
+   *  the right edge of the chart (#942). */
+  covered_seconds: number;
   queries_total: number;
   noerror: number;
   nxdomain: number;
@@ -10762,6 +10767,11 @@ export interface DNSMetricsSeries {
 
 export interface DHCPMetricsPoint {
   t: string;
+  /** Seconds this point actually covers (60 x distinct agent buckets), NOT
+   *  `bucket_seconds`. Derive rates from this: the newest bucket is always
+   *  partial, and dividing it by the nominal width draws a phantom dip at
+   *  the right edge of the chart (#942). */
+  covered_seconds: number;
   discover: number;
   offer: number;
   request: number;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8376,6 +8376,14 @@ export const dhcpApi = {
     api
       .get<DHCPPoolOccupancy[]>(`/dhcp/scopes/${scopeId}/pools/occupancy`)
       .then((r) => r.data),
+  // Fleet-wide, fullest first (#942) — one round trip whose cost does not
+  // grow with the number of scopes. Same dynamic-only filter as above.
+  fleetPoolOccupancy: (limit = 10) =>
+    api
+      .get<DHCPFleetPoolOccupancy>("/dhcp/pools/occupancy", {
+        params: { limit },
+      })
+      .then((r) => r.data),
 
   // Rogue-DHCP observed responders (#370).
   listResponders: (groupId: string, classification?: string) =>
@@ -8749,6 +8757,27 @@ export interface DHCPPoolOccupancy {
   percent: number;
   /** Derived from mirrored lease rows, so its freshness follows the last lease pull. */
   computed_at: string;
+}
+
+/** One row of the fleet-wide occupancy rollup (#942) — a pool plus the
+ *  context needed to identify it without a follow-up call. */
+export interface DHCPFleetPoolOccupancyRow extends DHCPPoolOccupancy {
+  scope_name: string;
+  scope_is_active: boolean;
+  subnet_network: string | null;
+  group_id: string;
+  group_name: string;
+}
+
+export interface DHCPFleetPoolOccupancy {
+  computed_at: string;
+  /** Every dynamic pool considered, not just the returned slice. */
+  pool_count: number;
+  pools_warning: number;
+  pools_critical: number;
+  /** Distinct (scope, address) pairs on an active lease, fleet-wide. */
+  active_lease_count: number;
+  pools: DHCPFleetPoolOccupancyRow[];
 }
 
 export interface DHCPPool {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10074,6 +10074,10 @@ export interface NetworkDashboardSummary {
   asn_drift_count: number;
   rpki_expiring_count: number;
   rpki_expired_count: number;
+  /** Total ROAs tracked, and when the pull last touched one. Lets the
+   *  panel tell a real all-clear from stale or absent data (#942). */
+  rpki_total_count: number;
+  rpki_last_checked_at: string | null;
   circuit_term_expiring_count: number;
   circuit_status_changed_count: number;
   service_orphan_count: number;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -190,7 +190,56 @@ function UtilColor(percent: number): string {
   return "bg-muted/60 dark:bg-muted/40";
 }
 
-function UtilizationBar({ percent }: { percent: number }) {
+/** True for an IPv6 prefix, whose capacity numbers are not comparable
+ *  to a v4 subnet's and must not be rendered as if they were. */
+function isV6(network: string): boolean {
+  return network.includes(":");
+}
+
+/**
+ * Capacity label for one subnet row (#942).
+ *
+ * A v6 prefix's ``total_ips`` is astronomical: a /64 is 2^64, which
+ * crosses `Number.MAX_SAFE_INTEGER` on the way through JSON and renders
+ * as "9223372036854776000" — a number that is both wrong and wide
+ * enough to wrap the row. The page already refuses to fold v6 into the
+ * aggregate totals for exactly this reason (see the reportingV4 /
+ * reportingV6 split); rows follow the same rule and show the allocation
+ * count alone, which is the only half that means anything.
+ */
+function capacityLabel(subnet: {
+  network: string;
+  allocated_ips: number;
+  total_ips: number;
+}): string {
+  if (isV6(subnet.network)) {
+    return `${subnet.allocated_ips.toLocaleString()} alloc`;
+  }
+  return `${subnet.allocated_ips.toLocaleString()} / ${subnet.total_ips.toLocaleString()}`;
+}
+
+function UtilizationBar({
+  percent,
+  network,
+}: {
+  percent: number;
+  /** When this is a v6 prefix the bar renders n/a: "0%" of a /64 is
+   *  true, useless, and indistinguishable from an empty v4 subnet. */
+  network?: string;
+}) {
+  if (network && isV6(network)) {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="h-1.5 flex-1 rounded-full bg-muted/40" />
+        <span
+          className="w-10 text-right text-xs text-muted-foreground/50"
+          title="Utilization is not meaningful for an IPv6 prefix"
+        >
+          n/a
+        </span>
+      </div>
+    );
+  }
   return (
     <div className="flex items-center gap-2">
       <div className="h-1.5 flex-1 rounded-full bg-muted overflow-hidden">
@@ -290,7 +339,11 @@ function SubnetHeatmap({ subnets }: { subnets: Subnet[] }) {
             <Link
               key={s.id}
               to={`/ipam?subnet=${s.id}`}
-              title={`${s.network}${s.name ? ` — ${s.name}` : ""}\n${s.utilization_percent.toFixed(1)}% · ${s.allocated_ips} / ${s.total_ips}`}
+              title={`${s.network}${s.name ? ` — ${s.name}` : ""}\n${
+                isV6(s.network)
+                  ? capacityLabel(s)
+                  : `${s.utilization_percent.toFixed(1)}% · ${capacityLabel(s)}`
+              }`}
               className={cn(
                 "aspect-square rounded transition-all hover:scale-110 hover:ring-2 hover:ring-primary/40",
                 UtilColor(s.utilization_percent),
@@ -1241,6 +1294,19 @@ export function DashboardPage() {
     refetchInterval: 30_000,
   });
 
+  // Open alert events (#942). Drives BOTH the header pill and the
+  // Overview "Open alerts" panel — one query key, one fetch. The pill
+  // used to render `critical + warning + unhealthyServers` computed on
+  // this page and link to /ipam: a count the alerts page could not
+  // corroborate, pointing at a page unrelated to most of what it
+  // counted. Capacity + server health still drive the health LABEL
+  // next to the title, which is what they actually describe.
+  const { data: openAlerts = [] } = useQuery({
+    queryKey: ["alert-events", { open: true }],
+    queryFn: () => alertsApi.listEvents({ open_only: true, limit: 200 }),
+    refetchInterval: 60_000,
+  });
+
   // IPAM-tab IP-space filter (issue #115). Multi-select dropdown above
   // the IPAM-tab cards scopes every subnet-derived stat to the chosen
   // spaces. Empty list = "All spaces" (no filter). Persisted per-session
@@ -1293,25 +1359,55 @@ export function DashboardPage() {
     ...allDnsServers.map((s) => ({ ...s, kind: "dns" as const })),
     ...dhcpServers.map((s) => ({ ...s, kind: "dhcp" as const })),
   ];
-  const unhealthyServers = allServers.filter(
+  // A server the operator has deliberately paused or put into
+  // maintenance is not a fault, and counting one as unhealthy pins the
+  // whole dashboard to "degraded" for as long as it stays parked
+  // (#942). Maintenance mode is the load-bearing half: #182 already
+  // suppresses the heartbeat-stale ALERT server-side for those, so
+  // counting them here contradicted our own alerting. ``is_enabled``
+  // is DNS-only — DHCP servers have no pause switch — hence the kind
+  // narrowing rather than a bare property read.
+  const supervisedServers = allServers.filter(
+    (s) => !s.maintenance_mode && (s.kind !== "dns" || s.is_enabled !== false),
+  );
+  const unhealthyServers = supervisedServers.filter(
     (s) => s.status === "unreachable" || s.status === "error",
   ).length;
-  const activeServers = allServers.filter((s) => s.status === "active").length;
+  const activeServers = supervisedServers.filter(
+    (s) => s.status === "active",
+  ).length;
+  // #882 — an agent that failed to apply its config keeps serving and
+  // keeps heartbeating, so ``status``, the health check and
+  // ``last_seen_at`` all read normal while the saved zone or scope is
+  // live nowhere. That is exactly the silent failure the dashboard
+  // should catch, so a failing verdict degrades the header even when
+  // the server is otherwise healthy. NULL is UNKNOWN, never ok — an
+  // agent too old to report is where a silent revert would hide, so it
+  // is deliberately not counted as a failure either.
+  const configFailedServers = supervisedServers.filter(
+    (s) => s.config_apply_status != null && s.config_apply_status !== "ok",
+  ).length;
 
-  // Aggregate alerts — shown as a pill next to the title.
-  const alertCount = critical + warning + unhealthyServers;
-  const healthTone: Tone =
-    unhealthyServers > 0 || critical > 0
-      ? "bad"
-      : warning > 0
-        ? "warn"
-        : "good";
-  const healthLabel =
-    unhealthyServers > 0 || critical > 0
-      ? "degraded"
-      : warning > 0
-        ? "near capacity"
-        : "healthy";
+  const degraded = unhealthyServers > 0 || configFailedServers > 0 || critical > 0;
+  const healthTone: Tone = degraded ? "bad" : warning > 0 ? "warn" : "good";
+  const healthLabel = degraded
+    ? "degraded"
+    : warning > 0
+      ? "near capacity"
+      : "healthy";
+  // The label is a rollup of four unrelated things; without this the
+  // operator sees "degraded" and has no idea which one to chase.
+  const healthDetail =
+    [
+      critical > 0 ? `${critical} subnet${critical === 1 ? "" : "s"} ≥95% full` : null,
+      warning > 0 ? `${warning} subnet${warning === 1 ? "" : "s"} ≥80% full` : null,
+      unhealthyServers > 0 ? `${unhealthyServers} server${unhealthyServers === 1 ? "" : "s"} unreachable` : null,
+      configFailedServers > 0
+        ? `${configFailedServers} agent${configFailedServers === 1 ? "" : "s"} failed to apply config`
+        : null,
+    ]
+      .filter(Boolean)
+      .join(" · ") || "No capacity or server-health problems detected";
 
   return (
     <div className="h-full overflow-auto p-6">
@@ -1330,7 +1426,10 @@ export function DashboardPage() {
                 {subnets?.length ?? 0} subnet{subnets?.length === 1 ? "" : "s"}
               </span>
               <span>·</span>
-              <span className="inline-flex items-center gap-1.5">
+              <span
+                className="inline-flex cursor-help items-center gap-1.5"
+                title={healthDetail}
+              >
                 <span
                   className={cn(
                     "inline-block h-1.5 w-1.5 rounded-full",
@@ -1351,40 +1450,37 @@ export function DashboardPage() {
                 onChange={setIpamSpaceFilter}
               />
             )}
-            {alertCount > 0 && (
+            {openAlerts.length > 0 && (
               <Link
-                to="/ipam"
+                to="/admin/alerts"
+                title={`${openAlerts.length} unresolved alert event${
+                  openAlerts.length === 1 ? "" : "s"
+                } — open the Alerts page to triage`}
                 className={cn(
                   "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium",
-                  "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400",
-                  "hover:bg-red-100 dark:hover:bg-red-950/50",
+                  openAlerts.some((e) => e.severity === "critical")
+                    ? "border-red-200 bg-red-50 text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400 hover:bg-red-100 dark:hover:bg-red-950/50"
+                    : "border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-950/50",
                 )}
               >
                 <AlertTriangle className="h-3.5 w-3.5" />
-                {alertCount} alert{alertCount === 1 ? "" : "s"} open
+                {openAlerts.length} alert{openAlerts.length === 1 ? "" : "s"}{" "}
+                open
               </Link>
             )}
+            {/* Blanket invalidate, deliberately (#942). This used to
+                enumerate twelve query keys, which covered the Overview and
+                missed every panel on the Network / Integrations /
+                Compliance / Conformity / Security tabs plus most of the
+                Overview summary cards — pressing Refresh on five of the
+                nine tabs did nothing at all. An allowlist on a button whose
+                whole contract is "reload everything on this page" can only
+                drift as panels are added; the correct scope is the page,
+                and React Query only refetches what is mounted. */}
             <button
               type="button"
-              onClick={() => {
-                for (const key of [
-                  ["spaces"],
-                  ["subnets"],
-                  ["settings"],
-                  ["dns-groups"],
-                  ["dns-zones"],
-                  ["dns-servers"],
-                  ["dhcp-servers"],
-                  ["dhcp-groups"],
-                  ["audit", "recent"],
-                  ["metrics"],
-                  ["nat-mappings", "count"],
-                  ["platform-health"],
-                ]) {
-                  qc.invalidateQueries({ queryKey: key });
-                }
-              }}
-              title="Reload every panel on the dashboard — IPAM, DNS, DHCP, activity feed, metrics charts."
+              onClick={() => void qc.invalidateQueries()}
+              title="Reload every panel on the dashboard."
               className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium hover:bg-accent"
             >
               <RefreshCw className="h-3.5 w-3.5" />
@@ -1709,10 +1805,11 @@ export function DashboardPage() {
                         <div className="flex-1">
                           <UtilizationBar
                             percent={subnet.utilization_percent}
+                            network={subnet.network}
                           />
                         </div>
-                        <span className="w-20 text-right text-[11px] tabular-nums text-muted-foreground">
-                          {subnet.allocated_ips} / {subnet.total_ips}
+                        <span className="w-24 shrink-0 whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                          {capacityLabel(subnet)}
                         </span>
                       </Link>
                     ))
@@ -1814,10 +1911,13 @@ export function DashboardPage() {
                       )}
                     </span>
                     <div className="flex-1">
-                      <UtilizationBar percent={subnet.utilization_percent} />
+                      <UtilizationBar
+                        percent={subnet.utilization_percent}
+                        network={subnet.network}
+                      />
                     </div>
-                    <span className="w-24 text-right text-[11px] tabular-nums text-muted-foreground">
-                      {subnet.allocated_ips} / {subnet.total_ips}
+                    <span className="w-28 shrink-0 whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                      {capacityLabel(subnet)}
                     </span>
                   </Link>
                 ))
@@ -3630,13 +3730,7 @@ function NetworkPanel() {
           tone={data.asn_drift_count > 0 ? "warn" : "good"}
           to="/network/asns"
         />
-        <NetworkKpi
-          label="RPKI expiring"
-          value={data.rpki_expiring_count}
-          tone={data.rpki_expiring_count > 0 ? "warn" : "good"}
-          to="/network/asns"
-          hint="< 30 d"
-        />
+        <RpkiExpiringKpi data={data} />
         <NetworkKpi
           label="RPKI expired"
           value={data.rpki_expired_count}
@@ -3803,23 +3897,82 @@ function NetworkPanel() {
   );
 }
 
+/**
+ * RPKI "expiring soon" KPI (#942).
+ *
+ * Three states, because a bare count answered the wrong question. An
+ * empty ROA table and a healthy one both rendered a green 0, and a pull
+ * that stopped days ago rendered whatever it last wrote as though it
+ * were current. The count is only meaningful if the data behind it is
+ * fresh, so freshness is checked first and reported instead of the
+ * count when it fails.
+ *
+ * The threshold is 24 h against a default refresh interval of 4 h (beat
+ * ticks hourly) — six missed cycles, generous enough not to flap on a
+ * slow sweep and short enough to notice a dead task the same day.
+ */
+function RpkiExpiringKpi({ data }: { data: NetworkDashboardSummary }) {
+  const STALE_AFTER_MS = 24 * 60 * 60 * 1000;
+  const checkedAt = data.rpki_last_checked_at;
+  const ageMs = checkedAt ? Date.now() - new Date(checkedAt).getTime() : null;
+  const stale = ageMs != null && ageMs > STALE_AFTER_MS;
+
+  if (data.rpki_total_count === 0) {
+    return (
+      <NetworkKpi
+        label="RPKI expiring"
+        value="—"
+        tone="default"
+        to="/network/asns"
+        hint="no ROAs tracked"
+        title="No RPKI ROAs have been pulled yet. Add a public ASN and the hourly refresh will populate them."
+      />
+    );
+  }
+  if (stale || checkedAt === null) {
+    return (
+      <NetworkKpi
+        label="RPKI expiring"
+        value="stale"
+        tone="warn"
+        to="/network/asns"
+        hint={checkedAt ? `checked ${humanTime(checkedAt)}` : "never checked"}
+        title={`The ROA refresh has not run recently, so any count here would be fiction. ${data.rpki_total_count} ROAs tracked.`}
+      />
+    );
+  }
+  return (
+    <NetworkKpi
+      label="RPKI expiring"
+      value={data.rpki_expiring_count}
+      tone={data.rpki_expiring_count > 0 ? "warn" : "good"}
+      to="/network/asns"
+      hint={`< 30 d · of ${data.rpki_total_count.toLocaleString()} · checked ${humanTime(checkedAt)}`}
+      title="ROAs inside 30 days of their certificate expiry. Only sources whose validity field is a per-ROA lifetime contribute — Cloudflare's rpki.json ships a short-cycle cache expiry that every ROA carries, so it is deliberately not counted here."
+    />
+  );
+}
+
 function NetworkKpi({
   label,
   value,
   tone,
   to,
   hint,
+  title,
 }: {
   label: string;
   value: number | string;
   tone: Tone;
   to: string;
   hint?: string;
+  title?: string;
 }) {
   const cls = TONE_CLASS[tone];
   return (
     <Link
       to={to}
+      title={title}
       className="rounded-lg border bg-card p-3 transition-colors hover:bg-accent/40"
     >
       <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
@@ -3873,8 +4026,7 @@ function IntegrationsDashboardTabPanel() {
           >
             Features → Integrations
           </Link>{" "}
-          to wire up Kubernetes / Docker / Proxmox / OPNsense / Cloud /
-          Tailscale / UniFi mirrors.
+          to enable read-only infrastructure mirrors.
         </p>
       </div>
     );
@@ -4024,17 +4176,29 @@ function IntegrationCard({ panel }: { panel: IntegrationsDashboardPanel }) {
  * say which one you mean, and only one of them is reassuring.
  */
 function DNSThreatCard() {
+  // Gate the QUERY on the module, not just the render (#942). Hiding
+  // the card on a 404 still fired the request — and with a 60 s
+  // refetch, that is a console error every minute forever on every
+  // install with the module off. The 404 handling below stays as a
+  // backstop for the module being turned off while the page is open.
+  // ``ready &&`` is load-bearing, not belt-and-braces: ``enabled``
+  // optimistically returns true until the module set has loaded, so
+  // gating on it alone still fires one 404 per hard page load — see
+  // the hook's own docstring.
+  const { enabled, ready } = useFeatureModules();
+  const moduleEnabled = ready && enabled("security.dns_threat");
   const { data, isLoading, error } = useQuery({
     queryKey: ["dashboards", "dns-threat"],
     queryFn: () => dnsThreatApi.summary({ hours: 24 }),
     refetchInterval: 60_000,
     retry: false,
+    enabled: moduleEnabled,
   });
 
   const moduleOff =
     (error as { response?: { status?: number } } | null)?.response?.status ===
     404;
-  if (moduleOff || isLoading) return null;
+  if (!moduleEnabled || moduleOff || isLoading) return null;
   if (!data) return null;
 
   const tone: Tone = !data.has_data

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -191,6 +191,44 @@ function UtilColor(percent: number): string {
   return "bg-muted/60 dark:bg-muted/40";
 }
 
+/** One entry in the Overview inventory strip (#942) — a value, its unit,
+ *  and the same click-through the KPI card it replaced had. */
+function InventoryStat({
+  value,
+  label,
+  to,
+  title,
+  tone,
+}: {
+  value: string | number;
+  label: string;
+  to: string;
+  title?: string;
+  tone?: "warn" | "bad";
+}) {
+  return (
+    <Link
+      to={to}
+      title={title}
+      className="inline-flex items-baseline gap-1.5 rounded px-2 py-0.5 transition-colors hover:bg-accent/60"
+    >
+      <span
+        className={cn(
+          "font-semibold tabular-nums",
+          tone === "bad"
+            ? "text-red-600 dark:text-red-400"
+            : tone === "warn"
+              ? "text-amber-600 dark:text-amber-400"
+              : "text-foreground",
+        )}
+      >
+        {value}
+      </span>
+      <span className="text-muted-foreground">{label}</span>
+    </Link>
+  );
+}
+
 /** True for an IPv6 prefix, whose capacity numbers are not comparable
  *  to a v4 subnet's and must not be rendered as if they were. */
 function isV6(network: string): boolean {
@@ -1658,115 +1696,222 @@ export function DashboardPage() {
           </div>
         </div>
 
-        {/* ── KPI grid (Overview / IPAM / DNS / DHCP — same data, different
-              lens. The focused tabs (Compliance / Conformity / Network /
-              Integrations / Security) own their own headline KPIs and
-              skip this grid). ──────────────────────────────────────── */}
-        {tab !== "compliance" &&
-          tab !== "conformity" &&
-          tab !== "network" &&
-          tab !== "integrations" &&
-          tab !== "security" && (
-            <div className="grid gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
-              <KpiCard
-                label="IP Spaces"
-                value={spaces?.length ?? "—"}
-                sub={spaces?.[0]?.name?.toUpperCase()}
-                icon={Layers}
-                to="/ipam"
-              />
-              <KpiCard
-                label="Subnets"
-                value={subnetsScoped.length}
-                sub={
-                  <>
-                    <span className="text-emerald-600 dark:text-emerald-400">
-                      {subnetsScoped.length - critical - warning} healthy
-                    </span>
-                    {(critical > 0 || warning > 0) && (
-                      <>
-                        {" · "}
-                        <span className="text-red-600 dark:text-red-400">
-                          {critical + warning} alert
-                          {critical + warning === 1 ? "" : "s"}
-                        </span>
-                      </>
-                    )}
-                  </>
-                }
-                icon={Network}
-                tone={critical > 0 ? "bad" : warning > 0 ? "warn" : "good"}
-                to="/ipam"
-              />
-              <KpiCard
-                label="Allocated IPs (IPv4)"
-                value={allocatedIPs.toLocaleString()}
-                sub={`${freeIPs.toLocaleString()} free`}
-                icon={Activity}
-                to="/ipam"
-              />
-              <KpiCard
-                label="Utilization (IPv4)"
-                value={`${overallUtil.toFixed(1)}%`}
-                sub={`${allocatedIPs.toLocaleString()} / ${totalIPs.toLocaleString()}`}
-                icon={Server}
-                tone={
-                  overallUtil >= 95
-                    ? "bad"
-                    : overallUtil >= 80
-                      ? "warn"
-                      : "default"
-                }
-              />
-              <KpiCard
-                label="DNS Zones"
-                value={totalZones}
-                sub={
-                  dnsGroups.length > 0
-                    ? `${dnsGroups.length} group${dnsGroups.length === 1 ? "" : "s"}`
-                    : "no groups"
-                }
-                icon={Globe2}
-                to="/dns"
-              />
-              <KpiCard
-                label="Servers"
-                value={allServers.length}
-                sub={
-                  unhealthyServers > 0 ? (
-                    <span className="text-red-600 dark:text-red-400">
-                      {activeServers} active · {unhealthyServers} unhealthy
-                    </span>
-                  ) : allServers.length > 0 ? (
-                    `${activeServers} active`
-                  ) : (
-                    "none registered"
-                  )
-                }
-                icon={Cpu}
-                tone={unhealthyServers > 0 ? "bad" : "default"}
-              />
-            </div>
-          )}
+        {/* ── Overview: what needs attention (#942) ──────────────────────
+              Overview used to open with the same six inventory counters
+              the IPAM / DNS / DHCP tabs repeat verbatim. Space and zone
+              counts do not change between visits, so the home page led
+              with the least informative thing on it while unhealthy
+              agents, capacity pressure and expiring certificates were
+              scattered across other tabs or absent. The counters are
+              still here — demoted to one line below — and the top of the
+              page now answers "what should I look at today". */}
+        {tab === "overview" && (
+          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            <KpiCard
+              label="Agents needing attention"
+              value={unhealthyServers + configFailedServers}
+              sub={
+                unhealthyServers + configFailedServers > 0 ? (
+                  <span className="text-red-600 dark:text-red-400">
+                    {unhealthyServers} unreachable
+                    {configFailedServers > 0 &&
+                      ` · ${configFailedServers} config failed`}
+                  </span>
+                ) : (
+                  `${activeServers} healthy · paused and maintenance excluded`
+                )
+              }
+              icon={Cpu}
+              tone={unhealthyServers + configFailedServers > 0 ? "bad" : "good"}
+              to="/dns"
+            />
+            <KpiCard
+              label="Capacity pressure"
+              value={critical + warning}
+              sub={
+                critical + warning > 0 ? (
+                  <span
+                    className={
+                      critical > 0
+                        ? "text-red-600 dark:text-red-400"
+                        : "text-amber-600 dark:text-amber-400"
+                    }
+                  >
+                    {critical} at ≥95% · {warning} at ≥80%
+                  </span>
+                ) : (
+                  "no subnet above 80%"
+                )
+              }
+              icon={Network}
+              tone={critical > 0 ? "bad" : warning > 0 ? "warn" : "good"}
+              to="/ipam"
+            />
+            <WidgetErrorBoundary title="Certificates expiring">
+              <CertsExpiringKpi />
+            </WidgetErrorBoundary>
+          </div>
+        )}
 
-        {/* ── Platform health (Overview only — sits directly below the
-              KPI row so the colour-coded health ribbon is the next
-              thing the eye lands on after the headline counters). ──── */}
+        {/* ── KPI grid (IPAM / DNS / DHCP — same data, different lens.
+              Overview gets the compact inventory strip instead, and the
+              focused tabs own their own headline KPIs). ─────────────── */}
+        {(tab === "ipam" || tab === "dns" || tab === "dhcp") && (
+          <div className="grid gap-3 grid-cols-2 md:grid-cols-3 lg:grid-cols-6">
+            <KpiCard
+              label="IP Spaces"
+              value={spaces?.length ?? "—"}
+              sub={spaces?.[0]?.name?.toUpperCase()}
+              icon={Layers}
+              to="/ipam"
+            />
+            <KpiCard
+              label="Subnets"
+              value={subnetsScoped.length}
+              sub={
+                <>
+                  <span className="text-emerald-600 dark:text-emerald-400">
+                    {subnetsScoped.length - critical - warning} healthy
+                  </span>
+                  {(critical > 0 || warning > 0) && (
+                    <>
+                      {" · "}
+                      <span className="text-red-600 dark:text-red-400">
+                        {critical + warning} alert
+                        {critical + warning === 1 ? "" : "s"}
+                      </span>
+                    </>
+                  )}
+                </>
+              }
+              icon={Network}
+              tone={critical > 0 ? "bad" : warning > 0 ? "warn" : "good"}
+              to="/ipam"
+            />
+            <KpiCard
+              label="Allocated IPs (IPv4)"
+              value={allocatedIPs.toLocaleString()}
+              sub={`${freeIPs.toLocaleString()} free`}
+              icon={Activity}
+              to="/ipam"
+            />
+            <KpiCard
+              label="Utilization (IPv4)"
+              value={`${overallUtil.toFixed(1)}%`}
+              sub={`${allocatedIPs.toLocaleString()} / ${totalIPs.toLocaleString()}`}
+              icon={Server}
+              tone={
+                overallUtil >= 95
+                  ? "bad"
+                  : overallUtil >= 80
+                    ? "warn"
+                    : "default"
+              }
+            />
+            <KpiCard
+              label="DNS Zones"
+              value={totalZones}
+              sub={
+                dnsGroups.length > 0
+                  ? `${dnsGroups.length} group${dnsGroups.length === 1 ? "" : "s"}`
+                  : "no groups"
+              }
+              icon={Globe2}
+              to="/dns"
+            />
+            <KpiCard
+              label="Servers"
+              value={allServers.length}
+              sub={
+                unhealthyServers > 0 ? (
+                  <span className="text-red-600 dark:text-red-400">
+                    {activeServers} active · {unhealthyServers} unhealthy
+                  </span>
+                ) : allServers.length > 0 ? (
+                  `${activeServers} active`
+                ) : (
+                  "none registered"
+                )
+              }
+              icon={Cpu}
+              tone={unhealthyServers > 0 ? "bad" : "default"}
+            />
+          </div>
+        )}
+
         {tab === "overview" && (
           <WidgetErrorBoundary title="Open alerts">
             <OpenAlertsPanel events={openAlerts} />
           </WidgetErrorBoundary>
         )}
 
+        {/* ── Platform health (Overview only) ───────────────────────── */}
         {tab === "overview" && platformHealth && (
           <WidgetErrorBoundary title="Platform health">
             <PlatformHealthCard health={platformHealth} />
           </WidgetErrorBoundary>
         )}
 
-        {/* ── Network overview cards (Overview tab) ─────────────────── */}
+        {/* ── Inventory strip (#942) — the demoted six KPI cards. Still
+              one click from everything they linked to, in a twelfth of
+              the vertical space, because "how many zones do we have" is
+              a reference lookup rather than a thing to monitor. ─────── */}
         {tab === "overview" && (
-          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="flex flex-wrap items-center gap-x-1 gap-y-2 rounded-lg border bg-card px-4 py-2.5 text-xs">
+            <InventoryStat
+              value={spaces?.length ?? 0}
+              label="spaces"
+              to="/ipam"
+            />
+            <InventoryStat
+              value={subnetsScoped.length}
+              label="subnets"
+              to="/ipam"
+            />
+            <InventoryStat
+              value={allocatedIPs.toLocaleString()}
+              label="allocated IPv4"
+              title={`${freeIPs.toLocaleString()} free of ${totalIPs.toLocaleString()}`}
+              to="/ipam"
+            />
+            <InventoryStat
+              value={`${overallUtil.toFixed(1)}%`}
+              label="utilization"
+              tone={
+                overallUtil >= 95
+                  ? "bad"
+                  : overallUtil >= 80
+                    ? "warn"
+                    : undefined
+              }
+              title={`${allocatedIPs.toLocaleString()} / ${totalIPs.toLocaleString()} IPv4 addresses`}
+              to="/ipam"
+            />
+            <InventoryStat
+              value={totalZones}
+              label="DNS zones"
+              title={`across ${dnsGroups.length} group${dnsGroups.length === 1 ? "" : "s"}`}
+              to="/dns"
+            />
+            <InventoryStat
+              value={allServers.length}
+              label="servers"
+              title={`${activeServers} active`}
+              to="/dns"
+            />
+          </div>
+        )}
+
+        {/* ── Network overview cards (Overview tab) ───────────────────
+              ``items-start`` is the fix for the whitespace, not styling
+              (#942): the grid's default stretch made every card as tall
+              as the tallest in its row, so a card whose whole content is
+              "No subnets scheduled for decommission" rendered as a
+              full-height panel of nothing. Each card is now its natural
+              height, which self-compacts the empty ones without five
+              components needing an empty-state variant. */}
+        {tab === "overview" && (
+          <div className="grid items-start gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
             <WidgetErrorBoundary title="ASN summary">
               <AsnSummaryCard />
             </WidgetErrorBoundary>
@@ -1981,24 +2126,37 @@ export function DashboardPage() {
                     recent.items.slice(0, 12).map((entry) => (
                       <div
                         key={entry.id}
-                        className="flex items-center gap-3 px-4 py-2 text-[11px]"
+                        className="flex items-center gap-2.5 px-4 py-2 text-[11px]"
                       >
                         <span className="w-14 flex-shrink-0 tabular-nums text-muted-foreground">
                           {humanTime(entry.timestamp)}
                         </span>
-                        <span className="w-36 flex-shrink-0 min-w-0">
+                        {/* The badge used to reserve 144 px for names that
+                            are usually six characters, so the two columns
+                            that identify WHAT changed and WHO changed it
+                            were squeezed into what was left and truncated
+                            to "Administr…". It now takes what it needs and
+                            truncates itself, with the full text on hover
+                            everywhere (#942). */}
+                        <span
+                          className="min-w-0 max-w-[9rem] flex-shrink-0 truncate"
+                          title={`${entry.action}${entry.resource_type ? ` · ${entry.resource_type.replace(/_/g, " ")}` : ""}`}
+                        >
                           <ActionBadge
                             action={entry.action}
                             result={entry.result}
                           />
                         </span>
-                        <span className="w-20 flex-shrink-0 truncate text-muted-foreground">
-                          {entry.resource_type.replace(/_/g, " ")}
-                        </span>
-                        <span className="flex-1 truncate font-mono">
+                        <span
+                          className="flex-1 truncate font-mono"
+                          title={entry.resource_display}
+                        >
                           {entry.resource_display}
                         </span>
-                        <span className="w-20 flex-shrink-0 truncate text-right text-muted-foreground">
+                        <span
+                          className="w-24 flex-shrink-0 truncate text-right text-muted-foreground"
+                          title={entry.user_display_name}
+                        >
                           {entry.user_display_name}
                         </span>
                       </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -72,6 +72,7 @@ import {
   type DNSServer,
   type DHCPServer,
   type DHCPServerGroup,
+  type DNSServerGroup,
   type KubernetesCluster,
   type DockerHost,
   type ProxmoxNode,
@@ -515,6 +516,119 @@ function StatusChip({
     >
       {label}
     </span>
+  );
+}
+
+/**
+ * Agents needing attention (#942).
+ *
+ * The KPI card above counts these; this names them. A card reading "4
+ * agents needing attention" that navigates to a page which does not show
+ * those four is the same defect as the old alerts pill, and here no
+ * single link can be honest — the set spans DNS and DHCP servers across
+ * different groups, and both pages restore their last-visited selection,
+ * so a bare `/dns` lands on whatever zone the operator was reading last.
+ *
+ * Each row therefore deep-links to the group whose server list contains
+ * that server: DNSPage restores from ``group`` (defaulting to its servers
+ * tab) and DHCPPage from ``group``.
+ */
+function AttentionAgentsPanel({
+  servers,
+  dnsGroups,
+  dhcpGroups,
+}: {
+  servers: {
+    id: string;
+    name: string;
+    status: string;
+    kind: "dns" | "dhcp";
+    group_id?: string;
+    server_group_id?: string | null;
+    config_apply_status?: ConfigApplyStatus | null;
+    config_apply_error?: string | null;
+  }[];
+  dnsGroups: DNSServerGroup[];
+  dhcpGroups: DHCPServerGroup[];
+}) {
+  function groupFor(s: (typeof servers)[number]): {
+    id: string | null;
+    name: string;
+  } {
+    if (s.kind === "dns") {
+      const g = dnsGroups.find((x) => x.id === s.group_id);
+      return { id: g?.id ?? null, name: g?.name ?? "ungrouped" };
+    }
+    const g = dhcpGroups.find((x) => x.id === s.server_group_id);
+    return { id: g?.id ?? null, name: g?.name ?? "ungrouped" };
+  }
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <Cpu className="h-3.5 w-3.5 text-red-500" />
+          <h3 className="text-xs font-semibold uppercase tracking-wider">
+            Agents needing attention ({servers.length})
+          </h3>
+          <span className="text-[11px] text-muted-foreground">
+            paused and maintenance-mode servers excluded
+          </span>
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <div className="min-w-[520px] divide-y">
+          {servers.map((s) => {
+            const group = groupFor(s);
+            const to =
+              group.id === null
+                ? s.kind === "dns"
+                  ? "/dns"
+                  : "/dhcp"
+                : `/${s.kind}?group=${group.id}`;
+            const unreachable =
+              s.status === "unreachable" || s.status === "error";
+            return (
+              <Link
+                key={`${s.kind}-${s.id}`}
+                to={to}
+                className="flex items-center gap-3 px-4 py-2 text-[11px] transition-colors hover:bg-accent/40"
+              >
+                <span className="inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full bg-red-500" />
+                <span
+                  className="w-40 flex-shrink-0 truncate font-semibold"
+                  title={s.name}
+                >
+                  {s.name}
+                </span>
+                <span className="w-12 flex-shrink-0 uppercase text-muted-foreground">
+                  {s.kind}
+                </span>
+                <span
+                  className="w-32 flex-shrink-0 truncate text-muted-foreground"
+                  title={group.name}
+                >
+                  {group.name}
+                </span>
+                <span className="flex flex-1 flex-wrap items-center gap-1.5">
+                  {unreachable && (
+                    <StatusChip
+                      tone="red"
+                      label={s.status}
+                      title="The health probe cannot reach this server."
+                    />
+                  )}
+                  <ConfigApplyChip
+                    status={s.config_apply_status ?? null}
+                    error={s.config_apply_error}
+                  />
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -1584,6 +1698,18 @@ export function DashboardPage() {
   const configFailedServers = supervisedServers.filter(
     (s) => s.config_apply_status != null && s.config_apply_status !== "ok",
   ).length;
+  // The actual offenders, not just how many. "4 agents needing attention"
+  // that navigates to a page which does not name those four is the same
+  // defect as the old alerts pill — and here no single link can be
+  // honest, because the set spans DNS and DHCP servers across different
+  // groups. So the Overview names them and each row deep-links to the
+  // group whose server list contains it.
+  const attentionServers = supervisedServers.filter(
+    (s) =>
+      s.status === "unreachable" ||
+      s.status === "error" ||
+      (s.config_apply_status != null && s.config_apply_status !== "ok"),
+  );
 
   const degraded =
     unhealthyServers > 0 || configFailedServers > 0 || critical > 0;
@@ -1771,7 +1897,6 @@ export function DashboardPage() {
               }
               icon={Cpu}
               tone={unhealthyServers + configFailedServers > 0 ? "bad" : "good"}
-              to="/dns"
             />
             <KpiCard
               label="Capacity pressure"
@@ -1885,6 +2010,16 @@ export function DashboardPage() {
               tone={unhealthyServers > 0 ? "bad" : "default"}
             />
           </div>
+        )}
+
+        {tab === "overview" && attentionServers.length > 0 && (
+          <WidgetErrorBoundary title="Agents needing attention">
+            <AttentionAgentsPanel
+              servers={attentionServers}
+              dnsGroups={dnsGroups}
+              dhcpGroups={dhcpGroups}
+            />
+          </WidgetErrorBoundary>
         )}
 
         {tab === "overview" && (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -529,12 +529,43 @@ function StatusChip({
  * Shares its query with the header pill (one key, one fetch); the events
  * arrive newest-first from the API.
  */
-function OpenAlertsPanel({ events }: { events: AlertEvent[] }) {
+function OpenAlertsPanel({
+  events,
+  failed = false,
+  truncated = false,
+}: {
+  events: AlertEvent[];
+  /** The fetch failed. Distinct from "no open alerts" — see below. */
+  failed?: boolean;
+  /** The response came back at the fetch cap, so the count is a floor. */
+  truncated?: boolean;
+}) {
   const bySeverity = {
     critical: events.filter((e) => e.severity === "critical").length,
     warning: events.filter((e) => e.severity === "warning").length,
     info: events.filter((e) => e.severity === "info").length,
   };
+
+  // A failed fetch renders as unknown, never as an all-clear. React Query
+  // hands back the `[]` default on error, which would otherwise paint the
+  // exact green "No open alerts" this panel exists to disprove.
+  if (failed) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 text-xs text-amber-700 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-400">
+        <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+        <span className="font-medium">Could not load alerts</span>
+        <span className="text-[11px]">
+          This is not an all-clear — the alert state is unknown.
+        </span>
+        <Link
+          to="/admin/alerts"
+          className="ml-auto text-[11px] underline hover:no-underline"
+        >
+          Alerts page →
+        </Link>
+      </div>
+    );
+  }
 
   if (events.length === 0) {
     return (
@@ -557,7 +588,8 @@ function OpenAlertsPanel({ events }: { events: AlertEvent[] }) {
         <div className="flex items-center gap-2">
           <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
           <h3 className="text-xs font-semibold uppercase tracking-wider">
-            Open alerts ({events.length})
+            Open alerts ({events.length}
+            {truncated ? "+" : ""})
           </h3>
           <span className="flex items-center gap-1.5 text-[11px]">
             {bySeverity.critical > 0 && (
@@ -1455,11 +1487,22 @@ export function DashboardPage() {
   // corroborate, pointing at a page unrelated to most of what it
   // counted. Capacity + server health still drive the health LABEL
   // next to the title, which is what they actually describe.
-  const { data: openAlerts = [] } = useQuery({
+  // ``limit`` is the API's own maximum. It is still a cap, and the count
+  // this drives is presented as authoritative — the RPKI misfire this same
+  // issue fixed had 928 events open at once, so the ceiling is reachable in
+  // practice. When the response comes back exactly full the total is
+  // rendered as "N+" rather than as a number we know is wrong.
+  const OPEN_ALERT_FETCH_LIMIT = 1000;
+  const { data: openAlerts = [], isError: openAlertsFailed } = useQuery({
     queryKey: ["alert-events", { open: true }],
-    queryFn: () => alertsApi.listEvents({ open_only: true, limit: 200 }),
+    queryFn: () =>
+      alertsApi.listEvents({
+        open_only: true,
+        limit: OPEN_ALERT_FETCH_LIMIT,
+      }),
     refetchInterval: 60_000,
   });
+  const openAlertsTruncated = openAlerts.length >= OPEN_ALERT_FETCH_LIMIT;
 
   // IPAM-tab IP-space filter (issue #115). Multi-select dropdown above
   // the IPAM-tab cards scopes every subnet-derived stat to the chosen
@@ -1614,9 +1657,13 @@ export function DashboardPage() {
             {openAlerts.length > 0 && (
               <Link
                 to="/admin/alerts"
-                title={`${openAlerts.length} unresolved alert event${
-                  openAlerts.length === 1 ? "" : "s"
-                } — open the Alerts page to triage`}
+                title={
+                  openAlertsTruncated
+                    ? `At least ${openAlerts.length} unresolved alert events — more than this page fetches. Open the Alerts page to triage.`
+                    : `${openAlerts.length} unresolved alert event${
+                        openAlerts.length === 1 ? "" : "s"
+                      } — open the Alerts page to triage`
+                }
                 className={cn(
                   "inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium",
                   openAlerts.some((e) => e.severity === "critical")
@@ -1625,8 +1672,9 @@ export function DashboardPage() {
                 )}
               >
                 <AlertTriangle className="h-3.5 w-3.5" />
-                {openAlerts.length} alert{openAlerts.length === 1 ? "" : "s"}{" "}
-                open
+                {openAlerts.length}
+                {openAlertsTruncated ? "+" : ""} alert
+                {openAlerts.length === 1 ? "" : "s"} open
               </Link>
             )}
             {/* Blanket invalidate, deliberately (#942). This used to
@@ -1841,7 +1889,11 @@ export function DashboardPage() {
 
         {tab === "overview" && (
           <WidgetErrorBoundary title="Open alerts">
-            <OpenAlertsPanel events={openAlerts} />
+            <OpenAlertsPanel
+              events={openAlerts}
+              failed={openAlertsFailed}
+              truncated={openAlertsTruncated}
+            />
           </WidgetErrorBoundary>
         )}
 
@@ -2693,12 +2745,23 @@ function ServerRow({
  * either would render as a red exhaustion bar for behaving correctly.
  */
 function DhcpPoolPressure() {
-  const { data, isLoading } = useQuery({
+  const { data, isLoading, isError } = useQuery({
     queryKey: ["dhcp-pool-occupancy", "fleet"],
     queryFn: () => dhcpApi.fleetPoolOccupancy(8),
     refetchInterval: 60_000,
   });
 
+  // A failed fetch must not render as "no pools configured" — that is the
+  // same false-calm this panel exists to prevent, and an error boundary
+  // does not catch a rejected query.
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-400">
+        Could not load pool occupancy — allocation pressure is unknown, not
+        clear.
+      </div>
+    );
+  }
   if (isLoading) {
     return (
       <div className="rounded-lg border bg-card px-4 py-3 text-xs text-muted-foreground">
@@ -2773,7 +2836,11 @@ function DhcpPoolPressure() {
             {data.pools.map((p) => (
               <Link
                 key={p.pool_id}
-                to={`/dhcp?scope=${p.scope_id}`}
+                // DHCPPage restores from ``group`` / ``server`` only —
+                // a ``scope`` param is silently dropped and the click
+                // lands on whatever was last selected. Deep-link to the
+                // owning group, whose panel lists this scope.
+                to={`/dhcp?group=${p.group_id}`}
                 className="flex items-center gap-4 px-4 py-2.5 transition-colors hover:bg-accent/40"
               >
                 <span

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -89,6 +89,7 @@ import {
   type VRF,
   type Domain,
   type AlertEvent,
+  type ConfigApplyStatus,
   type AlertRule,
   type ConformityResult,
   type ConformitySummary,
@@ -451,9 +452,11 @@ function futureTime(ts: string): string {
 function StatusChip({
   tone,
   label,
+  title,
 }: {
   tone: "green" | "amber" | "red" | "gray";
   label: string;
+  title?: string;
 }) {
   const cls =
     tone === "green"
@@ -465,13 +468,126 @@ function StatusChip({
           : "bg-muted text-muted-foreground";
   return (
     <span
+      title={title}
       className={cn(
         "inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold",
         cls,
+        title && "cursor-help",
       )}
     >
       {label}
     </span>
+  );
+}
+
+/**
+ * Open alerts rollup (#942).
+ *
+ * The alerts framework fires into `alert_event`, and until now the
+ * dashboard surfaced none of it — the header pill did arithmetic of its
+ * own and the Compliance tab showed a compliance-filtered slice. So the
+ * home page could look calm while the alerting was lit up.
+ *
+ * Shares its query with the header pill (one key, one fetch); the events
+ * arrive newest-first from the API.
+ */
+function OpenAlertsPanel({ events }: { events: AlertEvent[] }) {
+  const bySeverity = {
+    critical: events.filter((e) => e.severity === "critical").length,
+    warning: events.filter((e) => e.severity === "warning").length,
+    info: events.filter((e) => e.severity === "info").length,
+  };
+
+  if (events.length === 0) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border bg-card px-4 py-2.5 text-xs">
+        <span className="inline-block h-1.5 w-1.5 rounded-full bg-emerald-500" />
+        <span className="font-medium">No open alerts</span>
+        <Link
+          to="/admin/alerts"
+          className="ml-auto text-[11px] text-primary hover:underline"
+        >
+          Alert rules →
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />
+          <h3 className="text-xs font-semibold uppercase tracking-wider">
+            Open alerts ({events.length})
+          </h3>
+          <span className="flex items-center gap-1.5 text-[11px]">
+            {bySeverity.critical > 0 && (
+              <StatusChip
+                tone="red"
+                label={`${bySeverity.critical} critical`}
+              />
+            )}
+            {bySeverity.warning > 0 && (
+              <StatusChip
+                tone="amber"
+                label={`${bySeverity.warning} warning`}
+              />
+            )}
+            {bySeverity.info > 0 && (
+              <StatusChip tone="gray" label={`${bySeverity.info} info`} />
+            )}
+          </span>
+        </div>
+        <Link
+          to="/admin/alerts"
+          className="text-[11px] text-primary hover:underline"
+        >
+          view all →
+        </Link>
+      </div>
+      <div className="divide-y">
+        {events.slice(0, 5).map((e) => (
+          <Link
+            key={e.id}
+            to="/admin/alerts"
+            className="flex items-center gap-3 px-4 py-2 text-[11px] transition-colors hover:bg-accent/40"
+          >
+            <span
+              className={cn(
+                "inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full",
+                e.severity === "critical"
+                  ? "bg-red-500"
+                  : e.severity === "warning"
+                    ? "bg-amber-500"
+                    : "bg-muted-foreground/40",
+              )}
+              title={e.severity}
+            />
+            <span
+              className="w-40 flex-shrink-0 truncate font-semibold"
+              title={e.subject_display}
+            >
+              {e.subject_display || e.subject_type}
+            </span>
+            <span
+              className="flex-1 truncate text-muted-foreground"
+              title={e.message}
+            >
+              {e.message}
+            </span>
+            <span className="w-20 flex-shrink-0 text-right text-muted-foreground">
+              {humanTime(e.fired_at)}
+            </span>
+          </Link>
+        ))}
+      </div>
+      {events.length > 5 && (
+        <div className="border-t px-4 py-1.5 text-[11px] text-muted-foreground">
+          + {events.length - 5} more
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -1388,7 +1504,8 @@ export function DashboardPage() {
     (s) => s.config_apply_status != null && s.config_apply_status !== "ok",
   ).length;
 
-  const degraded = unhealthyServers > 0 || configFailedServers > 0 || critical > 0;
+  const degraded =
+    unhealthyServers > 0 || configFailedServers > 0 || critical > 0;
   const healthTone: Tone = degraded ? "bad" : warning > 0 ? "warn" : "good";
   const healthLabel = degraded
     ? "degraded"
@@ -1399,9 +1516,15 @@ export function DashboardPage() {
   // operator sees "degraded" and has no idea which one to chase.
   const healthDetail =
     [
-      critical > 0 ? `${critical} subnet${critical === 1 ? "" : "s"} ≥95% full` : null,
-      warning > 0 ? `${warning} subnet${warning === 1 ? "" : "s"} ≥80% full` : null,
-      unhealthyServers > 0 ? `${unhealthyServers} server${unhealthyServers === 1 ? "" : "s"} unreachable` : null,
+      critical > 0
+        ? `${critical} subnet${critical === 1 ? "" : "s"} ≥95% full`
+        : null,
+      warning > 0
+        ? `${warning} subnet${warning === 1 ? "" : "s"} ≥80% full`
+        : null,
+      unhealthyServers > 0
+        ? `${unhealthyServers} server${unhealthyServers === 1 ? "" : "s"} unreachable`
+        : null,
       configFailedServers > 0
         ? `${configFailedServers} agent${configFailedServers === 1 ? "" : "s"} failed to apply config`
         : null,
@@ -1629,6 +1752,12 @@ export function DashboardPage() {
         {/* ── Platform health (Overview only — sits directly below the
               KPI row so the colour-coded health ribbon is the next
               thing the eye lands on after the headline counters). ──── */}
+        {tab === "overview" && (
+          <WidgetErrorBoundary title="Open alerts">
+            <OpenAlertsPanel events={openAlerts} />
+          </WidgetErrorBoundary>
+        )}
+
         {tab === "overview" && platformHealth && (
           <WidgetErrorBoundary title="Platform health">
             <PlatformHealthCard health={platformHealth} />
@@ -1663,7 +1792,12 @@ export function DashboardPage() {
           </WidgetErrorBoundary>
         )}
 
-        {/* ── DHCP traffic (DHCP tab only) ───────────────────────────── */}
+        {/* ── DHCP pools + traffic (DHCP tab only) ───────────────────── */}
+        {tab === "dhcp" && (
+          <WidgetErrorBoundary title="DHCP pools">
+            <DhcpPoolPressure />
+          </WidgetErrorBoundary>
+        )}
         {tab === "dhcp" && (
           <WidgetErrorBoundary title="DHCP traffic">
             <DHCPTrafficCard dhcpServers={dhcpServers} />
@@ -1955,6 +2089,9 @@ export function DashboardPage() {
                       groupName={group?.name ?? "—"}
                       lastSeen={s.last_health_check_at}
                       isEnabled={s.is_enabled !== false}
+                      maintenance={s.maintenance_mode}
+                      configApplyStatus={s.config_apply_status}
+                      configApplyError={s.config_apply_error}
                     />
                   );
                 })}
@@ -2006,6 +2143,9 @@ export function DashboardPage() {
                       }
                       groupName={group?.name ?? "ungrouped"}
                       lastSeen={s.last_health_check_at}
+                      maintenance={s.maintenance_mode}
+                      configApplyStatus={s.config_apply_status}
+                      configApplyError={s.config_apply_error}
                     />
                   );
                 })}
@@ -2256,6 +2396,45 @@ function IpamSpaceFilter({
   );
 }
 
+/**
+ * Config-apply verdict chip (#882, surfaced here by #942).
+ *
+ * The failure this makes visible is silent by construction: an agent
+ * that could not apply its config keeps serving the PREVIOUS one and
+ * keeps heartbeating, so `status`, the health probe and `last_seen_at`
+ * all read normal while the zone or scope the operator saved is live
+ * nowhere.
+ *
+ * NULL renders nothing rather than "ok" — an agent too old to report a
+ * verdict is exactly where a silent revert would hide, and painting
+ * that green would be the same lie in a different colour.
+ */
+function ConfigApplyChip({
+  status,
+  error,
+}: {
+  status: ConfigApplyStatus | null;
+  error?: string | null;
+}) {
+  if (status == null || status === "ok") return null;
+  // `reverted` means a known-good config is still serving; the other two
+  // mean the running state is wrong or unknown.
+  const tone = status === "reverted" ? "amber" : "red";
+  const label = status === "reverted" ? "config reverted" : `config ${status}`;
+  return (
+    <StatusChip
+      tone={tone}
+      label={label.replace(/_/g, " ")}
+      title={
+        error ||
+        (status === "reverted"
+          ? "The saved config failed to apply; the agent rolled back and is serving the previous one."
+          : "The saved config failed to apply and the rollback did not succeed. Running state is unknown.")
+      }
+    />
+  );
+}
+
 function ServerRow({
   name,
   host,
@@ -2264,6 +2443,9 @@ function ServerRow({
   groupName,
   lastSeen,
   isEnabled = true,
+  maintenance = false,
+  configApplyStatus = null,
+  configApplyError = null,
 }: {
   name: string;
   host: string;
@@ -2272,6 +2454,9 @@ function ServerRow({
   groupName: string;
   lastSeen?: string | null;
   isEnabled?: boolean;
+  maintenance?: boolean;
+  configApplyStatus?: ConfigApplyStatus | null;
+  configApplyError?: string | null;
 }) {
   const dotCls =
     status === "active"
@@ -2318,10 +2503,158 @@ function ServerRow({
       <span className="w-24 truncate text-muted-foreground" title={groupName}>
         {groupName}
       </span>
-      <StatusIcon className="ml-auto h-3 w-3 flex-shrink-0 text-muted-foreground/50" />
+      <div className="ml-auto flex flex-shrink-0 items-center gap-1.5">
+        {maintenance && (
+          <StatusChip
+            tone="amber"
+            label="maintenance"
+            title="Operator-set maintenance mode — health alerts are suppressed for this server."
+          />
+        )}
+        <ConfigApplyChip status={configApplyStatus} error={configApplyError} />
+        <StatusIcon className="h-3 w-3 text-muted-foreground/50" />
+      </div>
       <span className="w-20 flex-shrink-0 text-right text-muted-foreground">
         {!isEnabled ? "disabled" : lastSeen ? humanTime(lastSeen) : "never"}
       </span>
+    </div>
+  );
+}
+
+/**
+ * DHCP pool pressure (#942, over the #913 occupancy computation).
+ *
+ * The DHCP tab used to show an empty traffic chart and a server list —
+ * nothing about leases or pools, despite "can a client still get an
+ * address" being the flagship DHCP question and the arithmetic having
+ * existed since #339. This answers it fleet-wide in one call.
+ *
+ * Dynamic pools only, matching the endpoint, the per-scope endpoint and
+ * the `dhcp_pool_exhaustion` alert evaluator: an excluded range is never
+ * offered to a client and a reserved one is *supposed* to fill up, so
+ * either would render as a red exhaustion bar for behaving correctly.
+ */
+function DhcpPoolPressure() {
+  const { data, isLoading } = useQuery({
+    queryKey: ["dhcp-pool-occupancy", "fleet"],
+    queryFn: () => dhcpApi.fleetPoolOccupancy(8),
+    refetchInterval: 60_000,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="rounded-lg border bg-card px-4 py-3 text-xs text-muted-foreground">
+        Loading pool occupancy…
+      </div>
+    );
+  }
+  if (!data || data.pool_count === 0) {
+    return (
+      <div className="rounded-lg border bg-card px-4 py-3 text-xs text-muted-foreground">
+        No dynamic DHCP pools configured. Add a pool to a scope to see
+        allocation pressure here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-3 grid-cols-2 lg:grid-cols-4">
+        <KpiCard
+          label="Active leases"
+          value={data.active_lease_count.toLocaleString()}
+          sub="distinct addresses"
+          icon={Activity}
+          to="/dhcp"
+        />
+        <KpiCard
+          label="Dynamic pools"
+          value={data.pool_count}
+          sub="fleet-wide"
+          icon={Layers}
+          to="/dhcp"
+        />
+        <KpiCard
+          label="Pools ≥ 80%"
+          value={data.pools_warning}
+          tone={data.pools_warning > 0 ? "warn" : "good"}
+          sub="nearing exhaustion"
+          icon={AlertTriangle}
+          to="/dhcp"
+        />
+        <KpiCard
+          label="Pools ≥ 95%"
+          value={data.pools_critical}
+          tone={data.pools_critical > 0 ? "bad" : "good"}
+          sub="effectively full"
+          icon={AlertTriangle}
+          to="/dhcp"
+        />
+      </div>
+
+      <div className="rounded-lg border bg-card">
+        <div className="flex flex-wrap items-center justify-between gap-2 border-b px-4 py-2.5">
+          <div className="flex items-center gap-2">
+            <Server className="h-3.5 w-3.5 text-muted-foreground" />
+            <h3 className="text-xs font-semibold uppercase tracking-wider">
+              Pools nearest exhaustion
+            </h3>
+            <span className="text-[11px] text-muted-foreground">
+              showing {data.pools.length} of {data.pool_count}
+            </span>
+          </div>
+          <span
+            className="text-[11px] text-muted-foreground"
+            title="Occupancy is derived from mirrored lease rows, so its freshness follows the last lease pull — not the moment this page rendered."
+          >
+            as of {humanTime(data.computed_at)}
+          </span>
+        </div>
+        <div className="overflow-x-auto">
+          <div className="min-w-[620px] divide-y">
+            {data.pools.map((p) => (
+              <Link
+                key={p.pool_id}
+                to={`/dhcp?scope=${p.scope_id}`}
+                className="flex items-center gap-4 px-4 py-2.5 transition-colors hover:bg-accent/40"
+              >
+                <span
+                  className="w-52 shrink-0 truncate font-mono text-xs"
+                  title={`${p.start_ip} – ${p.end_ip}`}
+                >
+                  {p.start_ip}–{p.end_ip}
+                </span>
+                <span className="w-36 truncate text-xs text-muted-foreground">
+                  {p.scope_name || p.subnet_network || (
+                    <span className="text-muted-foreground/40">—</span>
+                  )}
+                </span>
+                <span className="w-24 truncate text-[11px] text-muted-foreground">
+                  {p.group_name}
+                </span>
+                {/* A scope the operator deactivated is not handing out
+                    addresses, so its number is real but not urgent. Flagged
+                    rather than hidden — the exhaustion alert still fires on
+                    these, and a panel that silently disagreed with the
+                    alerting is how a wrong all-clear gets reported. */}
+                {!p.scope_is_active && (
+                  <StatusChip
+                    tone="gray"
+                    label="inactive"
+                    title="The parent scope is deactivated — it is not currently serving addresses."
+                  />
+                )}
+                <div className="flex-1">
+                  <UtilizationBar percent={p.percent} />
+                </div>
+                <span className="w-28 shrink-0 whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                  {p.assigned.toLocaleString()} / {p.total.toLocaleString()}
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/admin/AlertsPage.tsx
+++ b/frontend/src/pages/admin/AlertsPage.tsx
@@ -622,6 +622,121 @@ export function AlertsPage() {
           </div>
         </div>
 
+        {/* ── Events (first, deliberately) ──────────────────────────
+              Events are what an operator acts on; rules are the
+              configuration that produces them. With a populated rule
+              table this section used to sit well below the fold, so
+              arriving here from the dashboard's "N alerts open" pill
+              landed on a screen of rules with the alerts themselves
+              off-screen — the pill's whole job is to show them (#942).
+              ``openOnly`` already defaults on, so this opens on
+              exactly what the pill counted. ─────────────────────── */}
+        <div className="rounded-lg border bg-card">
+          <div className="flex items-center justify-between border-b px-4 py-2.5">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-4 w-4 text-amber-500" />
+              <h2 className="text-sm font-semibold">Events</h2>
+              <span className="text-xs text-muted-foreground">
+                {events.length} shown
+              </span>
+            </div>
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <input
+                type="checkbox"
+                checked={openOnly}
+                onChange={(e) => setOpenOnly(e.target.checked)}
+              />
+              Open only
+            </label>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead className="text-xs uppercase tracking-wider text-muted-foreground">
+                <tr className="border-b">
+                  <th className="px-4 py-2 text-left">Fired</th>
+                  <th className="px-4 py-2 text-left">Severity</th>
+                  <th className="px-4 py-2 text-left">Subject</th>
+                  <th className="px-4 py-2 text-left">Message</th>
+                  <th className="px-4 py-2 text-left">State</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody className={zebraBodyCls}>
+                {events.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={6}
+                      className="px-4 py-8 text-center text-xs text-muted-foreground"
+                    >
+                      {openOnly
+                        ? "No open events — all clear."
+                        : "No events yet."}
+                    </td>
+                  </tr>
+                )}
+                {events.map((ev) => (
+                  <tr key={ev.id} className="border-b">
+                    <td className="px-4 py-2 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                      {new Date(ev.fired_at).toLocaleString()}
+                    </td>
+                    <td className="px-4 py-2">
+                      <SeverityBadge severity={ev.severity} />
+                    </td>
+                    <td className="px-4 py-2 text-xs">
+                      <span className="text-muted-foreground">
+                        {ev.subject_type}:
+                      </span>{" "}
+                      <span className="font-medium">{ev.subject_display}</span>
+                    </td>
+                    <td className="px-4 py-2 text-xs text-muted-foreground">
+                      {ev.message}
+                    </td>
+                    <td className="px-4 py-2">
+                      {ev.resolved_at ? (
+                        <span className="text-xs text-emerald-600 dark:text-emerald-400">
+                          resolved {new Date(ev.resolved_at).toLocaleString()}
+                        </span>
+                      ) : (
+                        <span className="text-xs text-amber-600 dark:text-amber-400">
+                          open
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-2">
+                      <div className="flex items-center justify-end gap-1">
+                        <AskAIButton
+                          context={[
+                            `Alert event on ${ev.subject_type} ${ev.subject_display}`,
+                            `severity: ${ev.severity}`,
+                            `message: ${ev.message}`,
+                            `fired_at: ${ev.fired_at}`,
+                            ev.resolved_at
+                              ? `resolved_at: ${ev.resolved_at}`
+                              : "state: open",
+                            `event_id: ${ev.id}`,
+                          ].join(", ")}
+                          tooltip="Ask AI about this alert"
+                          prompt="Explain this alert — what tripped it, what it means, and the most likely remediation."
+                          iconOnly
+                          className="px-1.5 py-1"
+                        />
+                        {!ev.resolved_at && (
+                          <button
+                            onClick={() => resolve.mutate(ev.id)}
+                            className="rounded border px-2 py-0.5 text-[11px] hover:bg-accent"
+                          >
+                            Resolve
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
         {/* ── Rules ───────────────────────────────────────────────────── */}
         <div className="rounded-lg border bg-card">
           <div className="flex items-center justify-between border-b px-4 py-2.5">
@@ -763,113 +878,6 @@ export function AlertsPage() {
                         >
                           <Trash2 className="h-3.5 w-3.5" />
                         </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-
-        {/* ── Events ─────────────────────────────────────────────────── */}
-        <div className="rounded-lg border bg-card">
-          <div className="flex items-center justify-between border-b px-4 py-2.5">
-            <div className="flex items-center gap-2">
-              <AlertTriangle className="h-4 w-4 text-amber-500" />
-              <h2 className="text-sm font-semibold">Events</h2>
-              <span className="text-xs text-muted-foreground">
-                {events.length} shown
-              </span>
-            </div>
-            <label className="flex items-center gap-2 text-xs text-muted-foreground">
-              <input
-                type="checkbox"
-                checked={openOnly}
-                onChange={(e) => setOpenOnly(e.target.checked)}
-              />
-              Open only
-            </label>
-          </div>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="text-xs uppercase tracking-wider text-muted-foreground">
-                <tr className="border-b">
-                  <th className="px-4 py-2 text-left">Fired</th>
-                  <th className="px-4 py-2 text-left">Severity</th>
-                  <th className="px-4 py-2 text-left">Subject</th>
-                  <th className="px-4 py-2 text-left">Message</th>
-                  <th className="px-4 py-2 text-left">State</th>
-                  <th className="px-4 py-2" />
-                </tr>
-              </thead>
-              <tbody className={zebraBodyCls}>
-                {events.length === 0 && (
-                  <tr>
-                    <td
-                      colSpan={6}
-                      className="px-4 py-8 text-center text-xs text-muted-foreground"
-                    >
-                      {openOnly
-                        ? "No open events — all clear."
-                        : "No events yet."}
-                    </td>
-                  </tr>
-                )}
-                {events.map((ev) => (
-                  <tr key={ev.id} className="border-b">
-                    <td className="px-4 py-2 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
-                      {new Date(ev.fired_at).toLocaleString()}
-                    </td>
-                    <td className="px-4 py-2">
-                      <SeverityBadge severity={ev.severity} />
-                    </td>
-                    <td className="px-4 py-2 text-xs">
-                      <span className="text-muted-foreground">
-                        {ev.subject_type}:
-                      </span>{" "}
-                      <span className="font-medium">{ev.subject_display}</span>
-                    </td>
-                    <td className="px-4 py-2 text-xs text-muted-foreground">
-                      {ev.message}
-                    </td>
-                    <td className="px-4 py-2">
-                      {ev.resolved_at ? (
-                        <span className="text-xs text-emerald-600 dark:text-emerald-400">
-                          resolved {new Date(ev.resolved_at).toLocaleString()}
-                        </span>
-                      ) : (
-                        <span className="text-xs text-amber-600 dark:text-amber-400">
-                          open
-                        </span>
-                      )}
-                    </td>
-                    <td className="px-4 py-2">
-                      <div className="flex items-center justify-end gap-1">
-                        <AskAIButton
-                          context={[
-                            `Alert event on ${ev.subject_type} ${ev.subject_display}`,
-                            `severity: ${ev.severity}`,
-                            `message: ${ev.message}`,
-                            `fired_at: ${ev.fired_at}`,
-                            ev.resolved_at
-                              ? `resolved_at: ${ev.resolved_at}`
-                              : "state: open",
-                            `event_id: ${ev.id}`,
-                          ].join(", ")}
-                          tooltip="Ask AI about this alert"
-                          prompt="Explain this alert — what tripped it, what it means, and the most likely remediation."
-                          iconOnly
-                          className="px-1.5 py-1"
-                        />
-                        {!ev.resolved_at && (
-                          <button
-                            onClick={() => resolve.mutate(ev.id)}
-                            className="rounded border px-2 py-0.5 text-[11px] hover:bg-accent"
-                          >
-                            Resolve
-                          </button>
-                        )}
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary

Works #942 end to end: eight defects, three shipped capabilities the dashboards never picked up, and an Overview that leads with what needs attention rather than with inventory counters.

**The headline find was not in the issue text.** "RPKI EXPIRING 928" was neither stale data nor bad seed data (the two causes #942 speculated about). Cloudflare's `expires` — on the **default** source — is the validity of the VRP *cache entry*, not of the ROA, because RPKI CAs re-sign the objects in the validation chain every few hours. Measured against the live global dump on 2026-08-31: **of 997,298 ROAs, 100% expire within 7 days and 79% within 2.** The 30-day `expiring_soon` threshold therefore matched every ROA that will ever exist, permanently.

The dashboard number was the cosmetic half. `rpki_roa_expiring` fires **one alert event per ROA**, so on any default install the rule storms the alerts framework — 928 open events on a small dev estate. State derivation is now source-aware (`_LIFETIME_VALIDITY_SOURCES`); Cloudflare is excluded and RIPE's genuine EE-cert `notAfter` keeps the ladder. Verified end to end against the live source: all 928 transitioned `expiring_soon` → `valid`. No migration needed — the reconcile restamps state and the framework auto-resolves the events.

### Phase 1 — the eight defects

| | |
|---|---|
| **Alerts pill** | Counted `critical + warning + unhealthyServers` computed on the page and linked to `/ipam` — a number the alerts page could not corroborate, pointing somewhere unrelated to most of what it counted. Now counts open `alert_event` rows and links to `/admin/alerts`. |
| **Disabled servers** | Excluded from the health rollup. **Maintenance mode is the load-bearing half**: #182 already suppresses the heartbeat-stale alert server-side for those, so counting them contradicted our own alerting and pinned the header to "degraded" for as long as a server stayed parked. |
| **Chart smear** | `_bucket_seconds_for` only aggregated *above* 24 h, so the default window returned 1,440 raw points into a ~1,300 px plot — more points than pixels. Now 300 s / 288 points. |
| **Refresh button** | Invalidated twelve hardcoded keys and missed every panel on five of the nine tabs. Now a blanket invalidate, which is the button's actual contract and cannot drift. |
| **dns-threat 404** | Gated the query on the module, not just the card's render — it was a console error every 60 s forever with the module off. `ready &&` included, per the hook's own docstring. |
| **IPv6 rows** | `1 / 9223372036854776000` (wrapping) → `1 alloc`, utilization `n/a`. |
| **RPKI** | Above. Plus total-tracked + last-checked on the dashboard, so a real all-clear is distinguishable from a dead refresh task. |
| **Stale copy** | Integrations empty state no longer enumerates mirrors (it had already gone stale by four). |

### Phase 2 — shipped features the dashboards missed

- **DHCP pool pressure.** New `GET /dhcp/pools/occupancy` (top-N fleet-wide) over the #913 computation. Filters are deliberately **identical** to the per-scope endpoint and the `dhcp_pool_exhaustion` evaluator — dynamic only, no `is_active` filter — because a surface that quietly dropped rows the alerting still fires on is how "the pool is fine" gets reported about a pool that is paging someone. Lease count is DISTINCT `(scope, address)`: a Kea HA pair mirrors every lease twice.
- **Config-apply verdicts (#882)** on server rows, folded into the header rollup. This is the failure that is silent by construction — the agent keeps serving the *previous* config and keeps heartbeating, so `status`, the health probe and `last_seen_at` all read normal while the saved zone or scope is live nowhere. **NULL renders nothing, never "ok"**: an agent too old to report is exactly where a silent revert would hide.
- **Open-alerts panel** on Overview. On the dev estate it immediately surfaced three criticals that had been invisible: an RPKI-invalid route and two audit-chain breaks.

### Phase 3 — Overview relevance

Six inventory counters (repeated verbatim on three other tabs) demoted to one line; the top of the page now answers "what should I look at today". The empty summary cards were not a styling problem — the grid's default stretch made every card as tall as the tallest in its row, so `items-start` self-compacts them without five components each needing an empty-state variant.

### From `/code-review` (all six confirmed and fixed)

**Four were the same false-calm defect this PR exists to fix, reintroduced by the code that fixes it** — a failed pool fetch rendering "No dynamic DHCP pools configured", and React Query's `[]` default painting the green "No open alerts" the panel was added to disprove. Both now render unknown as unknown. Also: the alerts fetch capped at 200 while presenting the result as authoritative (the RPKI misfire in this same branch had 928 open, so the ceiling is reachable — raised, and rendered `N+` when full), and pool rows deep-linked to `/dhcp?scope=`, which `DHCPPage` does not parse.

The sixth was an edge artifact of my own bucketing fix: the newest 5-minute bucket has only had one or two 60 s samples reported into it, so dividing by a full 300 drew a **phantom 71% dip** at the right edge of both default charts, on every refresh. Points now carry `covered_seconds` — 60 × the **distinct** agent buckets, so it is a time span rather than a row count and stays correct when several servers report the same minute. This also fixes the same distortion for any bucket an agent was down for, which 7 d has had since it shipped.

### Follow-up from review-in-flight

Arriving from the pill landed on a screen of 39 rule rows with the alerts below the fold. Events now lead the Alerts page — on its own merits, since events are what an operator acts on and rules are the configuration that produces them.

## Area

- [x] DHCP
- [x] DNS
- [x] Audit / Observability
- [x] Frontend / UI
- [x] API

## Screenshots / API examples

Every tab was re-driven headless after each phase; **no console or HTTP errors** on any of the eight beyond the expected pre-auth 401 on the login page.

The partial-bucket fix, measured live (old math vs new):

```
2026-08-30T11:40Z  covered= 60  old=0.013  new=0.067   <- leading partial
2026-08-31T11:30Z  covered=300  old=0.093  new=0.093   <- full, unchanged
2026-08-31T11:40Z  covered=120  old=0.040  new=0.100   <- trailing partial
```

The RPKI fix, measured live:

```
before: {'rpki_expiring_count': 928, 'rpki_total_count': 928}
after:  {'rpki_expiring_count': 0,   'rpki_total_count': 928}
```

New endpoint:

```
GET /api/v1/dhcp/pools/occupancy?limit=5
{"computed_at": "...", "pool_count": 2, "pools_warning": 0, "pools_critical": 0,
 "active_lease_count": 0,
 "pools": [{"start_ip": "192.168.30.10", "end_ip": "192.168.30.254",
            "total": 245, "assigned": 0, "percent": 0.0,
            "scope_name": "test", "scope_is_active": true,
            "subnet_network": "192.168.30.0/24", "group_name": "windows"}, ...]}
```

## Test plan

- [x] `make lint` passes — `ruff` / `black` / `mypy` clean across the whole backend (861 files); all four frontend CI checks (`eslint --max-warnings 0`, `format:check`, `typecheck`, `vitest` 27/27) plus `npm run build`
- [ ] `make test` — **not run**, and deliberately: `-n auto` OOMs this box and its failure mode masquerades as a regression in the diff. 46 directly-affected backend tests run serially instead, all passing (`test_metrics`, `test_dhcp_pool_occupancy_api`, `test_rpki_roa_state`, `test_dhcp_pool_exhaustion`, plus the `test_model_attribute_references` / `test_response_media_types` guards)
- [x] Manually verified in the UI — full stack rebuilt, all eight tabs screenshotted, alerts deep-link walked
- [x] New/changed behavior is covered by a test — 23 new tests

Also checked: the untyped-route guard baseline is **unchanged** (87 = 87, the new route is typed), and no new unused module-level loggers.

One pre-existing thing surfaced but not touched: `tests/test_metrics.py` has two `union-attr` mypy errors that pre-date this branch. CI runs `mypy app` only, so they are not gated — left alone rather than folded into an unrelated diff.

## Migration / deployment notes

- [ ] Includes an Alembic migration — **none needed.** The RPKI state column is recomputed by the existing reconcile, and the alert events auto-resolve once their subjects stop matching.
- [ ] Updated `k8s/base/` manifests — no services or env changed
- [ ] Breaking change

One **API-visible addition** worth flagging for clients: `DNSTimePoint` / `DHCPTimePoint` gain a required `covered_seconds`. Additive on a read-only endpoint, and the frontend falls back to the nominal bucket width when the field is absent.

## Related issues

Closes #942
Refs #882, #913, #889, #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
